### PR TITLE
chore(examples): simplify server examples

### DIFF
--- a/examples/basic/src/server.ts
+++ b/examples/basic/src/server.ts
@@ -1,14 +1,24 @@
 import { Mpay, tempo } from 'mpay/server'
+import { createClient, http } from 'viem'
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
+import { tempoModerato } from 'viem/chains'
+import { Actions } from 'viem/tempo'
 
 const account = privateKeyToAccount(generatePrivateKey())
 const currency = '0x20c0000000000000000000000000000000000001' as const // alphaUSD
+
+const client = createClient({
+  chain: tempoModerato,
+  pollingInterval: 200,
+  transport: http(),
+})
 
 const mpay = Mpay.create({
   methods: [
     tempo.charge({
       currency,
       feePayer: account,
+      getClient: () => client,
       recipient: account.address,
       testnet: true,
     }),
@@ -47,19 +57,6 @@ const fortunes = [
   'A light heart carries you through all the hard times.',
   'A new perspective will come with the new year.',
 ]
-
-////////////////////////////////////////////////////////////////////
-// Internal
-
-import { createClient, http } from 'viem'
-import { tempoModerato } from 'viem/chains'
-import { Actions } from 'viem/tempo'
-
-const client = createClient({
-  chain: tempoModerato,
-  pollingInterval: 200,
-  transport: http(),
-})
 
 // Fund recipient account on startup
 await Actions.faucet.fundSync(client, { account })

--- a/examples/stream/src/server.ts
+++ b/examples/stream/src/server.ts
@@ -9,10 +9,17 @@ const account = privateKeyToAccount(generatePrivateKey())
 const currency = '0x20c0000000000000000000000000000000000001' as const
 const pricePerToken = '0.000075'
 
+const client = createClient({
+  chain: tempoModerato,
+  pollingInterval: 1_000,
+  transport: http(),
+})
+
 const mpay = Mpay.create({
   methods: [
     tempo.stream({
       currency,
+      getClient: () => client,
       recipient: account.address,
       storage: createMemoryStorage(),
       testnet: true,
@@ -80,12 +87,6 @@ function generateTokens(_prompt: string): string[] {
     ' answer.',
   ]
 }
-
-const client = createClient({
-  chain: tempoModerato,
-  pollingInterval: 1_000,
-  transport: http(),
-})
 
 console.log(`Server recipient: ${account.address}`)
 await Actions.faucet.fundSync(client, { account, timeout: 30_000 })


### PR DESCRIPTION
- Move imports and client creation to the top
- Pass `getClient` to reuse the same viem client instance
- Remove the separate "Internal" section in basic example