### PR TITLE
docs: add API docs for proxy and response helpers

### DIFF
--- a/src/proxy/internal/Headers.ts
+++ b/src/proxy/internal/Headers.ts
@@ -9,6 +9,7 @@ const hopByHopHeaders = new Set([
   'trailer',
 ])
 
+/** Strips hop-by-hop, auth, encoding, cookie, and forwarding headers from a request before proxying upstream. */
 export function scrub(headers: Headers): Headers {
   const scrubbed = new Headers()
 
@@ -28,6 +29,7 @@ export function scrub(headers: Headers): Headers {
   return scrubbed
 }
 
+/** Strips `content-encoding` and `content-length` from an upstream response so the proxy can re-stream it. */
 export function scrubResponse(response: Response): Response {
   const headers = new Headers(response.headers)
   headers.delete('content-encoding')

--- a/src/proxy/internal/Route.ts
+++ b/src/proxy/internal/Route.ts
@@ -1,5 +1,6 @@
 const httpMethods = new Set(['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS'])
 
+/** Extracts the pathname from a URL, stripping the optional `basePath` prefix. Returns `null` if the path doesn't match. */
 export function pathname(url: URL, basePath?: string): string | null {
   let pathname = url.pathname
   if (basePath) {
@@ -10,6 +11,7 @@ export function pathname(url: URL, basePath?: string): string | null {
   return pathname
 }
 
+/** Splits a `/{serviceId}/rest/of/path` pathname into its service ID and upstream path. */
 export function parse(pathname: string): { serviceId: string; upstreamPath: string } | null {
   const segments = pathname.split('/').filter(Boolean)
   const serviceId = segments[0]
@@ -19,6 +21,7 @@ export function parse(pathname: string): { serviceId: string; upstreamPath: stri
   return { serviceId, upstreamPath }
 }
 
+/** Finds the first route matching both the HTTP method and path (via `URLPattern`). */
 export function match(
   routes: Record<string, unknown>,
   method: string,
@@ -33,6 +36,7 @@ export function match(
   return null
 }
 
+/** Finds the first route matching just the path, ignoring the HTTP method. Used for management POST fallback. */
 export function matchPath(
   routes: Record<string, unknown>,
   path: string,

--- a/src/server/NodeListener.ts
+++ b/src/server/NodeListener.ts
@@ -1,3 +1,9 @@
 import * as FetchServer from '@remix-run/node-fetch-server'
 
+/**
+ * Writes a Fetch API `Response` to a Node.js `ServerResponse`.
+ *
+ * Delegates to `@remix-run/node-fetch-server`. Useful when bridging
+ * Fetch API handlers with Node.js HTTP servers.
+ */
 export const sendResponse = FetchServer.sendResponse

--- a/src/server/Response.ts
+++ b/src/server/Response.ts
@@ -1,6 +1,23 @@
 import * as Challenge from '../Challenge.js'
 import type * as Errors from '../Errors.js'
 
+/**
+ * Creates a 402 Payment Required response with a `WWW-Authenticate: Payment` header.
+ *
+ * Optionally includes RFC 9457 Problem Details in the response body when an error is provided.
+ *
+ * @param parameters - The challenge and optional error.
+ * @returns A 402 Response suitable for returning from a route handler.
+ *
+ * @example
+ * ```ts
+ * import { Challenge } from 'mppx'
+ * import { Response } from 'mppx/server'
+ *
+ * const challenge = Challenge.from({ id: '...', realm: 'api.example.com', method: 'tempo', intent: 'charge', request: { ... } })
+ * return Response.requirePayment({ challenge })
+ * ```
+ */
 export function requirePayment(parameters: requirePayment.Parameters): Response {
   const { challenge, error } = parameters
 


### PR DESCRIPTION
## Summary
- document request header scrubbing and response header normalization helpers in proxy internals
- document route parsing/matching helper behavior in proxy internals
- document Node listener response bridge helper
- document  server response helper with usage notes

## Testing
- pnpm exec biome check src/proxy/internal/Headers.ts src/proxy/internal/Route.ts src/server/NodeListener.ts src/server/Response.ts