### PR TITLE
fix: bind credential verification to route's configured request

### DIFF
--- a/src/server/Mppx.test.ts
+++ b/src/server/Mppx.test.ts
@@ -138,6 +138,48 @@ describe('request handler', () => {
     `)
   })
 
+  test('returns 402 when credential is from a different route (cross-route scope confusion)', async () => {
+    const handler = Mppx.create({ methods: [method], realm, secretKey })
+
+    // Get a challenge from the "cheap" route
+    const cheapHandle = handler.charge({
+      amount: '1',
+      currency: asset,
+      expires: new Date(Date.now() + 60_000).toISOString(),
+      recipient: accounts[0].address,
+    })
+    const cheapResult = await cheapHandle(new Request('https://example.com/cheap'))
+    expect(cheapResult.status).toBe(402)
+    if (cheapResult.status !== 402) throw new Error()
+
+    const cheapChallenge = Challenge.fromResponse(cheapResult.challenge)
+
+    // Build a credential from the cheap challenge
+    const credential = Credential.from({
+      challenge: cheapChallenge,
+      payload: { signature: '0x123', type: 'transaction' },
+    })
+
+    // Present it at the "expensive" route
+    const expensiveHandle = handler.charge({
+      amount: '1000000',
+      currency: asset,
+      expires: new Date(Date.now() + 60_000).toISOString(),
+      recipient: accounts[0].address,
+    })
+    const result = await expensiveHandle(
+      new Request('https://example.com/expensive', {
+        headers: { Authorization: Credential.serialize(credential) },
+      }),
+    )
+
+    expect(result.status).toBe(402)
+    if (result.status !== 402) throw new Error()
+
+    const body = (await result.challenge.json()) as { detail: string }
+    expect(body.detail).toContain('does not match')
+  })
+
   test('returns 402 when credential challenge is expired', async () => {
     const pastExpires = new Date(Date.now() - 60_000).toISOString()
 
@@ -187,7 +229,6 @@ describe('request handler', () => {
     `)
     expect((body as { detail: string }).detail).toContain('Payment expired at')
   })
-
   test('returns 402 when payload schema validation fails', async () => {
     const handle = Mppx.create({ methods: [method], realm, secretKey }).charge({
       amount: '1000',

--- a/src/server/Mppx.ts
+++ b/src/server/Mppx.ts
@@ -210,6 +210,31 @@ function createMethodFn(parameters: createMethodFn.Parameters): createMethodFn.R
           return { challenge: response, status: 402 }
         }
 
+        // Verify the credential's challenge matches this route's configured
+        // request. Prevents cross-route scope confusion where a credential
+        // issued for a cheap route is presented at an expensive route.
+        {
+          const routeReq = challenge.request as Record<string, unknown>
+          const echoedReq = credential.challenge.request as Record<string, unknown>
+          for (const field of ['amount', 'currency', 'recipient'] as const) {
+            if (
+              routeReq[field] !== undefined &&
+              echoedReq[field] !== undefined &&
+              String(routeReq[field]) !== String(echoedReq[field])
+            ) {
+              const response = await transport.respondChallenge({
+                challenge,
+                input,
+                error: new Errors.InvalidChallengeError({
+                  id: credential.challenge.id,
+                  reason: `credential ${field} does not match this route's requirements`,
+                }),
+              })
+              return { challenge: response, status: 402 }
+            }
+          }
+        }
+
         // Reject expired credentials
         if (credential.challenge.expires && new Date(credential.challenge.expires) < new Date()) {
           const response = await transport.respondChallenge({
@@ -221,7 +246,6 @@ function createMethodFn(parameters: createMethodFn.Parameters): createMethodFn.R
           })
           return { challenge: response, status: 402 }
         }
-
         // Validate payload structure against method schema
         try {
           method.schema.credential.payload.parse(credential.payload)


### PR DESCRIPTION
## Summary 

Double checks credentials inputs when a request is made -- ensuring you can't spoof cross-domain challenges
