### PR TITLE
fix: inject Tempo serializers onto plain clients for viem 2.47+ compat

### DIFF
--- a/src/client/internal/Fetch.test.ts
+++ b/src/client/internal/Fetch.test.ts
@@ -1,9 +1,10 @@
 import { Receipt } from 'mppx'
 import { tempo } from 'mppx/client'
 import { Mppx as Mppx_server, tempo as tempo_server } from 'mppx/server'
-import { createClient } from 'viem'
+import { createClient, defineChain } from 'viem'
 import { describe, expect, test, vi } from 'vitest'
 import * as Http from '~test/Http.js'
+import { rpcUrl } from '~test/tempo/prool.js'
 import { accounts, asset, chain, client, http } from '~test/tempo/viem.js'
 import * as Fetch from './Fetch.js'
 
@@ -229,6 +230,61 @@ describe('Fetch.from', () => {
         "timestamp": "[timestamp]",
       }
     `)
+
+    httpServer.close()
+  })
+
+  test('behavior: fee payer with plain chain client (no Tempo serializers)', async () => {
+    const plainChain = defineChain({
+      id: chain.id,
+      name: chain.name,
+      nativeCurrency: chain.nativeCurrency,
+      rpcUrls: chain.rpcUrls,
+    })
+    const plainClient = createClient({
+      account: accounts[1],
+      chain: plainChain,
+      transport: http(rpcUrl),
+    })
+
+    const serverWithFeePayer = Mppx_server.create({
+      methods: [
+        tempo_server.charge({
+          feePayer: accounts[0],
+          getClient: () => client,
+        }),
+      ],
+      realm,
+      secretKey,
+    })
+
+    const fetch = Fetch.from({
+      methods: [
+        tempo.charge({
+          account: accounts[1],
+          getClient: () => plainClient,
+        }),
+      ],
+    })
+
+    const httpServer = await Http.createServer(async (req, res) => {
+      const result = await Mppx_server.toNodeListener(
+        serverWithFeePayer.charge({
+          amount: '1',
+          currency: asset,
+          expires: new Date(Date.now() + 60_000).toISOString(),
+          recipient: accounts[0].address,
+        }),
+      )(req, res)
+      if (result.status === 402) return
+      res.end('OK')
+    })
+
+    const response = await fetch(httpServer.url)
+    expect(response.status).toBe(200)
+
+    const receipt = Receipt.fromResponse(response)
+    expect(receipt.status).toBe('success')
 
     httpServer.close()
   })

--- a/src/viem/Client.test.ts
+++ b/src/viem/Client.test.ts
@@ -1,3 +1,8 @@
+import { createClient, custom, defineChain, type Hex } from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+import { signTransaction } from 'viem/actions'
+import { tempoLocalnet } from 'viem/chains'
+import { Transaction } from 'viem/tempo'
 import { describe, expect, test } from 'vitest'
 import * as Client from './Client.js'
 
@@ -54,5 +59,196 @@ describe('getResolver', () => {
     expect(() => getClient({ chainId: 99 })).toThrowErrorMatchingInlineSnapshot(
       `[Error: No \`rpcUrl\` configured for \`chainId\` (99).]`,
     )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Serializer injection – ensures user-provided clients without Tempo chain
+// config get Tempo serializers merged in by getResolver.
+// ---------------------------------------------------------------------------
+
+const testAccount = privateKeyToAccount(
+  '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+)
+
+const chainIdHex = `0x${tempoLocalnet.id.toString(16)}`
+const mockTransport = custom({
+  async request({ method }: { method: string }) {
+    if (method === 'eth_chainId') return chainIdHex
+    throw new Error(`Unexpected RPC call: ${method}`)
+  },
+})
+
+const tempoClient = createClient({
+  account: testAccount,
+  chain: tempoLocalnet,
+  transport: mockTransport,
+})
+
+function createPlainClient() {
+  const plainChain = defineChain({
+    id: tempoLocalnet.id,
+    name: 'Tempo (no serializer)',
+    nativeCurrency: { name: 'ETH', symbol: 'ETH', decimals: 18 },
+    rpcUrls: { default: { http: ['http://127.0.0.1:1'] } },
+  })
+  return createClient({
+    account: testAccount,
+    chain: plainChain,
+    transport: mockTransport,
+  })
+}
+
+const feePayer_prepared = {
+  chainId: tempoLocalnet.id,
+  calls: [
+    {
+      to: '0x20c0000000000000000000000000000000000001' as const,
+      data: '0x1234' as Hex,
+    },
+  ],
+  feePayer: true as const,
+  feeToken: '0x20c0000000000000000000000000000000000001' as const,
+  gas: 100_000n,
+  maxFeePerGas: 1_000_000_000n,
+  maxPriorityFeePerGas: 1_000_000n,
+  nonce: 0,
+  nonceKey: 115792089237316195423570985008687907853269984665640564039457584007913129639935n,
+  validBefore: Math.floor(Date.now() / 1000) + 25,
+}
+
+describe('feePayer transaction serialization', () => {
+  test('behavior: signTransaction with Tempo chain and feePayer: true', async () => {
+    const serialized = await signTransaction(tempoClient, {
+      account: testAccount,
+      ...feePayer_prepared,
+    } as never)
+    expect(serialized).toMatch(/^0x7[68]/)
+  })
+
+  test('behavior: signTransaction with gasPrice + type legacy', async () => {
+    const serialized = await signTransaction(tempoClient, {
+      account: testAccount,
+      ...feePayer_prepared,
+      gasPrice: 1_000_000_000n,
+      type: 'legacy' as const,
+    } as never)
+    expect(serialized).toMatch(/^0x7[68]/)
+  })
+
+  test('behavior: fee-payer co-sign with Account object', async () => {
+    const feePayerAccount = privateKeyToAccount(
+      '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d',
+    )
+    const serialized = await signTransaction(tempoClient, {
+      account: feePayerAccount,
+      ...feePayer_prepared,
+      feePayer: feePayerAccount,
+    } as never)
+    expect(serialized).toMatch(/^0x7[68]/)
+  })
+
+  test('behavior: deserialized + re-signed tx (server charge flow)', async () => {
+    const feePayerAccount = privateKeyToAccount(
+      '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d',
+    )
+    const clientSigned = await signTransaction(tempoClient, {
+      account: testAccount,
+      ...feePayer_prepared,
+    } as never)
+    const deserialized = Transaction.deserialize(
+      clientSigned as Transaction.TransactionSerializedTempo,
+    )
+    const serverSigned = await signTransaction(tempoClient, {
+      ...deserialized,
+      account: feePayerAccount,
+      feePayer: feePayerAccount,
+      feeToken: '0x20c0000000000000000000000000000000000001' as const,
+    } as never)
+    expect(serverSigned).toMatch(/^0x7[68]/)
+  })
+})
+
+describe('getResolver serializer injection', () => {
+  test('behavior: injects Tempo serializer onto plain clients', async () => {
+    const plainClient = createPlainClient()
+    expect(plainClient.chain?.serializers?.transaction).toBeUndefined()
+
+    const resolver = Client.getResolver({
+      chain: tempoLocalnet,
+      getClient: () => plainClient,
+    })
+    const resolvedClient = await resolver({})
+
+    expect(resolvedClient.chain?.serializers?.transaction).toBeDefined()
+    const serialized = await signTransaction(resolvedClient, {
+      account: testAccount,
+      ...feePayer_prepared,
+    } as never)
+    expect(serialized).toMatch(/^0x7[68]/)
+  })
+
+  test('behavior: fixes legacy type + feePayer + maxFeePerGas', async () => {
+    const resolver = Client.getResolver({
+      chain: tempoLocalnet,
+      getClient: () => createPlainClient(),
+    })
+    const resolvedClient = await resolver({})
+
+    const serialized = await signTransaction(resolvedClient, {
+      account: testAccount,
+      ...feePayer_prepared,
+      type: 'legacy' as const,
+    } as never)
+    expect(serialized).toMatch(/^0x7[68]/)
+  })
+
+  test('behavior: preserves existing serializers', async () => {
+    const resolver = Client.getResolver({
+      chain: tempoLocalnet,
+      getClient: () => tempoClient,
+    })
+    const resolvedClient = await resolver({})
+
+    expect(resolvedClient.chain?.serializers?.transaction).toBe(
+      tempoClient.chain?.serializers?.transaction,
+    )
+  })
+
+  test('behavior: passes through getClient when chain has no serializers', async () => {
+    const getClient = () => createPlainClient()
+    const resolver = Client.getResolver({
+      chain: undefined,
+      getClient,
+    })
+
+    expect(resolver).toBe(getClient)
+  })
+
+  test('behavior: does not mutate the original client', async () => {
+    const plainClient = createPlainClient()
+    const originalChain = plainClient.chain
+
+    const resolver = Client.getResolver({
+      chain: tempoLocalnet,
+      getClient: () => plainClient,
+    })
+    const resolvedClient = await resolver({})
+
+    expect(plainClient.chain).toBe(originalChain)
+    expect(resolvedClient).not.toBe(plainClient)
+    expect(resolvedClient.chain?.serializers?.transaction).toBeDefined()
+  })
+
+  test('error: plain client without resolver throws on feePayer tx', async () => {
+    const plainClient = createPlainClient()
+
+    await expect(
+      signTransaction(plainClient, {
+        account: testAccount,
+        ...feePayer_prepared,
+        type: 'legacy' as const,
+      } as never),
+    ).rejects.toThrow()
   })
 })

--- a/src/viem/Client.ts
+++ b/src/viem/Client.ts
@@ -11,7 +11,29 @@ export function getResolver(
 ): (parameters: { chainId?: number | undefined }) => MaybePromise<Client> {
   const { chain, getClient, rpcUrl } = parameters
 
-  if (getClient) return getClient
+  if (getClient) {
+    // When a default chain with serializers is provided (e.g. Tempo chain config),
+    // ensure user-provided clients inherit those serializers. Without this, clients
+    // created without the Tempo chain config will use the default viem serializer,
+    // causing errors like "maxFeePerGas is not a valid Legacy Transaction attribute".
+    if (!chain?.serializers) return getClient
+    return async (params) => {
+      const client = await getClient(params)
+      if (client.chain?.serializers?.transaction) return client
+      return Object.assign({}, client, {
+        chain: {
+          ...chain,
+          ...client.chain,
+          formatters: client.chain?.formatters ?? chain.formatters,
+          prepareTransactionRequest:
+            client.chain?.prepareTransactionRequest ?? chain.prepareTransactionRequest,
+          serializers: client.chain?.serializers?.transaction
+            ? client.chain.serializers
+            : chain.serializers,
+        } as typeof client.chain,
+      })
+    }
+  }
 
   return ({ chainId }: { chainId?: number | undefined }) => {
     if (!rpcUrl) throw new Error('No `rpcUrl` provided.')


### PR DESCRIPTION
## Problem

In viem >=2.47, `prepareTransactionRequest` can set `type: 'legacy'` on fee-sponsored transactions. When a user creates a viem client with a plain chain config (no Tempo serializers) and passes it via `getClient`, `signTransaction` falls through to the default viem serializer, which throws:

> "maxFeePerGas/maxPriorityFeePerGas is not a valid Legacy Transaction attribute"

## Fix

`Client.getResolver` now wraps user-provided `getClient` functions to inject Tempo chain serializers, formatters, and `prepareTransactionRequest` onto clients that are missing them.