### PR TITLE
feat(tempo/client): add testnet parameter option

### DIFF
--- a/examples/basic/src/client.ts
+++ b/examples/basic/src/client.ts
@@ -2,17 +2,9 @@ import { Fetch, tempo } from 'mpay/client'
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
 
 const account = privateKeyToAccount(generatePrivateKey())
-const chainId = 42431
-const rpcUrl = 'https://rpc.moderato.tempo.xyz'
 
 Fetch.polyfill({
-  methods: [
-    tempo({
-      account,
-      chainId,
-      rpcUrl,
-    }),
-  ],
+  methods: [tempo({ account })],
 })
 
 document.getElementById('button')!.addEventListener('click', async () => {
@@ -42,11 +34,13 @@ const loadingMessages = [
 // Internal
 
 import { createClient, http } from 'viem'
+import { tempoModerato } from 'viem/chains'
 import { Actions } from 'viem/tempo'
 
 const client = createClient({
+  chain: tempoModerato,
   pollingInterval: 200,
-  transport: http(rpcUrl),
+  transport: http(),
 })
 const currency = '0x20c0000000000000000000000000000000000001' as const
 

--- a/examples/basic/src/server.ts
+++ b/examples/basic/src/server.ts
@@ -2,15 +2,12 @@ import { Expires, Mpay, tempo } from 'mpay/server'
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
 
 const account = privateKeyToAccount(generatePrivateKey())
-const chainId = 42431
 const currency = '0x20c0000000000000000000000000000000000001' as const // alphaUSD
-const rpcUrl = 'https://rpc.moderato.tempo.xyz'
 
 const mpay = Mpay.create({
   method: tempo({
-    chainId,
     feePayer: account,
-    rpcUrl,
+    testnet: true,
   }),
   realm: 'localhost',
   secretKey: 'top-secret-should-be-hidden-somewhere',
@@ -59,11 +56,13 @@ const fortunes = [
 // Internal
 
 import { createClient, http } from 'viem'
+import { tempoModerato } from 'viem/chains'
 import { Actions } from 'viem/tempo'
 
 const client = createClient({
+  chain: tempoModerato,
   pollingInterval: 200,
-  transport: http(rpcUrl),
+  transport: http(),
 })
 
 // Fund recipient account on startup

--- a/src/client/Fetch.test-d.ts
+++ b/src/client/Fetch.test-d.ts
@@ -9,7 +9,6 @@ describe('Fetch.from', () => {
       methods: [
         tempo_client.tempo({
           account: {} as Account,
-          rpcUrl: 'https://rpc.tempo.xyz',
         }),
       ],
     })
@@ -20,11 +19,7 @@ describe('Fetch.from', () => {
 
   test('behavior: accepts context in RequestInit when method has context', () => {
     const fetch = Fetch.from({
-      methods: [
-        tempo_client.tempo({
-          rpcUrl: 'https://rpc.tempo.xyz',
-        }),
-      ],
+      methods: [tempo_client.tempo()],
     })
 
     expectTypeOf(fetch).toBeCallableWith('https://example.com', {
@@ -37,7 +32,6 @@ describe('Fetch.from', () => {
       methods: [
         tempo_client.tempo({
           account: {} as Account,
-          rpcUrl: 'https://rpc.tempo.xyz',
         }),
       ],
     })
@@ -51,7 +45,6 @@ describe('Fetch.from', () => {
       methods: [
         tempo_client.tempo({
           account: {} as Account,
-          rpcUrl: 'https://rpc.tempo.xyz',
         }),
       ],
     })
@@ -66,9 +59,7 @@ describe('Fetch.from', () => {
 
 describe('Fetch.from.RequestInit', () => {
   test('behavior: has context property typed to method context', () => {
-    const method = tempo_client.tempo({
-      rpcUrl: 'https://rpc.tempo.xyz',
-    })
+    const method = tempo_client.tempo()
 
     type Methods = [typeof method]
     type Init = Fetch.from.RequestInit<Methods>

--- a/src/client/Fetch.test.ts
+++ b/src/client/Fetch.test.ts
@@ -14,8 +14,7 @@ const secretKey = 'test-secret-key'
 
 const server = Mpay_server.create({
   method: Methods_server.tempo({
-    chainId: chain.id,
-    rpcUrl,
+    rpcUrl: { [chain.id]: rpcUrl },
   }),
   realm,
   secretKey,
@@ -27,8 +26,7 @@ describe('Fetch.from', () => {
       methods: [
         Methods_client.tempo({
           account: accounts[1],
-          chainId: chain.id,
-          rpcUrl,
+          rpcUrl: { [chain.id]: rpcUrl },
         }),
       ],
     })
@@ -70,8 +68,7 @@ describe('Fetch.from', () => {
     const fetch = Fetch.from({
       methods: [
         Methods_client.tempo({
-          chainId: chain.id,
-          rpcUrl,
+          rpcUrl: { [chain.id]: rpcUrl },
         }),
       ],
     })
@@ -105,8 +102,7 @@ describe('Fetch.from', () => {
       methods: [
         Methods_client.tempo({
           account: accounts[0],
-          chainId: chain.id,
-          rpcUrl,
+          rpcUrl: { [chain.id]: rpcUrl },
         }),
       ],
     })
@@ -136,8 +132,7 @@ describe('Fetch.from', () => {
     const fetch = Fetch.from({
       methods: [
         Methods_client.tempo({
-          chainId: chain.id,
-          rpcUrl,
+          rpcUrl: { [chain.id]: rpcUrl },
         }),
       ],
     })
@@ -167,8 +162,7 @@ describe('Fetch.from', () => {
       methods: [
         Methods_client.tempo({
           account: accounts[1],
-          chainId: chain.id,
-          rpcUrl,
+          rpcUrl: { [chain.id]: rpcUrl },
         }),
       ],
     })
@@ -188,9 +182,8 @@ describe('Fetch.from', () => {
   test('behavior: fee payer', async () => {
     const serverWithFeePayer = Mpay_server.create({
       method: Methods_server.tempo({
-        chainId: chain.id,
         feePayer: accounts[0],
-        rpcUrl,
+        rpcUrl: { [chain.id]: rpcUrl },
       }),
       realm,
       secretKey,
@@ -200,8 +193,7 @@ describe('Fetch.from', () => {
       methods: [
         Methods_client.tempo({
           account: accounts[1],
-          chainId: chain.id,
-          rpcUrl,
+          rpcUrl: { [chain.id]: rpcUrl },
         }),
       ],
     })
@@ -246,8 +238,7 @@ describe('Fetch.polyfill', () => {
       methods: [
         Methods_client.tempo({
           account: accounts[1],
-          chainId: chain.id,
-          rpcUrl,
+          rpcUrl: { [chain.id]: rpcUrl },
         }),
       ],
     })

--- a/src/client/Fetch.ts
+++ b/src/client/Fetch.ts
@@ -18,7 +18,6 @@ let originalFetch: typeof globalThis.fetch | undefined
  *   methods: [
  *     tempo({
  *       account: privateKeyToAccount('0x...'),
- *       rpcUrl: 'https://rpc.tempo.xyz',
  *     }),
  *   ],
  * })
@@ -91,7 +90,6 @@ export declare namespace from {
  *   methods: [
  *     tempo({
  *       account: privateKeyToAccount('0x...'),
- *       rpcUrl: 'https://rpc.tempo.xyz',
  *     }),
  *   ],
  * })

--- a/src/client/Mpay.test-d.ts
+++ b/src/client/Mpay.test-d.ts
@@ -10,7 +10,6 @@ describe('Mpay', () => {
   test('has methods array', () => {
     const method = tempo_client.tempo({
       account: {} as Account,
-      rpcUrl: 'https://rpc.tempo.xyz',
     })
     const mpay = Mpay.create({ methods: [method] })
 
@@ -21,7 +20,6 @@ describe('Mpay', () => {
   test('has createCredential function', () => {
     const method = tempo_client.tempo({
       account: {} as Account,
-      rpcUrl: 'https://rpc.tempo.xyz',
     })
     const mpay = Mpay.create({ methods: [method] })
 
@@ -97,9 +95,7 @@ describe('Method.toClient', () => {
 
 describe('Mpay with context', () => {
   test('createCredential accepts context matching method schema', () => {
-    const method = tempo_client.tempo({
-      rpcUrl: 'https://rpc.tempo.xyz',
-    })
+    const method = tempo_client.tempo()
 
     const mpay = Mpay.create({ methods: [method] })
 
@@ -110,7 +106,6 @@ describe('Mpay with context', () => {
   test('createCredential context is optional when account provided at creation', () => {
     const method = tempo_client.tempo({
       account: {} as Account,
-      rpcUrl: 'https://rpc.tempo.xyz',
     })
 
     const mpay = Mpay.create({ methods: [method] })

--- a/src/client/Mpay.test.ts
+++ b/src/client/Mpay.test.ts
@@ -14,8 +14,7 @@ const realm = 'api.example.com'
 const secretKey = 'test-secret-key'
 const tempo = Methods.tempo({
   account: accounts[1],
-  chainId: chain.id,
-  rpcUrl,
+  rpcUrl: { [chain.id]: rpcUrl },
 })
 
 describe('Mpay.create', () => {
@@ -156,8 +155,7 @@ describe('createCredential', () => {
 
   test('behavior: passes context to createCredential', async () => {
     const method = Methods.tempo({
-      chainId: chain.id,
-      rpcUrl,
+      rpcUrl: { [chain.id]: rpcUrl },
     })
 
     const mpay = Mpay.create({ methods: [method] })

--- a/src/client/Mpay.ts
+++ b/src/client/Mpay.ts
@@ -31,11 +31,7 @@ export type Mpay<
  * import { Mpay, tempo } from 'mpay/client'
  *
  * const mpay = Mpay.create({
- *   methods: [
- *     tempo({
- *       rpcUrl: 'https://rpc.tempo.xyz',
- *     }),
- *   ],
+ *   methods: [tempo()],
  * })
  *
  * const response = await fetch('/resource')

--- a/src/mcp-sdk/client/McpClient.test-d.ts
+++ b/src/mcp-sdk/client/McpClient.test-d.ts
@@ -11,7 +11,6 @@ describe('McpClient.wrap', () => {
       methods: [
         tempo_client.tempo({
           account: {} as Account,
-          rpcUrl: 'https://rpc.tempo.xyz',
         }),
       ],
     })
@@ -26,7 +25,6 @@ describe('McpClient.wrap', () => {
       methods: [
         tempo_client.tempo({
           account: {} as Account,
-          rpcUrl: 'https://rpc.tempo.xyz',
         }),
       ],
     })
@@ -44,7 +42,6 @@ describe('McpClient.wrap', () => {
       methods: [
         tempo_client.tempo({
           account: {} as Account,
-          rpcUrl: 'https://rpc.tempo.xyz',
         }),
       ],
     })
@@ -55,11 +52,7 @@ describe('McpClient.wrap', () => {
   test('callTool accepts context when method has context', () => {
     const client = {} as Client
     const wrapped = McpClient.wrap(client, {
-      methods: [
-        tempo_client.tempo({
-          rpcUrl: 'https://rpc.tempo.xyz',
-        }),
-      ],
+      methods: [tempo_client.tempo({})],
     })
 
     expectTypeOf(wrapped.callTool).toBeCallableWith(
@@ -74,7 +67,6 @@ describe('McpClient.wrap', () => {
       methods: [
         tempo_client.tempo({
           account: {} as Account,
-          rpcUrl: 'https://rpc.tempo.xyz',
         }),
       ],
     })
@@ -90,7 +82,6 @@ describe('McpClient.wrap', () => {
       methods: [
         tempo_client.tempo({
           account: {} as Account,
-          rpcUrl: 'https://rpc.tempo.xyz',
         }),
       ],
     })

--- a/src/mcp-sdk/client/McpClient.test.ts
+++ b/src/mcp-sdk/client/McpClient.test.ts
@@ -24,8 +24,7 @@ describe('McpClient.wrap', () => {
 
   const mpayServer = Mpay_server.create({
     method: Methods_server.tempo({
-      chainId: chain.id,
-      rpcUrl,
+      rpcUrl: { [chain.id]: rpcUrl },
     }),
     realm,
     secretKey,
@@ -73,8 +72,7 @@ describe('McpClient.wrap', () => {
       methods: [
         Methods_client.tempo({
           account: accounts[1],
-          chainId: chain.id,
-          rpcUrl,
+          rpcUrl: { [chain.id]: rpcUrl },
         }),
       ],
     })
@@ -92,8 +90,7 @@ describe('McpClient.wrap', () => {
     const mcp = McpClient.wrap(client, {
       methods: [
         Methods_client.tempo({
-          chainId: chain.id,
-          rpcUrl,
+          rpcUrl: { [chain.id]: rpcUrl },
         }),
       ],
     })
@@ -112,8 +109,7 @@ describe('McpClient.wrap', () => {
       methods: [
         Methods_client.tempo({
           account: accounts[1],
-          chainId: chain.id,
-          rpcUrl,
+          rpcUrl: { [chain.id]: rpcUrl },
         }),
       ],
     })
@@ -128,8 +124,7 @@ describe('McpClient.wrap', () => {
     const mcp = McpClient.wrap(client, {
       methods: [
         Methods_client.tempo({
-          chainId: chain.id,
-          rpcUrl,
+          rpcUrl: { [chain.id]: rpcUrl },
         }),
       ],
     })
@@ -148,8 +143,7 @@ describe('McpClient.wrap', () => {
       methods: [
         Methods_client.tempo({
           account: accounts[1],
-          chainId: chain.id,
-          rpcUrl,
+          rpcUrl: { [chain.id]: rpcUrl },
         }),
       ],
     })
@@ -161,7 +155,7 @@ describe('McpClient.wrap', () => {
 
   test('error: throws when method not found', async () => {
     const challenge = Challenge.fromIntent(
-      Methods_server.tempo({ chainId: chain.id, rpcUrl }).intents.charge,
+      Methods_server.tempo({ rpcUrl: { [chain.id]: rpcUrl } }).intents.charge,
       {
         realm,
         secretKey,
@@ -185,8 +179,7 @@ describe('McpClient.wrap', () => {
       methods: [
         Methods_client.tempo({
           account: accounts[1],
-          chainId: chain.id,
-          rpcUrl,
+          rpcUrl: { [chain.id]: rpcUrl },
         }),
       ],
     })

--- a/src/mcp-sdk/client/McpClient.ts
+++ b/src/mcp-sdk/client/McpClient.ts
@@ -36,7 +36,6 @@ export type CallToolResult = Awaited<ReturnType<Client['callTool']>> & {
  *   methods: [
  *     tempo({
  *       account: privateKeyToAccount('0x...'),
- *       rpcUrl: 'https://rpc.tempo.xyz',
  *     }),
  *   ],
  * })

--- a/src/mcp-sdk/server/Transport.ts
+++ b/src/mcp-sdk/server/Transport.ts
@@ -32,8 +32,7 @@ export type McpSdk = Transport.Transport<Extra, McpError, CallToolResult>
  * import { Mpay, Transport } from 'mpay/server'
  *
  * const payment = Mpay.create({
- *   method: tempo({ ... }),
- *   realm: 'api.example.com',
+ *   method: tempo(),
  *   secretKey: process.env.SECRET_KEY,
  *   transport: Transport.mcpSdk(),
  * })

--- a/src/server/Mpay.test.ts
+++ b/src/server/Mpay.test.ts
@@ -17,8 +17,7 @@ const realm = 'api.example.com'
 const secretKey = 'test-secret-key'
 
 const method = tempo({
-  chainId: chain.id,
-  rpcUrl,
+  rpcUrl: { [chain.id]: rpcUrl },
 })
 
 describe('create', () => {

--- a/src/server/Mpay.ts
+++ b/src/server/Mpay.ts
@@ -79,7 +79,7 @@ export declare namespace create {
     method extends Method.AnyServer = Method.Server,
     transport extends Transport.AnyTransport = Transport.Http,
   > = {
-    /** Payment method (e.g., tempo({ ... })). */
+    /** Payment method (e.g., tempo()). */
     method: method
     /** Server realm (e.g., hostname). @default "MPP Payment". */
     realm?: string | undefined

--- a/src/tempo/client/Method.ts
+++ b/src/tempo/client/Method.ts
@@ -24,18 +24,19 @@ import * as Methods from '../Method.js'
  * ```
  */
 export function tempo(parameters: tempo.Parameters = {}) {
-  const { chainId = defaults.chainId, rpcUrl = defaults.rpcUrl } = parameters
+  const rpcUrl = parameters.rpcUrl ?? defaults.rpcUrl
 
-  const client = (() => {
-    if (parameters.client) return parameters.client
+  function getClient(chainId: number): Client {
+    if (parameters.client) return parameters.client(chainId)
+
+    const url = rpcUrl[chainId as keyof typeof rpcUrl]
+    if (!url) throw new Error(`No \`rpcUrl\` configured for \`chainId\` (${chainId}).`)
+
     return createClient({
-      chain: {
-        ...tempo_chain,
-        id: chainId,
-      },
-      transport: http(rpcUrl),
+      chain: { ...tempo_chain, id: chainId },
+      transport: http(url),
     })
-  })()
+  }
 
   return Method.toClient(Methods.tempo, {
     context: z.object({
@@ -46,6 +47,9 @@ export function tempo(parameters: tempo.Parameters = {}) {
       const account = context?.account ?? parameters.account
       if (!account)
         throw new Error('No `account` provided. Pass `account` to parameters or context.')
+
+      const chainId = (challenge.request.methodDetails?.chainId ?? Number(Object.keys(rpcUrl)[0]))!
+      const client = getClient(chainId)
 
       switch (challenge.intent) {
         case 'charge': {
@@ -69,7 +73,7 @@ export function tempo(parameters: tempo.Parameters = {}) {
           return Credential.serialize({
             challenge,
             payload: { signature, type: 'transaction' },
-            source: `did:pkh:eip155:${client.chain?.id}:${account.address}`,
+            source: `did:pkh:eip155:${chainId}:${account.address}`,
           })
         }
 
@@ -86,14 +90,12 @@ export declare namespace tempo {
     account?: Account | undefined
   } & OneOf<
     | {
-        /** Viem Client. */
-        client?: Client | undefined
+        /** Function that returns a client for the given chain ID. */
+        client?: ((chainId: number) => Client) | undefined
       }
     | {
-        /** Tempo chain ID. */
-        chainId?: number | undefined
-        /** Tempo RPC URL. */
-        rpcUrl?: string | undefined
+        /** RPC URLs keyed by chain ID. */
+        rpcUrl?: ({ [chainId: number]: string } & object) | undefined
       }
   >
 }

--- a/src/tempo/internal/defaults.ts
+++ b/src/tempo/internal/defaults.ts
@@ -1,2 +1,6 @@
-export const chainId = 4217
-export const rpcUrl = 'https://rpc.tempo.xyz'
+export const rpcUrl = {
+  4217: 'https://rpc.tempo.xyz',
+  42431: 'https://rpc.moderato.tempo.xyz',
+} as const
+
+export const testnetChainId = 42431

--- a/src/tempo/server/Method.test.ts
+++ b/src/tempo/server/Method.test.ts
@@ -18,10 +18,9 @@ const secretKey = 'test-secret-key'
 
 const server = Mpay_server.create({
   method: Methods_server.tempo({
-    chainId: chain.id,
     currency: asset,
     recipient: accounts[0].address,
-    rpcUrl,
+    rpcUrl: { [chain.id]: rpcUrl },
   }),
   realm,
   secretKey,
@@ -210,7 +209,7 @@ describe('tempo', () => {
       httpServer.close()
     })
 
-    test('behavior: rejects when chainId override mismatches configured chain', async () => {
+    test('behavior: rejects when chainId has no RPC URL configured', async () => {
       const httpServer = await Http.createServer(async (req, res) => {
         try {
           const result = await toNodeListener(
@@ -230,7 +229,7 @@ describe('tempo', () => {
       const response = await fetch(httpServer.url)
       expect(response.status).toBe(500)
       expect(await response.text()).toMatchInlineSnapshot(
-        `"Chain ID mismatch. Expected 1337 but got 999999."`,
+        `"No RPC URL configured for chainId 999999."`,
       )
 
       httpServer.close()
@@ -243,8 +242,7 @@ describe('tempo', () => {
         methods: [
           Methods_client.tempo({
             account: accounts[1],
-            chainId: chain.id,
-            rpcUrl,
+            rpcUrl: { [chain.id]: rpcUrl },
           }),
         ],
       })
@@ -299,8 +297,7 @@ describe('tempo', () => {
         methods: [
           Methods_client.tempo({
             account: accounts[1],
-            chainId: chain.id,
-            rpcUrl,
+            rpcUrl: { [chain.id]: rpcUrl },
           }),
         ],
       })
@@ -341,8 +338,7 @@ describe('tempo', () => {
         methods: [
           Methods_client.tempo({
             account: accounts[1],
-            chainId: chain.id,
-            rpcUrl,
+            rpcUrl: { [chain.id]: rpcUrl },
           }),
         ],
       })
@@ -394,19 +390,17 @@ describe('tempo', () => {
         methods: [
           Methods_client.tempo({
             account: accounts[1],
-            chainId: chain.id,
-            rpcUrl,
+            rpcUrl: { [chain.id]: rpcUrl },
           }),
         ],
       })
 
       const server = Mpay_server.create({
         method: Methods_server.tempo({
-          chainId: chain.id,
           currency: asset,
           feePayer: accounts[0],
           recipient: accounts[0].address,
-          rpcUrl,
+          rpcUrl: { [chain.id]: rpcUrl },
         }),
         realm,
         secretKey,
@@ -448,6 +442,55 @@ describe('tempo', () => {
               "timestamp": "[timestamp]",
             }
           `)
+      }
+
+      httpServer.close()
+    })
+
+    test('behavior: routes to correct chain based on chainId', async () => {
+      const server = Mpay_server.create({
+        method: Methods_server.tempo({
+          currency: asset,
+          recipient: accounts[0].address,
+          rpcUrl: { [chain.id]: rpcUrl, 999999: 'https://other-chain.example.com' },
+        }),
+        realm,
+        secretKey,
+      })
+
+      const client = Mpay_client.create({
+        methods: [
+          Methods_client.tempo({
+            account: accounts[1],
+            rpcUrl: { [chain.id]: rpcUrl, 999999: 'https://other-chain.example.com' },
+          }),
+        ],
+      })
+
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await toNodeListener(
+          server.charge({
+            amount: '1000000',
+            chainId: chain.id,
+          }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
+      })
+
+      const response = await fetch(httpServer.url)
+      expect(response.status).toBe(402)
+
+      const challenge = Challenge.fromResponse(response, { method: server.method })
+      expect(challenge.request.methodDetails?.chainId).toBe(chain.id)
+
+      const credential = await client.createCredential(response)
+
+      {
+        const response = await fetch(httpServer.url, {
+          headers: { Authorization: credential },
+        })
+        expect(response.status).toBe(200)
       }
 
       httpServer.close()

--- a/src/tempo/server/Method.ts
+++ b/src/tempo/server/Method.ts
@@ -38,28 +38,25 @@ const transferWithMemoSelector = /*#__PURE__*/ AbiFunction.getSelector(transferW
 export function tempo<const defaults extends tempo.Defaults>(
   parameters: tempo.Parameters<defaults> = {} as tempo.Parameters<defaults>,
 ) {
-  const {
-    amount,
-    chainId = defaults.chainId,
-    currency,
-    description,
-    externalId,
-    memo,
-    recipient,
-    rpcUrl = defaults.rpcUrl,
-  } = parameters
+  const { amount, currency, description, externalId, memo, recipient } = parameters
 
-  const client = (() => {
-    if (parameters.client) return parameters.client
+  const rpcUrl = parameters.rpcUrl ?? defaults.rpcUrl
+
+  function getClient(chainId: number): Client {
+    if (parameters.client) return parameters.client(chainId)
+
+    const url = rpcUrl[chainId as keyof typeof rpcUrl]
+    if (!url) throw new Error(`No \`rpcUrl\` configured for \`chainId\` (${chainId}).`)
+
     return createClient({
       chain: {
         ...tempo_chain,
         id: chainId,
         experimental_preconfirmationTime: 500,
       },
-      transport: http(rpcUrl),
+      transport: http(url),
     })
-  })()
+  }
 
   return Method.toServer<typeof Methods.tempo, defaults>(Methods.tempo, {
     defaults: {
@@ -72,9 +69,14 @@ export function tempo<const defaults extends tempo.Defaults>(
     } as defaults,
 
     request({ credential, request }) {
-      const chainId = request.chainId ?? client.chain?.id
-      if (chainId !== client.chain?.id)
-        throw new Error(`Chain ID mismatch. Expected ${client.chain?.id} but got ${chainId}.`)
+      const chainId = (() => {
+        if (request.chainId) return request.chainId
+        if (parameters.testnet) return defaults.testnetChainId
+        return Number(Object.keys(rpcUrl)[0])!
+      })()
+
+      if (!parameters.client && !rpcUrl[chainId as keyof typeof rpcUrl])
+        throw new Error(`No RPC URL configured for chainId ${chainId}.`)
 
       const feePayer = (() => {
         const account =
@@ -90,7 +92,9 @@ export function tempo<const defaults extends tempo.Defaults>(
 
     async verify({ credential, request }) {
       const { challenge } = credential
-      const { feePayer } = request
+      const { chainId, feePayer } = request
+
+      const client = getClient(chainId!)
 
       switch (challenge.intent) {
         case 'charge': {
@@ -250,17 +254,17 @@ export declare namespace tempo {
   type Parameters<defaults extends Defaults = {}> = {
     /** Optional fee payer account for covering transaction fees. */
     feePayer?: Account | undefined
+    /** Testnet mode. */
+    testnet?: boolean | undefined
   } & defaults &
     OneOf<
       | {
-          /** Viem Client. */
-          client?: Client | undefined
+          /** Function that returns a client for the given chain ID. */
+          client?: ((chainId: number) => Client) | undefined
         }
       | {
-          /** Tempo chain ID. */
-          chainId?: number | undefined
-          /** Tempo RPC URL. */
-          rpcUrl?: string | undefined
+          /** RPC URLs keyed by chain ID. */
+          rpcUrl?: ({ [chainId: number]: string } & object) | undefined
         }
     >
 }


### PR DESCRIPTION
Adds a `testnet: true` parameter to the `tempo()` client method that uses chainId `42431` (Moderato testnet) for the default RPC URL.

Also restructures the `rpcUrl` and `client` options to be part of a `OneOf` union type, so only one of `client`, `rpcUrl`, or `testnet` can be specified at a time.