### PR TITLE
fix: remove .filter(Boolean) from HMAC challenge ID computation

### DIFF
--- a/src/Challenge.test.ts
+++ b/src/Challenge.test.ts
@@ -53,21 +53,160 @@ describe('from', () => {
     `)
   })
 
-  test('behavior: creates challenge with HMAC-bound id via secretKey', () => {
-    const challenge = Challenge.from({
+  // ---------------------------------------------------------------------------
+  // HMAC Challenge ID Test Vectors
+  //
+  // HMAC input: realm | method | intent | base64url(canonicalize(request)) | expires | digest
+  // HMAC key:   UTF-8 bytes of secretKey
+  // Output:     base64url(HMAC-SHA256(key, input), no padding)
+  //
+  // These vectors cover every combination of optional HMAC fields (expires, digest)
+  // and variations in each required field (realm, method, intent, request).
+  // Use them to verify HMAC challenge ID computation in other implementations.
+  // ---------------------------------------------------------------------------
+  const hmacVectors = [
+    {
+      label: 'required fields only',
+      params: {
+        realm: 'api.example.com',
+        method: 'tempo',
+        intent: 'charge',
+        request: { amount: '1000000' },
+      },
+      expectedId: 'SOfbA51LV3LCkGE7RbomqwXdbWVlrZwlW-Z9aOHolxw',
+    },
+    {
+      label: 'with expires',
+      params: {
+        realm: 'api.example.com',
+        method: 'tempo',
+        intent: 'charge',
+        request: { amount: '1000000' },
+        expires: '2025-01-06T12:00:00Z',
+      },
+      expectedId: 'R1ZSIwoIjkFhMCSzUGiCTesiigf5vV65EQ_3gVNtsNw',
+    },
+    {
+      label: 'with digest',
+      params: {
+        realm: 'api.example.com',
+        method: 'tempo',
+        intent: 'charge',
+        request: { amount: '1000000' },
+        digest: 'sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE',
+      },
+      expectedId: 'AiMmBdsSOkOYpXTupMnzVnrzZbqMY_P2i80vENRUSN4',
+    },
+    {
+      label: 'with expires and digest',
+      params: {
+        realm: 'api.example.com',
+        method: 'tempo',
+        intent: 'charge',
+        request: { amount: '1000000' },
+        expires: '2025-01-06T12:00:00Z',
+        digest: 'sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE',
+      },
+      expectedId: 'FMBGqN7MzpKagHsCcartZM09CnUqv7UgmaCy45Ozgug',
+    },
+    {
+      label: 'with description (not in HMAC input)',
+      params: {
+        realm: 'api.example.com',
+        method: 'tempo',
+        intent: 'charge',
+        request: { amount: '1000000' },
+        description: 'Test payment',
+      },
+      expectedId: 'SOfbA51LV3LCkGE7RbomqwXdbWVlrZwlW-Z9aOHolxw',
+    },
+    {
+      label: 'with multi-field request',
+      params: {
+        realm: 'api.example.com',
+        method: 'tempo',
+        intent: 'charge',
+        request: { amount: '1000000', currency: '0x1234', recipient: '0xabcd' },
+      },
+      expectedId: '5CXJi4bWMz2W54WjnlmoxnwTYe-JKwhw0z32ICQ65Es',
+    },
+    {
+      label: 'with nested methodDetails in request',
+      params: {
+        realm: 'api.example.com',
+        method: 'tempo',
+        intent: 'charge',
+        request: { amount: '1000000', currency: '0x1234', methodDetails: { chainId: 42431 } },
+      },
+      expectedId: 'eid66xXUZsj46Pb30AfAf7m5kPehgianI16rZ-QY8HU',
+    },
+    {
+      label: 'with empty request',
+      params: {
+        realm: 'api.example.com',
+        method: 'tempo',
+        intent: 'charge',
+        request: {},
+      },
+      expectedId: '6kq-PYTyXtaGAHTHCVUrc_hIsAwLeskeQFtDZerMYhM',
+    },
+    {
+      label: 'different realm',
+      params: {
+        realm: 'payments.other.com',
+        method: 'tempo',
+        intent: 'charge',
+        request: { amount: '1000000' },
+      },
+      expectedId: '-gMjd8UeUvBcqUaUzarVj6ikH_YoDowpaNbEwK1Tmx8',
+    },
+    {
+      label: 'different method',
+      params: {
+        realm: 'api.example.com',
+        method: 'stripe',
+        intent: 'charge',
+        request: { amount: '1000000' },
+      },
+      expectedId: 'DRH9ycmIlZ2lYUatIHCrxpm9K7ig5pniZ3ulleb7vl0',
+    },
+    {
+      label: 'different intent',
+      params: {
+        realm: 'api.example.com',
+        method: 'tempo',
+        intent: 'session',
+        request: { amount: '1000000' },
+      },
+      expectedId: 'INeBi93MhinvbwdUxeUUIaT5Q_ufgLKPYZb5Tg43A1o',
+    },
+  ] as const
+
+  test.each(hmacVectors)('hmac: $label', ({ params, expectedId }) => {
+    const challenge = Challenge.from({ ...params, secretKey: 'test-vector-secret' })
+    expect(challenge.id).toBe(expectedId)
+  })
+
+  test('hmac: description does not affect id', () => {
+    const withDesc = Challenge.from({
       realm: 'api.example.com',
       method: 'tempo',
       intent: 'charge',
-      request: { amount: '1000000', currency: '0x1234', recipient: '0xabcd' },
-      secretKey: 'my-secret',
+      request: { amount: '1000000' },
+      description: 'Test payment',
+      secretKey: 'test-vector-secret',
     })
-
-    expect(challenge.id).toMatchInlineSnapshot(`"okjPWig-KcWGvMWYEMdA_oVwySaHKV2q3D1po2xUXI4"`)
-    expect(challenge.realm).toBe('api.example.com')
-    expect(challenge.method).toBe('tempo')
+    const without = Challenge.from({
+      realm: 'api.example.com',
+      method: 'tempo',
+      intent: 'charge',
+      request: { amount: '1000000' },
+      secretKey: 'test-vector-secret',
+    })
+    expect(withDesc.id).toBe(without.id)
   })
 
-  test('behavior: same params with same secretKey produce same id', () => {
+  test('hmac: same params with same secretKey produce same id', () => {
     const challenge1 = Challenge.from({
       realm: 'api.example.com',
       method: 'tempo',
@@ -86,7 +225,7 @@ describe('from', () => {
     expect(challenge1.id).toBe(challenge2.id)
   })
 
-  test('behavior: different secretKey produces different id', () => {
+  test('hmac: different secretKey produces different id', () => {
     const challenge1 = Challenge.from({
       realm: 'api.example.com',
       method: 'tempo',

--- a/src/Challenge.ts
+++ b/src/Challenge.ts
@@ -410,9 +410,7 @@ function computeId(challenge: Omit<Challenge, 'id'>, options: { secretKey: strin
     PaymentRequest.serialize(challenge.request),
     challenge.expires ?? '',
     challenge.digest ?? '',
-  ]
-    .filter(Boolean)
-    .join('|')
+  ].join('|')
 
   const key = Bytes.fromString(options.secretKey)
   const data = Bytes.fromString(input)

--- a/src/client/Transport.test.ts
+++ b/src/client/Transport.test.ts
@@ -60,7 +60,7 @@ describe('http', () => {
       expect(transport.getChallenge(response)).toMatchInlineSnapshot(`
         {
           "expires": "2025-01-01T00:00:00.000Z",
-          "id": "wv3vZAjsySM50i4f1sJCZxyOLNry0dLSOwuWDBqrXaw",
+          "id": "i1474pQ7BtfAx76cLch6u8_AQkcp3akMkerEYrL5Rwo",
           "intent": "charge",
           "method": "tempo",
           "realm": "api.example.com",
@@ -91,7 +91,7 @@ describe('http', () => {
       const headers = result.headers as Headers
 
       expect(headers.get('Authorization')).toMatchInlineSnapshot(
-        `"Payment eyJjaGFsbGVuZ2UiOnsiZXhwaXJlcyI6IjIwMjUtMDEtMDFUMDA6MDA6MDAuMDAwWiIsImlkIjoid3YzdlpBanN5U001MGk0ZjFzSkNaeHlPTE5yeTBkTFNPd3VXREJxclhhdyIsImludGVudCI6ImNoYXJnZSIsIm1ldGhvZCI6InRlbXBvIiwicmVhbG0iOiJhcGkuZXhhbXBsZS5jb20iLCJyZXF1ZXN0IjoiZXlKaGJXOTFiblFpT2lJeE1EQXdJaXdpWTNWeWNtVnVZM2tpT2lJd2VESXdZekF3TURBd01EQXdNREF3TURBd01EQXdNREF3TURBd01EQXdNREF3TURBd01EQXdNREVpTENKbGVIQnBjbVZ6SWpvaU1qQXlOUzB3TVMwd01WUXdNRG93TURvd01DNHdNREJhSWl3aWNtVmphWEJwWlc1MElqb2lNSGczTkRKa016VkRZelkyTXpSRE1EVXpNamt5TldFellqZzBORUpqT1dVM05UazFaamhtUlRBd0luMCJ9LCJwYXlsb2FkIjp7InNpZ25hdHVyZSI6IjB4YWJjMTIzIiwidHlwZSI6InRyYW5zYWN0aW9uIn19"`,
+        `"Payment eyJjaGFsbGVuZ2UiOnsiZXhwaXJlcyI6IjIwMjUtMDEtMDFUMDA6MDA6MDAuMDAwWiIsImlkIjoiaTE0NzRwUTdCdGZBeDc2Y0xjaDZ1OF9BUWtjcDNha01rZXJFWXJMNVJ3byIsImludGVudCI6ImNoYXJnZSIsIm1ldGhvZCI6InRlbXBvIiwicmVhbG0iOiJhcGkuZXhhbXBsZS5jb20iLCJyZXF1ZXN0IjoiZXlKaGJXOTFiblFpT2lJeE1EQXdJaXdpWTNWeWNtVnVZM2tpT2lJd2VESXdZekF3TURBd01EQXdNREF3TURBd01EQXdNREF3TURBd01EQXdNREF3TURBd01EQXdNREVpTENKbGVIQnBjbVZ6SWpvaU1qQXlOUzB3TVMwd01WUXdNRG93TURvd01DNHdNREJhSWl3aWNtVmphWEJwWlc1MElqb2lNSGczTkRKa016VkRZelkyTXpSRE1EVXpNamt5TldFellqZzBORUpqT1dVM05UazFaamhtUlRBd0luMCJ9LCJwYXlsb2FkIjp7InNpZ25hdHVyZSI6IjB4YWJjMTIzIiwidHlwZSI6InRyYW5zYWN0aW9uIn19"`,
       )
     })
 
@@ -182,7 +182,7 @@ describe('mcp', () => {
       expect(transport.getChallenge(response)).toMatchInlineSnapshot(`
         {
           "expires": "2025-01-01T00:00:00.000Z",
-          "id": "wv3vZAjsySM50i4f1sJCZxyOLNry0dLSOwuWDBqrXaw",
+          "id": "i1474pQ7BtfAx76cLch6u8_AQkcp3akMkerEYrL5Rwo",
           "intent": "charge",
           "method": "tempo",
           "realm": "api.example.com",
@@ -239,7 +239,7 @@ describe('mcp', () => {
               "org.paymentauth/credential": {
                 "challenge": {
                   "expires": "2025-01-01T00:00:00.000Z",
-                  "id": "wv3vZAjsySM50i4f1sJCZxyOLNry0dLSOwuWDBqrXaw",
+                  "id": "i1474pQ7BtfAx76cLch6u8_AQkcp3akMkerEYrL5Rwo",
                   "intent": "charge",
                   "method": "tempo",
                   "realm": "api.example.com",

--- a/src/server/Transport.test.ts
+++ b/src/server/Transport.test.ts
@@ -43,7 +43,7 @@ describe('http', () => {
         {
           "challenge": {
             "expires": "2025-01-01T00:00:00.000Z",
-            "id": "6FkNG-Uv4Ff-viAxYvfyNLhbXbEXcfsbdEtB74ADviw",
+            "id": "N_Q_IM9V5tO3JMcOTniz7anX81m7MdEp4aLW9q5KNK0",
             "intent": "charge",
             "method": "tempo",
             "realm": "api.example.com",
@@ -93,7 +93,7 @@ describe('http', () => {
         {
           "headers": {
             "cache-control": "no-store",
-            "www-authenticate": "Payment id="6FkNG-Uv4Ff-viAxYvfyNLhbXbEXcfsbdEtB74ADviw", realm="api.example.com", method="tempo", intent="charge", request="eyJhbW91bnQiOiIxMDAwMDAwMDAwIiwiY3VycmVuY3kiOiIweDIwYzAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDEiLCJleHBpcmVzIjoiMjAyNS0wMS0wMVQwMDowMDowMC4wMDBaIiwicmVjaXBpZW50IjoiMHg3NDJkMzVDYzY2MzRDMDUzMjkyNWEzYjg0NEJjOWU3NTk1ZjhmRTAwIn0", expires="2025-01-01T00:00:00.000Z"",
+            "www-authenticate": "Payment id="N_Q_IM9V5tO3JMcOTniz7anX81m7MdEp4aLW9q5KNK0", realm="api.example.com", method="tempo", intent="charge", request="eyJhbW91bnQiOiIxMDAwMDAwMDAwIiwiY3VycmVuY3kiOiIweDIwYzAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDEiLCJleHBpcmVzIjoiMjAyNS0wMS0wMVQwMDowMDowMC4wMDBaIiwicmVjaXBpZW50IjoiMHg3NDJkMzVDYzY2MzRDMDUzMjkyNWEzYjg0NEJjOWU3NTk1ZjhmRTAwIn0", expires="2025-01-01T00:00:00.000Z"",
           },
           "status": 402,
         }
@@ -183,7 +183,7 @@ describe('mcp', () => {
         {
           "challenge": {
             "expires": "2025-01-01T00:00:00.000Z",
-            "id": "6FkNG-Uv4Ff-viAxYvfyNLhbXbEXcfsbdEtB74ADviw",
+            "id": "N_Q_IM9V5tO3JMcOTniz7anX81m7MdEp4aLW9q5KNK0",
             "intent": "charge",
             "method": "tempo",
             "realm": "api.example.com",
@@ -221,7 +221,7 @@ describe('mcp', () => {
               "challenges": [
                 {
                   "expires": "2025-01-01T00:00:00.000Z",
-                  "id": "6FkNG-Uv4Ff-viAxYvfyNLhbXbEXcfsbdEtB74ADviw",
+                  "id": "N_Q_IM9V5tO3JMcOTniz7anX81m7MdEp4aLW9q5KNK0",
                   "intent": "charge",
                   "method": "tempo",
                   "realm": "api.example.com",
@@ -262,7 +262,7 @@ describe('mcp', () => {
           "result": {
             "_meta": {
               "org.paymentauth/receipt": {
-                "challengeId": "6FkNG-Uv4Ff-viAxYvfyNLhbXbEXcfsbdEtB74ADviw",
+                "challengeId": "N_Q_IM9V5tO3JMcOTniz7anX81m7MdEp4aLW9q5KNK0",
                 "method": "tempo",
                 "reference": "0xtxhash",
                 "status": "success",


### PR DESCRIPTION
## Summary

Removes `.filter(Boolean)` from the HMAC input array in `computeId()`, fixing a bug where optional challenge fields (`expires`, `digest`) could be stripped without invalidating the challenge ID.

## Problem

The HMAC input was constructed as:

```ts
[realm, method, intent, request, expires ?? "", digest ?? ""]
  .filter(Boolean)  // ← removes empty strings
  .join("|")
```

Because `.filter(Boolean)` removes empty strings, a challenge **with** `expires` unset and one **with** `expires` set to `""` produced the **same HMAC**. More critically, an attacker could strip `expires` from a valid challenge and the HMAC would still verify — effectively removing expiration enforcement.

## Fix

```diff
-  .filter(Boolean)
-  .join("|")
+  .join("|")
```

All fields are now always included in the pipe-delimited HMAC input, ensuring the ID is cryptographically bound to the exact set of parameters present.
