### PR TITLE
fix: add single-use credential enforcement / replay prevention

### DIFF
--- a/src/internal/NonceSet.test.ts
+++ b/src/internal/NonceSet.test.ts
@@ -1,0 +1,35 @@
+import { NonceSet } from './NonceSet.js'
+
+describe('NonceSet', () => {
+  test('returns false for unknown nonce', () => {
+    const set = new NonceSet()
+    expect(set.has('unknown')).toBe(false)
+  })
+
+  test('returns true for added nonce', () => {
+    const set = new NonceSet()
+    set.add('nonce-1')
+    expect(set.has('nonce-1')).toBe(true)
+  })
+
+  test('returns false for expired nonce', () => {
+    const set = new NonceSet()
+    const pastExpires = new Date(Date.now() - 1000).toISOString()
+    set.add('expired', pastExpires)
+    expect(set.has('expired')).toBe(false)
+  })
+
+  test('returns true for non-expired nonce', () => {
+    const set = new NonceSet()
+    const futureExpires = new Date(Date.now() + 60_000).toISOString()
+    set.add('valid', futureExpires)
+    expect(set.has('valid')).toBe(true)
+  })
+
+  test('different nonces are independent', () => {
+    const set = new NonceSet()
+    set.add('nonce-a')
+    expect(set.has('nonce-a')).toBe(true)
+    expect(set.has('nonce-b')).toBe(false)
+  })
+})

--- a/src/internal/NonceSet.ts
+++ b/src/internal/NonceSet.ts
@@ -1,0 +1,45 @@
+/** Default TTL for nonces without an explicit expiration (5 minutes). */
+const DEFAULT_TTL = 5 * 60_000
+
+/** Eviction threshold — run cleanup when map exceeds this size. */
+const EVICTION_THRESHOLD = 10_000
+
+/**
+ * In-memory set for tracking used nonces with TTL-based eviction.
+ *
+ * Used for replay prevention — once a nonce is added, `has()` returns
+ * `true` until the TTL expires.
+ */
+export class NonceSet {
+  private entries = new Map<string, number>()
+
+  /** Returns `true` if the nonce has been recorded and has not expired. */
+  has(nonce: string): boolean {
+    const expiry = this.entries.get(nonce)
+    if (expiry === undefined) return false
+    if (Date.now() > expiry) {
+      this.entries.delete(nonce)
+      return false
+    }
+    return true
+  }
+
+  /**
+   * Records a nonce with an expiration time.
+   *
+   * @param nonce - The nonce to record.
+   * @param expires - Optional ISO 8601 expiration. If not provided, uses a default TTL.
+   */
+  add(nonce: string, expires?: string): void {
+    const expiry = expires ? new Date(expires).getTime() : Date.now() + DEFAULT_TTL
+    this.entries.set(nonce, expiry)
+    if (this.entries.size > EVICTION_THRESHOLD) this.evict()
+  }
+
+  private evict(): void {
+    const now = Date.now()
+    for (const [key, expiry] of this.entries) {
+      if (now > expiry) this.entries.delete(key)
+    }
+  }
+}

--- a/src/server/Mppx.ts
+++ b/src/server/Mppx.ts
@@ -3,6 +3,7 @@ import * as Challenge from '../Challenge.js'
 import type * as Credential from '../Credential.js'
 import * as Errors from '../Errors.js'
 import * as Env from '../internal/env.js'
+import { NonceSet } from '../internal/NonceSet.js'
 import type * as Method from '../Method.js'
 import type * as Receipt from '../Receipt.js'
 import type * as z from '../zod.js'
@@ -79,6 +80,7 @@ export function create<
   } = config
 
   const methods = config.methods.flat() as unknown as FlattenMethods<methods>
+  const nonceSet = new NonceSet()
 
   const handlers: Record<string, unknown> = {}
 
@@ -86,6 +88,7 @@ export function create<
     handlers[mi.intent] = createMethodFn({
       defaults: mi.defaults,
       method: mi,
+      nonceSet,
       realm,
       request: mi.request as never,
       respond: mi.respond as never,
@@ -123,7 +126,7 @@ function createMethodFn<
 ): createMethodFn.ReturnType<method, transport, defaults>
 // biome-ignore lint/correctness/noUnusedVariables: _
 function createMethodFn(parameters: createMethodFn.Parameters): createMethodFn.ReturnType {
-  const { defaults, method, realm, respond, secretKey, transport, verify } = parameters
+  const { defaults, method, nonceSet, realm, respond, secretKey, transport, verify } = parameters
 
   return (options) => {
     const methodMeta = {
@@ -204,6 +207,19 @@ function createMethodFn(parameters: createMethodFn.Parameters): createMethodFn.R
           return { challenge: response, status: 402 }
         }
 
+        // Reject replayed credentials
+        if (nonceSet.has(credential.challenge.id)) {
+          const response = await transport.respondChallenge({
+            challenge,
+            input,
+            error: new Errors.InvalidChallengeError({
+              id: credential.challenge.id,
+              reason: 'credential has already been used',
+            }),
+          })
+          return { challenge: response, status: 402 }
+        }
+
         // Validate payload structure against method schema
         try {
           method.schema.credential.payload.parse(credential.payload)
@@ -233,6 +249,9 @@ function createMethodFn(parameters: createMethodFn.Parameters): createMethodFn.R
           })
           return { challenge: response, status: 402 }
         }
+
+        // Record challenge ID as used to prevent replay
+        nonceSet.add(credential.challenge.id, credential.challenge.expires)
 
         // If the method's `respond` hook returns a Response, it means this
         // request is a management action (e.g. channel open, voucher POST)
@@ -275,6 +294,7 @@ declare namespace createMethodFn {
   > = {
     defaults?: defaults
     method: method
+    nonceSet: NonceSet
     realm: string
     request?: Method.RequestFn<method>
     respond?: Method.RespondFn<method>

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -8,7 +8,8 @@ import {
 import { getTransactionReceipt, sendRawTransactionSync, signTransaction } from 'viem/actions'
 import { tempo as tempo_chain } from 'viem/chains'
 import { Abis, Transaction } from 'viem/tempo'
-import { PaymentExpiredError } from '../../Errors.js'
+import { PaymentExpiredError, VerificationFailedError } from '../../Errors.js'
+import { NonceSet } from '../../internal/NonceSet.js'
 import type { LooseOmit } from '../../internal/types.js'
 import * as Method from '../../Method.js'
 import * as Client from '../../viem/Client.js'
@@ -48,6 +49,7 @@ export function charge<const parameters extends charge.Parameters>(
   } = parameters
 
   const { recipient, feePayer } = Account.resolve(parameters)
+  const txHashNonces = new NonceSet()
 
   const getClient = Client.getResolver({
     chain: { ...tempo_chain, experimental_preconfirmationTime: 500 },
@@ -122,6 +124,13 @@ export function charge<const parameters extends charge.Parameters>(
       switch (payload.type) {
         case 'hash': {
           const hash = payload.hash as `0x${string}`
+
+          if (txHashNonces.has(hash)) {
+            throw new VerificationFailedError({
+              reason: 'transaction hash has already been used',
+            })
+          }
+
           const receipt = await getTransactionReceipt(client, {
             hash,
           })
@@ -179,6 +188,7 @@ export function charge<const parameters extends charge.Parameters>(
               })
           }
 
+          txHashNonces.add(hash, expires)
           return toReceipt(receipt)
         }
 


### PR DESCRIPTION
## Security Fix 4: Replay prevention

**Finding:** Credentials could be replayed indefinitely—the server never tracked whether a challenge ID had already been used. For `hash` charge payloads, the same transaction hash could be submitted multiple times.

**Fix:**
- Add `NonceSet` (`src/internal/NonceSet.ts`): in-memory set with TTL-based eviction for tracking used nonces
- Core handler (`src/server/Mppx.ts`): after HMAC verification, reject credentials whose challenge ID has already been used. Record used IDs with TTL bounded by challenge expiry.
- Charge handler (`src/tempo/server/Charge.ts`): for `hash` payloads, reject reused transaction hashes

**Tests:**
- `NonceSet` unit tests: unknown nonce, added nonce, expired nonce, non-expired nonce, independence