### PR TITLE
fix(stream): thread `feePayer` from `methodDetails` in stream client

### DIFF
--- a/.changeset/tiny-clouds-drift.md
+++ b/.changeset/tiny-clouds-drift.md
@@ -1,5 +1,0 @@
----
-"mpay": patch
----
-
-Stream client: thread `feePayer` from challenge `methodDetails` through to the open channel transaction.


### PR DESCRIPTION
Threads `feePayer` from challenge `methodDetails` through to the open channel transaction in the stream client.