### PR TITLE
fix: use PaymentExpiredError instead of plain Error for expired challenges

### DIFF
--- a/src/tempo/server/Charge.test.ts
+++ b/src/tempo/server/Charge.test.ts
@@ -218,7 +218,7 @@ describe('tempo', () => {
         })
         expect(response.status).toBe(402)
         const body = (await response.json()) as { detail: string }
-        expect(body.detail).toBe('Payment verification failed: Payment request expired.')
+        expect(body.detail).toMatch(/^Payment expired at /)
       }
 
       httpServer.close()

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -9,6 +9,7 @@ import {
 import { getTransactionReceipt, sendRawTransactionSync, signTransaction } from 'viem/actions'
 import { tempo as tempo_chain } from 'viem/chains'
 import { Abis, Transaction } from 'viem/tempo'
+import { PaymentExpiredError } from '../../Errors.js'
 import type { LooseOmit } from '../../internal/types.js'
 import * as MethodIntent from '../../MethodIntent.js'
 import * as Client from '../../viem/Client.js'
@@ -101,7 +102,7 @@ export function charge<const defaults extends charge.Defaults>(
       const currency = challengeRequest.currency as `0x${string}`
       const recipient = challengeRequest.recipient as `0x${string}`
 
-      if (expires && new Date(expires) < new Date()) throw new Error('Payment request expired')
+      if (expires && new Date(expires) < new Date()) throw new PaymentExpiredError({ expires })
 
       const payload = credential.payload
 


### PR DESCRIPTION
Previously threw a plain `Error('Payment request expired')` which got wrapped as `VerificationFailedError` with the wrong problem type URI (`verification-failed`).

Now throws `PaymentExpiredError` which extends `PaymentError` and propagates the correct `payment-expired` problem type URI through the framework's error handling in `Mpay.ts`.