### PR TITLE
fix: improve MPP_SECRET_KEY error message

### DIFF
--- a/src/server/Mppx.ts
+++ b/src/server/Mppx.ts
@@ -161,7 +161,8 @@ export function create<
 
   if (!secretKey) {
     throw new Error(
-      'Missing secret key. Set the MPP_SECRET_KEY environment variable or pass `secretKey` to Mppx.create().',
+      'Missing secret key — this is an arbitrary random string used as an HMAC secret for stateless challenge verification. ' +
+        'Set the MPP_SECRET_KEY environment variable or pass `secretKey` to Mppx.create().',
     )
   }
 


### PR DESCRIPTION
The error when `MPP_SECRET_KEY` is missing now explains that it's an arbitrary random string used as an HMAC secret for stateless challenge verification, rather than just saying "set the variable."