### PR TITLE
feat(stripe): inject MPP analytics metadata into Stripe PaymentIntents

### DIFF
--- a/src/stripe/server/Charge.ts
+++ b/src/stripe/server/Charge.ts
@@ -121,9 +121,7 @@ export declare namespace charge {
 }
 
 /** @internal */
-function buildAnalytics(parameters: {
-  credential: Credential.Credential
-}): Record<string, string> {
+function buildAnalytics(parameters: { credential: Credential.Credential }): Record<string, string> {
   const { credential } = parameters
   const { challenge } = credential
   return {


### PR DESCRIPTION
Auto-inject MPP analytics metadata into every Stripe PaymentIntent for Hubble tracking.

## Metadata keys

| Key | Value | Source |
|-----|-------|--------|
| `mpp_version` | `"1"` | Hardcoded |
| `mpp_is_mpp` | `"true"` | Hardcoded |
| `mpp_intent` | e.g. `"stripe.charge"` | `challenge.intent` |
| `mpp_challenge_id` | Challenge ID | `challenge.id` |
| `mpp_server_id` | Server realm | `challenge.realm` |
| `mpp_client_id` | Client DID (if present) | `credential.source` |

User-provided metadata takes precedence over MPP keys.

Isolated in a `buildAnalytics()` helper for reuse across future intents (e.g. `stripe.session`).