### PR TITLE
Harden fetch polyfill restore and wrapper safety

### DIFF
--- a/src/client/internal/Fetch.test.ts
+++ b/src/client/internal/Fetch.test.ts
@@ -610,6 +610,34 @@ describe('Fetch.from: 402 retry headers normalization', () => {
     expect(retryHeaders.Accept).toBe('application/json')
     expect(retryHeaders.Authorization).toBe('credential')
   })
+
+  test('replaces existing authorization header case-insensitively', async () => {
+    let callCount = 0
+    const calls: { init: RequestInit | undefined }[] = []
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      calls.push({ init })
+      callCount++
+      if (callCount === 1) return make402()
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [noopMethod],
+    })
+
+    await fetch('https://example.com/api', {
+      headers: { authorization: 'Bearer stale-token', 'X-Custom': 'value' },
+    })
+
+    const retryHeaders = (calls[1]!.init as Record<string, unknown>).headers as Record<
+      string,
+      string
+    >
+    expect(retryHeaders.authorization).toBeUndefined()
+    expect(retryHeaders.Authorization).toBe('credential')
+    expect(retryHeaders['X-Custom']).toBe('value')
+  })
 })
 
 describe('Fetch.from: input passthrough', () => {
@@ -721,5 +749,21 @@ describe('Fetch.polyfill / restore', () => {
 
     Fetch.restore()
     expect(globalThis.fetch).toBe(originalFetch)
+  })
+
+  test('restore is a no-op when fetch was replaced externally after polyfill', () => {
+    const originalFetch = globalThis.fetch
+    const externalFetch = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response('external', { status: 200 }),
+    ) as unknown as typeof globalThis.fetch
+
+    Fetch.polyfill({ methods: [noopMethod] })
+    globalThis.fetch = externalFetch
+
+    Fetch.restore()
+    expect(globalThis.fetch).toBe(externalFetch)
+
+    globalThis.fetch = originalFetch
   })
 })

--- a/src/client/internal/Fetch.ts
+++ b/src/client/internal/Fetch.ts
@@ -2,6 +2,15 @@ import * as Challenge from '../../Challenge.js'
 import type * as Method from '../../Method.js'
 import type * as z from '../../zod.js'
 
+// We tag wrappers with a global symbol so we can recognize wrappers created by mppx,
+// even across multiple module instances/bundles. This lets restore() avoid clobbering
+// an unrelated fetch installed by user code or another library.
+const MPPX_FETCH_WRAPPER = Symbol.for('mppx.fetch.wrapper')
+
+type WrappedFetch = typeof globalThis.fetch & {
+  [MPPX_FETCH_WRAPPER]?: typeof globalThis.fetch
+}
+
 let originalFetch: typeof globalThis.fetch | undefined
 
 /**
@@ -29,10 +38,13 @@ export function from<const methods extends readonly Method.AnyClient[]>(
   config: from.Config<methods>,
 ): from.Fetch<methods> {
   const { fetch = globalThis.fetch, methods, onChallenge } = config
+  // Always operate on the true underlying fetch to avoid wrapper-on-wrapper stacking,
+  // which can duplicate retries and make restore semantics fragile.
+  const baseFetch = unwrapFetch(fetch)
 
-  return async (input, init) => {
+  const wrappedFetch = async (input: RequestInfo | URL, init?: from.RequestInit<methods>) => {
     // Pass init through untouched to preserve object identity for non-402 responses.
-    const response = await fetch(input, init)
+    const response = await baseFetch(input, init)
 
     if (response.status !== 402) return response
 
@@ -55,15 +67,18 @@ export function from<const methods extends readonly Method.AnyClient[]>(
         })
       : undefined
     const credential = onChallengeCredential ?? (await resolveCredential(challenge, mi, context))
+    validateCredentialHeaderValue(credential)
 
-    return fetch(input, {
+    return baseFetch(input, {
       ...fetchInit,
-      headers: {
-        ...normalizeHeaders(fetchInit.headers),
-        Authorization: credential,
-      },
+      headers: withAuthorizationHeader(fetchInit.headers, credential),
     })
   }
+
+  // Record the wrapped target so future polyfill() / restore() calls can detect origin
+  // and safely unwrap only mppx-installed wrappers.
+  ;(wrappedFetch as WrappedFetch)[MPPX_FETCH_WRAPPER] = baseFetch
+  return wrappedFetch as from.Fetch<methods>
 }
 
 /** Union of all context types from all methods that have context schemas. */
@@ -127,8 +142,14 @@ export declare namespace from {
 export function polyfill<const methods extends readonly Method.AnyClient[]>(
   config: polyfill.Config<methods>,
 ): void {
+  // Defensive guard for runtimes/tests where fetch might be non-configurable.
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'fetch')
+  if (!descriptor || (!descriptor.writable && !descriptor.set)) {
+    throw new Error('globalThis.fetch is not writable')
+  }
+
   if (!originalFetch) originalFetch = globalThis.fetch
-  globalThis.fetch = from(config) as typeof globalThis.fetch
+  globalThis.fetch = from({ ...config, fetch: globalThis.fetch }) as typeof globalThis.fetch
 }
 
 export declare namespace polyfill {
@@ -151,7 +172,9 @@ export declare namespace polyfill {
  * ```
  */
 export function restore(): void {
-  if (originalFetch) {
+  // Only restore if the current fetch is still an mppx wrapper.
+  // If app code replaced fetch after polyfill(), we must not overwrite it.
+  if (originalFetch && isWrappedFetch(globalThis.fetch)) {
     globalThis.fetch = originalFetch
     originalFetch = undefined
   }
@@ -169,6 +192,40 @@ function normalizeHeaders(headers: unknown): Record<string, string> {
   }
   if (Array.isArray(headers)) return Object.fromEntries(headers)
   return headers as Record<string, string>
+}
+
+/** @internal */
+function withAuthorizationHeader(headers: unknown, credential: string): Record<string, string> {
+  const normalized = normalizeHeaders(headers)
+  // Remove any existing Authorization header regardless of casing to avoid
+  // duplicate/conflicting credentials on retry.
+  for (const key of Object.keys(normalized)) {
+    if (key.toLowerCase() === 'authorization') delete normalized[key]
+  }
+  normalized.Authorization = credential
+  return normalized
+}
+
+/** @internal */
+function unwrapFetch(fetch: typeof globalThis.fetch): typeof globalThis.fetch {
+  let current = fetch as WrappedFetch
+  while (current[MPPX_FETCH_WRAPPER]) {
+    current = current[MPPX_FETCH_WRAPPER] as WrappedFetch
+  }
+  return current as typeof globalThis.fetch
+}
+
+/** @internal */
+function isWrappedFetch(fetch: typeof globalThis.fetch): fetch is WrappedFetch {
+  return Boolean((fetch as WrappedFetch)[MPPX_FETCH_WRAPPER])
+}
+
+/** @internal */
+function validateCredentialHeaderValue(credential: string): void {
+  if (!credential.trim()) throw new Error('Credential header value must be non-empty')
+  if (credential.includes('\r') || credential.includes('\n')) {
+    throw new Error('Credential header value contains illegal newline characters')
+  }
 }
 
 /** @internal */


### PR DESCRIPTION
## Summary
- tag mppx fetch wrappers with a global symbol so we can reliably detect wrapper ownership
- unwrap to the true base fetch before wrapping to avoid wrapper-on-wrapper chains
- make restore conditional so it only restores when current fetch is still an mppx wrapper
- validate credential header values and replace existing Authorization headers case-insensitively
- add tests for authorization replacement and for restore being a no-op after external fetch replacement
- add inline comments documenting why these defensive measures are needed (especially symbol tagging)