### PR TITLE
fix: add zod as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
   },
   "peerDependencies": {
     "@modelcontextprotocol/sdk": ">=1.25.0",
-    "viem": ">=2.44.4"
+    "viem": ">=2.44.4",
+    "zod": ">=4.0.0"
   },
   "peerDependenciesMeta": {
     "@modelcontextprotocol/sdk": {


### PR DESCRIPTION
## Summary

- Add `zod >= 4.0.0` to `peerDependencies`

mpay imports from `zod/mini` and re-exports `z`, but doesn't declare zod as a dependency or peer dependency. In strict package managers like pnpm, this causes `zod/mini` to resolve to a hoisted zod v3 (from other packages in the workspace) which doesn't have the `./mini` subpath export, breaking both esbuild bundling and TypeScript type resolution.

Discovered while integrating mpay 0.1.0 into a Cloudflare Worker project in a pnpm workspace.

## Test plan

- Verify `pnpm install` in a fresh pnpm workspace with `mpay` properly resolves zod v4 into mpay's virtual store `node_modules`
- Verify `import { z } from 'mpay'` resolves types correctly without `pnpm.packageExtensions` workaround