### PR TITLE
feat: add escrowContract to ChannelStore.State

### DIFF
--- a/.changeset/channel-escrow-contract.md
+++ b/.changeset/channel-escrow-contract.md
@@ -1,0 +1,5 @@
+---
+'mpay': patch
+---
+
+Added `escrowContract` to `ChannelStore.State`, populated from `methodDetails.escrowContract` when a channel is created.

--- a/src/tempo/server/Session.test.ts
+++ b/src/tempo/server/Session.test.ts
@@ -1205,6 +1205,7 @@ describe('monotonicity and TOCTOU (unit tests)', () => {
       token: '0x0000000000000000000000000000000000000003' as Address,
       authorizedSigner: '0x0000000000000000000000000000000000000004' as Address,
       chainId: 42431,
+      escrowContract: '0x542831e3E4Ace07559b7C8787395f4Fb99F70787' as Address,
       deposit: 10000000n,
       settledOnChain: 0n,
       highestVoucherAmount: 5000000n,

--- a/src/tempo/server/Session.ts
+++ b/src/tempo/server/Session.ts
@@ -561,6 +561,7 @@ async function handleOpen(
     return {
       channelId: payload.channelId,
       chainId: methodDetails.chainId,
+      escrowContract: methodDetails.escrowContract,
       payer: onChain.payer,
       payee: onChain.payee,
       token: onChain.token,

--- a/src/tempo/server/Sse.test.ts
+++ b/src/tempo/server/Sse.test.ts
@@ -33,6 +33,7 @@ function seedChannel(
     token: '0x0000000000000000000000000000000000000003' as Address,
     authorizedSigner: '0x0000000000000000000000000000000000000004' as Address,
     chainId: 42431,
+    escrowContract: '0x542831e3E4Ace07559b7C8787395f4Fb99F70787' as Address,
     deposit: balance,
     settledOnChain: 0n,
     highestVoucherAmount: balance,

--- a/src/tempo/stream/ChannelStore.test.ts
+++ b/src/tempo/stream/ChannelStore.test.ts
@@ -13,6 +13,8 @@ function makeChannel(overrides?: Partial<ChannelStore.State>): ChannelStore.Stat
     payee: '0x0000000000000000000000000000000000000002' as Address,
     token: '0x0000000000000000000000000000000000000003' as Address,
     authorizedSigner: '0x0000000000000000000000000000000000000004' as Address,
+    chainId: 42431,
+    escrowContract: '0x542831e3E4Ace07559b7C8787395f4Fb99F70787' as Address,
     deposit: 10_000_000n,
     settledOnChain: 0n,
     highestVoucherAmount: 10_000_000n,

--- a/src/tempo/stream/ChannelStore.ts
+++ b/src/tempo/stream/ChannelStore.ts
@@ -23,6 +23,8 @@ export interface State {
   authorizedSigner: Address
   /** Chain ID the channel was opened on. */
   chainId: number
+  /** Escrow contract address the channel was opened on. */
+  escrowContract: Address
   /** Unique identifier for this payment channel. */
   channelId: Hex
   /** ISO 8601 timestamp when the channel was created. */

--- a/src/tempo/stream/Sse.test.ts
+++ b/src/tempo/stream/Sse.test.ts
@@ -218,6 +218,7 @@ describe('serve', () => {
       token: '0x0000000000000000000000000000000000000003' as Address,
       authorizedSigner: '0x0000000000000000000000000000000000000004' as Address,
       chainId: 42431,
+      escrowContract: '0x542831e3E4Ace07559b7C8787395f4Fb99F70787' as Address,
       deposit: balance,
       settledOnChain: 0n,
       highestVoucherAmount: balance,


### PR DESCRIPTION
Adds `escrowContract` to `ChannelStore.State`, populated from `methodDetails.escrowContract` when a new channel is created.

This lets consumers close/settle channels without maintaining their own chain-to-escrow mapping — they can use `channel.escrowContract` directly.