### PR TITLE
fix(client): harden fetch polyfill — normalize headers, guard polyfill stacking

### DIFF
--- a/src/client/internal/Fetch.test.ts
+++ b/src/client/internal/Fetch.test.ts
@@ -268,15 +268,30 @@ describe('Fetch.from', () => {
   })
 })
 
-describe('Fetch.from: init passthrough', () => {
-  // Minimal mock method — we never hit 402, so this is never invoked
-  const noopMethod = {
-    name: 'test',
-    intent: 'test',
-    context: undefined,
-    createCredential: async () => 'credential',
-  } as any
+// Minimal mock method — createCredential is only invoked on the 402 retry path.
+const noopMethod = {
+  name: 'test',
+  intent: 'test',
+  context: undefined,
+  createCredential: async () => 'credential',
+} as any
 
+/** Builds a valid 402 response with a WWW-Authenticate header. */
+function make402(overrides?: { method?: string; intent?: string }) {
+  const method = overrides?.method ?? 'test'
+  const intent = overrides?.intent ?? 'test'
+  const request = btoa(JSON.stringify({ amount: '1' }))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+  const header = `Payment id="abc", realm="test", method="${method}", intent="${intent}", request="${request}"`
+  return new Response(null, {
+    status: 402,
+    headers: { 'WWW-Authenticate': header },
+  })
+}
+
+describe('Fetch.from: init passthrough (non-402)', () => {
   test('passes unmodified init to underlying fetch for non-402 responses', async () => {
     const receivedInits: (RequestInit | undefined)[] = []
     const mockFetch: typeof globalThis.fetch = async (_input, init) => {
@@ -297,8 +312,6 @@ describe('Fetch.from: init passthrough', () => {
 
     await fetch('https://example.com/ws-upgrade', customInit)
 
-    // The underlying fetch should receive the EXACT same object reference,
-    // not a destructured copy with `context` stripped out
     expect(receivedInits[0]).toBe(customInit)
   })
 
@@ -317,17 +330,309 @@ describe('Fetch.from: init passthrough', () => {
     const customInit = {
       method: 'GET',
       headers: { Authorization: 'Bearer token123' },
-      // Simulates extra props that SDKs may attach
       signal: AbortSignal.timeout(5000),
     }
 
     await fetch('https://example.com/api', customInit)
 
-    // init should arrive with all original properties intact
     const received = receivedInits[0]!
     expect(received.method).toBe('GET')
     expect((received.headers as Record<string, string>).Authorization).toBe('Bearer token123')
     expect(received.signal).toBe(customInit.signal)
+  })
+
+  test('passes through undefined init', async () => {
+    const receivedInits: (RequestInit | undefined)[] = []
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      receivedInits.push(init)
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [noopMethod],
+    })
+
+    await fetch('https://example.com/api')
+    expect(receivedInits[0]).toBeUndefined()
+  })
+
+  test('passes init with context through untouched', async () => {
+    const receivedInits: (RequestInit | undefined)[] = []
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      receivedInits.push(init)
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [noopMethod],
+    })
+
+    const customInit = { method: 'POST', context: { account: '0xabc' } }
+    await fetch('https://example.com/api', customInit as any)
+
+    expect(receivedInits[0]).toBe(customInit)
+  })
+
+  test('preserves object identity across all non-402 status codes', async () => {
+    for (const status of [200, 201, 204, 301, 400, 401, 403, 404, 500, 503]) {
+      const receivedInits: (RequestInit | undefined)[] = []
+      const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+        receivedInits.push(init)
+        return new Response(null, { status })
+      }
+
+      const fetch = Fetch.from({
+        fetch: mockFetch,
+        methods: [noopMethod],
+      })
+
+      const customInit = { method: 'GET' }
+      await fetch('https://example.com/api', customInit)
+      expect(receivedInits[0]).toBe(customInit)
+    }
+  })
+})
+
+describe('Fetch.from: 402 retry path', () => {
+  test('strips context from init on retry', async () => {
+    const calls: { init: RequestInit | undefined }[] = []
+    let callCount = 0
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      calls.push({ init })
+      callCount++
+      if (callCount === 1) return make402()
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [noopMethod],
+    })
+
+    await fetch('https://example.com/api', {
+      method: 'POST',
+      context: { account: '0xabc' },
+    } as any)
+
+    expect(calls).toHaveLength(2)
+    const retryInit = calls[1]!.init as Record<string, unknown>
+    expect(retryInit).not.toHaveProperty('context')
+  })
+
+  test('adds Authorization header on retry', async () => {
+    let callCount = 0
+    const calls: { init: RequestInit | undefined }[] = []
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      calls.push({ init })
+      callCount++
+      if (callCount === 1) return make402()
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [noopMethod],
+    })
+
+    await fetch('https://example.com/api')
+
+    const retryInit = calls[1]!.init as Record<string, unknown>
+    const headers = retryInit.headers as Record<string, string>
+    expect(headers.Authorization).toBe('credential')
+  })
+
+  test('preserves existing headers on retry', async () => {
+    let callCount = 0
+    const calls: { init: RequestInit | undefined }[] = []
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      calls.push({ init })
+      callCount++
+      if (callCount === 1) return make402()
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [noopMethod],
+    })
+
+    await fetch('https://example.com/api', {
+      headers: { 'X-Custom': 'value', 'Content-Type': 'application/json' },
+    })
+
+    const retryInit = calls[1]!.init as Record<string, unknown>
+    const headers = retryInit.headers as Record<string, string>
+    expect(headers['X-Custom']).toBe('value')
+    expect(headers['Content-Type']).toBe('application/json')
+    expect(headers.Authorization).toBe('credential')
+  })
+
+  test('preserves method and other init properties on retry', async () => {
+    let callCount = 0
+    const calls: { init: RequestInit | undefined }[] = []
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      calls.push({ init })
+      callCount++
+      if (callCount === 1) return make402()
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [noopMethod],
+    })
+
+    await fetch('https://example.com/api', {
+      method: 'PUT',
+      body: JSON.stringify({ data: 'test' }),
+      credentials: 'include',
+      mode: 'cors',
+    })
+
+    const retryInit = calls[1]!.init as Record<string, unknown>
+    expect(retryInit.method).toBe('PUT')
+    expect(retryInit.body).toBe(JSON.stringify({ data: 'test' }))
+    expect(retryInit.credentials).toBe('include')
+    expect(retryInit.mode).toBe('cors')
+  })
+
+  test('handles undefined init on 402 retry', async () => {
+    let callCount = 0
+    const calls: { init: RequestInit | undefined }[] = []
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      calls.push({ init })
+      callCount++
+      if (callCount === 1) return make402()
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [noopMethod],
+    })
+
+    await fetch('https://example.com/api')
+
+    expect(calls).toHaveLength(2)
+    const retryInit = calls[1]!.init as Record<string, unknown>
+    expect(retryInit.headers).toEqual({ Authorization: 'credential' })
+  })
+
+  test('throws when no matching method for 402 challenge', async () => {
+    const mockFetch: typeof globalThis.fetch = async () =>
+      make402({ method: 'stripe', intent: 'charge' })
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [noopMethod],
+    })
+
+    await expect(fetch('https://example.com/api')).rejects.toThrow(
+      'No method found for "stripe.charge"',
+    )
+  })
+
+  test('retries exactly once — does not loop on repeated 402', async () => {
+    let callCount = 0
+    const mockFetch: typeof globalThis.fetch = async () => {
+      callCount++
+      return make402()
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [noopMethod],
+    })
+
+    const response = await fetch('https://example.com/api')
+    expect(callCount).toBe(2)
+    expect(response.status).toBe(402)
+  })
+})
+
+describe('Fetch.from: 402 retry headers normalization', () => {
+  test('preserves headers when passed as a Headers instance', async () => {
+    let callCount = 0
+    const calls: { init: RequestInit | undefined }[] = []
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      calls.push({ init })
+      callCount++
+      if (callCount === 1) return make402()
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [noopMethod],
+    })
+
+    const headers = new Headers({ 'X-Custom': 'value', 'Content-Type': 'application/json' })
+    await fetch('https://example.com/api', { headers })
+
+    const retryHeaders = (calls[1]!.init as Record<string, unknown>).headers as Record<
+      string,
+      string
+    >
+    expect(retryHeaders['x-custom']).toBe('value')
+    expect(retryHeaders['content-type']).toBe('application/json')
+    expect(retryHeaders.Authorization).toBe('credential')
+  })
+
+  test('preserves headers when passed as array of tuples', async () => {
+    let callCount = 0
+    const calls: { init: RequestInit | undefined }[] = []
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      calls.push({ init })
+      callCount++
+      if (callCount === 1) return make402()
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [noopMethod],
+    })
+
+    await fetch('https://example.com/api', {
+      headers: [
+        ['X-Custom', 'value'],
+        ['Accept', 'application/json'],
+      ],
+    })
+
+    const retryHeaders = (calls[1]!.init as Record<string, unknown>).headers as Record<
+      string,
+      string
+    >
+    expect(retryHeaders['X-Custom']).toBe('value')
+    expect(retryHeaders.Accept).toBe('application/json')
+    expect(retryHeaders.Authorization).toBe('credential')
+  })
+})
+
+describe('Fetch.from: input passthrough', () => {
+  test('passes URL input through on both initial and retry calls', async () => {
+    let callCount = 0
+    const receivedInputs: (RequestInfo | URL)[] = []
+    const mockFetch: typeof globalThis.fetch = async (input, _init) => {
+      receivedInputs.push(input)
+      callCount++
+      if (callCount === 1) return make402()
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [noopMethod],
+    })
+
+    const url = new URL('https://example.com/resource')
+    await fetch(url)
+
+    expect(receivedInputs[0]).toBe(url)
+    expect(receivedInputs[1]).toBe(url)
   })
 })
 
@@ -374,5 +679,47 @@ describe('Fetch.polyfill', () => {
 
     httpServer.close()
     Fetch.restore()
+  })
+})
+
+describe('Fetch.polyfill / restore', () => {
+  test('restore is a no-op when polyfill was never called', () => {
+    const before = globalThis.fetch
+    Fetch.restore()
+    expect(globalThis.fetch).toBe(before)
+  })
+
+  test('restore reverts to original fetch', () => {
+    const originalFetch = globalThis.fetch
+
+    Fetch.polyfill({ methods: [noopMethod] })
+    expect(globalThis.fetch).not.toBe(originalFetch)
+
+    Fetch.restore()
+    expect(globalThis.fetch).toBe(originalFetch)
+  })
+
+  test('stacked polyfill calls preserve the true original fetch', () => {
+    const originalFetch = globalThis.fetch
+
+    Fetch.polyfill({ methods: [noopMethod] })
+    const firstPolyfill = globalThis.fetch
+
+    Fetch.polyfill({ methods: [noopMethod] })
+    expect(globalThis.fetch).not.toBe(firstPolyfill)
+
+    Fetch.restore()
+    expect(globalThis.fetch).toBe(originalFetch)
+  })
+
+  test('double restore does not clobber fetch', () => {
+    const originalFetch = globalThis.fetch
+
+    Fetch.polyfill({ methods: [noopMethod] })
+    Fetch.restore()
+    expect(globalThis.fetch).toBe(originalFetch)
+
+    Fetch.restore()
+    expect(globalThis.fetch).toBe(originalFetch)
   })
 })

--- a/src/client/internal/Fetch.ts
+++ b/src/client/internal/Fetch.ts
@@ -59,7 +59,7 @@ export function from<const methods extends readonly Method.AnyClient[]>(
     return fetch(input, {
       ...fetchInit,
       headers: {
-        ...(fetchInit.headers as Record<string, string> | undefined),
+        ...normalizeHeaders(fetchInit.headers),
         Authorization: credential,
       },
     })
@@ -127,7 +127,7 @@ export declare namespace from {
 export function polyfill<const methods extends readonly Method.AnyClient[]>(
   config: polyfill.Config<methods>,
 ): void {
-  originalFetch = globalThis.fetch
+  if (!originalFetch) originalFetch = globalThis.fetch
   globalThis.fetch = from(config) as typeof globalThis.fetch
 }
 
@@ -155,6 +155,14 @@ export function restore(): void {
     globalThis.fetch = originalFetch
     originalFetch = undefined
   }
+}
+
+/** @internal Normalizes headers to a plain object for spreading. */
+function normalizeHeaders(headers: unknown): Record<string, string> {
+  if (!headers) return {}
+  if (headers instanceof Headers) return Object.fromEntries(headers.entries())
+  if (Array.isArray(headers)) return Object.fromEntries(headers)
+  return headers as Record<string, string>
 }
 
 /** @internal */


### PR DESCRIPTION
## Summary

Follow-up to #153. Hardens the fetch polyfill with two bug fixes and comprehensive test coverage.

## Fixes

### 1. Headers normalization on 402 retry

When `init.headers` is a `Headers` instance (or `[key, value][]` tuples), spreading it with `...` produces `{}` — silently dropping all headers on the authenticated retry request. Added `normalizeHeaders()` to convert all `HeadersInit` formats to a plain object before spreading.

### 2. Polyfill stacking guard

Calling `polyfill()` twice without `restore()` would overwrite `originalFetch` with the *first* polyfill wrapper, losing the reference to the true original `fetch`. Now guarded with `if (!originalFetch)` so the first original is always preserved.