### PR TITLE
fix: use correct MCP error codes per spec

### DIFF
--- a/src/client/Transport.ts
+++ b/src/client/Transport.ts
@@ -88,7 +88,11 @@ export function mcp() {
     name: 'mcp',
 
     isPaymentRequired(response) {
-      return 'error' in response && response.error?.code === Mcp.paymentRequiredCode
+      return (
+        'error' in response &&
+        (response.error?.code === Mcp.paymentRequiredCode ||
+          response.error?.code === Mcp.paymentVerificationFailedCode)
+      )
     },
 
     getChallenge(response) {

--- a/src/mcp-sdk/client/McpClient.ts
+++ b/src/mcp-sdk/client/McpClient.ts
@@ -159,7 +159,9 @@ export function isPaymentRequiredError(
 ): error is McpError & { data: { challenges: Challenge.Challenge[] } } {
   if (typeof error !== 'object' || error === null) return false
   if (!('code' in error) || !('message' in error)) return false
-  if ((error as { code: unknown }).code !== core_Mcp.paymentRequiredCode) return false
+  const code = (error as { code: unknown }).code
+  if (code !== core_Mcp.paymentRequiredCode && code !== core_Mcp.paymentVerificationFailedCode)
+    return false
   const data = (error as { data?: { challenges?: unknown } }).data
   return Array.isArray(data?.challenges) && data.challenges.length > 0
 }

--- a/src/mcp-sdk/server/Transport.ts
+++ b/src/mcp-sdk/server/Transport.ts
@@ -1,5 +1,6 @@
 import type { CallToolResult, McpError } from '@modelcontextprotocol/sdk/types.js'
 import type * as Credential from '../../Credential.js'
+import * as Errors from '../../Errors.js'
 import * as core_Mcp from '../../Mcp.js'
 import * as Transport from '../../server/Transport.js'
 
@@ -61,7 +62,7 @@ export function mcpSdk(): McpSdk {
         const mod = await import('@modelcontextprotocol/sdk/types.js')
         McpErrorClass = mod.McpError
       }
-      return new McpErrorClass(core_Mcp.paymentRequiredCode, error?.message ?? 'Payment Required', {
+      return new McpErrorClass(mcpSdkErrorCode(error), error?.message ?? 'Payment Required', {
         httpStatus: 402,
         challenges: [challenge],
         ...(error && { problem: error.toProblemDetails(challenge.id) }),
@@ -83,4 +84,11 @@ export function mcpSdk(): McpSdk {
       }
     },
   })
+}
+
+function mcpSdkErrorCode(error?: Errors.PaymentError): number {
+  if (!error) return core_Mcp.paymentRequiredCode
+  if (error instanceof Errors.MalformedCredentialError) return -32602
+  if (error instanceof Errors.PaymentRequiredError) return core_Mcp.paymentRequiredCode
+  return core_Mcp.paymentVerificationFailedCode
 }

--- a/src/server/Transport.ts
+++ b/src/server/Transport.ts
@@ -1,6 +1,6 @@
 import * as Challenge from '../Challenge.js'
 import * as Credential from '../Credential.js'
-import type * as Errors from '../Errors.js'
+import * as Errors from '../Errors.js'
 import * as core_Mcp from '../Mcp.js'
 import * as Receipt from '../Receipt.js'
 
@@ -126,7 +126,7 @@ export function http() {
  * MCP transport for server-side payment handling with raw JSON-RPC.
  *
  * - Reads credentials from `_meta["org.paymentauth/credential"]`
- * - Issues challenges via JSON-RPC error with code -32042
+ * - Issues challenges via JSON-RPC error with code -32042/-32043
  * - Attaches receipts via `_meta["org.paymentauth/receipt"]`
  *
  * Use this transport when handling raw JSON-RPC messages directly.
@@ -148,7 +148,7 @@ export function mcp() {
         jsonrpc: '2.0',
         id: input.id,
         error: {
-          code: core_Mcp.paymentRequiredCode,
+          code: mcpErrorCode(error),
           message: error?.message ?? 'Payment Required',
           data: {
             httpStatus: error?.status ?? 402,
@@ -179,4 +179,11 @@ export function mcp() {
       }
     },
   })
+}
+
+function mcpErrorCode(error?: Errors.PaymentError): number {
+  if (!error) return core_Mcp.paymentRequiredCode
+  if (error instanceof Errors.MalformedCredentialError) return -32602
+  if (error instanceof Errors.PaymentRequiredError) return core_Mcp.paymentRequiredCode
+  return core_Mcp.paymentVerificationFailedCode
 }


### PR DESCRIPTION
Per `draft-payment-transport-mcp-00` §9 Error Code Mapping:

| Condition | Code | Description |
|-----------|------|-------------|
| Payment required | `-32042` | Initial challenge (no credential) |
| Payment verification failed | `-32043` | Credential rejected, fresh challenge |
| Malformed credential | `-32602` | Invalid params (bad JSON structure) |

**Server changes**: Both raw MCP and MCP SDK transports now select the correct error code based on the error type:
- `PaymentRequiredError` / no error → `-32042`
- `MalformedCredentialError` → `-32602`
- All other verification errors (`InvalidChallengeError`, `VerificationFailedError`, `PaymentExpiredError`, `InvalidPayloadError`) → `-32043`

**Client changes**: Both raw MCP and MCP SDK clients now recognize `-32042` *and* `-32043` as payment challenge responses (both include fresh challenges for retry).