### PR TITLE
feat: add Channel.computeId to compute channel IDs locally

### DIFF
--- a/.changeset/calm-wolves-march.md
+++ b/.changeset/calm-wolves-march.md
@@ -1,0 +1,5 @@
+---
+"mpay": patch
+---
+
+Added `Channel.computeId` to compute stream channel IDs locally, eliminating a network round-trip to the contract.

--- a/src/tempo/client/Stream.ts
+++ b/src/tempo/client/Stream.ts
@@ -6,7 +6,7 @@ import {
   toHex,
   type Client as viem_Client,
 } from 'viem'
-import { prepareTransactionRequest, readContract, signTransaction } from 'viem/actions'
+import { prepareTransactionRequest, signTransaction } from 'viem/actions'
 import { tempo as tempo_chain } from 'viem/chains'
 import { Abis } from 'viem/tempo'
 import type * as Challenge from '../../Challenge.js'
@@ -17,6 +17,7 @@ import * as z from '../../zod.js'
 import * as Intents from '../Intents.js'
 import * as defaults from '../internal/defaults.js'
 import { escrowAbi, getOnChainChannel } from '../stream/Chain.js'
+import * as Channel from '../stream/Channel.js'
 import type { StreamCredentialPayload } from '../stream/Types.js'
 import { signVoucher } from '../stream/Voucher.js'
 
@@ -218,11 +219,15 @@ export function stream(parameters: stream.Parameters = {}) {
   ): Promise<{ entry: ChannelEntry; payload: StreamCredentialPayload }> {
     const salt = randomSalt()
 
-    const channelId = await readContract(client, {
-      address: escrowContract,
-      abi: escrowAbi,
-      functionName: 'computeChannelId',
-      args: [account.address, payee, currency, deposit, salt, account.address],
+    const channelId = Channel.computeId({
+      authorizedSigner: account.address,
+      chainId,
+      deposit,
+      escrowContract,
+      payee,
+      payer: account.address,
+      salt,
+      token: currency,
     })
 
     const approveData = encodeFunctionData({

--- a/src/tempo/stream/Channel.ts
+++ b/src/tempo/stream/Channel.ts
@@ -1,0 +1,54 @@
+import { AbiParameters, Hash } from 'ox'
+import type * as Hex from 'ox/Hex'
+
+/**
+ * Computes a channel ID from its parameters.
+ *
+ * Mirrors the onchain `computeChannelId` function: `keccak256(abi.encode(payer, payee, token, deposit, salt, authorizedSigner, escrowContract, chainId))`.
+ */
+export function computeId(parameters: computeId.Parameters): Hex.Hex {
+  const encoded = AbiParameters.encode(
+    AbiParameters.from([
+      'address payer',
+      'address payee',
+      'address token',
+      'uint128 deposit',
+      'bytes32 salt',
+      'address authorizedSigner',
+      'address escrowContract',
+      'uint256 chainId',
+    ]),
+    [
+      parameters.payer,
+      parameters.payee,
+      parameters.token,
+      parameters.deposit,
+      parameters.salt,
+      parameters.authorizedSigner,
+      parameters.escrowContract,
+      BigInt(parameters.chainId),
+    ],
+  )
+  return Hash.keccak256(encoded)
+}
+
+export declare namespace computeId {
+  type Parameters = {
+    /** Address authorized to sign vouchers on behalf of the payer. */
+    authorizedSigner: Hex.Hex
+    /** Chain ID of the network the escrow contract is deployed on. */
+    chainId: number
+    /** Initial deposit amount in the channel. */
+    deposit: bigint
+    /** Address of the escrow contract. */
+    escrowContract: Hex.Hex
+    /** Address of the payee (recipient). */
+    payee: Hex.Hex
+    /** Address of the payer (sender). */
+    payer: Hex.Hex
+    /** Unique salt to differentiate channels with the same parameters. */
+    salt: Hex.Hex
+    /** Address of the token used for payment. */
+    token: Hex.Hex
+  }
+}

--- a/src/tempo/stream/index.ts
+++ b/src/tempo/stream/index.ts
@@ -1,4 +1,5 @@
 export * as Chain from './Chain.js'
+export * as Channel from './Channel.js'
 export * as Receipt from './Receipt.js'
 export * as Sse from './Sse.js'
 export * as Storage from './Storage.js'

--- a/test/tempo/stream.ts
+++ b/test/tempo/stream.ts
@@ -9,13 +9,13 @@ import {
 import {
   deployContract,
   prepareTransactionRequest,
-  readContract,
   signTransaction,
   waitForTransactionReceipt,
   writeContractSync,
 } from 'viem/actions'
+import * as Channel from '../../src/tempo/stream/Channel.js'
 import artifact from '../fixtures/TempoStreamChannel.json' with { type: 'json' }
-import { client } from './viem.js'
+import { chain, client } from './viem.js'
 
 export const escrowAbi = artifact.abi
 
@@ -49,11 +49,15 @@ export async function openChannel(params: {
     args: [escrow, deposit],
   })
 
-  const channelId = await readContract(client, {
-    address: escrow,
-    abi: artifact.abi,
-    functionName: 'computeChannelId',
-    args: [payer.address, payee, token, deposit, salt, authorizedSigner],
+  const channelId = Channel.computeId({
+    authorizedSigner,
+    chainId: chain.id,
+    deposit,
+    escrowContract: escrow,
+    payee,
+    payer: payer.address,
+    salt,
+    token,
   })
 
   const txReceipt = await writeContractSync(client, {
@@ -127,11 +131,15 @@ export async function signOpenChannel(params: {
   const { escrow, payer, payee, token, deposit, salt } = params
   const authorizedSigner = params.authorizedSigner ?? zeroAddress
 
-  const channelId = await readContract(client, {
-    address: escrow,
-    abi: artifact.abi,
-    functionName: 'computeChannelId',
-    args: [payer.address, payee, token, deposit, salt, authorizedSigner],
+  const channelId = Channel.computeId({
+    authorizedSigner,
+    chainId: chain.id,
+    deposit,
+    escrowContract: escrow,
+    payee,
+    payer: payer.address,
+    salt,
+    token,
   })
 
   const approveData = encodeFunctionData({


### PR DESCRIPTION
Adds `Channel.computeId` to compute stream channel IDs locally using Ox's `AbiParameters.encode` + `Hash.keccak256`, eliminating a network round-trip to the contract's `computeChannelId` view function.

### Changes

- Added `src/tempo/stream/Channel.ts` with `computeId`
- Replaced `readContract` + `computeChannelId` calls in `src/tempo/client/Stream.ts` and `test/tempo/stream.ts`
- Exported `Channel` module from `src/tempo/stream/index.ts`