### PR TITLE
fix: normalize version in help snapshot

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -419,9 +419,10 @@ describe.skipIf(!!process.env.CI)('account', () => {
 })
 
 test('mpay --help', () => {
-  const stdout = run(['--help'])
+  const { version } = require('../package.json') as { version: string }
+  const stdout = run(['--help']).replace(`mpay/${version}`, 'mpay/x.x.x')
   expect(stdout).toMatchInlineSnapshot(`
-    "mpay/0.1.0
+    "mpay/x.x.x
 
     Usage:
       $ mpay [url]


### PR DESCRIPTION
The inline snapshot in `cli.test.ts` hardcoded the version string, causing it to break on every changeset version bump. This normalizes the version to `mpay/x.x.x` by reading it dynamically from `package.json` before comparing.