### PR TITLE
feat(stripe): accept pre-configured Stripe SDK instances

### DIFF
--- a/examples/stripe/package.json
+++ b/examples/stripe/package.json
@@ -14,6 +14,7 @@
     "@stripe/stripe-js": "^8.7.0",
     "@types/node": "latest",
     "mppx": "latest",
+    "stripe": "^17.7.0",
     "typescript": "latest",
     "vite": "latest"
   }

--- a/examples/stripe/src/client-simple.ts
+++ b/examples/stripe/src/client-simple.ts
@@ -1,11 +1,15 @@
 // Example of a simple client that creates an SPT and retries with the credential.
 // This is useful if you know the payment method ahead of time, and don't need to collect it from the user.
 
+import { loadStripe } from '@stripe/stripe-js'
 import { Mppx, stripe } from 'mppx/client'
+
+const stripeJs = (await loadStripe(import.meta.env.VITE_STRIPE_PUBLIC_KEY as string))!
 
 Mppx.create({
   methods: [
     stripe({
+      client: stripeJs,
       createToken: async (params) => {
         const res = await fetch('/api/create-spt', {
           method: 'POST',

--- a/examples/stripe/src/client.ts
+++ b/examples/stripe/src/client.ts
@@ -142,6 +142,7 @@ async function collectPaymentMethod(options: {
 const mppx = Mppx.create({
   methods: [
     stripe.charge({
+      client: stripeJs,
       createToken: async ({ amount, currency, expiresAt, metadata, networkId, paymentMethod }) => {
         log('Creating SPT...')
         const response = await fetch('/api/create-spt', {

--- a/examples/stripe/src/server.ts
+++ b/examples/stripe/src/server.ts
@@ -1,12 +1,14 @@
 import { Mppx, stripe } from 'mppx/server'
+import Stripe from 'stripe'
 
 const secretKey = process.env.VITE_STRIPE_SECRET_KEY!
+const stripeClient = new Stripe(secretKey)
 
 //
 const mppx = Mppx.create({
   methods: [
     stripe.charge({
-      secretKey,
+      client: stripeClient,
       // Stripe Business Network profile ID.
       networkId: 'internal',
       // Ensure only card is supported.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,6 +164,9 @@ importers:
       mppx:
         specifier: workspace:*
         version: link:../..
+      stripe:
+        specifier: ^17.7.0
+        version: 17.7.0
       typescript:
         specifier: latest
         version: 5.9.3
@@ -2070,6 +2073,10 @@ packages:
   strip-final-newline@4.0.0:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
     engines: {node: '>=18'}
+
+  stripe@17.7.0:
+    resolution: {integrity: sha512-aT2BU9KkizY9SATf14WhhYVv2uOapBWX0OFWF4xvcj1mPaNotlSc2CsxpS4DS46ZueSppmCF5BX1sNYBtwBvfw==}
+    engines: {node: '>=12.*'}
 
   strtok3@10.3.4:
     resolution: {integrity: sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==}
@@ -4281,6 +4288,11 @@ snapshots:
   strip-bom@3.0.0: {}
 
   strip-final-newline@4.0.0: {}
+
+  stripe@17.7.0:
+    dependencies:
+      '@types/node': 25.2.3
+      qs: 6.14.1
 
   strtok3@10.3.4:
     dependencies:

--- a/src/stripe/client/Charge.test.ts
+++ b/src/stripe/client/Charge.test.ts
@@ -1,0 +1,189 @@
+import { Challenge, Credential } from 'mppx'
+import { Mppx, stripe } from 'mppx/client'
+import { Mppx as Mppx_server, stripe as stripe_server } from 'mppx/server'
+import { describe, expect, test, vi } from 'vitest'
+import type { StripeJs } from '../internal/types.js'
+import { charge as clientCharge_ } from './Charge.js'
+
+const realm = 'api.example.com'
+const secretKey = 'test-hmac-key'
+
+const dummyClientCharge = clientCharge_({
+  createToken: async () => 'spt_test',
+  paymentMethod: 'pm_test',
+})
+
+async function createChallenge() {
+  const server = Mppx_server.create({
+    methods: [
+      stripe_server.charge({
+        networkId: 'internal',
+        paymentMethodTypes: ['card'],
+        secretKey: 'sk_test',
+      }),
+    ],
+    realm,
+    secretKey,
+  })
+
+  const handle = server.charge({ amount: '100', currency: 'usd', decimals: 2 })
+  const result = await handle(new Request('https://example.com'))
+  if (result.status !== 402) throw new Error('Expected 402')
+  return Challenge.fromResponse(result.challenge, { methods: [dummyClientCharge] })
+}
+
+function createMockStripeJs(): StripeJs {
+  return {
+    createPaymentMethod: vi.fn(async () => ({
+      error: null,
+      paymentMethod: { id: 'pm_mock_123' },
+    })),
+    elements: vi.fn(() => ({})),
+  }
+}
+
+describe('stripe.charge client param', () => {
+  test('default: forwards client to createToken callback', async () => {
+    const mockClient = createMockStripeJs()
+    let receivedClient: StripeJs | undefined
+
+    const charge = stripe.charge({
+      client: mockClient,
+      createToken: async (params) => {
+        receivedClient = params.client
+        return 'spt_test_123'
+      },
+      paymentMethod: 'pm_card_visa',
+    })
+
+    const challenge = await createChallenge()
+    await charge.createCredential({ challenge, context: {} })
+
+    expect(receivedClient).toBe(mockClient)
+  })
+
+  test('behavior: client is undefined when not provided', async () => {
+    let receivedClient: StripeJs | undefined = createMockStripeJs()
+
+    const charge = stripe.charge({
+      createToken: async (params) => {
+        receivedClient = params.client
+        return 'spt_test_123'
+      },
+      paymentMethod: 'pm_card_visa',
+    })
+
+    const challenge = await createChallenge()
+    await charge.createCredential({ challenge, context: {} })
+
+    expect(receivedClient).toBeUndefined()
+  })
+
+  test('behavior: createToken receives all expected params', async () => {
+    const mockClient = createMockStripeJs()
+    let receivedParams: Record<string, unknown> | undefined
+
+    const charge = stripe.charge({
+      client: mockClient,
+      createToken: async (params) => {
+        receivedParams = params as unknown as Record<string, unknown>
+        return 'spt_test_123'
+      },
+      paymentMethod: 'pm_card_visa',
+    })
+
+    const challenge = await createChallenge()
+    await charge.createCredential({ challenge, context: {} })
+
+    expect(receivedParams).toBeDefined()
+    expect(receivedParams!.amount).toBe('10000')
+    expect(receivedParams!.currency).toBe('usd')
+    expect(receivedParams!.networkId).toBe('internal')
+    expect(receivedParams!.paymentMethod).toBe('pm_card_visa')
+    expect(receivedParams!.client).toBe(mockClient)
+    expect(receivedParams!.challenge).toBeDefined()
+    expect(typeof receivedParams!.expiresAt).toBe('number')
+  })
+
+  test('behavior: produces valid credential string', async () => {
+    const charge = stripe.charge({
+      createToken: async () => 'spt_test_123',
+      paymentMethod: 'pm_card_visa',
+    })
+
+    const challenge = await createChallenge()
+    const credential = await charge.createCredential({ challenge, context: {} })
+
+    expect(credential).toMatch(/^Payment /)
+
+    const parsed = Credential.deserialize(credential)
+    expect(parsed.payload).toMatchObject({ spt: 'spt_test_123' })
+  })
+
+  test('behavior: includes externalId in credential payload', async () => {
+    const charge = stripe.charge({
+      createToken: async () => 'spt_test_123',
+      externalId: 'order_456',
+      paymentMethod: 'pm_card_visa',
+    })
+
+    const challenge = await createChallenge()
+    const credential = await charge.createCredential({ challenge, context: {} })
+    const parsed = Credential.deserialize(credential)
+    expect(parsed.payload).toMatchObject({
+      externalId: 'order_456',
+      spt: 'spt_test_123',
+    })
+  })
+
+  test('behavior: context paymentMethod overrides default', async () => {
+    let receivedPaymentMethod: string | undefined
+
+    const charge = stripe.charge({
+      createToken: async (params) => {
+        receivedPaymentMethod = params.paymentMethod
+        return 'spt_test_123'
+      },
+      paymentMethod: 'pm_default',
+    })
+
+    const challenge = await createChallenge()
+    await charge.createCredential({
+      challenge,
+      context: { paymentMethod: 'pm_override' },
+    })
+
+    expect(receivedPaymentMethod).toBe('pm_override')
+  })
+
+  test('behavior: Mppx.create with client forwards through createCredential', async () => {
+    const mockClient = createMockStripeJs()
+    let receivedClient: StripeJs | undefined
+
+    const mppx = Mppx.create({
+      methods: [
+        stripe.charge({
+          client: mockClient,
+          createToken: async (params) => {
+            receivedClient = params.client
+            return 'spt_test_123'
+          },
+          paymentMethod: 'pm_card_visa',
+        }),
+      ],
+      polyfill: false,
+    })
+
+    const challenge = await createChallenge()
+    const response = new Response(null, {
+      status: 402,
+      headers: {
+        'WWW-Authenticate': Challenge.serialize(challenge),
+      },
+    })
+
+    await mppx.createCredential(response)
+
+    expect(receivedClient).toBe(mockClient)
+  })
+})

--- a/src/stripe/client/Charge.ts
+++ b/src/stripe/client/Charge.ts
@@ -3,6 +3,7 @@ import * as Credential from '../../Credential.js'
 import * as MethodIntent from '../../MethodIntent.js'
 import * as z from '../../zod.js'
 import * as Intents from '../Intents.js'
+import type { StripeJs } from '../internal/types.js'
 
 /**
  * Creates a Stripe charge method intent for usage on the client.
@@ -14,11 +15,18 @@ import * as Intents from '../Intents.js'
  * The `paymentMethod` (e.g. from Stripe Elements) can be provided at
  * initialization or at credential-creation time via `context`.
  *
+ * Optionally accepts a `client` (a Stripe.js instance from `@stripe/stripe-js`)
+ * which is forwarded to the `createToken` callback for use with Elements.
+ *
  * @example
  * ```ts
+ * import { loadStripe } from '@stripe/stripe-js'
  * import { stripe } from 'mppx/client'
  *
+ * const stripeJs = await loadStripe('pk_...')
+ *
  * const charge = stripe.charge({
+ *   client: stripeJs,
  *   createToken: async ({ amount, currency, expiresAt, metadata, networkId, paymentMethod }) => {
  *     const res = await fetch('/api/create-spt', {
  *       method: 'POST',
@@ -32,7 +40,7 @@ import * as Intents from '../Intents.js'
  * ```
  */
 export function charge(parameters: charge.Parameters) {
-  const { createToken, externalId, paymentMethod: defaultPaymentMethod } = parameters
+  const { client, createToken, externalId, paymentMethod: defaultPaymentMethod } = parameters
 
   return MethodIntent.toClient(Intents.charge, {
     context: z.object({
@@ -63,13 +71,14 @@ export function charge(parameters: charge.Parameters) {
         : Math.floor(Date.now() / 1000) + 3600
 
       const spt = await createToken({
-        challenge,
-        paymentMethod,
         amount,
+        challenge,
+        client,
         currency,
-        networkId,
         expiresAt,
         metadata,
+        networkId,
+        paymentMethod,
       })
 
       return Credential.serialize({
@@ -85,6 +94,8 @@ export function charge(parameters: charge.Parameters) {
 
 export declare namespace charge {
   type Parameters = {
+    /** Stripe.js instance from `@stripe/stripe-js`. Forwarded to `createToken` for use with Elements. */
+    client?: StripeJs | undefined
     /** Called when a Stripe challenge is received. Create an SPT to retry. */
     createToken: (parameters: OnChallengeParameters) => Promise<string>
     /** Optional client-side external reference ID for the credential payload. */
@@ -94,22 +105,24 @@ export declare namespace charge {
   }
 
   type OnChallengeParameters = {
+    /** Payment amount (in smallest currency unit). */
+    amount: string
     challenge: Challenge.Challenge<
       z.output<typeof Intents.charge.schema.request>,
       typeof Intents.charge.name,
       typeof Intents.charge.method
     >
-    /** Stripe payment method ID (e.g. from Stripe Elements). */
-    paymentMethod?: string | undefined
-    /** Payment amount (in smallest currency unit). */
-    amount: string
+    /** Stripe.js instance, if provided to `stripe.charge()`. */
+    client?: StripeJs | undefined
     /** Three-letter ISO currency code. */
     currency: string
-    /** Stripe Business Network profile ID. */
-    networkId: string | undefined
     /** SPT expiration as a Unix timestamp (seconds). */
     expiresAt: number
     /** Optional metadata to associate with the SPT. */
     metadata?: Record<string, string> | undefined
+    /** Stripe Business Network profile ID. */
+    networkId: string | undefined
+    /** Stripe payment method ID (e.g. from Stripe Elements). */
+    paymentMethod?: string | undefined
   }
 }

--- a/src/stripe/internal/types.ts
+++ b/src/stripe/internal/types.ts
@@ -1,0 +1,22 @@
+/**
+ * Duck-typed interface for the Stripe Node SDK (`stripe` npm package).
+ * Matches the subset of the API used by mppx for server-side payment verification.
+ *
+ * Uses loose signatures so any Stripe SDK version is assignable.
+ */
+export type StripeClient = {
+  paymentIntents: {
+    create(...args: any[]): Promise<{ id: string; status: string }>
+  }
+}
+
+/**
+ * Duck-typed interface for Stripe.js (`@stripe/stripe-js`).
+ * Matches the subset of the API used by mppx for client-side payment method creation.
+ *
+ * Uses loose signatures so any Stripe.js version is assignable.
+ */
+export type StripeJs = {
+  createPaymentMethod(...args: any[]): Promise<Record<string, unknown>>
+  elements(...args: any[]): unknown
+}

--- a/src/stripe/server/Charge.test.ts
+++ b/src/stripe/server/Charge.test.ts
@@ -1,0 +1,241 @@
+import { Challenge, Credential } from 'mppx'
+import { Mppx, stripe } from 'mppx/server'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import * as Http from '~test/Http.js'
+import type { StripeClient } from '../internal/types.js'
+
+const realm = 'api.example.com'
+const secretKey = 'test-secret-key'
+
+let httpServer: Awaited<ReturnType<typeof Http.createServer>> | undefined
+
+afterEach(() => httpServer?.close())
+
+function createMockStripeClient(
+  overrides?: Partial<{ status: string; id: string; throws: boolean }>,
+): { client: StripeClient; create: ReturnType<typeof vi.fn> } {
+  const { status = 'succeeded', id = 'pi_mock_123', throws = false } = overrides ?? {}
+  const create = vi.fn(async () => {
+    if (throws) throw new Error('Stripe API error')
+    return { id, status }
+  })
+  return {
+    client: { paymentIntents: { create } },
+    create,
+  }
+}
+
+describe('stripe.charge with client', () => {
+  test('default: verifies payment via client.paymentIntents.create', async () => {
+    const { client, create } = createMockStripeClient()
+
+    const server = Mppx.create({
+      methods: [
+        stripe.charge({
+          client,
+          networkId: 'internal',
+          paymentMethodTypes: ['card'],
+        }),
+      ],
+      realm,
+      secretKey,
+    })
+
+    httpServer = await Http.createServer(async (req, res) => {
+      const result = await Mppx.toNodeListener(
+        server.charge({ amount: '1', currency: 'usd', decimals: 2 }),
+      )(req, res)
+      if (result.status === 402) return
+      res.end('OK')
+    })
+
+    const response = await fetch(httpServer.url)
+    expect(response.status).toBe(402)
+
+    const challenge = Challenge.fromResponse(response)
+    const credential = Credential.from({
+      challenge,
+      payload: { spt: 'spt_test_token' },
+    })
+
+    const paidResponse = await fetch(httpServer.url, {
+      headers: { Authorization: Credential.serialize(credential) },
+    })
+    expect(paidResponse.status).toBe(200)
+    expect(create).toHaveBeenCalledOnce()
+
+    const [params, options] = create.mock.calls[0]!
+    expect(params).toMatchObject({
+      amount: 100,
+      confirm: true,
+      currency: 'usd',
+      payment_method: 'spt_test_token',
+    })
+    expect(params.automatic_payment_methods).toMatchObject({
+      allow_redirects: 'never',
+      enabled: true,
+    })
+    expect(options.idempotencyKey).toMatch(/^mppx_/)
+  })
+
+  test('behavior: includes metadata in client call', async () => {
+    const { client, create } = createMockStripeClient()
+
+    const server = Mppx.create({
+      methods: [
+        stripe.charge({
+          client,
+          metadata: { plan: 'pro' },
+          networkId: 'internal',
+          paymentMethodTypes: ['card'],
+        }),
+      ],
+      realm,
+      secretKey,
+    })
+
+    httpServer = await Http.createServer(async (req, res) => {
+      const result = await Mppx.toNodeListener(
+        server.charge({ amount: '1', currency: 'usd', decimals: 2 }),
+      )(req, res)
+      if (result.status === 402) return
+      res.end('OK')
+    })
+
+    const response = await fetch(httpServer.url)
+    const challenge = Challenge.fromResponse(response)
+    const credential = Credential.from({
+      challenge,
+      payload: { spt: 'spt_test_token' },
+    })
+
+    await fetch(httpServer.url, {
+      headers: { Authorization: Credential.serialize(credential) },
+    })
+
+    const [params] = create.mock.calls[0]!
+    expect(params.metadata).toMatchObject({ plan: 'pro' })
+    expect(params.metadata.mpp_is_mpp).toBe('true')
+  })
+
+  test('behavior: rejects when client throws', async () => {
+    const { client } = createMockStripeClient({ throws: true })
+
+    const server = Mppx.create({
+      methods: [
+        stripe.charge({
+          client,
+          networkId: 'internal',
+          paymentMethodTypes: ['card'],
+        }),
+      ],
+      realm,
+      secretKey,
+    })
+
+    httpServer = await Http.createServer(async (req, res) => {
+      const result = await Mppx.toNodeListener(
+        server.charge({ amount: '1', currency: 'usd', decimals: 2 }),
+      )(req, res)
+      if (result.status === 402) return
+      res.end('OK')
+    })
+
+    const response = await fetch(httpServer.url)
+    const challenge = Challenge.fromResponse(response)
+    const credential = Credential.from({
+      challenge,
+      payload: { spt: 'spt_test_token' },
+    })
+
+    const paidResponse = await fetch(httpServer.url, {
+      headers: { Authorization: Credential.serialize(credential) },
+    })
+    expect(paidResponse.status).toBe(402)
+    const body = (await paidResponse.json()) as { detail: string }
+    expect(body.detail).toContain('Stripe PaymentIntent failed')
+  })
+
+  test('behavior: rejects requires_action status', async () => {
+    const { client } = createMockStripeClient({ status: 'requires_action' })
+
+    const server = Mppx.create({
+      methods: [
+        stripe.charge({
+          client,
+          networkId: 'internal',
+          paymentMethodTypes: ['card'],
+        }),
+      ],
+      realm,
+      secretKey,
+    })
+
+    httpServer = await Http.createServer(async (req, res) => {
+      const result = await Mppx.toNodeListener(
+        server.charge({ amount: '1', currency: 'usd', decimals: 2 }),
+      )(req, res)
+      if (result.status === 402) return
+      res.end('OK')
+    })
+
+    const response = await fetch(httpServer.url)
+    const challenge = Challenge.fromResponse(response)
+    const credential = Credential.from({
+      challenge,
+      payload: { spt: 'spt_test_token' },
+    })
+
+    const paidResponse = await fetch(httpServer.url, {
+      headers: { Authorization: Credential.serialize(credential) },
+    })
+    expect(paidResponse.status).toBe(402)
+    const body = (await paidResponse.json()) as { detail: string }
+    expect(body.detail).toContain('requires action')
+  })
+
+  test('behavior: receipt contains mock reference', async () => {
+    const { client } = createMockStripeClient({ id: 'pi_custom_ref' })
+
+    const server = Mppx.create({
+      methods: [
+        stripe.charge({
+          client,
+          networkId: 'internal',
+          paymentMethodTypes: ['card'],
+        }),
+      ],
+      realm,
+      secretKey,
+    })
+
+    const handle = server.charge({ amount: '1', currency: 'usd', decimals: 2 })
+
+    const firstResult = await handle(new Request('https://example.com'))
+    expect(firstResult.status).toBe(402)
+    if (firstResult.status !== 402) throw new Error()
+
+    const challenge = Challenge.fromResponse(firstResult.challenge)
+    const credential = Credential.from({
+      challenge,
+      payload: { spt: 'spt_test_token' },
+    })
+
+    const result = await handle(
+      new Request('https://example.com', {
+        headers: { Authorization: Credential.serialize(credential) },
+      }),
+    )
+    expect(result.status).toBe(200)
+    if (result.status !== 200) throw new Error()
+
+    const wrapped = result.withReceipt(Response.json({ ok: true }))
+    const receiptHeader = wrapped.headers.get('Payment-Receipt')
+    expect(receiptHeader).toBeTruthy()
+
+    const decoded = JSON.parse(
+      Buffer.from(receiptHeader!.replace('Payment ', ''), 'base64url').toString(),
+    ) as { reference: string }
+    expect(decoded.reference).toBe('pi_custom_ref')
+  })
+})

--- a/src/stripe/server/Charge.ts
+++ b/src/stripe/server/Charge.ts
@@ -4,20 +4,34 @@ import {
   PaymentExpiredError,
   VerificationFailedError,
 } from '../../Errors.js'
-import type { LooseOmit } from '../../internal/types.js'
+import type { LooseOmit, OneOf } from '../../internal/types.js'
 import * as MethodIntent from '../../MethodIntent.js'
 import * as Intents from '../Intents.js'
+import type { StripeClient } from '../internal/types.js'
 
 /**
  * Creates a Stripe charge method intent for usage on the server.
  *
  * Verifies payment by creating a Stripe PaymentIntent with the provided SPT.
  *
+ * Accepts either a `client` (a pre-configured Stripe SDK instance) or a raw
+ * `secretKey`. Using `client` is recommended—it lets you configure retries,
+ * API version, and other options on the Stripe instance you control.
+ *
+ * @example
+ * ```ts
+ * import Stripe from 'stripe'
+ * import { stripe } from 'mppx/server'
+ *
+ * const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!)
+ * const charge = stripe.charge({ client: stripeClient, networkId: 'internal', paymentMethodTypes: ['card'] })
+ * ```
+ *
  * @example
  * ```ts
  * import { stripe } from 'mppx/server'
  *
- * const charge = stripe.charge({ secretKey: 'sk_...' })
+ * const charge = stripe.charge({ secretKey: 'sk_...', networkId: 'internal', paymentMethodTypes: ['card'] })
  * ```
  */
 export function charge<const parameters extends charge.Parameters>(parameters: parameters) {
@@ -30,8 +44,10 @@ export function charge<const parameters extends charge.Parameters>(parameters: p
     metadata,
     networkId,
     paymentMethodTypes,
-    secretKey,
   } = parameters
+
+  const client = 'client' in parameters ? parameters.client : undefined
+  const secretKey = 'secretKey' in parameters ? parameters.secretKey : undefined
 
   type Defaults = charge.DeriveDefaults<parameters>
   return MethodIntent.toServer<typeof Intents.charge, Defaults>(Intents.charge, {
@@ -60,33 +76,18 @@ export function charge<const parameters extends charge.Parameters>(parameters: p
         externalId?: string
       }
 
-      const body = new URLSearchParams({
-        amount: request.amount as string,
-        currency: request.currency as string,
-        shared_payment_granted_token: spt,
-        confirm: 'true',
-        'automatic_payment_methods[enabled]': 'true',
-        'automatic_payment_methods[allow_redirects]': 'never',
-      })
       const userMetadata = request.methodDetails?.metadata as Record<string, string> | undefined
       const resolvedMetadata = { ...buildAnalytics({ credential }), ...userMetadata }
-      for (const [key, value] of Object.entries(resolvedMetadata)) {
-        body.set(`metadata[${key}]`, value)
-      }
 
-      const response = await fetch('https://api.stripe.com/v1/payment_intents', {
-        method: 'POST',
-        headers: {
-          Authorization: `Basic ${btoa(`${secretKey}:`)}`,
-          'Content-Type': 'application/x-www-form-urlencoded',
-          'Idempotency-Key': `mppx_${challenge.id}_${spt}`,
-        },
-        body,
-      })
-
-      if (!response.ok) throw new VerificationFailedError({ reason: 'Stripe PaymentIntent failed' })
-
-      const pi = (await response.json()) as { id: string; status: string }
+      const pi = client
+        ? await createWithClient({ client, challenge, request, spt, metadata: resolvedMetadata })
+        : await createWithSecretKey({
+            secretKey: secretKey!,
+            challenge,
+            request,
+            spt,
+            metadata: resolvedMetadata,
+          })
 
       if (pi.status === 'requires_action') {
         throw new PaymentActionRequiredError({ reason: 'Stripe PaymentIntent requires action' })
@@ -108,16 +109,87 @@ export declare namespace charge {
   type Defaults = LooseOmit<MethodIntent.RequestDefaults<typeof Intents.charge>, 'recipient'>
 
   type Parameters = {
-    /** Stripe secret API key. */
-    secretKey: string
     /** Optional metadata to include in SPT creation requests. */
     metadata?: Record<string, string> | undefined
-  } & Defaults
+  } & Defaults &
+    OneOf<
+      | {
+          /** Pre-configured Stripe SDK instance. Any object matching the duck-typed `StripeClient` shape works. */
+          client: StripeClient
+        }
+      | {
+          /** Stripe secret API key. */
+          secretKey: string
+        }
+    >
 
   type DeriveDefaults<parameters extends Parameters> = Pick<
     parameters,
     Extract<keyof parameters, keyof Defaults>
   > & { decimals: number }
+}
+
+/** Creates a PaymentIntent using the Stripe SDK client. */
+async function createWithClient(parameters: {
+  client: StripeClient
+  challenge: { id: string }
+  metadata: Record<string, string>
+  request: { amount: unknown; currency: unknown }
+  spt: string
+}): Promise<{ id: string; status: string }> {
+  const { client, challenge, metadata, request, spt } = parameters
+  try {
+    const result = await client.paymentIntents.create(
+      {
+        amount: Number(request.amount),
+        automatic_payment_methods: { allow_redirects: 'never', enabled: true },
+        confirm: true,
+        currency: request.currency as string,
+        metadata,
+        payment_method: spt,
+      },
+      { idempotencyKey: `mppx_${challenge.id}_${spt}` },
+    )
+    return { id: result.id, status: result.status }
+  } catch {
+    throw new VerificationFailedError({ reason: 'Stripe PaymentIntent failed' })
+  }
+}
+
+/** Creates a PaymentIntent using a raw secret key and fetch. */
+async function createWithSecretKey(parameters: {
+  secretKey: string
+  challenge: { id: string }
+  metadata: Record<string, string>
+  request: { amount: unknown; currency: unknown }
+  spt: string
+}): Promise<{ id: string; status: string }> {
+  const { secretKey, challenge, metadata, request, spt } = parameters
+
+  const body = new URLSearchParams({
+    amount: request.amount as string,
+    'automatic_payment_methods[allow_redirects]': 'never',
+    'automatic_payment_methods[enabled]': 'true',
+    confirm: 'true',
+    currency: request.currency as string,
+    shared_payment_granted_token: spt,
+  })
+  for (const [key, value] of Object.entries(metadata)) {
+    body.set(`metadata[${key}]`, value)
+  }
+
+  const response = await fetch('https://api.stripe.com/v1/payment_intents', {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${btoa(`${secretKey}:`)}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Idempotency-Key': `mppx_${challenge.id}_${spt}`,
+    },
+    body,
+  })
+
+  if (!response.ok) throw new VerificationFailedError({ reason: 'Stripe PaymentIntent failed' })
+  return (await response.json()) as { id: string; status: string }
 }
 
 /** @internal */


### PR DESCRIPTION
## Summary

Accept pre-configured Stripe SDK instances on both server and client instead of requiring raw secret keys and manual fetch calls.

### Server

`stripe.charge()` now accepts either `client` (a Stripe SDK instance) or `secretKey` (raw key, existing behavior):

```ts
import Stripe from "stripe"
import { stripe } from "mppx/server"

const stripeClient = new Stripe(process.env.STRIPE_SECRET_KEY!)

stripe.charge({
  client: stripeClient,
  networkId: "internal",
  paymentMethodTypes: ["card"],
})
```

The `client` path calls `client.paymentIntents.create()` instead of raw fetch. `secretKey` continues to work as before.

### Client

`stripe.charge()` now accepts an optional `client` (a Stripe.js instance from `@stripe/stripe-js`) which is forwarded to the `createToken` callback:

```ts
import { loadStripe } from "@stripe/stripe-js"
import { stripe } from "mppx/client"

const stripeJs = await loadStripe("pk_...")

stripe.charge({
  client: stripeJs,
  createToken: async ({ client, amount, currency, ... }) => {
    // client is the Stripe.js instance
    // ...
  },
})
```

### Design decisions

- **Duck-typed interfaces** (`StripeClient`, `StripeJs`) — neither `stripe` nor `@stripe/stripe-js` are hard dependencies. Users can pass any compatible version and configure retries, API version, etc.
- **`OneOf` union** — server-side `client` and `secretKey` are mutually exclusive via the existing `OneOf` type utility
- **Backwards compatible** — `secretKey` still works, all existing tests pass (484/484)

### Changes

- `src/stripe/internal/types.ts` — new duck-typed `StripeClient` and `StripeJs` interfaces
- `src/stripe/server/Charge.ts` — accept `client | secretKey`, split verify into `createWithClient` / `createWithSecretKey`
- `src/stripe/client/Charge.ts` — accept optional `client`, forward to `createToken` callback
- `examples/stripe/` — updated to use `client` pattern on both sides