### PR TITLE
ci: add CI Gate job for branch protection

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4,6 +4,18 @@ on:
   workflow_dispatch:
 
 jobs:
+  ci-gate:
+    name: CI Gate
+    if: always()
+    needs: [checks, test]
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more required jobs failed or were cancelled"
+            exit 1
+          fi
+
   checks:
     name: Checks
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a single `CI Gate` job to `verify.yml` that `needs: [checks, test]` with `if: always()`. This lets branch protection require only `Verify / CI Gate` instead of maintaining individual job names.

After merging, set `Verify / CI Gate` as the required status check on `main`.