### PR TITLE
fix: align error type URIs with spec (paymentauth.org)

### DIFF
--- a/src/Errors.test.ts
+++ b/src/Errors.test.ts
@@ -11,6 +11,8 @@ import {
   InvalidSignatureError,
   MalformedCredentialError,
   PaymentExpiredError,
+  PaymentInsufficientError,
+  PaymentMethodUnsupportedError,
   PaymentRequiredError,
   SignerMismatchError,
   VerificationFailedError,
@@ -31,8 +33,8 @@ describe('MalformedCredentialError', () => {
       {
         "message": "Credential is malformed.",
         "name": "MalformedCredentialError",
-        "status": 402,
-        "type": "https://tempoxyz.github.io/payment-auth-spec/problems/malformed-credential",
+        "status": 400,
+        "type": "https://paymentauth.org/problems/malformed-credential",
       }
     `)
   })
@@ -44,8 +46,8 @@ describe('MalformedCredentialError', () => {
         {
           "message": "Credential is malformed: invalid base64url.",
           "name": "MalformedCredentialError",
-          "status": 402,
-          "type": "https://tempoxyz.github.io/payment-auth-spec/problems/malformed-credential",
+          "status": 400,
+          "type": "https://paymentauth.org/problems/malformed-credential",
         }
       `)
   })
@@ -57,8 +59,8 @@ describe('InvalidChallengeError', () => {
       {
         "message": "Challenge is invalid.",
         "name": "InvalidChallengeError",
-        "status": 402,
-        "type": "https://tempoxyz.github.io/payment-auth-spec/problems/invalid-challenge",
+        "status": 400,
+        "type": "https://paymentauth.org/problems/invalid-challenge",
       }
     `)
   })
@@ -68,8 +70,8 @@ describe('InvalidChallengeError', () => {
       {
         "message": "Challenge "abc123" is invalid.",
         "name": "InvalidChallengeError",
-        "status": 402,
-        "type": "https://tempoxyz.github.io/payment-auth-spec/problems/invalid-challenge",
+        "status": 400,
+        "type": "https://paymentauth.org/problems/invalid-challenge",
       }
     `)
   })
@@ -79,8 +81,8 @@ describe('InvalidChallengeError', () => {
       {
         "message": "Challenge is invalid: expired.",
         "name": "InvalidChallengeError",
-        "status": 402,
-        "type": "https://tempoxyz.github.io/payment-auth-spec/problems/invalid-challenge",
+        "status": 400,
+        "type": "https://paymentauth.org/problems/invalid-challenge",
       }
     `)
   })
@@ -92,8 +94,8 @@ describe('InvalidChallengeError', () => {
         {
           "message": "Challenge "abc123" is invalid: already used.",
           "name": "InvalidChallengeError",
-          "status": 402,
-          "type": "https://tempoxyz.github.io/payment-auth-spec/problems/invalid-challenge",
+          "status": 400,
+          "type": "https://paymentauth.org/problems/invalid-challenge",
         }
       `)
   })
@@ -106,7 +108,7 @@ describe('VerificationFailedError', () => {
         "message": "Payment verification failed.",
         "name": "VerificationFailedError",
         "status": 402,
-        "type": "https://tempoxyz.github.io/payment-auth-spec/problems/verification-failed",
+        "type": "https://paymentauth.org/problems/verification-failed",
       }
     `)
   })
@@ -119,7 +121,7 @@ describe('VerificationFailedError', () => {
           "message": "Payment verification failed: invalid signature.",
           "name": "VerificationFailedError",
           "status": 402,
-          "type": "https://tempoxyz.github.io/payment-auth-spec/problems/verification-failed",
+          "type": "https://paymentauth.org/problems/verification-failed",
         }
       `)
   })
@@ -132,7 +134,7 @@ describe('PaymentExpiredError', () => {
         "message": "Payment has expired.",
         "name": "PaymentExpiredError",
         "status": 402,
-        "type": "https://tempoxyz.github.io/payment-auth-spec/problems/payment-expired",
+        "type": "https://paymentauth.org/problems/payment-expired",
       }
     `)
   })
@@ -145,7 +147,7 @@ describe('PaymentExpiredError', () => {
           "message": "Payment expired at 2025-01-26T12:00:00Z.",
           "name": "PaymentExpiredError",
           "status": 402,
-          "type": "https://tempoxyz.github.io/payment-auth-spec/problems/payment-expired",
+          "type": "https://paymentauth.org/problems/payment-expired",
         }
       `)
   })
@@ -158,7 +160,7 @@ describe('PaymentRequiredError', () => {
         "message": "Payment is required.",
         "name": "PaymentRequiredError",
         "status": 402,
-        "type": "https://tempoxyz.github.io/payment-auth-spec/problems/payment-required",
+        "type": "https://paymentauth.org/problems/payment-required",
       }
     `)
   })
@@ -171,7 +173,7 @@ describe('PaymentRequiredError', () => {
           "message": "Payment is required for "api.example.com".",
           "name": "PaymentRequiredError",
           "status": 402,
-          "type": "https://tempoxyz.github.io/payment-auth-spec/problems/payment-required",
+          "type": "https://paymentauth.org/problems/payment-required",
         }
       `)
   })
@@ -186,7 +188,7 @@ describe('PaymentRequiredError', () => {
           "message": "Payment is required for "api.example.com" (API access fee).",
           "name": "PaymentRequiredError",
           "status": 402,
-          "type": "https://tempoxyz.github.io/payment-auth-spec/problems/payment-required",
+          "type": "https://paymentauth.org/problems/payment-required",
         }
       `)
   })
@@ -199,7 +201,7 @@ describe('InvalidPayloadError', () => {
         "message": "Credential payload is invalid.",
         "name": "InvalidPayloadError",
         "status": 402,
-        "type": "https://tempoxyz.github.io/payment-auth-spec/problems/invalid-payload",
+        "type": "https://paymentauth.org/problems/invalid-payload",
       }
     `)
   })
@@ -212,7 +214,7 @@ describe('InvalidPayloadError', () => {
           "message": "Credential payload is invalid: missing signature field.",
           "name": "InvalidPayloadError",
           "status": 402,
-          "type": "https://tempoxyz.github.io/payment-auth-spec/problems/invalid-payload",
+          "type": "https://paymentauth.org/problems/invalid-payload",
         }
       `)
   })
@@ -225,7 +227,7 @@ describe('BadRequestError', () => {
         "message": "Bad request.",
         "name": "BadRequestError",
         "status": 400,
-        "type": "https://tempoxyz.github.io/payment-auth-spec/problems/bad-request",
+        "type": "https://paymentauth.org/problems/bad-request",
       }
     `)
   })
@@ -238,7 +240,59 @@ describe('BadRequestError', () => {
           "message": "Bad request: cannot combine hash type with feePayer.",
           "name": "BadRequestError",
           "status": 400,
-          "type": "https://tempoxyz.github.io/payment-auth-spec/problems/bad-request",
+          "type": "https://paymentauth.org/problems/bad-request",
+        }
+      `)
+  })
+})
+
+describe('PaymentInsufficientError', () => {
+  test('default', () => {
+    expect(errorSnapshot(new PaymentInsufficientError())).toMatchInlineSnapshot(`
+      {
+        "message": "Payment amount is insufficient.",
+        "name": "PaymentInsufficientError",
+        "status": 402,
+        "type": "https://paymentauth.org/problems/payment-insufficient",
+      }
+    `)
+  })
+
+  test('with reason', () => {
+    expect(
+      errorSnapshot(new PaymentInsufficientError({ reason: 'expected 1000, received 500' })),
+    ).toMatchInlineSnapshot(`
+        {
+          "message": "Payment insufficient: expected 1000, received 500.",
+          "name": "PaymentInsufficientError",
+          "status": 402,
+          "type": "https://paymentauth.org/problems/payment-insufficient",
+        }
+      `)
+  })
+})
+
+describe('PaymentMethodUnsupportedError', () => {
+  test('default', () => {
+    expect(errorSnapshot(new PaymentMethodUnsupportedError())).toMatchInlineSnapshot(`
+      {
+        "message": "Payment method is not supported.",
+        "name": "PaymentMethodUnsupportedError",
+        "status": 400,
+        "type": "https://paymentauth.org/problems/method-unsupported",
+      }
+    `)
+  })
+
+  test('with method', () => {
+    expect(
+      errorSnapshot(new PaymentMethodUnsupportedError({ method: 'bitcoin' })),
+    ).toMatchInlineSnapshot(`
+        {
+          "message": "Payment method "bitcoin" is not supported.",
+          "name": "PaymentMethodUnsupportedError",
+          "status": 400,
+          "type": "https://paymentauth.org/problems/method-unsupported",
         }
       `)
   })
@@ -380,9 +434,9 @@ describe('toProblemDetails', () => {
     expect(error.toProblemDetails()).toMatchInlineSnapshot(`
       {
         "detail": "Credential is malformed: invalid JSON.",
-        "status": 402,
-        "title": "MalformedCredentialError",
-        "type": "https://tempoxyz.github.io/payment-auth-spec/problems/malformed-credential",
+        "status": 400,
+        "title": "Malformed Credential",
+        "type": "https://paymentauth.org/problems/malformed-credential",
       }
     `)
   })
@@ -393,9 +447,9 @@ describe('toProblemDetails', () => {
       {
         "challengeId": "abc123",
         "detail": "Challenge "abc123" is invalid: expired.",
-        "status": 402,
-        "title": "InvalidChallengeError",
-        "type": "https://tempoxyz.github.io/payment-auth-spec/problems/invalid-challenge",
+        "status": 400,
+        "title": "Invalid Challenge",
+        "type": "https://paymentauth.org/problems/invalid-challenge",
       }
     `)
   })

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -5,6 +5,9 @@ export abstract class PaymentError extends Error {
   /** RFC 9457 Problem Details type URI. */
   abstract readonly type: string
 
+  /** Human-readable summary for RFC 9457 Problem Details. */
+  abstract readonly title: string
+
   /** HTTP status code. */
   readonly status: number = 402
 
@@ -12,7 +15,7 @@ export abstract class PaymentError extends Error {
   toProblemDetails(challengeId?: string): PaymentError.ProblemDetails {
     return {
       type: this.type,
-      title: this.name,
+      title: this.title,
       status: this.status,
       detail: this.message,
       ...(challengeId && { challengeId }),
@@ -40,7 +43,9 @@ export declare namespace PaymentError {
  */
 export class MalformedCredentialError extends PaymentError {
   override readonly name = 'MalformedCredentialError'
-  readonly type = 'https://tempoxyz.github.io/payment-auth-spec/problems/malformed-credential'
+  readonly title = 'Malformed Credential'
+  override readonly status = 400
+  readonly type = 'https://paymentauth.org/problems/malformed-credential'
 
   constructor(options: MalformedCredentialError.Options = {}) {
     const { reason } = options
@@ -60,7 +65,9 @@ export declare namespace MalformedCredentialError {
  */
 export class InvalidChallengeError extends PaymentError {
   override readonly name = 'InvalidChallengeError'
-  readonly type = 'https://tempoxyz.github.io/payment-auth-spec/problems/invalid-challenge'
+  readonly title = 'Invalid Challenge'
+  override readonly status = 400
+  readonly type = 'https://paymentauth.org/problems/invalid-challenge'
 
   constructor(options: InvalidChallengeError.Options = {}) {
     const { id, reason } = options
@@ -84,7 +91,8 @@ export declare namespace InvalidChallengeError {
  */
 export class VerificationFailedError extends PaymentError {
   override readonly name = 'VerificationFailedError'
-  readonly type = 'https://tempoxyz.github.io/payment-auth-spec/problems/verification-failed'
+  readonly title = 'Verification Failed'
+  readonly type = 'https://paymentauth.org/problems/verification-failed'
 
   constructor(options: VerificationFailedError.Options = {}) {
     const { reason } = options
@@ -104,7 +112,8 @@ export declare namespace VerificationFailedError {
  */
 export class PaymentActionRequiredError extends PaymentError {
   override readonly name = 'PaymentActionRequiredError'
-  readonly type = 'https://tempoxyz.github.io/payment-auth-spec/problems/payment-action-required'
+  readonly title = 'Payment Action Required'
+  readonly type = 'https://paymentauth.org/problems/payment-action-required'
 
   constructor(options: PaymentActionRequiredError.Options = {}) {
     const { reason } = options
@@ -124,7 +133,8 @@ export declare namespace PaymentActionRequiredError {
  */
 export class PaymentExpiredError extends PaymentError {
   override readonly name = 'PaymentExpiredError'
-  readonly type = 'https://tempoxyz.github.io/payment-auth-spec/problems/payment-expired'
+  readonly title = 'Payment Expired'
+  readonly type = 'https://paymentauth.org/problems/payment-expired'
 
   constructor(options: PaymentExpiredError.Options = {}) {
     const { expires } = options
@@ -144,7 +154,8 @@ export declare namespace PaymentExpiredError {
  */
 export class PaymentRequiredError extends PaymentError {
   override readonly name = 'PaymentRequiredError'
-  readonly type = 'https://tempoxyz.github.io/payment-auth-spec/problems/payment-required'
+  readonly title = 'Payment Required'
+  readonly type = 'https://paymentauth.org/problems/payment-required'
 
   constructor(options: PaymentRequiredError.Options = {}) {
     const { description, realm } = options
@@ -169,7 +180,8 @@ export declare namespace PaymentRequiredError {
  */
 export class InvalidPayloadError extends PaymentError {
   override readonly name = 'InvalidPayloadError'
-  readonly type = 'https://tempoxyz.github.io/payment-auth-spec/problems/invalid-payload'
+  readonly title = 'Invalid Payload'
+  readonly type = 'https://paymentauth.org/problems/invalid-payload'
 
   constructor(options: InvalidPayloadError.Options = {}) {
     const { reason } = options
@@ -189,8 +201,9 @@ export declare namespace InvalidPayloadError {
  */
 export class BadRequestError extends PaymentError {
   override readonly name = 'BadRequestError'
+  readonly title = 'Bad Request'
   override readonly status = 400
-  readonly type = 'https://tempoxyz.github.io/payment-auth-spec/problems/bad-request'
+  readonly type = 'https://paymentauth.org/problems/bad-request'
 
   constructor(options: BadRequestError.Options = {}) {
     const { reason } = options
@@ -206,10 +219,56 @@ export declare namespace BadRequestError {
 }
 
 /**
+ * Payment amount is insufficient (too low).
+ */
+export class PaymentInsufficientError extends PaymentError {
+  override readonly name = 'PaymentInsufficientError'
+  readonly title = 'Payment Insufficient'
+  readonly type = 'https://paymentauth.org/problems/payment-insufficient'
+
+  constructor(options: PaymentInsufficientError.Options = {}) {
+    const { reason } = options
+    super(reason ? `Payment insufficient: ${reason}.` : 'Payment amount is insufficient.')
+  }
+}
+
+export declare namespace PaymentInsufficientError {
+  type Options = {
+    /** Reason the payment is insufficient (e.g., "expected 1000, received 500"). */
+    reason?: string
+  }
+}
+
+/**
+ * Payment method is not supported by the server.
+ */
+export class PaymentMethodUnsupportedError extends PaymentError {
+  override readonly name = 'PaymentMethodUnsupportedError'
+  readonly title = 'Method Unsupported'
+  override readonly status = 400
+  readonly type = 'https://paymentauth.org/problems/method-unsupported'
+
+  constructor(options: PaymentMethodUnsupportedError.Options = {}) {
+    const { method } = options
+    super(
+      method ? `Payment method "${method}" is not supported.` : 'Payment method is not supported.',
+    )
+  }
+}
+
+export declare namespace PaymentMethodUnsupportedError {
+  type Options = {
+    /** The unsupported method identifier. */
+    method?: string
+  }
+}
+
+/**
  * Insufficient balance in the payment channel.
  */
 export class InsufficientBalanceError extends PaymentError {
   override readonly name = 'InsufficientBalanceError'
+  readonly title = 'Insufficient Balance'
   override readonly status = 402
   readonly type = 'https://paymentauth.org/problems/stream/insufficient-balance'
 
@@ -231,6 +290,7 @@ export declare namespace InsufficientBalanceError {
  */
 export class InvalidSignatureError extends PaymentError {
   override readonly name = 'InvalidSignatureError'
+  readonly title = 'Invalid Signature'
   override readonly status = 402
   readonly type = 'https://paymentauth.org/problems/stream/invalid-signature'
 
@@ -251,6 +311,7 @@ export declare namespace InvalidSignatureError {
  */
 export class SignerMismatchError extends PaymentError {
   override readonly name = 'SignerMismatchError'
+  readonly title = 'Signer Mismatch'
   override readonly status = 402
   readonly type = 'https://paymentauth.org/problems/stream/signer-mismatch'
 
@@ -271,6 +332,7 @@ export declare namespace SignerMismatchError {
  */
 export class AmountExceedsDepositError extends PaymentError {
   override readonly name = 'AmountExceedsDepositError'
+  readonly title = 'Amount Exceeds Deposit'
   override readonly status = 402
   readonly type = 'https://paymentauth.org/problems/stream/amount-exceeds-deposit'
 
@@ -291,6 +353,7 @@ export declare namespace AmountExceedsDepositError {
  */
 export class DeltaTooSmallError extends PaymentError {
   override readonly name = 'DeltaTooSmallError'
+  readonly title = 'Delta Too Small'
   override readonly status = 402
   readonly type = 'https://paymentauth.org/problems/stream/delta-too-small'
 
@@ -311,6 +374,7 @@ export declare namespace DeltaTooSmallError {
  */
 export class ChannelNotFoundError extends PaymentError {
   override readonly name = 'ChannelNotFoundError'
+  readonly title = 'Channel Not Found'
   override readonly status = 410
   readonly type = 'https://paymentauth.org/problems/stream/channel-not-found'
 
@@ -331,6 +395,7 @@ export declare namespace ChannelNotFoundError {
  */
 export class ChannelClosedError extends PaymentError {
   override readonly name = 'ChannelClosedError'
+  readonly title = 'Channel Closed'
   override readonly status = 410
   readonly type = 'https://paymentauth.org/problems/stream/channel-finalized'
 

--- a/src/server/Mppx.test.ts
+++ b/src/server/Mppx.test.ts
@@ -56,8 +56,8 @@ describe('request handler', () => {
         "detail": "Payment is required for "api.example.com".",
         "instance": "[instance]",
         "status": 402,
-        "title": "PaymentRequiredError",
-        "type": "https://tempoxyz.github.io/payment-auth-spec/problems/payment-required",
+        "title": "Payment Required",
+        "type": "https://paymentauth.org/problems/payment-required",
       }
     `)
   })
@@ -87,9 +87,9 @@ describe('request handler', () => {
         "challengeId": "[challengeId]",
         "detail": "Credential is malformed: Invalid base64url or JSON..",
         "instance": "[instance]",
-        "status": 402,
-        "title": "MalformedCredentialError",
-        "type": "https://tempoxyz.github.io/payment-auth-spec/problems/malformed-credential",
+        "status": 400,
+        "title": "Malformed Credential",
+        "type": "https://paymentauth.org/problems/malformed-credential",
       }
     `)
   })
@@ -131,9 +131,9 @@ describe('request handler', () => {
         "challengeId": "[challengeId]",
         "detail": "Challenge "wrong-id" is invalid: challenge was not issued by this server.",
         "instance": "[instance]",
-        "status": 402,
-        "title": "InvalidChallengeError",
-        "type": "https://tempoxyz.github.io/payment-auth-spec/problems/invalid-challenge",
+        "status": 400,
+        "title": "Invalid Challenge",
+        "type": "https://paymentauth.org/problems/invalid-challenge",
       }
     `)
   })
@@ -178,8 +178,8 @@ describe('request handler', () => {
         "detail": "[detail]",
         "instance": "[instance]",
         "status": 402,
-        "title": "InvalidPayloadError",
-        "type": "https://tempoxyz.github.io/payment-auth-spec/problems/invalid-payload",
+        "title": "Invalid Payload",
+        "type": "https://paymentauth.org/problems/invalid-payload",
       }
     `)
     expect(body.detail).toContain('Credential payload is invalid')
@@ -218,8 +218,8 @@ describe('request handler (node)', () => {
         "detail": "Payment is required for "api.example.com".",
         "instance": "[instance]",
         "status": 402,
-        "title": "PaymentRequiredError",
-        "type": "https://tempoxyz.github.io/payment-auth-spec/problems/payment-required",
+        "title": "Payment Required",
+        "type": "https://paymentauth.org/problems/payment-required",
       }
     `)
 
@@ -271,8 +271,8 @@ describe('request handler (node)', () => {
         "detail": "[detail]",
         "instance": "[instance]",
         "status": 402,
-        "title": "VerificationFailedError",
-        "type": "https://tempoxyz.github.io/payment-auth-spec/problems/verification-failed",
+        "title": "Verification Failed",
+        "type": "https://paymentauth.org/problems/verification-failed",
       }
     `)
     expect(body.detail).toContain('Payment verification failed')

--- a/src/server/Transport.test.ts
+++ b/src/server/Transport.test.ts
@@ -111,7 +111,7 @@ describe('http', () => {
 
       expect(response.status).toBe(400)
       const body = await response.json()
-      expect(body.type).toBe('https://tempoxyz.github.io/payment-auth-spec/problems/bad-request')
+      expect(body.type).toBe('https://paymentauth.org/problems/bad-request')
       expect(body.status).toBe(400)
     })
 


### PR DESCRIPTION
Updates all RFC 9457 Problem Details `type` URIs from `https://tempoxyz.github.io/payment-auth-spec/problems/...` to `https://paymentauth.org/problems/...` to match the canonical spec ([draft-httpauth-payment-00](https://paymentauth.tempo.xyz/draft-httpauth-payment-00.txt), Section 8.1).