### PR TITLE
chore(examples): simplify stream example to use library defaults

### DIFF
--- a/examples/stream/src/server.ts
+++ b/examples/stream/src/server.ts
@@ -9,19 +9,15 @@ const account = privateKeyToAccount(generatePrivateKey())
 const currency = '0x20c0000000000000000000000000000000000001' as const
 const pricePerToken = '0.000075'
 
-const storage = createMemoryStorage()
-
 const mpay = Mpay.create({
   methods: [
     tempo.stream({
       currency,
       recipient: account.address,
-      storage,
+      storage: createMemoryStorage(),
+      testnet: true,
     }),
   ],
-  realm: 'localhost',
-  // Example-only. In production, use a strong random secret from env.
-  secretKey: process.env.SECRET_KEY ?? 'stream-example-secret',
 })
 
 export async function handler(request: Request): Promise<Response | null> {


### PR DESCRIPTION
Simplifies the stream example server to use built-in defaults instead of explicit configuration:

- **Remove** explicit `realm` and `secretKey` from `Mpay.create()` — both have defaults (`"MPP Payment"` and `"tmp"`)
- **Add** `testnet: true` to `tempo.stream()` so `chainId`/`escrowContract`/`rpcUrl` auto-resolve for Moderato
- **Inline** `createMemoryStorage()` call (no need for a separate variable)

Net result: 6 lines removed, 2 added — the example is simpler and consistent with the basic example's patterns.