### PR TITLE
feat: add chainId to ChannelStore.State

### DIFF
--- a/.changeset/channel-chain-id.md
+++ b/.changeset/channel-chain-id.md
@@ -1,0 +1,5 @@
+---
+'mpay': patch
+---
+
+Added `chainId` to `ChannelStore.State` so channels track which chain they were opened on.

--- a/src/tempo/server/Session.test.ts
+++ b/src/tempo/server/Session.test.ts
@@ -1204,6 +1204,7 @@ describe('monotonicity and TOCTOU (unit tests)', () => {
       payee: '0x0000000000000000000000000000000000000002' as Address,
       token: '0x0000000000000000000000000000000000000003' as Address,
       authorizedSigner: '0x0000000000000000000000000000000000000004' as Address,
+      chainId: 42431,
       deposit: 10000000n,
       settledOnChain: 0n,
       highestVoucherAmount: 5000000n,

--- a/src/tempo/server/Session.ts
+++ b/src/tempo/server/Session.ts
@@ -560,6 +560,7 @@ async function handleOpen(
     }
     return {
       channelId: payload.channelId,
+      chainId: methodDetails.chainId,
       payer: onChain.payer,
       payee: onChain.payee,
       token: onChain.token,

--- a/src/tempo/server/Sse.test.ts
+++ b/src/tempo/server/Sse.test.ts
@@ -32,6 +32,7 @@ function seedChannel(
     payee: '0x0000000000000000000000000000000000000002' as Address,
     token: '0x0000000000000000000000000000000000000003' as Address,
     authorizedSigner: '0x0000000000000000000000000000000000000004' as Address,
+    chainId: 42431,
     deposit: balance,
     settledOnChain: 0n,
     highestVoucherAmount: balance,

--- a/src/tempo/stream/ChannelStore.ts
+++ b/src/tempo/stream/ChannelStore.ts
@@ -21,6 +21,8 @@ import type { SignedVoucher } from './Types.js'
 export interface State {
   /** Address authorized to sign vouchers on behalf of the payer. */
   authorizedSigner: Address
+  /** Chain ID the channel was opened on. */
+  chainId: number
   /** Unique identifier for this payment channel. */
   channelId: Hex
   /** ISO 8601 timestamp when the channel was created. */

--- a/src/tempo/stream/Sse.test.ts
+++ b/src/tempo/stream/Sse.test.ts
@@ -217,6 +217,7 @@ describe('serve', () => {
       payee: '0x0000000000000000000000000000000000000002' as Address,
       token: '0x0000000000000000000000000000000000000003' as Address,
       authorizedSigner: '0x0000000000000000000000000000000000000004' as Address,
+      chainId: 42431,
       deposit: balance,
       settledOnChain: 0n,
       highestVoucherAmount: balance,


### PR DESCRIPTION
Adds a `chainId` field to `ChannelStore.State`, populated from `methodDetails.chainId` when a new channel is created via `verifyAndAcceptVoucher`.

This enables consumers (e.g. djbox) to resolve escrow contracts dynamically based on the chain the payment channel was opened on.