### PR TITLE
feat: mandate JCS (RFC 8785) for canonical JSON serialization of request parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "@remix-run/fetch-proxy": "^0.7.1",
     "@remix-run/node-fetch-server": "^0.13.0",
     "cac": "^6.7.14",
+    "canonicalize": "^2.1.0",
     "ox": "^0.12.0",
     "zod": "^4.3.6"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ importers:
       cac:
         specifier: ^6.7.14
         version: 6.7.14
+      canonicalize:
+        specifier: ^2.1.0
+        version: 2.1.0
       ox:
         specifier: ^0.12.0
         version: 0.12.0(typescript@5.9.3)(zod@4.3.6)
@@ -1062,6 +1065,10 @@ packages:
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
+
+  canonicalize@2.1.0:
+    resolution: {integrity: sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==}
+    hasBin: true
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -3249,6 +3256,8 @@ snapshots:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
+
+  canonicalize@2.1.0: {}
 
   chai@6.2.2: {}
 

--- a/src/PaymentRequest.ts
+++ b/src/PaymentRequest.ts
@@ -1,7 +1,11 @@
+import { createRequire } from 'node:module'
 import { Base64 } from 'ox'
 import type { Compute } from './internal/types.js'
 import type * as Method from './Method.js'
 import type * as z from './zod.js'
+
+const require = createRequire(import.meta.url)
+const canonicalize = require('canonicalize') as (input: unknown) => string | undefined
 
 /**
  * Intent-specific payment parameters.
@@ -102,6 +106,7 @@ export function fromIntent<const method extends Method.Method>(
  * ```
  */
 export function serialize(request: Request): string {
-  const json = JSON.stringify(request)
+  const json = canonicalize(request)
+  if (!json) throw new Error('Failed to canonicalize request')
   return Base64.fromString(json, { pad: false, url: true })
 }

--- a/src/client/Transport.test.ts
+++ b/src/client/Transport.test.ts
@@ -60,7 +60,7 @@ describe('http', () => {
       expect(transport.getChallenge(response)).toMatchInlineSnapshot(`
         {
           "expires": "2025-01-01T00:00:00.000Z",
-          "id": "EUAHxZRCSFB29SAs5TEcB4cQDS0uVDzl8uSYuA58aVs",
+          "id": "wv3vZAjsySM50i4f1sJCZxyOLNry0dLSOwuWDBqrXaw",
           "intent": "charge",
           "method": "tempo",
           "realm": "api.example.com",
@@ -91,7 +91,7 @@ describe('http', () => {
       const headers = result.headers as Headers
 
       expect(headers.get('Authorization')).toMatchInlineSnapshot(
-        `"Payment eyJjaGFsbGVuZ2UiOnsiZXhwaXJlcyI6IjIwMjUtMDEtMDFUMDA6MDA6MDAuMDAwWiIsImlkIjoiRVVBSHhaUkNTRkIyOVNBczVURWNCNGNRRFMwdVZEemw4dVNZdUE1OGFWcyIsImludGVudCI6ImNoYXJnZSIsIm1ldGhvZCI6InRlbXBvIiwicmVhbG0iOiJhcGkuZXhhbXBsZS5jb20iLCJyZXF1ZXN0IjoiZXlKamRYSnlaVzVqZVNJNklqQjRNakJqTURBd01EQXdNREF3TURBd01EQXdNREF3TURBd01EQXdNREF3TURBd01EQXdNREF3TVNJc0ltVjRjR2x5WlhNaU9pSXlNREkxTFRBeExUQXhWREF3T2pBd09qQXdMakF3TUZvaUxDSnlaV05wY0dsbGJuUWlPaUl3ZURjME1tUXpOVU5qTmpZek5FTXdOVE15T1RJMVlUTmlPRFEwUW1NNVpUYzFPVFZtT0daRk1EQWlMQ0poYlc5MWJuUWlPaUl4TURBd0luMCJ9LCJwYXlsb2FkIjp7InNpZ25hdHVyZSI6IjB4YWJjMTIzIiwidHlwZSI6InRyYW5zYWN0aW9uIn19"`,
+        `"Payment eyJjaGFsbGVuZ2UiOnsiZXhwaXJlcyI6IjIwMjUtMDEtMDFUMDA6MDA6MDAuMDAwWiIsImlkIjoid3YzdlpBanN5U001MGk0ZjFzSkNaeHlPTE5yeTBkTFNPd3VXREJxclhhdyIsImludGVudCI6ImNoYXJnZSIsIm1ldGhvZCI6InRlbXBvIiwicmVhbG0iOiJhcGkuZXhhbXBsZS5jb20iLCJyZXF1ZXN0IjoiZXlKaGJXOTFiblFpT2lJeE1EQXdJaXdpWTNWeWNtVnVZM2tpT2lJd2VESXdZekF3TURBd01EQXdNREF3TURBd01EQXdNREF3TURBd01EQXdNREF3TURBd01EQXdNREVpTENKbGVIQnBjbVZ6SWpvaU1qQXlOUzB3TVMwd01WUXdNRG93TURvd01DNHdNREJhSWl3aWNtVmphWEJwWlc1MElqb2lNSGczTkRKa016VkRZelkyTXpSRE1EVXpNamt5TldFellqZzBORUpqT1dVM05UazFaamhtUlRBd0luMCJ9LCJwYXlsb2FkIjp7InNpZ25hdHVyZSI6IjB4YWJjMTIzIiwidHlwZSI6InRyYW5zYWN0aW9uIn19"`,
       )
     })
 
@@ -182,7 +182,7 @@ describe('mcp', () => {
       expect(transport.getChallenge(response)).toMatchInlineSnapshot(`
         {
           "expires": "2025-01-01T00:00:00.000Z",
-          "id": "EUAHxZRCSFB29SAs5TEcB4cQDS0uVDzl8uSYuA58aVs",
+          "id": "wv3vZAjsySM50i4f1sJCZxyOLNry0dLSOwuWDBqrXaw",
           "intent": "charge",
           "method": "tempo",
           "realm": "api.example.com",
@@ -239,7 +239,7 @@ describe('mcp', () => {
               "org.paymentauth/credential": {
                 "challenge": {
                   "expires": "2025-01-01T00:00:00.000Z",
-                  "id": "EUAHxZRCSFB29SAs5TEcB4cQDS0uVDzl8uSYuA58aVs",
+                  "id": "wv3vZAjsySM50i4f1sJCZxyOLNry0dLSOwuWDBqrXaw",
                   "intent": "charge",
                   "method": "tempo",
                   "realm": "api.example.com",

--- a/src/server/Transport.test.ts
+++ b/src/server/Transport.test.ts
@@ -43,7 +43,7 @@ describe('http', () => {
         {
           "challenge": {
             "expires": "2025-01-01T00:00:00.000Z",
-            "id": "jIuTUdphF_TyhJ-NT1lK2r5YzPXw4tuELfslOVa3nls",
+            "id": "6FkNG-Uv4Ff-viAxYvfyNLhbXbEXcfsbdEtB74ADviw",
             "intent": "charge",
             "method": "tempo",
             "realm": "api.example.com",
@@ -93,7 +93,7 @@ describe('http', () => {
         {
           "headers": {
             "cache-control": "no-store",
-            "www-authenticate": "Payment id="jIuTUdphF_TyhJ-NT1lK2r5YzPXw4tuELfslOVa3nls", realm="api.example.com", method="tempo", intent="charge", request="eyJjdXJyZW5jeSI6IjB4MjBjMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMSIsImV4cGlyZXMiOiIyMDI1LTAxLTAxVDAwOjAwOjAwLjAwMFoiLCJyZWNpcGllbnQiOiIweDc0MmQzNUNjNjYzNEMwNTMyOTI1YTNiODQ0QmM5ZTc1OTVmOGZFMDAiLCJhbW91bnQiOiIxMDAwMDAwMDAwIn0", expires="2025-01-01T00:00:00.000Z"",
+            "www-authenticate": "Payment id="6FkNG-Uv4Ff-viAxYvfyNLhbXbEXcfsbdEtB74ADviw", realm="api.example.com", method="tempo", intent="charge", request="eyJhbW91bnQiOiIxMDAwMDAwMDAwIiwiY3VycmVuY3kiOiIweDIwYzAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDEiLCJleHBpcmVzIjoiMjAyNS0wMS0wMVQwMDowMDowMC4wMDBaIiwicmVjaXBpZW50IjoiMHg3NDJkMzVDYzY2MzRDMDUzMjkyNWEzYjg0NEJjOWU3NTk1ZjhmRTAwIn0", expires="2025-01-01T00:00:00.000Z"",
           },
           "status": 402,
         }
@@ -183,7 +183,7 @@ describe('mcp', () => {
         {
           "challenge": {
             "expires": "2025-01-01T00:00:00.000Z",
-            "id": "jIuTUdphF_TyhJ-NT1lK2r5YzPXw4tuELfslOVa3nls",
+            "id": "6FkNG-Uv4Ff-viAxYvfyNLhbXbEXcfsbdEtB74ADviw",
             "intent": "charge",
             "method": "tempo",
             "realm": "api.example.com",
@@ -221,7 +221,7 @@ describe('mcp', () => {
               "challenges": [
                 {
                   "expires": "2025-01-01T00:00:00.000Z",
-                  "id": "jIuTUdphF_TyhJ-NT1lK2r5YzPXw4tuELfslOVa3nls",
+                  "id": "6FkNG-Uv4Ff-viAxYvfyNLhbXbEXcfsbdEtB74ADviw",
                   "intent": "charge",
                   "method": "tempo",
                   "realm": "api.example.com",
@@ -262,7 +262,7 @@ describe('mcp', () => {
           "result": {
             "_meta": {
               "org.paymentauth/receipt": {
-                "challengeId": "jIuTUdphF_TyhJ-NT1lK2r5YzPXw4tuELfslOVa3nls",
+                "challengeId": "6FkNG-Uv4Ff-viAxYvfyNLhbXbEXcfsbdEtB74ADviw",
                 "method": "tempo",
                 "reference": "0xtxhash",
                 "status": "success",


### PR DESCRIPTION
## Problem

The `request` parameter is base64url-encoded JSON that feeds into the HMAC-SHA256 challenge ID computation. Without canonical serialization, different implementations may produce different JSON key orderings, resulting in different HMAC values for the same logical request.

This breaks cross-implementation interoperability: a challenge created by one implementation may not be verifiable by another if the JSON keys happen to be in a different order.

## Changes

- Adds `canonicalize` (RFC 8785 JCS implementation) as a dependency
- Updates `PaymentRequest.serialize()` to use JCS before base64url encoding
- Ensures deterministic HMAC computation across all implementations
- Updates inline snapshots to reflect new canonical key ordering

Spec change: https://github.com/tempoxyz/mpp-specs/pull/141