### PR TITLE
refine stripe payment method client API

### DIFF
--- a/examples/stripe/README.md
+++ b/examples/stripe/README.md
@@ -2,7 +2,7 @@
 
 End-to-end demo of the HTTP 402 payment flow using Stripe SPTs and Stripe.js.
 
-Uses the automatic mppx client — `Mppx.create()` polyfills `globalThis.fetch` so any `fetch()` call that gets a 402 automatically creates an SPT and retries with the credential. The server verifies the SPT by creating a Stripe PaymentIntent.
+Uses the automatic mppx client — `Mppx.create()` polyfills `globalThis.fetch` so any `fetch()` call that gets a 402 automatically runs `onChallenge`, creates an SPT, and retries with the credential. The server verifies the SPT by creating a Stripe PaymentIntent.
 
 The server advertises supported payment methods and a Stripe Business Network profile ID in `methodDetails`. The client uses those values to create an SPT, then retries with the credential payload.
 
@@ -35,7 +35,7 @@ Browser                          Server                          Stripe
   │  402 + WWW-Authenticate        │                               │
   │<────────────────────────────── │                               │
   │                                │                               │
-  │  (mppx auto: create SPT)       │                               │
+  │  (mppx auto: onChallenge)      │                               │
   ├──────────────────────────────────────────────────────────────> │
   │                       spt_...  │                               │
   │<────────────────────────────────────────────────────────────── │

--- a/examples/stripe/index.html
+++ b/examples/stripe/index.html
@@ -11,8 +11,6 @@
     p { color: #666; margin-top: 0; }
     #payment-form { border: 1px solid #e5e7eb; border-radius: 6px; padding: 1rem; margin-bottom: 1rem; background: #fff; display: grid; gap: 0.75rem; }
     #payment-form:empty, #payment-form.hidden { display: none; }
-    #test-helpers { margin-bottom: 1rem; display: grid; gap: 0.5rem; }
-    #test-helpers label { font-weight: 600; font-size: 0.9rem; }
     button { padding: 0.75rem; font-size: 1rem; background: #6b7280; color: #f8fafc; border: none; border-radius: 0; cursor: pointer; width: 100%; }
     button:hover { background: #4b5563; }
     button:disabled { background: #9ca3af; cursor: not-allowed; }
@@ -21,6 +19,8 @@
     #button:disabled { background: #93c5fd; }
     #submit-payment { background: #2563eb; }
     #submit-payment:hover { background: #1d4ed8; }
+    #test-helpers { margin-bottom: 1rem; display: grid; gap: 0.5rem; }
+    #test-helpers label { font-weight: 600; font-size: 0.9rem; }
     .test-values { display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: center; font-size: 0.9rem; color: #475569; }
     .copy-pill { width: auto; padding: 0.35rem 0.6rem; font-size: 0.85rem; background: #e5e7eb; color: #111827; border-radius: 0; border: 1px solid #cbd5e1; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
     .copy-pill:hover { background: #d1d5db; }

--- a/examples/stripe/src/client-simple.ts
+++ b/examples/stripe/src/client-simple.ts
@@ -6,7 +6,7 @@ import { Mppx, stripe } from 'mppx/client'
 Mppx.create({
   methods: [
     stripe({
-      createSpt: async (params) => {
+      createToken: async (params) => {
         const res = await fetch('/api/create-spt', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },

--- a/examples/stripe/src/client.ts
+++ b/examples/stripe/src/client.ts
@@ -1,30 +1,15 @@
+import type { StripeElements, StripePaymentElement } from '@stripe/stripe-js'
 import { loadStripe } from '@stripe/stripe-js'
-import { Challenge, Receipt } from 'mppx'
-import { stripe } from 'mppx/client'
+import { Receipt } from 'mppx'
+import { Mppx, stripe } from 'mppx/client'
 
 const stripePublishableKey = import.meta.env.VITE_STRIPE_PUBLIC_KEY as string
 if (!stripePublishableKey) {
   throw new Error('Missing VITE_STRIPE_PUBLIC_KEY')
 }
 
-// MPPX client for handling stripe charges
-const charge = stripe.charge({
-  createSpt: async (params) => {
-    log('Creating SPT...')
-    const response = await fetch('/api/create-spt', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(params),
-    })
-    if (!response.ok) throw new Error('Failed to create SPT')
-    const { spt } = await response.json()
-    log(`SPT: ${spt}`)
-    return spt
-  },
-})
-
-const stripeClient = await loadStripe(stripePublishableKey)
-if (!stripeClient) throw new Error('Stripe.js failed to load')
+const stripeJs = (await loadStripe(stripePublishableKey))!
+if (!stripeJs) throw new Error('Stripe.js failed to load')
 
 const output = document.getElementById('output')!
 const formError = document.getElementById('form-error')
@@ -82,6 +67,124 @@ copyCard?.addEventListener('click', () => copyText(TEST_VALUES.number))
 copyExp?.addEventListener('click', () => copyText(TEST_VALUES.exp))
 copyCvc?.addEventListener('click', () => copyText(TEST_VALUES.cvc))
 
+let _paymentElements: StripeElements | undefined
+let paymentElementInstance: StripePaymentElement | undefined
+
+async function collectPaymentMethod(options: {
+  amount: string
+  currency: string
+  paymentMethodTypes: string[]
+}) {
+  const { amount, currency, paymentMethodTypes } = options
+  const elements = stripeJs.elements({
+    mode: 'payment',
+    amount: Number(amount),
+    currency,
+    paymentMethodTypes,
+    paymentMethodCreation: 'manual',
+  })
+  _paymentElements = elements
+
+  const paymentElement = elements.create('payment', {
+    fields: {
+      billingDetails: { address: { postalCode: 'never', country: 'never' } },
+    },
+  })
+  if (paymentForm) {
+    paymentForm.innerHTML = '<div id="payment-element"></div>'
+    paymentForm.classList.remove('hidden')
+  }
+  paymentElement.mount('#payment-element')
+  paymentElementInstance = paymentElement
+
+  if (actionButton) actionButton.classList.add('hidden')
+  if (testHelpers) testHelpers.classList.remove('hidden')
+
+  log('Collecting payment details...')
+  const submitButton = document.getElementById('submit-payment') as HTMLButtonElement | null
+  if (!submitButton) throw new Error('Missing submit payment button')
+  submitButton.classList.remove('hidden')
+
+  // Wait for user to click "Confirm Payment"
+  const paymentMethod = await new Promise<{ id: string }>((resolve, reject) => {
+    submitButton.addEventListener(
+      'click',
+      async () => {
+        try {
+          const { error: submitError } = await elements.submit()
+          if (submitError?.message) return reject(new Error(submitError.message))
+
+          const { error: pmError, paymentMethod } = await stripeJs.createPaymentMethod({
+            elements,
+            params: {
+              billing_details: {
+                address: { postal_code: '10001', country: 'US' },
+              },
+            },
+          })
+          if (pmError?.message) return reject(new Error(pmError.message))
+          if (!paymentMethod?.id) return reject(new Error('Failed to create PaymentMethod'))
+          submitButton.classList.add('hidden')
+          if (paymentForm) paymentForm.classList.add('hidden')
+          if (testHelpers) testHelpers.classList.add('hidden')
+          resolve(paymentMethod)
+        } catch (err) {
+          reject(err)
+        }
+      },
+      { once: true },
+    )
+  })
+
+  return paymentMethod
+}
+
+const mppx = Mppx.create({
+  methods: [
+    stripe.charge({
+      createToken: async ({ amount, currency, expiresAt, metadata, networkId, paymentMethod }) => {
+        log('Creating SPT...')
+        const response = await fetch('/api/create-spt', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            paymentMethod,
+            amount,
+            currency,
+            networkId,
+            expiresAt,
+            metadata,
+          }),
+        })
+        if (!response.ok) throw new Error('Failed to create SPT')
+        const { spt } = await response.json()
+        log(`SPT: ${spt}`)
+        return spt
+      },
+    }),
+  ],
+  onChallenge: async (challenge, { createCredential }) => {
+    const methodDetails = challenge.request.methodDetails as
+      | { paymentMethodTypes?: string[] }
+      | undefined
+    const paymentMethodTypes = methodDetails?.paymentMethodTypes
+    if (!paymentMethodTypes?.length) throw new Error('Missing payment method types')
+    log(`Payment method types: ${paymentMethodTypes.join(', ')}`)
+
+    const amount = challenge.request.amount as string
+    const currency = challenge.request.currency as string
+
+    const paymentMethod = await collectPaymentMethod({
+      amount,
+      currency,
+      paymentMethodTypes,
+    })
+
+    return createCredential({ paymentMethod: paymentMethod.id })
+  },
+  polyfill: false,
+})
+
 actionButton?.addEventListener('click', async () => {
   output.textContent = ''
   log('GET /api/fortune')
@@ -90,99 +193,23 @@ actionButton?.addEventListener('click', async () => {
   if (actionButton) actionButton.disabled = true
 
   try {
-    const response = await fetch('/api/fortune')
+    const response = await mppx.fetch('/api/fortune')
     log(`HTTP ${response.status}`)
 
-    if (response.status !== 402) throw new Error(`Unexpected status: ${response.status}`)
+    if (!response.ok) throw new Error(`Payment failed: ${response.status}`)
 
-    const challenge = Challenge.fromResponse(response, { methods: [charge] })
-    log(`→ challenge:\n${JSON.stringify(challenge, null, 2)}`)
-
-    const paymentMethodTypes = challenge.request.methodDetails?.paymentMethodTypes as string[]
-    log(`Payment method types: ${paymentMethodTypes.join(', ')}`)
-
-    // Create Payment Element using types from the challenge
-    const elements = stripeClient.elements({
-      mode: 'payment',
-      amount: Number(challenge.request.amount),
-      currency: challenge.request.currency as string,
-      paymentMethodTypes,
-      paymentMethodCreation: 'manual',
-    })
-    const paymentElement = elements.create('payment', {
-      fields: {
-        billingDetails: { address: { postalCode: 'never', country: 'never' } },
-      },
-    })
-    if (paymentForm) {
-      paymentForm.innerHTML = '<div id="payment-element"></div>'
-      paymentForm.classList.remove('hidden')
-    }
-    paymentElement.mount('#payment-element')
-    // Expose for testing
-    ;(window as any).__stripeElements = elements
-    if (actionButton) actionButton.classList.add('hidden')
-    if (testHelpers) testHelpers.classList.remove('hidden')
-
-    log('Collecting payment details...')
-    const submitButton = document.getElementById('submit-payment') as HTMLButtonElement | null
-    if (submitButton) submitButton.classList.remove('hidden')
-
-    // Wait for user to click "Confirm Payment"
-    const paymentMethod = await new Promise<{ id: string }>((resolve, reject) => {
-      submitButton?.addEventListener(
-        'click',
-        async () => {
-          try {
-            const { error: submitError } = await elements.submit()
-            if (submitError?.message) return reject(new Error(submitError.message))
-
-            const { error: pmError, paymentMethod } = await stripeClient.createPaymentMethod({
-              elements,
-              params: {
-                billing_details: {
-                  address: { postal_code: '10001', country: 'US' },
-                },
-              },
-            })
-            if (pmError?.message) return reject(new Error(pmError.message))
-            if (!paymentMethod?.id) return reject(new Error('Failed to create PaymentMethod'))
-            if (submitButton) submitButton.classList.add('hidden')
-            if (paymentForm) paymentForm.classList.add('hidden')
-            if (testHelpers) testHelpers.classList.add('hidden')
-            resolve(paymentMethod)
-          } catch (err) {
-            reject(err)
-          }
-        },
-        { once: true },
-      )
-    })
-
-    const credential = await charge.createCredential({
-      challenge,
-      context: {
-        paymentMethod: paymentMethod.id,
-      },
-    })
-    log('Retrying with credential...')
-
-    const paid = await fetch('/api/fortune', {
-      headers: { Authorization: credential },
-    })
-    log(`HTTP ${paid.status}`)
-
-    if (!paid.ok) throw new Error(`Payment failed: ${paid.status}`)
-
-    const receipt = Receipt.fromResponse(paid)
+    const receipt = Receipt.fromResponse(response)
     log(`${receipt.method} / ${receipt.status} / ${receipt.reference}`)
 
-    const { fortune } = await paid.json()
+    const { fortune } = await response.json()
     if (fortuneEl) fortuneEl.textContent = fortune
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
     log(`Error: ${message}`)
     setFormError(message)
+    paymentElementInstance?.destroy()
+    _paymentElements = undefined
+    paymentElementInstance = undefined
     if (actionButton) actionButton.disabled = false
   }
 })

--- a/src/client/Mppx.ts
+++ b/src/client/Mppx.ts
@@ -54,12 +54,19 @@ export function create<
     Response
   >,
 >(config: create.Config<methods, transport>): Mppx<methods, transport> {
-  const { polyfill = true, transport = Transport.http() as transport } = config
+  const { onChallenge, polyfill = true, transport = Transport.http() as transport } = config
 
   const methods = config.methods.flat() as unknown as FlattenMethods<methods>
 
-  const config_fetch = { ...(config.fetch && { fetch: config.fetch }), methods }
-  const fetch = Fetch.from(config_fetch)
+  const resolvedOnChallenge = onChallenge as Fetch.from.Config<
+    FlattenMethods<methods>
+  >['onChallenge']
+  const config_fetch = {
+    ...(config.fetch && { fetch: config.fetch }),
+    ...(resolvedOnChallenge && { onChallenge: resolvedOnChallenge }),
+    methods,
+  } satisfies Fetch.from.Config<FlattenMethods<methods>>
+  const fetch = Fetch.from<FlattenMethods<methods>>(config_fetch)
 
   if (polyfill) Fetch.polyfill(config_fetch)
   return {
@@ -112,6 +119,15 @@ export declare namespace create {
   > = {
     /** Custom fetch function to wrap. Defaults to `globalThis.fetch`. */
     fetch?: typeof globalThis.fetch
+    /** Called when a 402 challenge is received, before credential creation. */
+    onChallenge?:
+      | ((
+          challenge: Challenge.Challenge,
+          helpers: {
+            createCredential: (context?: AnyContextFor<FlattenMethods<methods>>) => Promise<string>
+          },
+        ) => Promise<string | undefined>)
+      | undefined
     /** Array of method intents to use. Accepts individual clients or tuples (e.g. from `tempo()`). */
     methods: methods
     /** Whether to polyfill `globalThis.fetch` with the payment-aware wrapper. @default true */

--- a/src/client/internal/Fetch.test.ts
+++ b/src/client/internal/Fetch.test.ts
@@ -2,7 +2,7 @@ import { Receipt } from 'mppx'
 import { tempo } from 'mppx/client'
 import { Mppx as Mppx_server, tempo as tempo_server } from 'mppx/server'
 import { createClient } from 'viem'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import * as Http from '~test/Http.js'
 import { accounts, asset, chain, client, http } from '~test/tempo/viem.js'
 import * as Fetch from './Fetch.js'
@@ -229,6 +229,40 @@ describe('Fetch.from', () => {
         "timestamp": "[timestamp]",
       }
     `)
+
+    httpServer.close()
+  })
+
+  test('behavior: onChallenge can create credential', async () => {
+    const onChallenge = vi.fn(async (_challenge, { createCredential }) =>
+      createCredential({ account: accounts[1] }),
+    )
+
+    const fetch = Fetch.from({
+      methods: [
+        tempo.charge({
+          getClient: () => client,
+        }),
+      ],
+      onChallenge,
+    })
+
+    const httpServer = await Http.createServer(async (req, res) => {
+      const result = await Mppx_server.toNodeListener(
+        server.charge({
+          amount: '1',
+          currency: asset,
+          expires: new Date(Date.now() + 60_000).toISOString(),
+          recipient: accounts[0].address,
+        }),
+      )(req, res)
+      if (result.status === 402) return
+      res.end('OK')
+    })
+
+    const response = await fetch(httpServer.url)
+    expect(response.status).toBe(200)
+    expect(onChallenge).toHaveBeenCalledTimes(1)
 
     httpServer.close()
   })

--- a/src/client/internal/Fetch.ts
+++ b/src/client/internal/Fetch.ts
@@ -37,7 +37,6 @@ export function from<const methods extends readonly MethodIntent.AnyClient[]>(
     if (response.status !== 402) return response
 
     const challenge = Challenge.fromResponse(response)
-    onChallenge?.(challenge)
 
     const mi = methods.find((m) => m.method === challenge.method && m.name === challenge.intent)
     if (!mi)
@@ -45,7 +44,13 @@ export function from<const methods extends readonly MethodIntent.AnyClient[]>(
         `No method intent found for "${challenge.method}.${challenge.intent}". Available: ${methods.map((m) => `${m.method}.${m.name}`).join(', ')}`,
       )
 
-    const credential = await resolveCredential(challenge, mi, context)
+    const onChallengeCredential = onChallenge
+      ? await onChallenge(challenge, {
+          createCredential: async (overrideContext?: AnyContextFor<methods>) =>
+            resolveCredential(challenge, mi, overrideContext ?? context),
+        })
+      : undefined
+    const credential = onChallengeCredential ?? (await resolveCredential(challenge, mi, context))
 
     return fetch(input, {
       ...fetchInit,
@@ -75,7 +80,14 @@ export declare namespace from {
     /** Array of method intents to use. */
     methods: methods
     /** Called when a 402 challenge is received, before credential creation. */
-    onChallenge?: ((challenge: Challenge.Challenge) => void) | undefined
+    onChallenge?:
+      | ((
+          challenge: Challenge.Challenge,
+          helpers: {
+            createCredential: (context?: AnyContextFor<methods>) => Promise<string>
+          },
+        ) => Promise<string | undefined>)
+      | undefined
   }
 
   type Fetch<

--- a/src/stripe/Charge.integration.test.ts
+++ b/src/stripe/Charge.integration.test.ts
@@ -87,7 +87,10 @@ describe.skipIf(!stripeSecretKey)('stripe', () => {
   })
 
   const clientCharge = stripe_client.charge({
-    createSpt: createTestSpt,
+    createToken: async (params) => {
+      if (!params.paymentMethod) throw new Error('paymentMethod is required')
+      return createTestSpt({ ...params, paymentMethod: params.paymentMethod })
+    },
     paymentMethod: 'pm_card_visa',
     externalId: 'client_order_789',
   })

--- a/src/stripe/client/Charge.ts
+++ b/src/stripe/client/Charge.ts
@@ -1,3 +1,4 @@
+import type * as Challenge from '../../Challenge.js'
 import * as Credential from '../../Credential.js'
 import * as MethodIntent from '../../MethodIntent.js'
 import * as z from '../../zod.js'
@@ -6,8 +7,9 @@ import * as Intents from '../Intents.js'
 /**
  * Creates a Stripe charge method intent for usage on the client.
  *
- * Accepts a `createSpt` callback that handles SPT creation (requires
- * a secret key, so typically proxied through a server endpoint).
+ * Accepts a `createToken` callback that handles SPT creation (requires
+ * a secret key, so typically proxied through a server endpoint) and
+ * returns a credential for retrying the request.
  *
  * The `paymentMethod` (e.g. from Stripe Elements) can be provided at
  * initialization or at credential-creation time via `context`.
@@ -17,7 +19,7 @@ import * as Intents from '../Intents.js'
  * import { stripe } from 'mppx/client'
  *
  * const charge = stripe.charge({
- *   createSpt: async ({ paymentMethod, amount, currency, networkId, expiresAt, metadata }) => {
+ *   createToken: async ({ amount, currency, expiresAt, metadata, networkId, paymentMethod }) => {
  *     const res = await fetch('/api/create-spt', {
  *       method: 'POST',
  *       headers: { 'Content-Type': 'application/json' },
@@ -27,16 +29,10 @@ import * as Intents from '../Intents.js'
  *     return spt
  *   },
  * })
- *
- * // paymentMethod comes from Stripe Elements at credential-creation time
- * const credential = await charge.createCredential({
- *   challenge,
- *   context: { paymentMethod: 'pm_xxx' },
- * })
  * ```
  */
 export function charge(parameters: charge.Parameters) {
-  const { createSpt, externalId, paymentMethod: defaultPaymentMethod } = parameters
+  const { createToken, externalId, paymentMethod: defaultPaymentMethod } = parameters
 
   return MethodIntent.toClient(Intents.charge, {
     context: z.object({
@@ -45,8 +41,9 @@ export function charge(parameters: charge.Parameters) {
 
     async createCredential({ challenge, context }) {
       const paymentMethod = context?.paymentMethod ?? defaultPaymentMethod
-      if (!paymentMethod)
+      if (!paymentMethod) {
         throw new Error('paymentMethod is required (pass via context or parameters)')
+      }
 
       const amount = challenge.request.amount as string
       const currency = challenge.request.currency as string
@@ -65,7 +62,8 @@ export function charge(parameters: charge.Parameters) {
         ? Math.floor(new Date(challenge.request.expires as string).getTime() / 1000)
         : Math.floor(Date.now() / 1000) + 3600
 
-      const spt = await createSpt({
+      const spt = await createToken({
+        challenge,
         paymentMethod,
         amount,
         currency,
@@ -87,24 +85,22 @@ export function charge(parameters: charge.Parameters) {
 
 export declare namespace charge {
   type Parameters = {
-    /**
-     * Creates a Shared Payment Token (SPT) for the given parameters.
-     *
-     * SPT creation requires a Stripe secret key, so this typically
-     * proxies through a server endpoint (e.g. `POST /api/create-spt`).
-     * If you are running a client in an enviroment with a secret key, you can just create the
-     * SPT directly in this callback.
-     */
-    createSpt: (parameters: CreateSptParameters) => Promise<string>
+    /** Called when a Stripe challenge is received. Create an SPT to retry. */
+    createToken: (parameters: OnChallengeParameters) => Promise<string>
     /** Optional client-side external reference ID for the credential payload. */
     externalId?: string | undefined
     /** Default payment method ID. Overridden by `context.paymentMethod`. */
     paymentMethod?: string | undefined
   }
 
-  type CreateSptParameters = {
+  type OnChallengeParameters = {
+    challenge: Challenge.Challenge<
+      z.output<typeof Intents.charge.schema.request>,
+      typeof Intents.charge.name,
+      typeof Intents.charge.method
+    >
     /** Stripe payment method ID (e.g. from Stripe Elements). */
-    paymentMethod: string
+    paymentMethod?: string | undefined
     /** Payment amount (in smallest currency unit). */
     amount: string
     /** Three-letter ISO currency code. */

--- a/src/stripe/client/MethodIntents.ts
+++ b/src/stripe/client/MethodIntents.ts
@@ -10,7 +10,7 @@ import { charge as charge_ } from './Charge.js'
  * const mppx = Mppx.create({
  *   methods: [
  *     stripe({
- *       createSpt: async (params) => {
+ *       createToken: async (params) => {
  *         const res = await fetch('/api/create-spt', {
  *           method: 'POST',
  *           headers: { 'Content-Type': 'application/json' },

--- a/src/tempo/client/SessionManager.ts
+++ b/src/tempo/client/SessionManager.ts
@@ -75,8 +75,9 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
   const wrappedFetch = Fetch.from({
     fetch: fetchFn,
     methods: [method],
-    onChallenge(c) {
-      lastChallenge = c
+    onChallenge: async (challenge, _helpers) => {
+      lastChallenge = challenge
+      return undefined
     },
   })
 


### PR DESCRIPTION
## Changes

- **Rename `createSpt` → `createToken`** on `stripe.charge` client for clearer naming
- **Add `onChallenge` hook** to `Mpay.create` and `Fetch.from` — enables UI orchestration (e.g. collecting payment method via Stripe Elements) before credential creation
- **Update `Fetch.from` `onChallenge`** signature to support credential creation via `helpers.createCredential`
- **Fix `SessionManager` `onChallenge`** to explicitly return `undefined` (clarifies intent as fire-and-forget)
- **Fix integration test** type narrowing for `paymentMethod` (`string | undefined` → `string`)
- **Clean up stripe example**: consolidate `stripeJs` variable, remove redundant `paymentMethod` guard
- **Update examples and docs** to use `createToken`