### PR TITLE
fix(mppx): normalize session minVoucherDelta and add coverage

### DIFF
--- a/src/tempo/Methods.test.ts
+++ b/src/tempo/Methods.test.ts
@@ -82,3 +82,25 @@ describe('charge', () => {
     expect(result.success).toBe(false)
   })
 })
+
+describe('session', () => {
+  test('has correct name and intent', () => {
+    expect(Methods.session.intent).toBe('session')
+    expect(Methods.session.name).toBe('tempo')
+  })
+
+  test('schema: encodes minVoucherDelta in base units', () => {
+    const request = Methods.session.schema.request.parse({
+      amount: '1',
+      currency: '0x20c0000000000000000000000000000000000001',
+      decimals: 6,
+      escrowContract: '0x1234567890abcdef1234567890abcdef12345678',
+      minVoucherDelta: '0.1',
+      recipient: '0x1234567890abcdef1234567890abcdef12345678',
+      unitType: 'token',
+    })
+
+    expect(request.amount).toBe('1000000')
+    expect(request.methodDetails?.minVoucherDelta).toBe('100000')
+  })
+})

--- a/src/tempo/Methods.ts
+++ b/src/tempo/Methods.ts
@@ -137,7 +137,9 @@ export const session = Method.from({
           methodDetails: {
             escrowContract,
             ...(channelId !== undefined && { channelId }),
-            ...(minVoucherDelta !== undefined && { minVoucherDelta }),
+            ...(minVoucherDelta !== undefined && {
+              minVoucherDelta: parseUnits(minVoucherDelta, decimals).toString(),
+            }),
             ...(chainId !== undefined && { chainId }),
             ...(feePayer !== undefined && { feePayer }),
           },


### PR DESCRIPTION
Summary:
- convert session request minVoucherDelta to base units in Methods.session transform
- add session schema test coverage for minVoucherDelta normalization