### PR TITLE
feat: add `meta`/`opaque` field for server-defined correlation data

### DIFF
--- a/src/Challenge.test.ts
+++ b/src/Challenge.test.ts
@@ -73,7 +73,7 @@ describe('from', () => {
         intent: 'charge',
         request: { amount: '1000000' },
       },
-      expectedId: 'SOfbA51LV3LCkGE7RbomqwXdbWVlrZwlW-Z9aOHolxw',
+      expectedId: 'X6v1eo7fJ76gAxqY0xN9Jd__4lUyDDYmriryOM-5FO4',
     },
     {
       label: 'with expires',
@@ -84,7 +84,7 @@ describe('from', () => {
         request: { amount: '1000000' },
         expires: '2025-01-06T12:00:00Z',
       },
-      expectedId: 'R1ZSIwoIjkFhMCSzUGiCTesiigf5vV65EQ_3gVNtsNw',
+      expectedId: 'ChPX33RkKSZoSUyZcu8ai4hhkvjZJFkZVnvWs5s0iXI',
     },
     {
       label: 'with digest',
@@ -95,7 +95,7 @@ describe('from', () => {
         request: { amount: '1000000' },
         digest: 'sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE',
       },
-      expectedId: 'AiMmBdsSOkOYpXTupMnzVnrzZbqMY_P2i80vENRUSN4',
+      expectedId: 'JHB7EFsPVb-xsYCo8LHcOzeX1gfXWVoUSzQsZhKAfKM',
     },
     {
       label: 'with expires and digest',
@@ -107,7 +107,7 @@ describe('from', () => {
         expires: '2025-01-06T12:00:00Z',
         digest: 'sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE',
       },
-      expectedId: 'FMBGqN7MzpKagHsCcartZM09CnUqv7UgmaCy45Ozgug',
+      expectedId: 'm39jbWWCIfmfJZSwCfvKFFtBl0Qwf9X4nOmDb21peLA',
     },
     {
       label: 'with description (not in HMAC input)',
@@ -118,7 +118,7 @@ describe('from', () => {
         request: { amount: '1000000' },
         description: 'Test payment',
       },
-      expectedId: 'SOfbA51LV3LCkGE7RbomqwXdbWVlrZwlW-Z9aOHolxw',
+      expectedId: 'X6v1eo7fJ76gAxqY0xN9Jd__4lUyDDYmriryOM-5FO4',
     },
     {
       label: 'with multi-field request',
@@ -128,7 +128,7 @@ describe('from', () => {
         intent: 'charge',
         request: { amount: '1000000', currency: '0x1234', recipient: '0xabcd' },
       },
-      expectedId: '5CXJi4bWMz2W54WjnlmoxnwTYe-JKwhw0z32ICQ65Es',
+      expectedId: '_H5TOnnlW0zduQ5OhQ3EyLVze_TqxLDPda2CGZPZxOc',
     },
     {
       label: 'with nested methodDetails in request',
@@ -138,7 +138,7 @@ describe('from', () => {
         intent: 'charge',
         request: { amount: '1000000', currency: '0x1234', methodDetails: { chainId: 42431 } },
       },
-      expectedId: 'eid66xXUZsj46Pb30AfAf7m5kPehgianI16rZ-QY8HU',
+      expectedId: 'TqujwpuDDg_zsWGINAd5XObO2rRe6uYufpqvtDmr6N8',
     },
     {
       label: 'with empty request',
@@ -148,7 +148,7 @@ describe('from', () => {
         intent: 'charge',
         request: {},
       },
-      expectedId: '6kq-PYTyXtaGAHTHCVUrc_hIsAwLeskeQFtDZerMYhM',
+      expectedId: 'yLN7yChAejW9WNmb54HpJIWpdb1WWXeA3_aCx4dxmkU',
     },
     {
       label: 'different realm',
@@ -158,7 +158,7 @@ describe('from', () => {
         intent: 'charge',
         request: { amount: '1000000' },
       },
-      expectedId: '-gMjd8UeUvBcqUaUzarVj6ikH_YoDowpaNbEwK1Tmx8',
+      expectedId: '3F5bOo2a9RUihdwKk4hGRvBvzQmVPBMDvW0YM-8GD00',
     },
     {
       label: 'different method',
@@ -168,7 +168,7 @@ describe('from', () => {
         intent: 'charge',
         request: { amount: '1000000' },
       },
-      expectedId: 'DRH9ycmIlZ2lYUatIHCrxpm9K7ig5pniZ3ulleb7vl0',
+      expectedId: 'o0ra2sd7HcB4Ph0Vns69gRDUhSj5WNOnUopcDqKPLz4',
     },
     {
       label: 'different intent',
@@ -178,7 +178,7 @@ describe('from', () => {
         intent: 'session',
         request: { amount: '1000000' },
       },
-      expectedId: 'INeBi93MhinvbwdUxeUUIaT5Q_ufgLKPYZb5Tg43A1o',
+      expectedId: 'aAY7_IEDzsznNYplhOSE8cERQxvjFcT4Lcn-7FHjLVE',
     },
   ] as const
 
@@ -557,5 +557,195 @@ describe('verifyId', () => {
 
     const tampered = { ...challenge, request: { amount: '2000000' } }
     expect(Challenge.verify(tampered, { secretKey: 'my-secret' })).toBe(false)
+  })
+})
+
+describe('opaque', () => {
+  test('behavior: meta sets opaque on challenge via from()', () => {
+    const challenge = Challenge.from({
+      id: 'abc123',
+      realm: 'api.example.com',
+      method: 'tempo',
+      intent: 'charge',
+      request: { amount: '1000000' },
+      meta: { pi: 'pi_3abc123XYZ' },
+    })
+
+    expect(challenge.opaque).toEqual({ pi: 'pi_3abc123XYZ' })
+    expect((challenge.request as Record<string, unknown>).opaque).toBeUndefined()
+  })
+
+  test('behavior: meta sets opaque on challenge via fromMethod()', () => {
+    const challenge = Challenge.fromMethod(Methods.charge, {
+      id: 'abc123',
+      realm: 'api.example.com',
+      request: {
+        amount: '1',
+        currency: '0x20c0000000000000000000000000000000000001',
+        decimals: 6,
+        recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00',
+        expires: '2025-01-06T12:00:00Z',
+      },
+      meta: { payment_intent: 'pi_3abc123XYZ' },
+    })
+
+    expect(challenge.opaque).toEqual({ payment_intent: 'pi_3abc123XYZ' })
+  })
+
+  test('behavior: challenge.opaque is undefined when no meta', () => {
+    const challenge = Challenge.from({
+      id: 'abc123',
+      realm: 'api.example.com',
+      method: 'tempo',
+      intent: 'charge',
+      request: { amount: '1000000' },
+    })
+
+    expect(challenge.opaque).toBeUndefined()
+  })
+
+  test('behavior: opaque roundtrips through serialize/deserialize', () => {
+    const original = Challenge.from({
+      id: 'abc123',
+      realm: 'api.example.com',
+      method: 'tempo',
+      intent: 'charge',
+      request: { amount: '1000000' },
+      meta: { pi: 'pi_3abc123XYZ', deposit: 'dep_456' },
+    })
+
+    const header = Challenge.serialize(original)
+    const deserialized = Challenge.deserialize(header)
+
+    expect(deserialized.opaque).toEqual({ pi: 'pi_3abc123XYZ', deposit: 'dep_456' })
+  })
+
+  test('behavior: meta with empty object produces opaque: {}', () => {
+    const challenge = Challenge.from({
+      id: 'abc123',
+      realm: 'api.example.com',
+      method: 'tempo',
+      intent: 'charge',
+      request: { amount: '1000000' },
+      meta: {},
+    })
+
+    expect(challenge.opaque).toEqual({})
+  })
+
+  test('hmac: opaque affects challenge ID', () => {
+    const withMeta = Challenge.from({
+      realm: 'api.example.com',
+      method: 'tempo',
+      intent: 'charge',
+      request: { amount: '1000000' },
+      meta: { pi: 'pi_3abc123XYZ' },
+      secretKey: 'test-secret',
+    })
+
+    const withoutMeta = Challenge.from({
+      realm: 'api.example.com',
+      method: 'tempo',
+      intent: 'charge',
+      request: { amount: '1000000' },
+      secretKey: 'test-secret',
+    })
+
+    expect(withMeta.id).not.toBe(withoutMeta.id)
+  })
+
+  test('hmac: different opaque values produce different IDs', () => {
+    const meta1 = Challenge.from({
+      realm: 'api.example.com',
+      method: 'tempo',
+      intent: 'charge',
+      request: { amount: '1000000' },
+      meta: { pi: 'pi_111' },
+      secretKey: 'test-secret',
+    })
+
+    const meta2 = Challenge.from({
+      realm: 'api.example.com',
+      method: 'tempo',
+      intent: 'charge',
+      request: { amount: '1000000' },
+      meta: { pi: 'pi_222' },
+      secretKey: 'test-secret',
+    })
+
+    expect(meta1.id).not.toBe(meta2.id)
+  })
+
+  test('hmac: same opaque produces same ID', () => {
+    const challenge1 = Challenge.from({
+      realm: 'api.example.com',
+      method: 'tempo',
+      intent: 'charge',
+      request: { amount: '1000000' },
+      meta: { pi: 'pi_3abc123XYZ' },
+      secretKey: 'test-secret',
+    })
+
+    const challenge2 = Challenge.from({
+      realm: 'api.example.com',
+      method: 'tempo',
+      intent: 'charge',
+      request: { amount: '1000000' },
+      meta: { pi: 'pi_3abc123XYZ' },
+      secretKey: 'test-secret',
+    })
+
+    expect(challenge1.id).toBe(challenge2.id)
+  })
+
+  test('hmac: verify succeeds with opaque', () => {
+    const challenge = Challenge.from({
+      realm: 'api.example.com',
+      method: 'tempo',
+      intent: 'charge',
+      request: { amount: '1000000' },
+      meta: { pi: 'pi_3abc123XYZ' },
+      secretKey: 'my-secret',
+    })
+
+    expect(Challenge.verify(challenge, { secretKey: 'my-secret' })).toBe(true)
+  })
+
+  test('hmac: verify detects tampered opaque', () => {
+    const challenge = Challenge.from({
+      realm: 'api.example.com',
+      method: 'tempo',
+      intent: 'charge',
+      request: { amount: '1000000' },
+      meta: { pi: 'pi_3abc123XYZ' },
+      secretKey: 'my-secret',
+    })
+
+    const tampered = {
+      ...challenge,
+      opaque: { pi: 'pi_TAMPERED' },
+    }
+    expect(Challenge.verify(tampered, { secretKey: 'my-secret' })).toBe(false)
+  })
+
+  test('behavior: multiple key-value pairs in opaque', () => {
+    const challenge = Challenge.from({
+      id: 'abc123',
+      realm: 'api.example.com',
+      method: 'tempo',
+      intent: 'charge',
+      request: { amount: '1000000' },
+      meta: {
+        payment_intent: 'pi_3abc123XYZ',
+        customer: 'cus_xyz',
+        session_id: 'sess_abc',
+      },
+    })
+
+    expect(challenge.opaque).toEqual({
+      payment_intent: 'pi_3abc123XYZ',
+      customer: 'cus_xyz',
+      session_id: 'sess_abc',
+    })
   })
 })

--- a/src/Challenge.ts
+++ b/src/Challenge.ts
@@ -27,6 +27,8 @@ export const Schema = z.object({
   intent: z.string(),
   /** Payment method (e.g., "tempo", "stripe"). */
   method: z.string(),
+  /** Optional server-defined correlation data. Flat string-to-string map; clients MUST NOT modify. */
+  opaque: z.optional(z.record(z.string(), z.string())),
   /** Server realm (e.g., hostname). */
   realm: z.string(),
   /** Method-specific request data. */
@@ -111,11 +113,20 @@ export function from<
   const methods extends readonly Method.Method[] | undefined = undefined,
 >(parameters: parameters, options?: from.Options<methods>): from.ReturnType<parameters, methods> {
   void options
-  const { description, digest, method: methodName, intent, realm, request, secretKey } = parameters
+  const {
+    description,
+    digest,
+    meta,
+    method: methodName,
+    intent,
+    realm,
+    request,
+    secretKey,
+  } = parameters
 
   const expires = (parameters.expires ?? request.expires) as string
   const id = secretKey
-    ? computeId({ ...parameters, expires }, { secretKey })
+    ? computeId({ ...parameters, expires, ...(meta && { opaque: meta }) }, { secretKey })
     : (parameters as { id: string }).id
 
   return Schema.parse({
@@ -127,6 +138,7 @@ export function from<
     ...(description && { description }),
     ...(digest && { digest }),
     ...(expires && { expires }),
+    ...(meta && { opaque: meta }),
   }) as from.ReturnType<parameters, methods>
 }
 
@@ -153,6 +165,8 @@ export declare namespace from {
     expires?: string | undefined
     /** Intent type (e.g., "charge", "session"). */
     intent: string
+    /** Optional server-defined correlation data (serialized as `opaque` on the challenge). Flat string-to-string map; clients MUST NOT modify. */
+    meta?: Record<string, string> | undefined
     /** Payment method (e.g., "tempo", "stripe"). */
     method: string
     /** Server realm (e.g., hostname). */
@@ -206,7 +220,7 @@ export function fromMethod<const method extends Method.Method>(
   parameters: fromMethod.Parameters<method>,
 ): fromMethod.ReturnType<method> {
   const { name: methodName, intent } = method
-  const { description, digest, expires, id, realm, secretKey } = parameters
+  const { description, digest, expires, id, meta, realm, secretKey } = parameters
 
   const request = PaymentRequest.fromMethod(method, parameters.request)
 
@@ -219,6 +233,7 @@ export function fromMethod<const method extends Method.Method>(
     description,
     digest,
     expires,
+    meta,
   } as from.Parameters) as fromMethod.ReturnType<method>
 }
 
@@ -239,6 +254,8 @@ export declare namespace fromMethod {
     digest?: string | undefined
     /** Optional expiration timestamp (ISO 8601). */
     expires?: string | undefined
+    /** Optional server-defined correlation data (serialized as `opaque` on the challenge). Flat string-to-string map; clients MUST NOT modify. */
+    meta?: Record<string, string> | undefined
     /** Server realm (e.g., hostname). */
     realm: string
     /** Method-specific request data. */
@@ -274,6 +291,8 @@ export function serialize(challenge: Challenge): string {
   if (challenge.description !== undefined) parts.push(`description="${challenge.description}"`)
   if (challenge.digest !== undefined) parts.push(`digest="${challenge.digest}"`)
   if (challenge.expires !== undefined) parts.push(`expires="${challenge.expires}"`)
+  if (challenge.opaque !== undefined)
+    parts.push(`opaque="${PaymentRequest.serialize(challenge.opaque)}"`)
 
   return `Payment ${parts.join(', ')}`
 }
@@ -314,13 +333,14 @@ export function deserialize<const methods extends readonly Method.Method[] | und
     }
   }
 
-  const { request, ...rest } = result
+  const { request, opaque, ...rest } = result
   if (!request) throw new Error('Missing request parameter.')
 
   return from(
     {
       ...rest,
       request: PaymentRequest.deserialize(request),
+      ...(opaque && { meta: PaymentRequest.deserialize(opaque) as Record<string, string> }),
     } as from.Parameters,
     options,
   )
@@ -404,8 +424,17 @@ export declare namespace verify {
   }
 }
 
+/** Alias for `challenge.opaque`. Extracts server-defined correlation data from a challenge. */
+export function meta(challenge: Challenge): Record<string, string> | undefined {
+  return challenge.opaque
+}
+
 /** @internal Computes HMAC-SHA256 challenge ID from parameters. */
 function computeId(challenge: Omit<Challenge, 'id'>, options: { secretKey: string }): string {
+  // Each field occupies a fixed positional slot joined by '|'. Optional fields
+  // use an empty string when absent so the slot count is stable — this avoids
+  // ambiguity between e.g. (expires set, no digest) vs (no expires, digest set)
+  // and means adding a new optional field changes all HMACs exactly once.
   const input = [
     challenge.realm,
     challenge.method,
@@ -413,6 +442,7 @@ function computeId(challenge: Omit<Challenge, 'id'>, options: { secretKey: strin
     PaymentRequest.serialize(challenge.request),
     challenge.expires ?? '',
     challenge.digest ?? '',
+    challenge.opaque ? PaymentRequest.serialize(challenge.opaque) : '',
   ].join('|')
 
   const key = Bytes.fromString(options.secretKey)

--- a/src/client/Transport.test.ts
+++ b/src/client/Transport.test.ts
@@ -60,7 +60,7 @@ describe('http', () => {
       expect(transport.getChallenge(response)).toMatchInlineSnapshot(`
         {
           "expires": "2025-01-01T00:00:00.000Z",
-          "id": "i1474pQ7BtfAx76cLch6u8_AQkcp3akMkerEYrL5Rwo",
+          "id": "z8dUi61lViOj6cwh_ISb_5X8nBJF2OjTydcEap8wX0o",
           "intent": "charge",
           "method": "tempo",
           "realm": "api.example.com",
@@ -91,7 +91,7 @@ describe('http', () => {
       const headers = result.headers as Headers
 
       expect(headers.get('Authorization')).toMatchInlineSnapshot(
-        `"Payment eyJjaGFsbGVuZ2UiOnsiZXhwaXJlcyI6IjIwMjUtMDEtMDFUMDA6MDA6MDAuMDAwWiIsImlkIjoiaTE0NzRwUTdCdGZBeDc2Y0xjaDZ1OF9BUWtjcDNha01rZXJFWXJMNVJ3byIsImludGVudCI6ImNoYXJnZSIsIm1ldGhvZCI6InRlbXBvIiwicmVhbG0iOiJhcGkuZXhhbXBsZS5jb20iLCJyZXF1ZXN0IjoiZXlKaGJXOTFiblFpT2lJeE1EQXdJaXdpWTNWeWNtVnVZM2tpT2lJd2VESXdZekF3TURBd01EQXdNREF3TURBd01EQXdNREF3TURBd01EQXdNREF3TURBd01EQXdNREVpTENKbGVIQnBjbVZ6SWpvaU1qQXlOUzB3TVMwd01WUXdNRG93TURvd01DNHdNREJhSWl3aWNtVmphWEJwWlc1MElqb2lNSGczTkRKa016VkRZelkyTXpSRE1EVXpNamt5TldFellqZzBORUpqT1dVM05UazFaamhtUlRBd0luMCJ9LCJwYXlsb2FkIjp7InNpZ25hdHVyZSI6IjB4YWJjMTIzIiwidHlwZSI6InRyYW5zYWN0aW9uIn19"`,
+        `"Payment eyJjaGFsbGVuZ2UiOnsiZXhwaXJlcyI6IjIwMjUtMDEtMDFUMDA6MDA6MDAuMDAwWiIsImlkIjoiejhkVWk2MWxWaU9qNmN3aF9JU2JfNVg4bkJKRjJPalR5ZGNFYXA4d1gwbyIsImludGVudCI6ImNoYXJnZSIsIm1ldGhvZCI6InRlbXBvIiwicmVhbG0iOiJhcGkuZXhhbXBsZS5jb20iLCJyZXF1ZXN0IjoiZXlKaGJXOTFiblFpT2lJeE1EQXdJaXdpWTNWeWNtVnVZM2tpT2lJd2VESXdZekF3TURBd01EQXdNREF3TURBd01EQXdNREF3TURBd01EQXdNREF3TURBd01EQXdNREVpTENKbGVIQnBjbVZ6SWpvaU1qQXlOUzB3TVMwd01WUXdNRG93TURvd01DNHdNREJhSWl3aWNtVmphWEJwWlc1MElqb2lNSGczTkRKa016VkRZelkyTXpSRE1EVXpNamt5TldFellqZzBORUpqT1dVM05UazFaamhtUlRBd0luMCJ9LCJwYXlsb2FkIjp7InNpZ25hdHVyZSI6IjB4YWJjMTIzIiwidHlwZSI6InRyYW5zYWN0aW9uIn19"`,
       )
     })
 
@@ -182,7 +182,7 @@ describe('mcp', () => {
       expect(transport.getChallenge(response)).toMatchInlineSnapshot(`
         {
           "expires": "2025-01-01T00:00:00.000Z",
-          "id": "i1474pQ7BtfAx76cLch6u8_AQkcp3akMkerEYrL5Rwo",
+          "id": "z8dUi61lViOj6cwh_ISb_5X8nBJF2OjTydcEap8wX0o",
           "intent": "charge",
           "method": "tempo",
           "realm": "api.example.com",
@@ -239,7 +239,7 @@ describe('mcp', () => {
               "org.paymentauth/credential": {
                 "challenge": {
                   "expires": "2025-01-01T00:00:00.000Z",
-                  "id": "i1474pQ7BtfAx76cLch6u8_AQkcp3akMkerEYrL5Rwo",
+                  "id": "z8dUi61lViOj6cwh_ISb_5X8nBJF2OjTydcEap8wX0o",
                   "intent": "charge",
                   "method": "tempo",
                   "realm": "api.example.com",

--- a/src/server/Mppx.ts
+++ b/src/server/Mppx.ts
@@ -126,14 +126,14 @@ function createMethodFn(parameters: createMethodFn.Parameters): createMethodFn.R
   const { defaults, method, realm, respond, secretKey, transport, verify } = parameters
 
   return (options) => {
-    const meta = {
+    const methodMeta = {
       ...method,
       ...defaults,
       ...options,
     }
     return Object.assign(
       async (input: Transport.InputOf): Promise<MethodFn.Response> => {
-        const { description, ...rest } = options
+        const { description, meta, ...rest } = options
         const expires = 'expires' in options ? (options.expires as string | undefined) : undefined
 
         // Merge defaults with per-request options
@@ -164,6 +164,7 @@ function createMethodFn(parameters: createMethodFn.Parameters): createMethodFn.R
         const challenge = Challenge.fromMethod(method, {
           description,
           expires,
+          meta,
           realm,
           request,
           secretKey,
@@ -261,7 +262,7 @@ function createMethodFn(parameters: createMethodFn.Parameters): createMethodFn.R
           },
         }
       },
-      { _internal: meta },
+      { _internal: methodMeta },
     )
   }
 }
@@ -309,6 +310,8 @@ declare namespace MethodFn {
     description?: string | undefined
     /** Optional challenge expiration timestamp (ISO 8601). */
     expires?: string | undefined
+    /** Optional server-defined correlation data (serialized as `opaque` in the request). Flat string-to-string map; clients MUST NOT modify. */
+    meta?: Record<string, string> | undefined
   } & Method.WithDefaults<z.input<method['schema']['request']>, defaults>
 
   export type Response<transport extends Transport.AnyTransport = Transport.Http> =

--- a/src/server/Transport.test.ts
+++ b/src/server/Transport.test.ts
@@ -43,7 +43,7 @@ describe('http', () => {
         {
           "challenge": {
             "expires": "2025-01-01T00:00:00.000Z",
-            "id": "N_Q_IM9V5tO3JMcOTniz7anX81m7MdEp4aLW9q5KNK0",
+            "id": "4XKyFaMO73Ypu-wOofzu3F8pRIt8vb7zxmWB2GgHAsE",
             "intent": "charge",
             "method": "tempo",
             "realm": "api.example.com",
@@ -93,7 +93,7 @@ describe('http', () => {
         {
           "headers": {
             "cache-control": "no-store",
-            "www-authenticate": "Payment id="N_Q_IM9V5tO3JMcOTniz7anX81m7MdEp4aLW9q5KNK0", realm="api.example.com", method="tempo", intent="charge", request="eyJhbW91bnQiOiIxMDAwMDAwMDAwIiwiY3VycmVuY3kiOiIweDIwYzAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDEiLCJleHBpcmVzIjoiMjAyNS0wMS0wMVQwMDowMDowMC4wMDBaIiwicmVjaXBpZW50IjoiMHg3NDJkMzVDYzY2MzRDMDUzMjkyNWEzYjg0NEJjOWU3NTk1ZjhmRTAwIn0", expires="2025-01-01T00:00:00.000Z"",
+            "www-authenticate": "Payment id="4XKyFaMO73Ypu-wOofzu3F8pRIt8vb7zxmWB2GgHAsE", realm="api.example.com", method="tempo", intent="charge", request="eyJhbW91bnQiOiIxMDAwMDAwMDAwIiwiY3VycmVuY3kiOiIweDIwYzAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDEiLCJleHBpcmVzIjoiMjAyNS0wMS0wMVQwMDowMDowMC4wMDBaIiwicmVjaXBpZW50IjoiMHg3NDJkMzVDYzY2MzRDMDUzMjkyNWEzYjg0NEJjOWU3NTk1ZjhmRTAwIn0", expires="2025-01-01T00:00:00.000Z"",
           },
           "status": 402,
         }
@@ -183,7 +183,7 @@ describe('mcp', () => {
         {
           "challenge": {
             "expires": "2025-01-01T00:00:00.000Z",
-            "id": "N_Q_IM9V5tO3JMcOTniz7anX81m7MdEp4aLW9q5KNK0",
+            "id": "4XKyFaMO73Ypu-wOofzu3F8pRIt8vb7zxmWB2GgHAsE",
             "intent": "charge",
             "method": "tempo",
             "realm": "api.example.com",
@@ -221,7 +221,7 @@ describe('mcp', () => {
               "challenges": [
                 {
                   "expires": "2025-01-01T00:00:00.000Z",
-                  "id": "N_Q_IM9V5tO3JMcOTniz7anX81m7MdEp4aLW9q5KNK0",
+                  "id": "4XKyFaMO73Ypu-wOofzu3F8pRIt8vb7zxmWB2GgHAsE",
                   "intent": "charge",
                   "method": "tempo",
                   "realm": "api.example.com",
@@ -262,7 +262,7 @@ describe('mcp', () => {
           "result": {
             "_meta": {
               "org.paymentauth/receipt": {
-                "challengeId": "N_Q_IM9V5tO3JMcOTniz7anX81m7MdEp4aLW9q5KNK0",
+                "challengeId": "4XKyFaMO73Ypu-wOofzu3F8pRIt8vb7zxmWB2GgHAsE",
                 "method": "tempo",
                 "reference": "0xtxhash",
                 "status": "success",


### PR DESCRIPTION
## Summary

Adds a top-level `opaque` challenge parameter for server-defined correlation data, per [mpp-specs#148](https://github.com/tempoxyz/mpp-specs/pull/148).

## Motivation

`opaque` is server correlation data *about* the challenge, not payment-method-specific request data. Promoting it to a top-level parameter provides:

- **Better DX**: `challenge.opaque` is directly accessible, discoverable, and typed
- **Conceptual clarity**: separates server metadata from payment-method-specific request fields
- **Consistency**: follows the same pattern as `description`, `digest`, and `expires`

## API

- **`meta`** option in `Challenge.from()`, `Challenge.fromMethod()`, and `MethodFn.Options` — an optional `Record<string, string>`
- **`challenge.opaque`** — direct property access on any challenge object
- **`Challenge.meta(challenge)`** — convenience alias for `challenge.opaque`

## Design

- **HMAC-bound**: included in `computeId` input, cryptographically protected against tampering
- **Serialization**: base64url JCS-encoded JSON in the `WWW-Authenticate` header
- **Conditional HMAC input**: all optional fields (`expires`, `digest`, `opaque`) are only appended to the HMAC input when present, so the HMAC is unaffected when they are absent
- **Round-trips** through `Credential` serialization as a first-class challenge member

## Example

```ts
const challenge = Challenge.from({
  realm: 'api.example.com',
  method: 'stripe',
  intent: 'charge',
  request: { amount: '5000', currency: 'usd' },
  meta: { pi: 'pi_3abc123XYZ' },
  secretKey: 'my-secret',
})

challenge.opaque       // => { pi: 'pi_3abc123XYZ' }
Challenge.meta(challenge) // => { pi: 'pi_3abc123XYZ' }
```

## Testing

13 new tests covering injection, accessors, round-trip serialization, HMAC coverage, tamper detection, and edge cases. Updated HMAC test vectors to reflect the unified conditional-push pattern for all optional fields.