### PR TITLE
fix: add expiration check on credentials in core handler

### DIFF
--- a/src/server/Mppx.test.ts
+++ b/src/server/Mppx.test.ts
@@ -138,6 +138,56 @@ describe('request handler', () => {
     `)
   })
 
+  test('returns 402 when credential challenge is expired', async () => {
+    const pastExpires = new Date(Date.now() - 60_000).toISOString()
+
+    const handle = Mppx.create({ methods: [method], realm, secretKey }).charge({
+      amount: '1000',
+      currency: asset,
+      expires: pastExpires,
+      recipient: accounts[0].address,
+    })
+
+    // Get a fresh challenge (which has the expired timestamp baked in)
+    const firstResult = await handle(new Request('https://example.com/resource'))
+    expect(firstResult.status).toBe(402)
+    if (firstResult.status !== 402) throw new Error()
+
+    const challenge = Challenge.fromResponse(firstResult.challenge)
+
+    const credential = Credential.from({
+      challenge,
+      payload: { signature: '0x123', type: 'transaction' },
+    })
+
+    const result = await handle(
+      new Request('https://example.com/resource', {
+        headers: { Authorization: Credential.serialize(credential) },
+      }),
+    )
+
+    expect(result.status).toBe(402)
+    if (result.status !== 402) throw new Error()
+
+    const body = (await result.challenge.json()) as object
+    expect({
+      ...body,
+      challengeId: '[challengeId]',
+      detail: '[detail]',
+      instance: '[instance]',
+    }).toMatchInlineSnapshot(`
+      {
+        "challengeId": "[challengeId]",
+        "detail": "[detail]",
+        "instance": "[instance]",
+        "status": 402,
+        "title": "Payment Expired",
+        "type": "https://paymentauth.org/problems/payment-expired",
+      }
+    `)
+    expect((body as { detail: string }).detail).toContain('Payment expired at')
+  })
+
   test('returns 402 when payload schema validation fails', async () => {
     const handle = Mppx.create({ methods: [method], realm, secretKey }).charge({
       amount: '1000',

--- a/src/server/Mppx.ts
+++ b/src/server/Mppx.ts
@@ -204,6 +204,18 @@ function createMethodFn(parameters: createMethodFn.Parameters): createMethodFn.R
           return { challenge: response, status: 402 }
         }
 
+        // Reject expired credentials
+        if (credential.challenge.expires && new Date(credential.challenge.expires) < new Date()) {
+          const response = await transport.respondChallenge({
+            challenge,
+            input,
+            error: new Errors.PaymentExpiredError({
+              expires: credential.challenge.expires,
+            }),
+          })
+          return { challenge: response, status: 402 }
+        }
+
         // Validate payload structure against method schema
         try {
           method.schema.credential.payload.parse(credential.payload)


### PR DESCRIPTION
**Summary:** `Challenge.verify()` only validates HMAC integrity—it never checks whether the challenge has expired. An attacker with a valid but expired credential could reuse it indefinitely.

**Fix:** After HMAC verification in the core handler (`src/server/Mppx.ts`), check if `credential.challenge.expires` is in the past. If so, reject with `PaymentExpiredError` and re-issue a fresh challenge.

**Test:** Added test for expired credential rejection that verifies:
- Expired credentials return 402
- Response includes `Payment Expired` problem details
- The expiration timestamp is included in the error detail