### PR TITLE
chore: add patch changeset

### DIFF
--- a/.changeset/fix-snapshot-version.md
+++ b/.changeset/fix-snapshot-version.md
@@ -1,0 +1,5 @@
+---
+"mpay": patch
+---
+
+Fix version snapshot test to survive changeset bumps


### PR DESCRIPTION
Adds a patch changeset for the snapshot fix. Once merged, the changesets action will open a version PR bumping to 0.2.1.