### PR TITLE
fix: consolidate expires into challenge auth-param only

### DIFF
--- a/.changeset/consolidate-expires-authparam.md
+++ b/.changeset/consolidate-expires-authparam.md
@@ -1,0 +1,5 @@
+---
+"mppx": patch
+---
+
+Removed `expires` from charge request schemas (tempo, stripe). Expiry is now conveyed exclusively via the `expires` auth-param on the Challenge, not duplicated in the request body. Server handlers default to `Expires.minutes(5)` when `expires` is not explicitly provided.

--- a/src/Challenge.test.ts
+++ b/src/Challenge.test.ts
@@ -250,12 +250,12 @@ describe('fromMethod', () => {
     const challenge = Challenge.fromMethod(Methods.charge, {
       id: 'abc123',
       realm: 'api.example.com',
+      expires: '2025-01-06T12:00:00Z',
       request: {
         amount: '1',
         currency: '0x20c0000000000000000000000000000000000001',
         decimals: 6,
         recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00',
-        expires: '2025-01-06T12:00:00Z',
       },
     })
 
@@ -269,7 +269,6 @@ describe('fromMethod', () => {
         "request": {
           "amount": "1000000",
           "currency": "0x20c0000000000000000000000000000000000001",
-          "expires": "2025-01-06T12:00:00Z",
           "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00",
         },
       }
@@ -280,12 +279,12 @@ describe('fromMethod', () => {
     const challenge = Challenge.fromMethod(Methods.charge, {
       id: 'abc123',
       realm: 'api.example.com',
+      expires: '2025-01-06T12:00:00Z',
       request: {
         amount: '1',
         currency: '0x20c0000000000000000000000000000000000001',
         decimals: 6,
         recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00',
-        expires: '2025-01-06T12:00:00Z',
         chainId: 42431,
         feePayer: true,
       },
@@ -301,7 +300,6 @@ describe('fromMethod', () => {
         "request": {
           "amount": "1000000",
           "currency": "0x20c0000000000000000000000000000000000001",
-          "expires": "2025-01-06T12:00:00Z",
           "methodDetails": {
             "chainId": 42431,
             "feePayer": true,
@@ -321,7 +319,6 @@ describe('fromMethod', () => {
         currency: '0x20c0000000000000000000000000000000000001',
         decimals: 6,
         recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00',
-        expires: '2025-01-06T12:00:00Z',
       },
       digest: 'sha-256=abc',
       expires: '2025-01-06T12:00:00Z',
@@ -334,12 +331,12 @@ describe('fromMethod', () => {
   test('behavior: creates challenge with HMAC-bound id via secretKey', () => {
     const challenge = Challenge.fromMethod(Methods.charge, {
       realm: 'api.example.com',
+      expires: '2025-01-06T12:00:00Z',
       request: {
         amount: '1',
         currency: '0x20c0000000000000000000000000000000000001',
         decimals: 6,
         recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00',
-        expires: '2025-01-06T12:00:00Z',
       },
       secretKey: 'my-secret',
     })
@@ -358,7 +355,6 @@ describe('fromMethod', () => {
           amount: 123,
           currency: '0x20c0000000000000000000000000000000000001',
           recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00',
-          expires: '2025-01-06T12:00:00Z',
         } as any,
       }),
     ).toThrow()
@@ -584,7 +580,6 @@ describe('opaque', () => {
         currency: '0x20c0000000000000000000000000000000000001',
         decimals: 6,
         recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00',
-        expires: '2025-01-06T12:00:00Z',
       },
       meta: { payment_intent: 'pi_3abc123XYZ' },
     })

--- a/src/Challenge.ts
+++ b/src/Challenge.ts
@@ -125,7 +125,7 @@ export function from<
     secretKey,
   } = parameters
 
-  const expires = (parameters.expires ?? request.expires) as string
+  const expires = parameters.expires as string
   const id = secretKey
     ? computeId({ ...parameters, expires, ...(meta && { opaque: meta }) }, { secretKey })
     : (parameters as { id: string }).id
@@ -205,11 +205,11 @@ export declare namespace from {
  *   Methods.charge,
  *   {
  *     realm: 'api.example.com',
+ *     expires: '2025-01-06T12:00:00Z',
  *     request: {
  *       amount: '1000000',
  *       currency: '0x20c0000000000000000000000000000000000001',
  *       recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00',
- *       expires: '2025-01-06T12:00:00Z',
  *     },
  *   },
  *   { secretKey: 'my-secret' },

--- a/src/PaymentRequest.test.ts
+++ b/src/PaymentRequest.test.ts
@@ -26,13 +26,11 @@ describe('fromMethod', () => {
       currency: '0x20c0000000000000000000000000000000000001',
       decimals: 6,
       recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00',
-      expires: '2025-01-06T12:00:00Z',
     })
     expect(request).toMatchInlineSnapshot(`
       {
         "amount": "1000000",
         "currency": "0x20c0000000000000000000000000000000000001",
-        "expires": "2025-01-06T12:00:00Z",
         "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00",
       }
     `)
@@ -44,14 +42,12 @@ describe('fromMethod', () => {
       currency: '0x20c0000000000000000000000000000000000001',
       decimals: 6,
       recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00',
-      expires: '2025-01-06T12:00:00Z',
       chainId: 42431,
     })
     expect(request).toMatchInlineSnapshot(`
       {
         "amount": "1000000",
         "currency": "0x20c0000000000000000000000000000000000001",
-        "expires": "2025-01-06T12:00:00Z",
         "methodDetails": {
           "chainId": 42431,
         },
@@ -66,7 +62,6 @@ describe('fromMethod', () => {
         amount: 123,
         currency: '0x20c0000000000000000000000000000000000001',
         recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00',
-        expires: '2025-01-06T12:00:00Z',
       } as any),
     ).toThrowErrorMatchingInlineSnapshot(`
       [$ZodError: [

--- a/src/client/Mppx.test.ts
+++ b/src/client/Mppx.test.ts
@@ -82,12 +82,12 @@ describe('createCredential', () => {
     const challenge = Challenge.fromMethod(Methods.charge, {
       realm,
       secretKey,
+      expires: new Date(Date.now() + 60_000).toISOString(),
       request: {
         amount: '1000',
         currency: '0x1234567890123456789012345678901234567890',
         decimals: 6,
         recipient: '0x1234567890123456789012345678901234567890',
-        expires: new Date(Date.now() + 60_000).toISOString(),
       },
     })
 
@@ -164,11 +164,11 @@ describe('createCredential', () => {
       realm,
       method: 'stripe',
       intent: 'charge',
+      expires: new Date(Date.now() + 60_000).toISOString(),
       request: {
         amount: '2000',
         currency: '0xabcd',
         recipient: '0xefgh',
-        expires: new Date(Date.now() + 60_000).toISOString(),
       },
     })
 
@@ -195,12 +195,12 @@ describe('createCredential', () => {
     const challenge = Challenge.fromMethod(Methods.charge, {
       realm,
       secretKey,
+      expires: new Date(Date.now() + 60_000).toISOString(),
       request: {
         amount: '1000',
         currency: '0x1234567890123456789012345678901234567890',
         decimals: 6,
         recipient: '0x1234567890123456789012345678901234567890',
-        expires: new Date(Date.now() + 60_000).toISOString(),
       },
     })
 
@@ -227,12 +227,12 @@ describe('createCredential', () => {
     const challenge = Challenge.fromMethod(Methods.charge, {
       realm,
       secretKey,
+      expires: new Date(Date.now() + 60_000).toISOString(),
       request: {
         amount: '1000',
         currency: '0x1234567890123456789012345678901234567890',
         decimals: 6,
         recipient: '0x1234567890123456789012345678901234567890',
-        expires: new Date(Date.now() + 60_000).toISOString(),
       },
     })
 
@@ -258,12 +258,12 @@ describe('createCredential', () => {
     const challenge = Challenge.fromMethod(Methods.charge, {
       realm,
       secretKey,
+      expires: new Date(Date.now() + 60_000).toISOString(),
       request: {
         amount: '1000',
         currency: '0x1234567890123456789012345678901234567890',
         decimals: 6,
         recipient: '0x1234567890123456789012345678901234567890',
-        expires: new Date(Date.now() + 60_000).toISOString(),
       },
     })
 

--- a/src/client/Transport.test.ts
+++ b/src/client/Transport.test.ts
@@ -9,12 +9,12 @@ const secretKey = 'test-secret-key'
 const challenge = Challenge.fromMethod(Methods.charge, {
   realm,
   secretKey,
+  expires: '2025-01-01T00:00:00.000Z',
   request: {
     amount: '0.001',
     currency: '0x20c0000000000000000000000000000000000001',
     decimals: 6,
     recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00',
-    expires: '2025-01-01T00:00:00.000Z',
   },
 })
 
@@ -60,14 +60,13 @@ describe('http', () => {
       expect(transport.getChallenge(response)).toMatchInlineSnapshot(`
         {
           "expires": "2025-01-01T00:00:00.000Z",
-          "id": "z8dUi61lViOj6cwh_ISb_5X8nBJF2OjTydcEap8wX0o",
+          "id": "0hnrySRDqWfttlDIJpuxV4mJsRJIS7d7RjnufuonJOE",
           "intent": "charge",
           "method": "tempo",
           "realm": "api.example.com",
           "request": {
             "amount": "1000",
             "currency": "0x20c0000000000000000000000000000000000001",
-            "expires": "2025-01-01T00:00:00.000Z",
             "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00",
           },
         }
@@ -91,7 +90,7 @@ describe('http', () => {
       const headers = result.headers as Headers
 
       expect(headers.get('Authorization')).toMatchInlineSnapshot(
-        `"Payment eyJjaGFsbGVuZ2UiOnsiZXhwaXJlcyI6IjIwMjUtMDEtMDFUMDA6MDA6MDAuMDAwWiIsImlkIjoiejhkVWk2MWxWaU9qNmN3aF9JU2JfNVg4bkJKRjJPalR5ZGNFYXA4d1gwbyIsImludGVudCI6ImNoYXJnZSIsIm1ldGhvZCI6InRlbXBvIiwicmVhbG0iOiJhcGkuZXhhbXBsZS5jb20iLCJyZXF1ZXN0IjoiZXlKaGJXOTFiblFpT2lJeE1EQXdJaXdpWTNWeWNtVnVZM2tpT2lJd2VESXdZekF3TURBd01EQXdNREF3TURBd01EQXdNREF3TURBd01EQXdNREF3TURBd01EQXdNREVpTENKbGVIQnBjbVZ6SWpvaU1qQXlOUzB3TVMwd01WUXdNRG93TURvd01DNHdNREJhSWl3aWNtVmphWEJwWlc1MElqb2lNSGczTkRKa016VkRZelkyTXpSRE1EVXpNamt5TldFellqZzBORUpqT1dVM05UazFaamhtUlRBd0luMCJ9LCJwYXlsb2FkIjp7InNpZ25hdHVyZSI6IjB4YWJjMTIzIiwidHlwZSI6InRyYW5zYWN0aW9uIn19"`,
+        `"Payment eyJjaGFsbGVuZ2UiOnsiZXhwaXJlcyI6IjIwMjUtMDEtMDFUMDA6MDA6MDAuMDAwWiIsImlkIjoiMGhucnlTUkRxV2Z0dGxESUpwdXhWNG1Kc1JKSVM3ZDdSam51ZnVvbkpPRSIsImludGVudCI6ImNoYXJnZSIsIm1ldGhvZCI6InRlbXBvIiwicmVhbG0iOiJhcGkuZXhhbXBsZS5jb20iLCJyZXF1ZXN0IjoiZXlKaGJXOTFiblFpT2lJeE1EQXdJaXdpWTNWeWNtVnVZM2tpT2lJd2VESXdZekF3TURBd01EQXdNREF3TURBd01EQXdNREF3TURBd01EQXdNREF3TURBd01EQXdNREVpTENKeVpXTnBjR2xsYm5RaU9pSXdlRGMwTW1Rek5VTmpOall6TkVNd05UTXlPVEkxWVROaU9EUTBRbU01WlRjMU9UVm1PR1pGTURBaWZRIn0sInBheWxvYWQiOnsic2lnbmF0dXJlIjoiMHhhYmMxMjMiLCJ0eXBlIjoidHJhbnNhY3Rpb24ifX0"`,
       )
     })
 
@@ -182,14 +181,13 @@ describe('mcp', () => {
       expect(transport.getChallenge(response)).toMatchInlineSnapshot(`
         {
           "expires": "2025-01-01T00:00:00.000Z",
-          "id": "z8dUi61lViOj6cwh_ISb_5X8nBJF2OjTydcEap8wX0o",
+          "id": "0hnrySRDqWfttlDIJpuxV4mJsRJIS7d7RjnufuonJOE",
           "intent": "charge",
           "method": "tempo",
           "realm": "api.example.com",
           "request": {
             "amount": "1000",
             "currency": "0x20c0000000000000000000000000000000000001",
-            "expires": "2025-01-01T00:00:00.000Z",
             "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00",
           },
         }
@@ -239,14 +237,13 @@ describe('mcp', () => {
               "org.paymentauth/credential": {
                 "challenge": {
                   "expires": "2025-01-01T00:00:00.000Z",
-                  "id": "z8dUi61lViOj6cwh_ISb_5X8nBJF2OjTydcEap8wX0o",
+                  "id": "0hnrySRDqWfttlDIJpuxV4mJsRJIS7d7RjnufuonJOE",
                   "intent": "charge",
                   "method": "tempo",
                   "realm": "api.example.com",
                   "request": {
                     "amount": "1000",
                     "currency": "0x20c0000000000000000000000000000000000001",
-                    "expires": "2025-01-01T00:00:00.000Z",
                     "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00",
                   },
                 },

--- a/src/mcp-sdk/client/McpClient.test.ts
+++ b/src/mcp-sdk/client/McpClient.test.ts
@@ -157,11 +157,11 @@ describe('McpClient.wrap', () => {
     const challenge = Challenge.fromMethod(tempo_server.charge({ getClient: () => testClient }), {
       realm,
       secretKey,
+      expires: new Date(Date.now() + 60_000).toISOString(),
       request: {
         amount: '1',
         currency: asset,
         decimals: 6,
-        expires: new Date(Date.now() + 60_000).toISOString(),
         recipient: accounts[0].address,
       },
     })

--- a/src/server/Mppx.ts
+++ b/src/server/Mppx.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http'
 import * as Challenge from '../Challenge.js'
 import type * as Credential from '../Credential.js'
 import * as Errors from '../Errors.js'
+import * as Expires from '../Expires.js'
 import * as Env from '../internal/env.js'
 import type * as Method from '../Method.js'
 import type * as Receipt from '../Receipt.js'
@@ -173,7 +174,8 @@ function createMethodFn(parameters: createMethodFn.Parameters): createMethodFn.R
     return Object.assign(
       async (input: Transport.InputOf): Promise<MethodFn.Response> => {
         const { description, meta, ...rest } = options
-        const expires = 'expires' in options ? (options.expires as string | undefined) : undefined
+        const expires =
+          'expires' in options ? (options.expires as string | undefined) : Expires.minutes(5)
 
         // Merge defaults with per-request options
         const merged = { ...defaults, ...rest }

--- a/src/server/Transport.test.ts
+++ b/src/server/Transport.test.ts
@@ -10,12 +10,12 @@ const secretKey = 'test-secret-key'
 const challenge = Challenge.fromMethod(Methods.charge, {
   realm,
   secretKey,
+  expires: '2025-01-01T00:00:00.000Z',
   request: {
     amount: '1000',
     currency: '0x20c0000000000000000000000000000000000001',
     decimals: 6,
     recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00',
-    expires: '2025-01-01T00:00:00.000Z',
   },
 })
 
@@ -43,14 +43,13 @@ describe('http', () => {
         {
           "challenge": {
             "expires": "2025-01-01T00:00:00.000Z",
-            "id": "4XKyFaMO73Ypu-wOofzu3F8pRIt8vb7zxmWB2GgHAsE",
+            "id": "QNLtjAvrKKR0VlEGSIowhULqcGlCDU4fjrP-O7js8XE",
             "intent": "charge",
             "method": "tempo",
             "realm": "api.example.com",
             "request": {
               "amount": "1000000000",
               "currency": "0x20c0000000000000000000000000000000000001",
-              "expires": "2025-01-01T00:00:00.000Z",
               "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00",
             },
           },
@@ -93,7 +92,7 @@ describe('http', () => {
         {
           "headers": {
             "cache-control": "no-store",
-            "www-authenticate": "Payment id="4XKyFaMO73Ypu-wOofzu3F8pRIt8vb7zxmWB2GgHAsE", realm="api.example.com", method="tempo", intent="charge", request="eyJhbW91bnQiOiIxMDAwMDAwMDAwIiwiY3VycmVuY3kiOiIweDIwYzAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDEiLCJleHBpcmVzIjoiMjAyNS0wMS0wMVQwMDowMDowMC4wMDBaIiwicmVjaXBpZW50IjoiMHg3NDJkMzVDYzY2MzRDMDUzMjkyNWEzYjg0NEJjOWU3NTk1ZjhmRTAwIn0", expires="2025-01-01T00:00:00.000Z"",
+            "www-authenticate": "Payment id="QNLtjAvrKKR0VlEGSIowhULqcGlCDU4fjrP-O7js8XE", realm="api.example.com", method="tempo", intent="charge", request="eyJhbW91bnQiOiIxMDAwMDAwMDAwIiwiY3VycmVuY3kiOiIweDIwYzAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDEiLCJyZWNpcGllbnQiOiIweDc0MmQzNUNjNjYzNEMwNTMyOTI1YTNiODQ0QmM5ZTc1OTVmOGZFMDAifQ", expires="2025-01-01T00:00:00.000Z"",
           },
           "status": 402,
         }
@@ -183,14 +182,13 @@ describe('mcp', () => {
         {
           "challenge": {
             "expires": "2025-01-01T00:00:00.000Z",
-            "id": "4XKyFaMO73Ypu-wOofzu3F8pRIt8vb7zxmWB2GgHAsE",
+            "id": "QNLtjAvrKKR0VlEGSIowhULqcGlCDU4fjrP-O7js8XE",
             "intent": "charge",
             "method": "tempo",
             "realm": "api.example.com",
             "request": {
               "amount": "1000000000",
               "currency": "0x20c0000000000000000000000000000000000001",
-              "expires": "2025-01-01T00:00:00.000Z",
               "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00",
             },
           },
@@ -221,14 +219,13 @@ describe('mcp', () => {
               "challenges": [
                 {
                   "expires": "2025-01-01T00:00:00.000Z",
-                  "id": "4XKyFaMO73Ypu-wOofzu3F8pRIt8vb7zxmWB2GgHAsE",
+                  "id": "QNLtjAvrKKR0VlEGSIowhULqcGlCDU4fjrP-O7js8XE",
                   "intent": "charge",
                   "method": "tempo",
                   "realm": "api.example.com",
                   "request": {
                     "amount": "1000000000",
                     "currency": "0x20c0000000000000000000000000000000000001",
-                    "expires": "2025-01-01T00:00:00.000Z",
                     "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00",
                   },
                 },
@@ -262,7 +259,7 @@ describe('mcp', () => {
           "result": {
             "_meta": {
               "org.paymentauth/receipt": {
-                "challengeId": "4XKyFaMO73Ypu-wOofzu3F8pRIt8vb7zxmWB2GgHAsE",
+                "challengeId": "QNLtjAvrKKR0VlEGSIowhULqcGlCDU4fjrP-O7js8XE",
                 "method": "tempo",
                 "reference": "0xtxhash",
                 "status": "success",

--- a/src/stripe/Methods.ts
+++ b/src/stripe/Methods.ts
@@ -1,5 +1,4 @@
 import { parseUnits } from 'viem'
-import * as Expires from '../Expires.js'
 import * as Method from '../Method.js'
 import * as z from '../zod.js'
 
@@ -24,7 +23,6 @@ export const charge = Method.from({
         currency: z.string(),
         decimals: z.number(),
         description: z.optional(z.string()),
-        expires: z._default(z.datetime(), () => Expires.minutes(5)),
         externalId: z.optional(z.string()),
         metadata: z.optional(z.record(z.string(), z.string())),
         networkId: z.string(),

--- a/src/stripe/client/Charge.ts
+++ b/src/stripe/client/Charge.ts
@@ -66,8 +66,8 @@ export function charge(parameters: charge.Parameters) {
         )
       }
 
-      const expiresAt = challenge.request.expires
-        ? Math.floor(new Date(challenge.request.expires as string).getTime() / 1000)
+      const expiresAt = challenge.expires
+        ? Math.floor(new Date(challenge.expires).getTime() / 1000)
         : Math.floor(Date.now() / 1000) + 3600
 
       const spt = await createToken({

--- a/src/stripe/server/Charge.ts
+++ b/src/stripe/server/Charge.ts
@@ -66,8 +66,8 @@ export function charge<const parameters extends charge.Parameters>(parameters: p
       const { challenge } = credential
       const { request } = challenge
 
-      if (request.expires && new Date(request.expires) < new Date())
-        throw new PaymentExpiredError({ expires: request.expires })
+      if (challenge.expires && new Date(challenge.expires) < new Date())
+        throw new PaymentExpiredError({ expires: challenge.expires })
 
       const parsed = Methods.charge.schema.credential.payload.safeParse(credential.payload)
       if (!parsed.success) throw new Error('Invalid credential payload: missing or malformed spt')

--- a/src/tempo/Methods.ts
+++ b/src/tempo/Methods.ts
@@ -1,6 +1,5 @@
 import type { Account } from 'viem'
 import { parseUnits } from 'viem'
-import * as Expires from '../Expires.js'
 import * as Method from '../Method.js'
 import * as z from '../zod.js'
 
@@ -26,7 +25,6 @@ export const charge = Method.from({
         currency: z.string(),
         decimals: z.number(),
         description: z.optional(z.string()),
-        expires: z._default(z.datetime(), () => Expires.minutes(5)),
         externalId: z.optional(z.string()),
         feePayer: z.optional(
           z.pipe(

--- a/src/tempo/server/Charge.test.ts
+++ b/src/tempo/server/Charge.test.ts
@@ -114,7 +114,7 @@ describe('tempo', () => {
       const request = challenge.request
       expect(request.recipient).toBe(overrideRecipient)
       expect(request.currency).toBe(overrideCurrency)
-      expect(request.expires).toBe(overrideExpires)
+      expect(challenge.expires).toBe(overrideExpires)
 
       const memo = Attribution.encode({ serverId: challenge.realm })
 

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -103,7 +103,8 @@ export function charge<const parameters extends charge.Parameters>(
       const client = await getClient({ chainId })
 
       const { request: challengeRequest } = challenge
-      const { amount, expires, methodDetails } = challengeRequest
+      const { amount, methodDetails } = challengeRequest
+      const expires = challenge.expires
 
       const currency = challengeRequest.currency as `0x${string}`
       const recipient = challengeRequest.recipient as `0x${string}`


### PR DESCRIPTION
## Summary

Removes `expires` from the charge request schemas. Expiry is now conveyed exclusively via the `expires` auth-param on the Challenge per the core spec.

Implements [tempoxyz/mpp-specs#165](https://github.com/tempoxyz/mpp-specs/pull/165).

### Motivation

`expires` was duplicated in two places — inside the request body AND as a challenge auth-param. This created ambiguity about which value is authoritative. Expiry is a property of the **challenge lifecycle**, not the payment request content. The request describes *what* to pay; the challenge controls *how long you have* to pay it.

### Changes

- **`tempo/Methods.ts`**: Remove `expires` from charge request schema
- **`stripe/Methods.ts`**: Remove `expires` from charge request schema
- **`server/Mppx.ts`**: Add `Expires.minutes(5)` default when `expires` not explicitly provided in handler options
- **`Challenge.ts`**: Remove `request.expires` fallback in `Challenge.from()`
- **`tempo/server/Charge.ts`**: Read expiry from `challenge.expires` (auth-param) instead of `challengeRequest.expires`
- **`stripe/server/Charge.ts`**: Read expiry from `challenge.expires` instead of `request.expires`
- **`stripe/client/Charge.ts`**: Read expiry from `challenge.expires` instead of `challenge.request.expires`
- Updated all tests and snapshots

### Breaking Changes

1. **Server request schemas**: `expires` is no longer accepted in the request input for `tempo.charge()` or `stripe.charge()`. Use the `expires` option at the handler level instead.
2. **Client code reading `challenge.request.expires`**: Must use `challenge.expires` (the auth-param) instead.