### PR TITLE
docs: SDK integration examples for all major LLM providers

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -8,6 +8,7 @@ Standalone, runnable examples demonstrating the mpay HTTP 402 payment flow.
 |---------|-------------|
 | [basic](./basic/) | Bun server with pay-per-request fortune API |
 | [stream](./stream/) | Streaming payment channels with per-token LLM metering |
+| [sdk-integrations](./sdk-integrations/) | How mpay composes with every major LLM/AI SDK |
 
 ## Running Examples
 

--- a/examples/sdk-integrations/README.md
+++ b/examples/sdk-integrations/README.md
@@ -1,0 +1,84 @@
+# SDK Integrations
+
+Shows how mpay composes with every major LLM/AI SDK in TypeScript.
+
+## Key Insight
+
+**mpay works with every SDK out of the box** because it operates at the `fetch` layer. Since all LLM SDKs use `fetch` (or HTTP) internally, mpay's fetch polyfill transparently handles 402 Payment Required flows without any SDK-specific integration code.
+
+## Client-Side (Paying for AI APIs)
+
+How a **consumer** pays for AI API calls using mpay:
+
+| Example | SDK | Pattern |
+|---------|-----|---------|
+| [client-openai.ts](./src/client-openai.ts) | OpenAI SDK (12.2M npm/week) | Fetch polyfill — zero code changes |
+| [client-anthropic.ts](./src/client-anthropic.ts) | Anthropic SDK | Fetch polyfill — zero code changes |
+| [client-vercel-ai.ts](./src/client-vercel-ai.ts) | Vercel AI SDK (20.8k stars) | Inject `mpay.fetch` into provider |
+| [client-openrouter.ts](./src/client-openrouter.ts) | OpenRouter SDK (387k npm/week) | Fetch polyfill via OpenAI SDK |
+| [client-litellm.ts](./src/client-litellm.ts) | LiteLLM / Together / Fireworks | OpenAI SDK + different `baseURL` |
+| [client-google-gemini.ts](./src/client-google-gemini.ts) | Google GenAI SDK | Fetch polyfill — zero code changes |
+
+### How it works (client)
+
+```ts
+import { Mpay, tempo } from 'mpay/client'
+
+// 1. Polyfill fetch — every SDK gains 402 payment handling
+Mpay.create({ methods: [tempo({ account })] })
+
+// 2. Use any SDK normally — mpay handles payment transparently
+const stream = await openai.responses.create({ model: 'gpt-5.2', input: '...', stream: true })
+```
+
+## Server-Side (Charging for LLM Streaming)
+
+How an **API provider** charges per-token for LLM responses using mpay:
+
+| Example | SDK | Streaming Pattern |
+|---------|-----|-------------------|
+| [server-openai.ts](./src/server-openai.ts) | OpenAI SDK | `for await (event of stream)` → SSE |
+| [server-anthropic.ts](./src/server-anthropic.ts) | Anthropic SDK | `messages.stream()` → SSE |
+| [server-vercel-ai.ts](./src/server-vercel-ai.ts) | Vercel AI SDK | `streamText().textStream` → SSE |
+| [server-google-gemini.ts](./src/server-google-gemini.ts) | Google GenAI SDK | `generateContentStream()` → SSE |
+| [server-cohere.ts](./src/server-cohere.ts) | Cohere SDK | `chatStream()` → SSE |
+
+### How it works (server)
+
+```ts
+import { Mpay, tempo } from 'mpay/server'
+
+const mpay = Mpay.create({ methods: [tempo.stream({ ... })] })
+
+export async function handler(request: Request) {
+  // 1. Require payment
+  const result = await mpay.stream({ amount: '0.0001', unitType: 'token' })(request)
+  if (result.status === 402) return result.challenge
+
+  // 2. Stream from any LLM SDK
+  const stream = await openai.responses.create({ model: 'gpt-5.2', input: '...', stream: true })
+
+  // 3. Relay as SSE with payment receipt
+  return result.withReceipt(new Response(readable, { headers: { 'Content-Type': 'text/event-stream' } }))
+}
+```
+
+## Transport: SSE Everywhere
+
+Every major LLM provider uses **Server-Sent Events (SSE)** for streaming. This is significant for mpay because:
+
+1. SSE is unidirectional (server → client), built on HTTP — fits the 402 flow naturally
+2. The `stream: true` flag is universal across all SDKs
+3. All SDKs expose async iterables (`for await...of`) for consuming streams
+4. Payment credentials are sent via HTTP headers, which SSE inherits from the initial request
+
+WebSocket is only used by OpenAI's Realtime (voice) API — not relevant for text/token streaming.
+
+## SDK Landscape Summary
+
+| Tier | SDKs | mpay Integration |
+|------|------|------------------|
+| **Provider-native** | OpenAI, Anthropic, Google, Mistral, Cohere | Fetch polyfill (zero changes) |
+| **Abstraction layers** | Vercel AI SDK, LangChain | Inject `mpay.fetch` or polyfill |
+| **Routers/gateways** | OpenRouter, LiteLLM | OpenAI SDK + `baseURL` swap |
+| **OpenAI-compatible** | Together, Fireworks, Ollama, vLLM | OpenAI SDK + `baseURL` swap |

--- a/examples/sdk-integrations/src/client-anthropic.ts
+++ b/examples/sdk-integrations/src/client-anthropic.ts
@@ -1,0 +1,35 @@
+/**
+ * Client: Pay for an Anthropic-compatible API using mpay.
+ *
+ * Same fetch polyfill pattern — Anthropic's SDK uses httpx/fetch
+ * internally, so mpay intercepts 402 responses automatically.
+ */
+import Anthropic from '@anthropic-ai/sdk'
+import { Mpay, tempo } from 'mpay/client'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x...')
+
+Mpay.create({
+  methods: [tempo({ account })],
+})
+
+const anthropic = new Anthropic({
+  baseURL: 'https://paid-api.example.com',
+  apiKey: 'not-needed-payment-is-onchain',
+})
+
+const stream = anthropic.messages.stream({
+  model: 'claude-sonnet-4-5-20250514',
+  max_tokens: 1024,
+  messages: [{ role: 'user', content: 'What is the 402 status code?' }],
+})
+
+for await (const event of stream) {
+  if (
+    event.type === 'content_block_delta' &&
+    event.delta.type === 'text_delta'
+  ) {
+    process.stdout.write(event.delta.text)
+  }
+}

--- a/examples/sdk-integrations/src/client-google-gemini.ts
+++ b/examples/sdk-integrations/src/client-google-gemini.ts
@@ -1,0 +1,29 @@
+/**
+ * Client: Pay for Google Gemini API calls using mpay.
+ *
+ * Google's GenAI SDK uses fetch internally. mpay's fetch polyfill
+ * intercepts 402 responses from paid Gemini-compatible endpoints.
+ */
+import { GoogleGenAI } from '@google/genai'
+import { Mpay, tempo } from 'mpay/client'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x...')
+
+Mpay.create({
+  methods: [tempo({ account })],
+})
+
+const genai = new GoogleGenAI({
+  apiKey: process.env.GOOGLE_API_KEY!,
+})
+
+const response = await genai.models.generateContentStream({
+  model: 'gemini-2.5-flash',
+  contents: 'What are machine-to-machine payments?',
+})
+
+for await (const chunk of response) {
+  const text = chunk.text
+  if (text) process.stdout.write(text)
+}

--- a/examples/sdk-integrations/src/client-litellm.ts
+++ b/examples/sdk-integrations/src/client-litellm.ts
@@ -1,0 +1,59 @@
+/**
+ * Client: Pay for LiteLLM proxy calls using mpay.
+ *
+ * LiteLLM (35.6k GitHub stars) is the dominant Python-side LLM gateway.
+ * It exposes an OpenAI-compatible API, so the TS client uses the OpenAI
+ * SDK pointed at the LiteLLM proxy — mpay handles payment transparently.
+ *
+ * This is the pattern for any OpenAI-compatible proxy:
+ * - LiteLLM
+ * - Together AI
+ * - Fireworks AI
+ * - Ollama
+ * - vLLM
+ * - Any custom proxy
+ */
+import OpenAI from 'openai'
+import { Mpay, tempo } from 'mpay/client'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x...')
+
+Mpay.create({
+  methods: [tempo({ account })],
+})
+
+// Point at any OpenAI-compatible proxy with 402 payment support
+const litellm = new OpenAI({
+  baseURL: 'https://litellm-proxy.example.com',
+  apiKey: 'not-needed',
+})
+
+// LiteLLM routes to any backend (Anthropic, Gemini, Bedrock, etc.)
+const stream = await litellm.chat.completions.create({
+  model: 'anthropic/claude-sonnet-4-5',
+  messages: [{ role: 'user', content: 'Explain payment channels.' }],
+  stream: true,
+})
+
+for await (const chunk of stream) {
+  const content = chunk.choices[0]?.delta?.content
+  if (content) process.stdout.write(content)
+}
+
+// Together AI — same pattern, different baseURL
+const together = new OpenAI({
+  baseURL: 'https://api.together.xyz/v1',
+  apiKey: process.env.TOGETHER_API_KEY,
+})
+
+const togetherStream = await together.chat.completions.create({
+  model: 'meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo',
+  messages: [{ role: 'user', content: 'Hello!' }],
+  stream: true,
+})
+
+for await (const chunk of togetherStream) {
+  const content = chunk.choices[0]?.delta?.content
+  if (content) process.stdout.write(content)
+}

--- a/examples/sdk-integrations/src/client-openai.ts
+++ b/examples/sdk-integrations/src/client-openai.ts
@@ -1,0 +1,39 @@
+/**
+ * Client: Pay for an OpenAI-compatible API using mpay.
+ *
+ * The OpenAI SDK is the de facto standard (12.2M npm weekly downloads).
+ * Most providers (OpenRouter, Together, Fireworks, LiteLLM) are
+ * OpenAI-compatible, so this pattern covers ~80% of use cases.
+ *
+ * mpay.fetch polyfills globalThis.fetch, so the OpenAI SDK's internal
+ * fetch calls automatically handle 402 Payment Required responses.
+ */
+import OpenAI from 'openai'
+import { Mpay, tempo } from 'mpay/client'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x...')
+
+// 1. mpay polyfills globalThis.fetch — all HTTP requests gain 402 handling
+Mpay.create({
+  methods: [tempo({ account })],
+})
+
+// 2. Point OpenAI SDK at a paid API (no code changes needed)
+const openai = new OpenAI({
+  baseURL: 'https://paid-api.example.com/v1',
+  apiKey: 'not-needed-payment-is-onchain',
+})
+
+// 3. Use the SDK normally — mpay handles payment transparently
+const stream = await openai.responses.create({
+  model: 'gpt-5.2',
+  input: 'Explain how HTTP 402 payment works.',
+  stream: true,
+})
+
+for await (const event of stream) {
+  if (event.type === 'response.output_text.delta') {
+    process.stdout.write(event.delta)
+  }
+}

--- a/examples/sdk-integrations/src/client-openrouter.ts
+++ b/examples/sdk-integrations/src/client-openrouter.ts
@@ -1,0 +1,54 @@
+/**
+ * Client: Pay for OpenRouter API calls using mpay.
+ *
+ * OpenRouter (387k npm weekly downloads) provides access to 300+ models
+ * through a unified API. It supports both its own SDK and the OpenAI SDK
+ * (via baseURL swap). Both patterns work with mpay.
+ */
+import OpenAI from 'openai'
+import { Mpay, tempo } from 'mpay/client'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x...')
+
+// Pattern 1: OpenRouter via OpenAI SDK (most common)
+// ───────────────────────────────────────────────────
+Mpay.create({
+  methods: [tempo({ account })],
+})
+
+const openrouter = new OpenAI({
+  baseURL: 'https://openrouter.ai/api/v1',
+  apiKey: process.env.OPENROUTER_API_KEY,
+  defaultHeaders: {
+    'HTTP-Referer': 'https://myapp.example.com',
+    'X-Title': 'My App',
+  },
+})
+
+const stream = await openrouter.chat.completions.create({
+  model: 'anthropic/claude-sonnet-4-5',
+  messages: [{ role: 'user', content: 'What is HTTP 402?' }],
+  stream: true,
+})
+
+for await (const chunk of stream) {
+  const content = chunk.choices[0]?.delta?.content
+  if (content) process.stdout.write(content)
+}
+
+// Pattern 2: OpenRouter's own SDK
+// ────────────────────────────────
+// import { OpenRouter } from '@openrouter/sdk'
+//
+// The @openrouter/sdk uses fetch internally, so mpay.fetch polyfill
+// works here too. Streaming via getTextStream():
+//
+// const result = openRouter.callModel({
+//   model: 'openai/gpt-5.2',
+//   input: 'Hello!',
+// })
+//
+// for await (const delta of result.getTextStream()) {
+//   process.stdout.write(delta)
+// }

--- a/examples/sdk-integrations/src/client-vercel-ai.ts
+++ b/examples/sdk-integrations/src/client-vercel-ai.ts
@@ -1,0 +1,37 @@
+/**
+ * Client: Pay for AI APIs using Vercel AI SDK + mpay.
+ *
+ * The Vercel AI SDK (20.8k stars) is the dominant abstraction layer
+ * for LLM streaming in Next.js/React apps. It supports 25+ providers
+ * and single-line model switching.
+ *
+ * mpay.fetch wraps the underlying fetch, so `streamText()` and
+ * `generateText()` automatically handle 402 payment flows.
+ */
+import { streamText } from 'ai'
+import { createOpenAI } from '@ai-sdk/openai'
+import { Mpay, tempo } from 'mpay/client'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const account = privateKeyToAccount('0x...')
+
+const mpay = Mpay.create({
+  methods: [tempo({ account })],
+  polyfill: false,
+})
+
+// Point any Vercel AI SDK provider at a paid endpoint
+const paidProvider = createOpenAI({
+  baseURL: 'https://paid-api.example.com/v1',
+  apiKey: 'not-needed',
+  fetch: mpay.fetch, // <-- inject mpay's payment-aware fetch
+})
+
+const result = streamText({
+  model: paidProvider('gpt-5.2'),
+  prompt: 'Explain machine payments in one paragraph.',
+})
+
+for await (const chunk of result.textStream) {
+  process.stdout.write(chunk)
+}

--- a/examples/sdk-integrations/src/server-anthropic.ts
+++ b/examples/sdk-integrations/src/server-anthropic.ts
@@ -1,0 +1,66 @@
+/**
+ * Server: Charge per-token for Anthropic Claude streaming responses.
+ *
+ * Shows how an API provider wraps Anthropic's SDK with mpay to charge
+ * callers per LLM token via the 402 Payment flow + SSE streaming.
+ */
+import Anthropic from '@anthropic-ai/sdk'
+import { Mpay, tempo } from 'mpay/server'
+import { createMemoryStorage } from './storage.js'
+
+const anthropic = new Anthropic()
+
+const mpay = Mpay.create({
+  methods: [
+    tempo.stream({
+      currency: '0x20c0000000000000000000000000000000000001',
+      getClient: () => client,
+      recipient: account.address,
+      storage: createMemoryStorage(),
+    }),
+  ],
+})
+
+export async function handler(request: Request): Promise<Response> {
+  const { prompt } = await request.json()
+
+  const result = await mpay.stream({
+    amount: '0.0001',
+    unitType: 'token',
+  })(request)
+
+  if (result.status === 402) return result.challenge as Response
+
+  const stream = anthropic.messages.stream({
+    model: 'claude-sonnet-4-5-20250514',
+    max_tokens: 1024,
+    messages: [{ role: 'user', content: prompt }],
+  })
+
+  const encoder = new TextEncoder()
+  const readable = new ReadableStream({
+    async start(controller) {
+      for await (const event of stream) {
+        if (
+          event.type === 'content_block_delta' &&
+          event.delta.type === 'text_delta'
+        ) {
+          const data = JSON.stringify({ token: event.delta.text })
+          controller.enqueue(encoder.encode(`data: ${data}\n\n`))
+        }
+      }
+      controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+      controller.close()
+    },
+  })
+
+  return result.withReceipt(
+    new Response(readable, {
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+      },
+    }),
+  )
+}

--- a/examples/sdk-integrations/src/server-cohere.ts
+++ b/examples/sdk-integrations/src/server-cohere.ts
@@ -1,0 +1,65 @@
+/**
+ * Server: Charge per-token for Cohere streaming responses.
+ *
+ * Cohere's SDK uses `chatStream()` which returns an event-based
+ * async iterable with `content-delta` events for token chunks.
+ */
+import { CohereClientV2 } from 'cohere-ai'
+import { Mpay, tempo } from 'mpay/server'
+import { createMemoryStorage } from './storage.js'
+
+const cohere = new CohereClientV2({ token: process.env.COHERE_API_KEY! })
+
+const mpay = Mpay.create({
+  methods: [
+    tempo.stream({
+      currency: '0x20c0000000000000000000000000000000000001',
+      getClient: () => client,
+      recipient: account.address,
+      storage: createMemoryStorage(),
+    }),
+  ],
+})
+
+export async function handler(request: Request): Promise<Response> {
+  const { prompt } = await request.json()
+
+  const result = await mpay.stream({
+    amount: '0.0001',
+    unitType: 'token',
+  })(request)
+
+  if (result.status === 402) return result.challenge as Response
+
+  const stream = await cohere.chatStream({
+    model: 'command-a-03-2025',
+    messages: [{ role: 'user', content: prompt }],
+  })
+
+  const encoder = new TextEncoder()
+  const readable = new ReadableStream({
+    async start(controller) {
+      for await (const event of stream) {
+        if (event.type === 'content-delta') {
+          const text = event.delta?.message?.content?.text
+          if (text) {
+            const data = JSON.stringify({ token: text })
+            controller.enqueue(encoder.encode(`data: ${data}\n\n`))
+          }
+        }
+      }
+      controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+      controller.close()
+    },
+  })
+
+  return result.withReceipt(
+    new Response(readable, {
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+      },
+    }),
+  )
+}

--- a/examples/sdk-integrations/src/server-google-gemini.ts
+++ b/examples/sdk-integrations/src/server-google-gemini.ts
@@ -1,0 +1,63 @@
+/**
+ * Server: Charge per-token for Google Gemini streaming responses.
+ *
+ * Google's Gemini SDK uses `generateContentStream()` which returns
+ * an async iterable of chunks — same SSE pattern as everyone else.
+ */
+import { GoogleGenAI } from '@google/genai'
+import { Mpay, tempo } from 'mpay/server'
+import { createMemoryStorage } from './storage.js'
+
+const genai = new GoogleGenAI({ apiKey: process.env.GOOGLE_API_KEY! })
+
+const mpay = Mpay.create({
+  methods: [
+    tempo.stream({
+      currency: '0x20c0000000000000000000000000000000000001',
+      getClient: () => client,
+      recipient: account.address,
+      storage: createMemoryStorage(),
+    }),
+  ],
+})
+
+export async function handler(request: Request): Promise<Response> {
+  const { prompt } = await request.json()
+
+  const result = await mpay.stream({
+    amount: '0.0001',
+    unitType: 'token',
+  })(request)
+
+  if (result.status === 402) return result.challenge as Response
+
+  const response = await genai.models.generateContentStream({
+    model: 'gemini-2.5-flash',
+    contents: prompt,
+  })
+
+  const encoder = new TextEncoder()
+  const readable = new ReadableStream({
+    async start(controller) {
+      for await (const chunk of response) {
+        const text = chunk.text
+        if (text) {
+          const data = JSON.stringify({ token: text })
+          controller.enqueue(encoder.encode(`data: ${data}\n\n`))
+        }
+      }
+      controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+      controller.close()
+    },
+  })
+
+  return result.withReceipt(
+    new Response(readable, {
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+      },
+    }),
+  )
+}

--- a/examples/sdk-integrations/src/server-openai.ts
+++ b/examples/sdk-integrations/src/server-openai.ts
@@ -1,0 +1,66 @@
+/**
+ * Server: Charge per-token for OpenAI-style streaming responses.
+ *
+ * Shows how an API provider wraps OpenAI's SDK with mpay to charge
+ * callers per LLM token via the 402 Payment flow + SSE streaming.
+ */
+import OpenAI from 'openai'
+import { Mpay, tempo } from 'mpay/server'
+import { createMemoryStorage } from './storage.js'
+
+const openai = new OpenAI()
+
+const mpay = Mpay.create({
+  methods: [
+    tempo.stream({
+      currency: '0x20c0000000000000000000000000000000000001',
+      getClient: () => client,
+      recipient: account.address,
+      storage: createMemoryStorage(),
+    }),
+  ],
+})
+
+export async function handler(request: Request): Promise<Response> {
+  const { prompt } = await request.json()
+
+  // 1. Require payment — returns 402 challenge if no credential
+  const result = await mpay.stream({
+    amount: '0.0001',
+    unitType: 'token',
+  })(request)
+
+  if (result.status === 402) return result.challenge as Response
+
+  // 2. Stream from OpenAI, relay as SSE to the caller
+  const stream = await openai.responses.create({
+    model: 'gpt-5.2',
+    input: prompt,
+    stream: true,
+  })
+
+  const encoder = new TextEncoder()
+  const readable = new ReadableStream({
+    async start(controller) {
+      for await (const event of stream) {
+        if (event.type === 'response.output_text.delta') {
+          const data = JSON.stringify({ token: event.delta })
+          controller.enqueue(encoder.encode(`data: ${data}\n\n`))
+        }
+      }
+      controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+      controller.close()
+    },
+  })
+
+  // 3. Attach payment receipt to the streaming response
+  return result.withReceipt(
+    new Response(readable, {
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+      },
+    }),
+  )
+}

--- a/examples/sdk-integrations/src/server-vercel-ai.ts
+++ b/examples/sdk-integrations/src/server-vercel-ai.ts
@@ -1,0 +1,71 @@
+/**
+ * Server: Charge per-token using Vercel AI SDK's `streamText`.
+ *
+ * The Vercel AI SDK is the most popular abstraction layer for LLM streaming
+ * in Next.js/React apps (20.8k GitHub stars, 25+ providers). This shows
+ * how mpay composes with `streamText()` and provider-switching.
+ */
+import { streamText } from 'ai'
+import { openai } from '@ai-sdk/openai'
+import { anthropic } from '@ai-sdk/anthropic'
+import { google } from '@ai-sdk/google'
+import { Mpay, tempo } from 'mpay/server'
+import { createMemoryStorage } from './storage.js'
+
+const mpay = Mpay.create({
+  methods: [
+    tempo.stream({
+      currency: '0x20c0000000000000000000000000000000000001',
+      getClient: () => client,
+      recipient: account.address,
+      storage: createMemoryStorage(),
+    }),
+  ],
+})
+
+export async function handler(request: Request): Promise<Response> {
+  const { prompt, provider = 'openai' } = await request.json()
+
+  const result = await mpay.stream({
+    amount: '0.0001',
+    unitType: 'token',
+  })(request)
+
+  if (result.status === 402) return result.challenge as Response
+
+  // Vercel AI SDK: swap providers with one line
+  const model =
+    provider === 'anthropic'
+      ? anthropic('claude-sonnet-4-5-20250514')
+      : provider === 'google'
+        ? google('gemini-2.5-flash')
+        : openai('gpt-5.2')
+
+  const aiStream = streamText({
+    model,
+    prompt,
+  })
+
+  // streamText returns a Response-compatible stream
+  const encoder = new TextEncoder()
+  const readable = new ReadableStream({
+    async start(controller) {
+      for await (const chunk of aiStream.textStream) {
+        const data = JSON.stringify({ token: chunk })
+        controller.enqueue(encoder.encode(`data: ${data}\n\n`))
+      }
+      controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+      controller.close()
+    },
+  })
+
+  return result.withReceipt(
+    new Response(readable, {
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+      },
+    }),
+  )
+}

--- a/examples/sdk-integrations/src/storage.ts
+++ b/examples/sdk-integrations/src/storage.ts
@@ -1,0 +1,33 @@
+import type { tempo } from 'mpay/server'
+
+type ChannelStorage = tempo.ChannelStorage
+type ChannelState = tempo.ChannelState
+type SessionState = tempo.SessionState
+
+export function createMemoryStorage(): ChannelStorage {
+  const channels = new Map<string, ChannelState>()
+  const sessions = new Map<string, SessionState>()
+
+  return {
+    async getChannel(channelId) {
+      return channels.get(channelId) ?? null
+    },
+    async getSession(challengeId) {
+      return sessions.get(challengeId) ?? null
+    },
+    async updateChannel(channelId, fn) {
+      const current = channels.get(channelId) ?? null
+      const next = fn(current)
+      if (next) channels.set(channelId, next)
+      else channels.delete(channelId)
+      return next
+    },
+    async updateSession(challengeId, fn) {
+      const current = sessions.get(challengeId) ?? null
+      const next = fn(current)
+      if (next) sessions.set(challengeId, next)
+      else sessions.delete(challengeId)
+      return next
+    },
+  }
+}


### PR DESCRIPTION
## Summary

Shows how mpay composes with every major LLM/AI SDK in TypeScript — both client-side (paying for AI APIs) and server-side (charging per-token for LLM streaming).

## Context

From [Slack thread](https://tempoxyz.slack.com/archives/C0A8YB63Q91/p1770681268226719) — researched the most popular SDKs AI companies use and how they all handle streaming (SSE everywhere).

## Key finding

**mpay works with every SDK out of the box** because it operates at the `fetch` layer. All LLM SDKs use fetch internally, so mpay's polyfill handles 402 flows transparently — no SDK-specific integration code needed.

## Examples added

### Client-side (consumer paying for AI APIs)

| File | SDK | Weekly Downloads |
|------|-----|-----------------|
| `client-openai.ts` | OpenAI SDK | 12.2M npm |
| `client-anthropic.ts` | Anthropic SDK | ~1M+ npm |
| `client-vercel-ai.ts` | Vercel AI SDK | 20.8k stars |
| `client-openrouter.ts` | OpenRouter SDK | 387k npm |
| `client-litellm.ts` | LiteLLM / Together / Fireworks | 35.6k stars |
| `client-google-gemini.ts` | Google GenAI SDK | - |

### Server-side (provider charging per-token)

| File | SDK |
|------|-----|
| `server-openai.ts` | OpenAI SDK |
| `server-anthropic.ts` | Anthropic SDK |
| `server-vercel-ai.ts` | Vercel AI SDK (multi-provider) |
| `server-google-gemini.ts` | Google GenAI SDK |
| `server-cohere.ts` | Cohere SDK |

## Two integration patterns

1. **Fetch polyfill** (most SDKs): `Mpay.create({ methods: [...] })` polyfills `globalThis.fetch` — zero code changes to any SDK
2. **Explicit fetch injection** (Vercel AI SDK): pass `mpay.fetch` to the provider's `fetch` option