### PR TITLE
fix: mcp optional import

### DIFF
--- a/src/mcp-sdk/client/McpClient.ts
+++ b/src/mcp-sdk/client/McpClient.ts
@@ -1,5 +1,5 @@
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js'
-import { McpError } from '@modelcontextprotocol/sdk/types.js'
+import type { McpError } from '@modelcontextprotocol/sdk/types.js'
 import type * as Challenge from '../../Challenge.js'
 import * as Credential from '../../Credential.js'
 import * as core_Mcp from '../../Mcp.js'
@@ -150,9 +150,10 @@ export declare namespace wrap {
 export function isPaymentRequiredError(
   error: unknown,
 ): error is McpError & { data: { challenges: Challenge.Challenge[] } } {
-  if (!(error instanceof McpError)) return false
-  if (error.code !== core_Mcp.paymentRequiredCode) return false
-  const data = error.data as { challenges?: unknown } | undefined
+  if (typeof error !== 'object' || error === null) return false
+  if (!('code' in error) || !('message' in error)) return false
+  if ((error as { code: unknown }).code !== core_Mcp.paymentRequiredCode) return false
+  const data = (error as { data?: { challenges?: unknown } }).data
   return Array.isArray(data?.challenges) && data.challenges.length > 0
 }
 

--- a/src/mcp-sdk/server/Transport.ts
+++ b/src/mcp-sdk/server/Transport.ts
@@ -1,5 +1,4 @@
-import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
-import { McpError } from '@modelcontextprotocol/sdk/types.js'
+import type { CallToolResult, McpError } from '@modelcontextprotocol/sdk/types.js'
 import type * as Credential from '../../Credential.js'
 import * as core_Mcp from '../../Mcp.js'
 import * as Transport from '../../server/Transport.js'
@@ -47,6 +46,8 @@ export type McpSdk = Transport.Transport<Extra, McpError, CallToolResult>
  * ```
  */
 export function mcpSdk(): McpSdk {
+  let McpErrorClass: typeof McpError | undefined
+
   return Transport.from<Extra, McpError, CallToolResult>({
     name: 'mcp-sdk',
 
@@ -56,8 +57,12 @@ export function mcpSdk(): McpSdk {
       return credential
     },
 
-    respondChallenge({ challenge, error }) {
-      return new McpError(core_Mcp.paymentRequiredCode, error?.message ?? 'Payment Required', {
+    async respondChallenge({ challenge, error }) {
+      if (!McpErrorClass) {
+        const mod = await import('@modelcontextprotocol/sdk/types.js')
+        McpErrorClass = mod.McpError
+      }
+      return new McpErrorClass(core_Mcp.paymentRequiredCode, error?.message ?? 'Payment Required', {
         httpStatus: 402,
         challenges: [challenge],
         ...(error && { problem: error.toProblemDetails(challenge.id) }),

--- a/src/server/Mpay.ts
+++ b/src/server/Mpay.ts
@@ -125,7 +125,7 @@ function createIntentFn(parameters: createIntentFn.Parameters): createIntentFn.R
       } catch (e) {
         // Credential was provided but malformed
         return {
-          challenge: transport.respondChallenge({
+          challenge: await transport.respondChallenge({
             challenge,
             input,
             error: new Errors.MalformedCredentialError({ reason: (e as Error).message }),
@@ -137,7 +137,7 @@ function createIntentFn(parameters: createIntentFn.Parameters): createIntentFn.R
       // No credential provided—issue challenge
       if (!credential)
         return {
-          challenge: transport.respondChallenge({
+          challenge: await transport.respondChallenge({
             challenge,
             input,
             error: new Errors.PaymentRequiredError({ realm, description }),
@@ -149,7 +149,7 @@ function createIntentFn(parameters: createIntentFn.Parameters): createIntentFn.R
       // This is stateless—no database lookup needed.
       if (!Challenge.verify(credential.challenge, { secretKey }))
         return {
-          challenge: transport.respondChallenge({
+          challenge: await transport.respondChallenge({
             challenge,
             input,
             error: new Errors.InvalidChallengeError({
@@ -165,7 +165,7 @@ function createIntentFn(parameters: createIntentFn.Parameters): createIntentFn.R
         intent.schema.credential.payload.parse(credential.payload)
       } catch (e) {
         return {
-          challenge: transport.respondChallenge({
+          challenge: await transport.respondChallenge({
             challenge,
             input,
             error: new Errors.InvalidPayloadError({ reason: (e as Error).message }),
@@ -180,7 +180,7 @@ function createIntentFn(parameters: createIntentFn.Parameters): createIntentFn.R
         receiptData = await verify({ context, credential, request } as never)
       } catch (e) {
         return {
-          challenge: transport.respondChallenge({
+          challenge: await transport.respondChallenge({
             challenge,
             input,
             error: new Errors.VerificationFailedError({ reason: (e as Error).message }),

--- a/src/server/Transport.test.ts
+++ b/src/server/Transport.test.ts
@@ -84,7 +84,7 @@ describe('http', () => {
       const transport = Transport.http()
       const request = new Request('https://example.com')
 
-      const response = transport.respondChallenge({ challenge, input: request })
+      const response = await transport.respondChallenge({ challenge, input: request })
 
       expect({
         status: response.status,

--- a/src/server/Transport.ts
+++ b/src/server/Transport.ts
@@ -29,7 +29,7 @@ export type Transport<
     challenge: Challenge.Challenge
     error?: Errors.PaymentError | undefined
     input: input
-  }) => challengeOutput
+  }) => challengeOutput | Promise<challengeOutput>
   /** Attaches a receipt to a successful response. */
   respondReceipt: (options: {
     challengeId: string


### PR DESCRIPTION
`@modelcontextprotocol/sdk` is optional peer dep and was causing import issues when not installed and using the following:

```ts
import { Mpay, tempo } from "mpay/server"
```

```bash
11:19:40 PM [vite] Internal server error: Cannot find package '@modelcontextprotocol/sdk' imported from /app/node_modules/.pnpm/mpay@https+++pkg.pr.new+wevm+mpay@3a269e4_typescript@5.9.3_viem@2.45.0_typescript@5.9.3_zod@4.3.6__zod@4.3.6/node_modules/mpay/dist/mcp-sdk/server/Transport.js
      at Object.getPackageJSONURL (node:internal/modules/package_json_reader:316:9)
      at packageResolve (node:internal/modules/esm/resolve:768:81)
      at moduleResolve (node:internal/modules/esm/resolve:858:18)
      at defaultResolve (node:internal/modules/esm/resolve:990:11)
      at nextResolve (node:internal/modules/esm/hooks:785:28)
      at resolve (data:text/javascript,export const resolve = async function(specifier, context, nextResolve) {if (specifier === "cloudflare:workers") return {shortCircuit: true,url: specifier};return nextResolve(specifier, context);};export const load = async function(url, context, nextLoad) {if (url === "cloudflare:workers") return {shortCircuit: true,format: "module",source: `\export const env = globalThis.__node_loader_cloudflare_platform_proxy.env;const __ctx = globalThis.__node_loader_cloudflare_platform_proxy.ctx;export const waitUntil = __ctx.waitUntil.bind(__ctx);`};return nextLoad(url, context);};:1:163)
      at nextResolve (node:internal/modules/esm/hooks:785:28)
      at AsyncLoaderHooksOnLoaderHookWorker.resolve (node:internal/modules/esm/hooks:269:30)
      at MessagePort.handleMessage (node:internal/modules/esm/worker:251:24)
      at [nodejs.internal.kHybridDispatch] (node:internal/event_target:845:20)
```