### PR TITLE
fix(streams): support `authorizedSigner` for access key signing

### DIFF
--- a/.changeset/authorized-signer.md
+++ b/.changeset/authorized-signer.md
@@ -1,0 +1,5 @@
+---
+"mpay": patch
+---
+
+Added `authorizedSigner` parameter to `session()` and `sessionManager()`. This allows a separate address (e.g. a secp256k1 access key) to sign vouchers while the root account funds the escrow channel. When `authorizedSigner` is set, keychain envelope signatures are automatically unwrapped to raw ECDSA for on-chain verification. This is a workaround until TIP-1020 enshrinement.

--- a/src/tempo/client/ChannelOps.ts
+++ b/src/tempo/client/ChannelOps.ts
@@ -75,6 +75,7 @@ export async function createVoucherPayload(
   cumulativeAmount: bigint,
   escrowContract: Address,
   chainId: number,
+  authorizedSigner?: Address | undefined,
 ): Promise<StreamCredentialPayload> {
   const signature = await signVoucher(
     client,
@@ -82,6 +83,7 @@ export async function createVoucherPayload(
     { channelId, cumulativeAmount },
     escrowContract,
     chainId,
+    authorizedSigner,
   )
   return {
     action: 'voucher',
@@ -98,6 +100,7 @@ export async function createClosePayload(
   cumulativeAmount: bigint,
   escrowContract: Address,
   chainId: number,
+  authorizedSigner?: Address | undefined,
 ): Promise<StreamCredentialPayload> {
   const signature = await signVoucher(
     client,
@@ -105,6 +108,7 @@ export async function createClosePayload(
     { channelId, cumulativeAmount },
     escrowContract,
     chainId,
+    authorizedSigner,
   )
   return {
     action: 'close',
@@ -118,6 +122,7 @@ export async function createOpenPayload(
   client: viem_Client,
   account: viem_Account,
   options: {
+    authorizedSigner?: Address | undefined
     escrowContract: Address
     payee: Address
     currency: Address
@@ -128,10 +133,11 @@ export async function createOpenPayload(
   },
 ): Promise<{ entry: ChannelEntry; payload: StreamCredentialPayload }> {
   const { escrowContract, payee, currency, deposit, initialAmount, chainId, feePayer } = options
+  const authorizedSigner = options.authorizedSigner ?? account.address
 
   const salt = Hex.random(32)
   const channelId = Channel.computeId({
-    authorizedSigner: account.address,
+    authorizedSigner,
     chainId,
     escrowContract,
     payee,
@@ -148,7 +154,7 @@ export async function createOpenPayload(
   const openData = encodeFunctionData({
     abi: escrowAbi,
     functionName: 'open',
-    args: [payee, currency, deposit, salt, account.address],
+    args: [payee, currency, deposit, salt, authorizedSigner],
   })
 
   const prepared = await prepareTransactionRequest(client, {
@@ -168,6 +174,7 @@ export async function createOpenPayload(
     { channelId, cumulativeAmount: initialAmount },
     escrowContract,
     chainId,
+    options.authorizedSigner,
   )
 
   return {
@@ -184,7 +191,7 @@ export async function createOpenPayload(
       type: 'transaction',
       channelId,
       transaction,
-      authorizedSigner: account.address,
+      authorizedSigner,
       cumulativeAmount: initialAmount.toString(),
       signature,
     },

--- a/src/tempo/client/Session.ts
+++ b/src/tempo/client/Session.ts
@@ -180,10 +180,12 @@ export function session(parameters: session.Parameters = {}) {
         entry.cumulativeAmount,
         escrowContract,
         chainId,
+        parameters.authorizedSigner,
       )
       notifyUpdate(entry)
     } else {
       const result = await createOpenPayload(client, account, {
+        authorizedSigner: parameters.authorizedSigner,
         escrowContract,
         payee,
         currency,
@@ -243,6 +245,7 @@ export function session(parameters: session.Parameters = {}) {
           { channelId, cumulativeAmount },
           escrowContract,
           chainId,
+          parameters.authorizedSigner,
         )
         payload = {
           action: 'open',
@@ -279,6 +282,7 @@ export function session(parameters: session.Parameters = {}) {
           cumulativeAmount,
           escrowContract,
           chainId,
+          parameters.authorizedSigner,
         )
         const key = channelIdToKey.get(channelId)
         if (key) {
@@ -301,6 +305,7 @@ export function session(parameters: session.Parameters = {}) {
           { channelId, cumulativeAmount },
           escrowContract,
           chainId,
+          parameters.authorizedSigner,
         )
         payload = {
           action: 'close',
@@ -348,6 +353,8 @@ export function session(parameters: session.Parameters = {}) {
 export declare namespace session {
   type Parameters = Account.getResolver.Parameters &
     Client.getResolver.Parameters & {
+      /** Address authorized to sign vouchers. Defaults to the account address. Use when a separate access key (e.g. secp256k1) signs vouchers while the root account funds the channel. */
+      authorizedSigner?: Address | undefined
       /** Token decimals for parsing human-readable amounts (default: 6). */
       decimals?: number | undefined
       /** Initial deposit amount in human-readable units (e.g. "10" for 10 tokens). When set, the method handles the full channel lifecycle (open, voucher, cumulative tracking) automatically. */

--- a/src/tempo/client/SessionManager.ts
+++ b/src/tempo/client/SessionManager.ts
@@ -62,6 +62,7 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
 
   const method = sessionPlugin({
     account: parameters.account,
+    authorizedSigner: parameters.authorizedSigner,
     getClient: parameters.client ? () => parameters.client! : parameters.getClient,
     escrowContract: parameters.escrowContract,
     decimals: parameters.decimals,
@@ -254,10 +255,13 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
 export declare namespace sessionManager {
   type Parameters = Account.getResolver.Parameters &
     Client.getResolver.Parameters & {
+      /** Address authorized to sign vouchers. Defaults to the account address. */
+      authorizedSigner?: Address | undefined
       /** Viem client instance. Shorthand for `getClient: () => client`. */
       client?: import('viem').Client | undefined
       /** Token decimals used to convert `maxDeposit` to raw units. Defaults to `6`. */
       decimals?: number | undefined
+      /** Escrow contract address. */
       escrowContract?: Address | undefined
       fetch?: typeof globalThis.fetch | undefined
       /** Maximum deposit in human-readable units (e.g. `'10'` for 10 tokens). Converted to raw units via `decimals`. */

--- a/src/tempo/server/Session.ts
+++ b/src/tempo/server/Session.ts
@@ -208,7 +208,14 @@ export function session<const parameters extends session.Parameters>(p?: paramet
           break
 
         case 'close':
-          streamReceipt = await handleClose(store, client, challenge, payload, methodDetails, account)
+          streamReceipt = await handleClose(
+            store,
+            client,
+            challenge,
+            payload,
+            methodDetails,
+            account,
+          )
           break
 
         default:

--- a/src/tempo/stream/Voucher.ts
+++ b/src/tempo/stream/Voucher.ts
@@ -1,4 +1,4 @@
-import type { Address } from 'ox'
+import { type Address, Signature } from 'ox'
 import { SignatureEnvelope } from 'ox/tempo'
 import type { Account, Client, Hex } from 'viem'
 import { isAddressEqual, recoverTypedDataAddress } from 'viem'
@@ -42,8 +42,9 @@ export async function signVoucher(
   message: Voucher,
   escrowContract: Address.Address,
   chainId: number,
+  authorizedSigner?: Address.Address | undefined,
 ): Promise<Hex> {
-  return signTypedData(client, {
+  const signature = await signTypedData(client, {
     account,
     domain: getVoucherDomain(escrowContract, chainId),
     types: voucherTypes,
@@ -53,6 +54,20 @@ export async function signVoucher(
       cumulativeAmount: message.cumulativeAmount,
     },
   })
+
+  // When a separate authorizedSigner is used (e.g. access key), unwrap the
+  // keychain envelope — the escrow contract verifies raw ECDSA signatures
+  // against authorizedSigner, not keychain-wrapped ones.
+  // TODO: when TIP-1020 is implemented, we can remove this.
+  if (authorizedSigner) {
+    try {
+      const envelope = SignatureEnvelope.from(signature as SignatureEnvelope.Serialized)
+      if (envelope.type === 'keychain' && envelope.inner.type === 'secp256k1')
+        return Signature.toHex(envelope.inner.signature)
+    } catch {}
+  }
+
+  return signature
 }
 
 /**


### PR DESCRIPTION
Workaround to enable Tempo access keys (secp256k1) to sign payment vouchers while the root account (WebAuthn passkey) funds the escrow channel.

## Changes

- **Voucher.ts**: Unwrap keychain envelope signatures so the escrow contract receives raw ECDSA signatures it can verify against `authorizedSigner`
- **ChannelOps.ts**: Accept optional `authorizedSigner` in `createOpenPayload`, use it in `Channel.computeId`, escrow `open()` calldata, and returned payload
- **Session.ts**: Thread `authorizedSigner` from `session.Parameters` into `createOpenPayload`
- **SessionManager.ts**: Thread `authorizedSigner` through to the session plugin

## Motivation

When using Tempo access keys for streaming payments (e.g. pay-per-second DJ sessions), the root WebAuthn passkey funds the channel but an ephemeral secp256k1 access key signs vouchers. The escrow contract expects raw ECDSA signatures, but access keys produce keychain-wrapped `SignatureEnvelope`s. This PR:

1. Unwraps keychain envelopes in `signVoucher` to extract the inner signature
2. Lets callers specify which address is authorized to sign vouchers on the channel