### PR TITLE
fix: remove mcp-sdk re-export from server/Transport

### DIFF
--- a/src/mcp-sdk/client/McpClient.ts
+++ b/src/mcp-sdk/client/McpClient.ts
@@ -68,9 +68,10 @@ export function wrap<const methods extends readonly AnyClient[]>(
           ...result,
           receipt: result._meta?.[core_Mcp.receiptMetaKey] as core_Mcp.Receipt | undefined,
         }
-      } catch (error) {
+      } catch (error_) {
         // Check if this is a payment required error
-        if (!isPaymentRequiredError(error)) throw error
+        if (!isPaymentRequiredError(error_)) throw error_
+        const error = error_ as McpError
 
         const challenges = (error.data as { challenges?: Challenge.Challenge[] })?.challenges
         if (!challenges?.length) throw error
@@ -147,9 +148,7 @@ export declare namespace wrap {
 /**
  * Checks if an error is a payment required error.
  */
-export function isPaymentRequiredError(
-  error: unknown,
-): error is McpError & { data: { challenges: Challenge.Challenge[] } } {
+export function isPaymentRequiredError(error: unknown): boolean {
   if (!(error instanceof McpError)) return false
   if (error.code !== core_Mcp.paymentRequiredCode) return false
   const data = error.data as { challenges?: unknown } | undefined

--- a/src/server/Transport.ts
+++ b/src/server/Transport.ts
@@ -4,8 +4,6 @@ import type * as Errors from '../Errors.js'
 import * as core_Mcp from '../Mcp.js'
 import * as Receipt from '../Receipt.js'
 
-export { type McpSdk, mcpSdk } from '../mcp-sdk/server/Transport.js'
-
 /**
  * Server-side transport adapter.
  *


### PR DESCRIPTION
Prevents bundlers from resolving `@modelcontextprotocol/sdk` when importing from `mpay/server` without using MCP features.

Users who don't use the MCP SDK integration were getting bundler errors because Vite's dependency optimizer scans all imports, including the re-exported `mcpSdk` function that imports from `@modelcontextprotocol/sdk/types.js`.