### PR TITLE
fix: fall back to feePayer for session close when account is not set

### DIFF
--- a/src/tempo/server/Session.test.ts
+++ b/src/tempo/server/Session.test.ts
@@ -758,6 +758,7 @@ describe('session', () => {
     test('close throws when client has no account', async () => {
       const { channelId, serializedTransaction } = await createSignedOpenTransaction(10000000n)
       const server = createServer({
+        account: undefined,
         getClient: () => createClient({ chain, transport: http() }),
       })
       await openServerChannel(server, channelId, serializedTransaction)
@@ -776,6 +777,35 @@ describe('session', () => {
           request: makeRequest(),
         }),
       ).rejects.toThrow('Cannot close channel: no account available')
+    })
+
+    test('close uses feePayer when account is not set', async () => {
+      const { channelId, serializedTransaction } = await createSignedOpenTransaction(10000000n)
+      const server = createServer({
+        account: undefined,
+        feePayer: accounts[0],
+        getClient: () => createClient({ chain, transport: http() }),
+      })
+      await openServerChannel(server, channelId, serializedTransaction)
+
+      const receipt = await server.verify({
+        credential: {
+          challenge: makeChallenge({ id: 'challenge-2', channelId }),
+          payload: {
+            action: 'close' as const,
+            channelId,
+            cumulativeAmount: '1000000',
+            signature: await signTestVoucher(channelId, 1000000n),
+          },
+        },
+        request: makeRequest(),
+      })
+
+      expect(receipt.status).toBe('success')
+      expect((receipt as SessionReceipt).txHash).toMatch(/^0x/)
+
+      const ch = await store.getChannel(channelId)
+      expect(ch!.finalized).toBe(true)
     })
   })
 

--- a/src/tempo/server/Session.ts
+++ b/src/tempo/server/Session.ts
@@ -219,7 +219,7 @@ export function session<const parameters extends session.Parameters>(p?: paramet
             challenge,
             payload,
             methodDetails,
-            account,
+            account ?? feePayer,
           )
           break
 


### PR DESCRIPTION
When only `feePayer` is configured (without an explicit `account`), `handleClose` received `undefined` as the account parameter, causing `closeOnChain` to throw and the server to return 402 instead of settling the channel on-chain.

## Problem

`Account.resolve()` only sets `account` when `parameters.account` is an `Account` object. When users configure:

```ts
tempo({
  feePayer: privateKeyToAccount(key),
  recipient: '0x...',
  // no account
})
```

`account` resolves to `undefined`, but `feePayer` is correctly set. The `verify()` function passes `account` (undefined) to `handleClose`, which then fails in `closeOnChain` because neither `account` nor `client.account` is available.

## Fix

Pass `account ?? feePayer` to `handleClose` so the feePayer's signing account is used for close operations when no explicit account is configured.