### PR TITLE
chore: update moderato escrow contract address

### DIFF
--- a/.changeset/update-moderato-escrow.md
+++ b/.changeset/update-moderato-escrow.md
@@ -1,0 +1,5 @@
+---
+"mppx": patch
+---
+
+Updated Moderato (testnet) escrow contract address to `0xe1c4d3dce17bc111181ddf716f75bae49e61a336`.

--- a/src/tempo/client/ChannelOps.test.ts
+++ b/src/tempo/client/ChannelOps.test.ts
@@ -7,6 +7,10 @@ import { deployEscrow, openChannel } from '~test/tempo/session.js'
 import { accounts, asset, chain, client, fundAccount, http } from '~test/tempo/viem.js'
 import type { Challenge } from '../../Challenge.js'
 import * as Credential from '../../Credential.js'
+import {
+  chainId as chainIdDefaults,
+  escrowContract as escrowContractDefaults,
+} from '../internal/defaults.js'
 import { verifyVoucher } from '../session/Voucher.js'
 import {
   createClosePayload,
@@ -17,7 +21,7 @@ import {
   tryRecoverChannel,
 } from './ChannelOps.js'
 
-const escrow42431 = '0x542831e3E4Ace07559b7C8787395f4Fb99F70787' as Address
+const escrow42431 = escrowContractDefaults[chainIdDefaults.testnet] as Address
 
 const localAccount = privateKeyToAccount(
   '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',

--- a/src/tempo/client/Session.test.ts
+++ b/src/tempo/client/Session.test.ts
@@ -6,6 +6,7 @@ import { deployEscrow, openChannel } from '~test/tempo/session.js'
 import { accounts, asset, chain, client, fundAccount } from '~test/tempo/viem.js'
 import * as Challenge from '../../Challenge.js'
 import * as Credential from '../../Credential.js'
+import { chainId, escrowContract as escrowContractDefaults } from '../internal/defaults.js'
 import type { SessionCredentialPayload } from '../session/Types.js'
 import { session } from './Session.js'
 
@@ -22,7 +23,7 @@ const pureClient = createClient({
   transport: http('http://127.0.0.1'),
 })
 
-const escrowAddress = '0x542831e3E4Ace07559b7C8787395f4Fb99F70787' as Address
+const escrowAddress = escrowContractDefaults[chainId.testnet] as Address
 const recipient = '0x2222222222222222222222222222222222222222' as Address
 const currency = '0x3333333333333333333333333333333333333333' as Address
 

--- a/src/tempo/internal/defaults.test.ts
+++ b/src/tempo/internal/defaults.test.ts
@@ -53,7 +53,7 @@ describe('escrowContract', () => {
   })
 
   test('testnet escrow contract', () => {
-    expect(escrowContract[chainId.testnet]).toBe('0x542831e3E4Ace07559b7C8787395f4Fb99F70787')
+    expect(escrowContract[chainId.testnet]).toBe('0xe1c4d3dce17bc111181ddf716f75bae49e61a336')
   })
 })
 

--- a/src/tempo/internal/defaults.ts
+++ b/src/tempo/internal/defaults.ts
@@ -32,7 +32,7 @@ export const decimals = 6
 /** Default payment-channel escrow contract addresses per chain. */
 export const escrowContract = {
   [chainId.mainnet]: '0x33b901018174DDabE4841042ab76ba85D4e24f25',
-  [chainId.testnet]: '0x542831e3E4Ace07559b7C8787395f4Fb99F70787',
+  [chainId.testnet]: '0xe1c4d3dce17bc111181ddf716f75bae49e61a336',
 } as const satisfies Record<ChainId, string>
 
 /** Default RPC URLs for each Tempo chain. */

--- a/src/tempo/server/Session.test.ts
+++ b/src/tempo/server/Session.test.ts
@@ -18,6 +18,10 @@ import {
   InvalidSignatureError,
 } from '../../Errors.js'
 import * as Store from '../../Store.js'
+import {
+  chainId as chainIdDefaults,
+  escrowContract as escrowContractDefaults,
+} from '../internal/defaults.js'
 import type * as Methods from '../Methods.js'
 import * as ChannelStore from '../session/ChannelStore.js'
 import type { SessionReceipt } from '../session/Types.js'
@@ -1309,7 +1313,7 @@ describe('monotonicity and TOCTOU (unit tests)', () => {
       token: '0x0000000000000000000000000000000000000003' as Address,
       authorizedSigner: '0x0000000000000000000000000000000000000004' as Address,
       chainId: 42431,
-      escrowContract: '0x542831e3E4Ace07559b7C8787395f4Fb99F70787' as Address,
+      escrowContract: escrowContractDefaults[chainIdDefaults.testnet] as Address,
       deposit: 10000000n,
       settledOnChain: 0n,
       highestVoucherAmount: 5000000n,

--- a/src/tempo/server/Sse.test.ts
+++ b/src/tempo/server/Sse.test.ts
@@ -1,5 +1,6 @@
 import type { Address, Hex } from 'viem'
 import { describe, expect, test } from 'vitest'
+import { chainId, escrowContract as escrowContractDefaults } from '../internal/defaults.js'
 import type * as ChannelStore from '../session/ChannelStore.js'
 import { serve, toResponse } from '../session/Sse.js'
 
@@ -33,7 +34,7 @@ function seedChannel(
     token: '0x0000000000000000000000000000000000000003' as Address,
     authorizedSigner: '0x0000000000000000000000000000000000000004' as Address,
     chainId: 42431,
-    escrowContract: '0x542831e3E4Ace07559b7C8787395f4Fb99F70787' as Address,
+    escrowContract: escrowContractDefaults[chainId.testnet] as Address,
     deposit: balance,
     settledOnChain: 0n,
     highestVoucherAmount: balance,

--- a/src/tempo/server/internal/transport.test.ts
+++ b/src/tempo/server/internal/transport.test.ts
@@ -2,6 +2,7 @@ import { Challenge, Credential } from 'mppx'
 import type { Address, Hex } from 'viem'
 import { describe, expect, test } from 'vitest'
 import * as Store from '../../../Store.js'
+import { chainId, escrowContract as escrowContractDefaults } from '../../internal/defaults.js'
 import * as ChannelStore from '../../session/ChannelStore.js'
 import { sse } from './transport.js'
 
@@ -23,7 +24,7 @@ function seedChannel(
     token: '0x0000000000000000000000000000000000000003' as Address,
     authorizedSigner: '0x0000000000000000000000000000000000000004' as Address,
     chainId: 42431,
-    escrowContract: '0x542831e3E4Ace07559b7C8787395f4Fb99F70787' as Address,
+    escrowContract: escrowContractDefaults[chainId.testnet] as Address,
     deposit: balance,
     settledOnChain: 0n,
     highestVoucherAmount: balance,

--- a/src/tempo/session/ChannelStore.test.ts
+++ b/src/tempo/session/ChannelStore.test.ts
@@ -1,6 +1,7 @@
 import type { Address, Hex } from 'viem'
 import { describe, expect, test } from 'vitest'
 import * as Store from '../../Store.js'
+import { chainId, escrowContract as escrowContractDefaults } from '../internal/defaults.js'
 import * as ChannelStore from './ChannelStore.js'
 
 const channelId = '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex
@@ -14,7 +15,7 @@ function makeChannel(overrides?: Partial<ChannelStore.State>): ChannelStore.Stat
     token: '0x0000000000000000000000000000000000000003' as Address,
     authorizedSigner: '0x0000000000000000000000000000000000000004' as Address,
     chainId: 42431,
-    escrowContract: '0x542831e3E4Ace07559b7C8787395f4Fb99F70787' as Address,
+    escrowContract: escrowContractDefaults[chainId.testnet] as Address,
     deposit: 10_000_000n,
     settledOnChain: 0n,
     highestVoucherAmount: 10_000_000n,

--- a/src/tempo/session/Sse.test.ts
+++ b/src/tempo/session/Sse.test.ts
@@ -1,5 +1,6 @@
 import type { Address, Hex } from 'viem'
 import { describe, expect, test } from 'vitest'
+import { chainId, escrowContract as escrowContractDefaults } from '../internal/defaults.js'
 import type * as ChannelStore from './ChannelStore.js'
 import { formatNeedVoucherEvent, formatReceiptEvent, parseEvent, serve } from './Sse.js'
 import type { NeedVoucherEvent, SessionReceipt } from './Types.js'
@@ -218,7 +219,7 @@ describe('serve', () => {
       token: '0x0000000000000000000000000000000000000003' as Address,
       authorizedSigner: '0x0000000000000000000000000000000000000004' as Address,
       chainId: 42431,
-      escrowContract: '0x542831e3E4Ace07559b7C8787395f4Fb99F70787' as Address,
+      escrowContract: escrowContractDefaults[chainId.testnet] as Address,
       deposit: balance,
       settledOnChain: 0n,
       highestVoucherAmount: balance,


### PR DESCRIPTION
Update testnet escrow contract to `0xe1c4d3dce17bc111181ddf716f75bae49e61a336`.

Also replaced all hardcoded escrow addresses in test files with imports from `src/tempo/internal/defaults.ts` so they stay in sync.