### PR TITLE
feat: add Whop as a payment method

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ mppx provides abstractions for the complete HTTP 402 payment flow — both clien
 │ payment            │       │ tempo/charge   │
 │                    │       │ tempo/session  │
 │                    │       │ stripe/charge  │
+│                    │       │ whop/charge    │
 └────────────────────┘       └────────────────┘
 ```
 
@@ -115,6 +116,7 @@ Canonical specs live at [tempoxyz/payment-auth-spec](https://github.com/tempoxyz
 | **Intent** | [draft-payment-intent-session-00](https://github.com/tempoxyz/payment-auth-spec/blob/main/specs/intents/draft-payment-intent-session-00.md) | Pay-as-you-go streaming payments |
 | **Method** | [draft-tempo-charge-00](https://github.com/tempoxyz/payment-auth-spec/blob/main/specs/methods/tempo/draft-tempo-charge-00.md) | TIP-20 token transfers on Tempo |
 | **Method** | [draft-tempo-session-00](https://github.com/tempoxyz/payment-auth-spec/blob/main/specs/methods/tempo/draft-tempo-session-00.md) | Tempo payment channels for streaming |
+| **Method** | N/A (uses Whop public API) | Whop checkout-based fiat payments |
 | **Extension** | [draft-payment-discovery-00](https://github.com/tempoxyz/payment-auth-spec/blob/main/specs/extensions/draft-payment-discovery-00.md) | `/.well-known/payment` discovery |
 
 ### Key Protocol Details
@@ -141,6 +143,66 @@ id = base64url(HMAC-SHA256(server_secret, input))
 ```
 
 **Verification:** Server recomputes HMAC from echoed challenge parameters and compares to `id`. If mismatch, reject credential.
+
+### Whop Method (`whop/charge`)
+
+The `whop/charge` method uses Whop's existing public API for fiat payments — no Whop backend changes required.
+
+**Flow:**
+1. Server creates a Whop checkout configuration via `checkoutConfigurations.create()` and embeds the `purchase_url` in the challenge `meta`
+2. Client opens the checkout URL (popup/new tab), user enters card and pays
+3. Client sends the Whop payment ID as the credential payload
+4. Server verifies via `payments.retrieve()` on the Whop API
+
+**Server setup:**
+```ts
+import { Mppx, whop } from 'mppx/server'
+
+const mppx = Mppx.create({
+  methods: [
+    whop({
+      apiKey: process.env.WHOP_API_KEY!,  // or client: whopSdkInstance
+      companyId: 'biz_xxx',
+      currency: 'usd',
+    }),
+  ],
+})
+
+// In handler: create checkout config, pass purchase_url via meta
+const checkout = await createCheckout({ apiKey, companyId, amount: 5.0 })
+const result = await mppx.charge({
+  amount: 5.0,
+  meta: { purchase_url: checkout.purchase_url },
+})(request)
+```
+
+**Client setup:**
+```ts
+import { Mppx, whop } from 'mppx/client'
+
+const mppx = Mppx.create({
+  methods: [
+    whop({
+      completeCheckout: async ({ purchaseUrl }) => {
+        window.open(purchaseUrl, '_blank')
+        // wait for payment completion, return payment ID
+        return paymentId
+      },
+    }),
+  ],
+})
+```
+
+**Key files:**
+- `src/whop/Methods.ts` — method definition (name: `whop`, intent: `charge`)
+- `src/whop/client/Charge.ts` — client credential creation via `completeCheckout` callback
+- `src/whop/server/Charge.ts` — server verification via Whop `payments.retrieve()`, plus `createCheckout` utility
+- `src/whop/internal/types.ts` — duck-typed `WhopClient` interface
+- `src/cli/plugins/whop.ts` — CLI plugin (opens browser, prompts for payment ID)
+- `src/proxy/services/whop.ts` — Whop proxy service definition
+
+**Environment variables:**
+- `WHOP_API_KEY` — Whop Company or App API key (needs `checkout_configuration:create`, `payment:basic:read`)
 
 ## Commands
 

--- a/examples/whop/index.html
+++ b/examples/whop/index.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>mppx + Whop Checkout Example</title>
+    <style>
+      * { box-sizing: border-box; margin: 0; padding: 0; }
+      body {
+        font-family: system-ui, -apple-system, sans-serif;
+        background: #0a0a0a;
+        color: #fafafa;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        min-height: 100vh;
+      }
+      .container { text-align: center; max-width: 520px; padding: 2rem; width: 100%; }
+      h1 { font-size: 1.5rem; margin-bottom: 0.5rem; }
+      .subtitle { color: #888; margin-bottom: 2rem; font-size: 0.9rem; }
+      button {
+        background: #6c5ce7; color: white; border: none;
+        padding: 12px 32px; border-radius: 8px; font-size: 1rem;
+        cursor: pointer; transition: opacity 0.2s;
+      }
+      button:hover { opacity: 0.9; }
+      button:disabled { opacity: 0.5; cursor: not-allowed; }
+      #output { margin-top: 1.5rem; min-height: 60px; }
+      .fortune {
+        background: #1a1a2e; border: 1px solid #333; border-radius: 8px;
+        padding: 1.5rem; font-style: italic; line-height: 1.6;
+      }
+      .placeholder { color: #666; }
+      .error { color: #e74c3c; }
+      #setup { color: #888; }
+      #ready { display: none; }
+      .price { color: #6c5ce7; font-weight: bold; }
+      .payment-form {
+        background: #1a1a2e; border: 1px solid #333; border-radius: 8px;
+        padding: 1.5rem; margin-top: 1.5rem; display: none;
+      }
+      .payment-form.visible { display: block; }
+      .status-text { font-size: 0.9rem; color: #aaa; margin-bottom: 1rem; }
+      .spinner { display: inline-block; width: 16px; height: 16px;
+        border: 2px solid #444; border-top-color: #6c5ce7;
+        border-radius: 50%; animation: spin 0.8s linear infinite;
+        vertical-align: middle; margin-right: 8px;
+      }
+      @keyframes spin { to { transform: rotate(360deg); } }
+      .checkout-link { margin-bottom: 1rem; }
+      .checkout-link a { color: #6c5ce7; text-decoration: none; font-size: 0.9rem; }
+      .checkout-link a:hover { text-decoration: underline; }
+      .manual-input { margin-top: 1rem; padding-top: 1rem; border-top: 1px solid #333; display: none; }
+      .manual-input label { display: block; font-size: 0.8rem; color: #888; margin-bottom: 0.5rem; text-align: left; }
+      .input-row { display: flex; gap: 0.5rem; }
+      .manual-input input {
+        flex: 1; background: #0a0a0a; border: 1px solid #444; border-radius: 6px;
+        padding: 10px 12px; color: #fafafa; font-family: monospace; font-size: 0.9rem;
+      }
+      .manual-input input:focus { outline: none; border-color: #6c5ce7; }
+      .manual-input input::placeholder { color: #555; }
+      .manual-input button { padding: 10px 20px; font-size: 0.9rem; }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1>Fortune Cookie</h1>
+      <p class="subtitle">Pay <span class="price">$1.00</span> via Whop Checkout for a fortune</p>
+      <div id="setup">Loading...</div>
+      <div id="ready">
+        <button id="button">Get Fortune ($1.00)</button>
+        <div id="payment-form" class="payment-form">
+          <div id="checkout-status" class="status-text">
+            <span class="spinner"></span> Waiting for payment...
+          </div>
+          <div id="checkout-link" class="checkout-link"></div>
+          <div id="manual-input" class="manual-input">
+            <label for="payment-id-input">Or paste your payment ID manually</label>
+            <div class="input-row">
+              <input type="text" id="payment-id-input" placeholder="pay_xxxxxxxxxxxxx" autocomplete="off" spellcheck="false" />
+              <button id="submit-payment">Submit</button>
+            </div>
+          </div>
+        </div>
+        <div id="output"></div>
+      </div>
+    </div>
+    <script type="module" src="/src/client.ts"></script>
+  </body>
+</html>

--- a/examples/whop/package.json
+++ b/examples/whop/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "whop",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@remix-run/node-fetch-server": "latest",
+    "@types/node": "latest",
+    "mppx": "latest",
+    "typescript": "latest",
+    "vite": "latest"
+  }
+}

--- a/examples/whop/src/client.ts
+++ b/examples/whop/src/client.ts
@@ -1,0 +1,103 @@
+import { Mppx, whop } from 'mppx/client'
+
+let resolvePaymentId: ((id: string) => void) | null = null
+
+const mppx = Mppx.create({
+  methods: [
+    whop({
+      completeCheckout: async ({ purchaseUrl }) => {
+        const form = document.getElementById('payment-form')!
+        const statusEl = document.getElementById('checkout-status')!
+        const linkEl = document.getElementById('checkout-link')!
+        const manualInput = document.getElementById('manual-input')!
+
+        // Show the waiting UI
+        form.classList.add('visible')
+        statusEl.innerHTML = '<span class="spinner"></span> Waiting for payment...'
+        linkEl.innerHTML = `<a href="${purchaseUrl}" target="_blank">Open checkout again &rarr;</a>`
+        manualInput.style.display = 'none'
+
+        // Open checkout in a new tab
+        window.open(purchaseUrl, '_blank')
+
+        // Extract session ID for polling
+        const sessionId = new URL(purchaseUrl).searchParams.get('session') ?? ''
+
+        return new Promise<string>((resolve, reject) => {
+          resolvePaymentId = resolve
+          let attempts = 0
+
+          const poll = setInterval(async () => {
+            attempts++
+
+            // Show manual fallback after 20 seconds
+            if (attempts === 10) {
+              manualInput.style.display = 'block'
+            }
+
+            // Give up polling after 5 minutes
+            if (attempts > 150) {
+              clearInterval(poll)
+              statusEl.innerHTML = 'Polling timed out. Enter payment ID manually:'
+              return
+            }
+
+            try {
+              const res = await fetch(`/api/check-payment?session=${encodeURIComponent(sessionId)}`)
+              const data = (await res.json()) as { status: string; paymentId?: string }
+
+              if (data.status === 'paid' && data.paymentId) {
+                clearInterval(poll)
+                statusEl.innerHTML = `Payment confirmed: <code>${data.paymentId}</code>`
+                form.classList.remove('visible')
+                resolvePaymentId = null
+                resolve(data.paymentId)
+              }
+            } catch {
+              // will retry
+            }
+          }, 2000)
+        })
+      },
+    }),
+  ],
+})
+
+// Manual fallback
+function submitPaymentId() {
+  const input = document.getElementById('payment-id-input') as HTMLInputElement
+  const id = input.value.trim()
+  if (!id) return
+  document.getElementById('payment-form')!.classList.remove('visible')
+  if (resolvePaymentId) {
+    resolvePaymentId(id)
+    resolvePaymentId = null
+  }
+}
+document.getElementById('submit-payment')!.addEventListener('click', submitPaymentId)
+document.getElementById('payment-id-input')!.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter') submitPaymentId()
+})
+
+// Main button
+document.getElementById('button')!.addEventListener('click', async () => {
+  const output = document.getElementById('output')!
+  const button = document.getElementById('button') as HTMLButtonElement
+  button.disabled = true
+  output.innerHTML = '<div class="placeholder">Requesting payment...</div>'
+  try {
+    const res = await mppx.fetch('/api/fortune')
+    if (!res.ok) throw new Error(`Request failed: ${res.status}`)
+    const { fortune } = (await res.json()) as { fortune: string }
+    output.innerHTML = `<div class="fortune">${fortune}</div>`
+  } catch (err) {
+    output.innerHTML = `<span class="error">${String(err)}</span>`
+  } finally {
+    button.disabled = false
+  }
+})
+
+const setup = document.getElementById('setup')
+const ready = document.getElementById('ready')
+if (setup) setup.style.display = 'none'
+if (ready) ready.style.display = 'block'

--- a/examples/whop/src/server.ts
+++ b/examples/whop/src/server.ts
@@ -1,0 +1,138 @@
+import { Mppx, whop } from 'mppx/server'
+
+const apiKey = process.env.WHOP_API_KEY!
+const companyId = process.env.WHOP_COMPANY_ID!
+
+if (!apiKey) throw new Error('WHOP_API_KEY environment variable is required')
+if (!companyId) throw new Error('WHOP_COMPANY_ID environment variable is required')
+
+const mppx = Mppx.create({
+  methods: [
+    whop({
+      apiKey,
+      companyId,
+      currency: 'usd',
+    }),
+  ],
+})
+
+// Track checkout sessions → payment IDs
+const pendingCheckouts = new Map<string, { planId: string; paymentId?: string; createdAt: number }>()
+
+export async function handler(request: Request): Promise<Response | null> {
+  const url = new URL(request.url)
+
+  // Free health check
+  if (url.pathname === '/api/health') {
+    return Response.json({ status: 'ok' })
+  }
+
+  // Paid fortune endpoint
+  if (url.pathname === '/api/fortune') {
+    const checkoutConfig = await createCheckoutConfig(apiKey, companyId, 1.0)
+
+    // Store the session for polling
+    const sessionTag = new URL(checkoutConfig.purchase_url).searchParams.get('session') ??
+      checkoutConfig.id
+    pendingCheckouts.set(sessionTag, {
+      planId: checkoutConfig.plan_id ?? '',
+      createdAt: Date.now(),
+    })
+
+    const result = await mppx.charge({
+      amount: 1.0,
+      meta: {
+        purchase_url: checkoutConfig.purchase_url,
+        session_id: sessionTag,
+      },
+    })(request)
+
+    if (result.status === 402) return result.challenge
+
+    const fortune = fortunes[Math.floor(Math.random() * fortunes.length)]!
+    return result.withReceipt(Response.json({ fortune }))
+  }
+
+  // Poll endpoint — client checks if payment completed for a session
+  if (url.pathname === '/api/check-payment') {
+    const sessionId = url.searchParams.get('session')
+    if (!sessionId) return Response.json({ error: 'session required' }, { status: 400 })
+
+    const entry = pendingCheckouts.get(sessionId)
+    if (!entry) return Response.json({ status: 'unknown' })
+
+    // If we already found the payment, return it
+    if (entry.paymentId) {
+      return Response.json({ status: 'paid', paymentId: entry.paymentId })
+    }
+
+    // Poll Whop API for recent payments
+    try {
+      const res = await fetch(
+        `https://api.whop.com/api/v1/payments?company_id=${companyId}&per=10`,
+        { headers: { Authorization: `Bearer ${apiKey}` } },
+      )
+      if (res.ok) {
+        const data = (await res.json()) as {
+          data: Array<{ id: string; status: string; total: number; created_at: string }>
+        }
+        // Find a recent paid payment matching our amount
+        for (const payment of data.data) {
+          if (
+            (payment.status === 'paid' || payment.status === 'succeeded') &&
+            payment.total === 1.0 &&
+            // Only consider payments created after our checkout
+            new Date(payment.created_at).getTime() >= entry.createdAt - 5000
+          ) {
+            entry.paymentId = payment.id
+            return Response.json({ status: 'paid', paymentId: payment.id })
+          }
+        }
+      }
+    } catch {
+      // Polling failed, client will retry
+    }
+
+    return Response.json({ status: 'pending' })
+  }
+
+  return null
+}
+
+async function createCheckoutConfig(apiKey: string, companyId: string, amount: number) {
+  const response = await fetch('https://api.whop.com/api/v1/checkout_configurations', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      plan: {
+        initial_price: amount,
+        plan_type: 'one_time',
+        currency: 'usd',
+        company_id: companyId,
+      },
+    }),
+  })
+
+  if (!response.ok) {
+    const error = await response.text()
+    throw new Error(`Failed to create checkout config: ${error}`)
+  }
+
+  return (await response.json()) as { id: string; purchase_url: string; plan_id?: string }
+}
+
+const fortunes = [
+  'A beautiful, smart, and loving person will come into your life.',
+  'A dubious friend may be an enemy in camouflage.',
+  'A faithful friend is a strong defense.',
+  'A fresh start will put you on your way.',
+  'A golden egg of opportunity falls into your lap this month.',
+  'A good time to finish up old tasks.',
+  'A hunch is creativity trying to tell you something.',
+  'A lifetime of happiness lies ahead of you.',
+  'A light heart carries you through all the hard times.',
+  'A new perspective will come with the new year.',
+]

--- a/examples/whop/tsconfig.json
+++ b/examples/whop/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "lib": ["ESNext", "DOM", "DOM.Iterable"]
+  },
+  "include": ["src"]
+}

--- a/examples/whop/vite.config.ts
+++ b/examples/whop/vite.config.ts
@@ -1,0 +1,29 @@
+import { createRequest, sendResponse } from '@remix-run/node-fetch-server'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  plugins: [
+    {
+      name: 'api',
+      async configureServer(server) {
+        const { handler } = await import('./src/server.ts')
+        server.middlewares.use(async (req, res, next) => {
+          const request = createRequest(req, res)
+          const response = await handler(request)
+          if (response) await sendResponse(res, response)
+          else next()
+        })
+        server.httpServer?.once('listening', () => {
+          const addr = server.httpServer!.address()
+          const host =
+            typeof addr === 'object' && addr ? `localhost:${addr.port}` : 'localhost:5173'
+          const pm = process.env.npm_config_user_agent?.split('/')[0] ?? 'npx'
+          setTimeout(
+            () => console.log(`\n  ${pm === 'npm' ? 'npx' : pm} mppx ${host}/api/fortune\n`),
+            100,
+          )
+        })
+      },
+    },
+  ],
+})

--- a/package.json
+++ b/package.json
@@ -141,6 +141,21 @@
       "src": "./src/stripe/server/index.ts",
       "default": "./dist/stripe/server/index.js"
     },
+    "./whop": {
+      "types": "./dist/whop/index.d.ts",
+      "src": "./src/whop/index.ts",
+      "default": "./dist/whop/index.js"
+    },
+    "./whop/client": {
+      "types": "./dist/whop/client/index.d.ts",
+      "src": "./src/whop/client/index.ts",
+      "default": "./dist/whop/client/index.js"
+    },
+    "./whop/server": {
+      "types": "./dist/whop/server/index.d.ts",
+      "src": "./src/whop/server/index.ts",
+      "default": "./dist/whop/server/index.js"
+    },
     "./tempo": {
       "types": "./dist/tempo/index.d.ts",
       "src": "./src/tempo/index.ts",

--- a/src/cli/plugins/index.ts
+++ b/src/cli/plugins/index.ts
@@ -1,3 +1,4 @@
 export { createPlugin, type Plugin } from './plugin.js'
 export { stripe } from './stripe.js'
 export { tempo } from './tempo.js'
+export { whop } from './whop.js'

--- a/src/cli/plugins/whop.ts
+++ b/src/cli/plugins/whop.ts
@@ -1,0 +1,98 @@
+import { Errors } from 'incur'
+import { whop as whopMethods } from '../../whop/client/index.js'
+import { pc } from '../utils.js'
+import { createPlugin } from './plugin.js'
+
+export function whop() {
+  return createPlugin({
+    method: 'whop',
+
+    async setup({ challenge }) {
+      const challengeRequest = challenge.request as Record<string, unknown>
+      const currency = challengeRequest.currency as string | undefined
+      const purchaseUrl = challenge.opaque?.purchase_url as string | undefined
+
+      return {
+        tokenSymbol: currency?.toUpperCase() ?? 'USD',
+        tokenDecimals: 2,
+        methods: [
+          whopMethods.charge({
+            completeCheckout: async ({ purchaseUrl: url }) => {
+              const checkoutUrl = url || purchaseUrl
+              if (!checkoutUrl) {
+                throw new Errors.IncurError({
+                  code: 'MISSING_CHECKOUT_URL',
+                  message:
+                    'No Whop checkout URL available. The server must include a purchase_url in the challenge.',
+                  exitCode: 2,
+                })
+              }
+
+              // Open the checkout URL in the default browser
+              console.log(`\n${pc.bold('Whop Checkout')}`)
+              console.log(`Opening checkout in your browser...\n`)
+              console.log(`  ${pc.link(checkoutUrl, checkoutUrl, true)}\n`)
+
+              // Open URL in the default browser using platform-native commands
+              try {
+                const { exec } = await import('node:child_process')
+                const cmd =
+                  process.platform === 'darwin'
+                    ? `open "${checkoutUrl}"`
+                    : process.platform === 'win32'
+                      ? `start "${checkoutUrl}"`
+                      : `xdg-open "${checkoutUrl}"`
+                exec(cmd)
+              } catch {
+                console.log(`Open this URL manually to complete payment.`)
+              }
+
+              // Prompt the user to paste the payment ID after checkout
+              console.log(
+                `After completing payment, paste the payment ID from the redirect URL.`,
+              )
+              console.log(
+                `(The payment ID looks like: ${pc.dim('pay_xxxxxxxxxxxxx')})\n`,
+              )
+
+              const paymentId = await promptForPaymentId()
+              if (!paymentId) {
+                throw new Errors.IncurError({
+                  code: 'PAYMENT_CANCELLED',
+                  message: 'Payment was cancelled or no payment ID was provided.',
+                  exitCode: 1,
+                })
+              }
+
+              return paymentId
+            },
+          }),
+        ],
+      }
+    },
+
+    formatReceiptField(key, value) {
+      if (key === 'reference' && typeof value === 'string') {
+        const url = `https://whop.com/dashboard/payments`
+        return pc.link(url, value, true)
+      }
+    },
+  })
+}
+
+/** Prompts the user to enter the payment ID from the CLI. */
+async function promptForPaymentId(): Promise<string | null> {
+  const readline = await import('node:readline')
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  })
+
+  return new Promise((resolve) => {
+    rl.question('Payment ID: ', (answer) => {
+      rl.close()
+      const trimmed = answer.trim()
+      resolve(trimmed || null)
+    })
+  })
+}

--- a/src/client/Methods.ts
+++ b/src/client/Methods.ts
@@ -1,3 +1,4 @@
 export { stripe } from '../stripe/client/index.js'
 export { tempo } from '../tempo/client/index.js'
 export { session } from '../tempo/client/Session.js'
+export { whop } from '../whop/client/index.js'

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,4 +1,4 @@
 export * as Expires from '../Expires.js'
-export { session, stripe, tempo } from './Methods.js'
+export { session, stripe, tempo, whop } from './Methods.js'
 export * as Mppx from './Mppx.js'
 export * as Transport from './Transport.js'

--- a/src/proxy/services/whop.ts
+++ b/src/proxy/services/whop.ts
@@ -1,0 +1,54 @@
+import * as Service from '../Service.js'
+
+/**
+ * Creates a Whop proxy service definition.
+ *
+ * Proxies requests to the Whop API with authentication.
+ * Useful for gating access to Whop API endpoints behind MPP payments.
+ *
+ * @example
+ * ```ts
+ * import { whop } from 'mppx/proxy'
+ *
+ * whop({
+ *   apiKey: process.env.WHOP_API_KEY!,
+ *   routes: {
+ *     'GET /api/v1/products': mppx.charge({ amount: 1 }),
+ *     'GET /api/v1/products/:id': true,
+ *   },
+ * })
+ * ```
+ */
+export function whop(config: whop.Config) {
+  return Service.from<whop.Config>('whop', {
+    baseUrl: config.baseUrl ?? 'https://api.whop.com',
+    description: 'Digital products, memberships, and community access.',
+    docsLlmsUrl: 'https://docs.whop.com/llms.txt',
+    rewriteRequest(request, ctx) {
+      const key = ctx.apiKey ?? config.apiKey
+      request.headers.set('Authorization', `Bearer ${key}`)
+      return request
+    },
+    routes: config.routes,
+    title: 'Whop',
+  })
+}
+
+export declare namespace whop {
+  export type Config = Service.From<{
+    /** Whop API key (Company or App API key). */
+    apiKey: string
+    /** Base URL override. Defaults to `'https://api.whop.com'`. */
+    baseUrl?: string | undefined
+    routes:
+      | 'GET /api/v1/products'
+      | 'GET /api/v1/products/:id'
+      | 'GET /api/v1/plans'
+      | 'GET /api/v1/plans/:id'
+      | 'GET /api/v1/memberships'
+      | 'GET /api/v1/memberships/:id'
+      | 'POST /api/v1/checkout_configurations'
+      | 'GET /api/v1/payments'
+      | 'GET /api/v1/payments/:id'
+  }>
+}

--- a/src/server/Methods.ts
+++ b/src/server/Methods.ts
@@ -1,2 +1,3 @@
 export { stripe } from '../stripe/server/index.js'
 export { tempo } from '../tempo/server/index.js'
+export { whop } from '../whop/server/index.js'

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,6 +1,6 @@
 export * as Expires from '../Expires.js'
 export * as Store from '../Store.js'
-export { stripe, tempo } from './Methods.js'
+export { stripe, tempo, whop } from './Methods.js'
 export * as Mppx from './Mppx.js'
 export * as NodeListener from './NodeListener.js'
 export * as Request from './Request.js'

--- a/src/whop/Methods.test.ts
+++ b/src/whop/Methods.test.ts
@@ -1,0 +1,66 @@
+import { Methods } from 'mppx/whop'
+import { describe, expect, expectTypeOf, test } from 'vitest'
+
+describe('charge', () => {
+  test('has correct name and intent', () => {
+    expect(Methods.charge.intent).toBe('charge')
+    expect(Methods.charge.name).toBe('whop')
+  })
+
+  test('types: intent is literal', () => {
+    expectTypeOf(Methods.charge.intent).toEqualTypeOf<'charge'>()
+  })
+
+  test('types: name is literal', () => {
+    expectTypeOf(Methods.charge.name).toEqualTypeOf<'whop'>()
+  })
+
+  test('schema: validates valid request', () => {
+    const result = Methods.charge.schema.request.safeParse({
+      amount: 5.0,
+      currency: 'usd',
+      companyId: 'biz_xxx',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  test('schema: validates request with description', () => {
+    const result = Methods.charge.schema.request.safeParse({
+      amount: 1.0,
+      currency: 'usd',
+      companyId: 'biz_xxx',
+      description: 'Fortune cookie',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  test('schema: rejects invalid request (missing companyId)', () => {
+    const result = Methods.charge.schema.request.safeParse({
+      amount: 5.0,
+      currency: 'usd',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  test('schema: validates paymentId payload', () => {
+    const result = Methods.charge.schema.credential.payload.safeParse({
+      paymentId: 'pay_hJ5qYeTJlbirjW',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  test('schema: validates payload with externalId', () => {
+    const result = Methods.charge.schema.credential.payload.safeParse({
+      paymentId: 'pay_hJ5qYeTJlbirjW',
+      externalId: 'order_123',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  test('schema: rejects invalid payload (missing paymentId)', () => {
+    const result = Methods.charge.schema.credential.payload.safeParse({
+      spt: 'spt_test_123',
+    })
+    expect(result.success).toBe(false)
+  })
+})

--- a/src/whop/Methods.ts
+++ b/src/whop/Methods.ts
@@ -1,0 +1,37 @@
+import * as Method from '../Method.js'
+import * as z from '../zod.js'
+
+/**
+ * Whop charge intent for one-time payments via Whop Checkout.
+ *
+ * The payer completes a Whop-hosted checkout (card, Apple Pay, etc.)
+ * and the server verifies the payment via the Whop API.
+ *
+ * No Whop backend changes required — uses the existing public API:
+ * - `checkoutConfigurations.create()` to generate a purchase URL
+ * - `payments.retrieve()` to verify payment after completion
+ */
+export const charge = Method.from({
+  name: 'whop',
+  intent: 'charge',
+  schema: {
+    credential: {
+      payload: z.object({
+        /** Whop payment ID returned after checkout completion. */
+        paymentId: z.string(),
+        /** Optional client-side external reference ID. */
+        externalId: z.optional(z.string()),
+      }),
+    },
+    request: z.object({
+      /** Payment amount in decimal units (e.g., 5.00 for $5). */
+      amount: z.number(),
+      /** ISO currency code (e.g., "usd"). */
+      currency: z.string(),
+      /** Merchant's Whop company ID (biz_xxx). */
+      companyId: z.string(),
+      /** Optional human-readable description. */
+      description: z.optional(z.string()),
+    }),
+  },
+})

--- a/src/whop/client/Charge.test.ts
+++ b/src/whop/client/Charge.test.ts
@@ -1,0 +1,146 @@
+import { Challenge, Credential } from 'mppx'
+import { Mppx, whop } from 'mppx/client'
+import { Mppx as Mppx_server, whop as whop_server } from 'mppx/server'
+import { describe, expect, test, vi } from 'vitest'
+import { charge as clientCharge_ } from './Charge.js'
+
+const realm = 'api.example.com'
+const secretKey = 'test-hmac-key'
+
+function createMockWhopClient() {
+  return {
+    payments: {
+      retrieve: vi.fn(async () => ({
+        id: 'pay_mock_123',
+        status: 'paid',
+        total: 5.0,
+        subtotal: 5.0,
+        currency: 'usd',
+      })),
+    },
+    checkoutConfigurations: {
+      create: vi.fn(async () => ({
+        id: 'ch_mock_123',
+        purchase_url: 'https://whop.com/checkout/plan_xxx/?session=ch_mock_123',
+      })),
+    },
+  }
+}
+
+const dummyClientCharge = clientCharge_({
+  completeCheckout: async () => 'pay_mock_123',
+})
+
+async function createChallenge() {
+  const mockClient = createMockWhopClient()
+  const server = Mppx_server.create({
+    methods: [
+      whop_server({
+        client: mockClient,
+        companyId: 'biz_test',
+        currency: 'usd',
+      }),
+    ],
+    realm,
+    secretKey,
+  })
+
+  const handle = server.charge({
+    amount: 5.0,
+    meta: { purchase_url: 'https://whop.com/checkout/test' },
+  })
+  const result = await handle(new Request('https://example.com'))
+  if (result.status !== 402) throw new Error('Expected 402')
+  return Challenge.fromResponse(result.challenge, { methods: [dummyClientCharge] })
+}
+
+describe('whop.charge client', () => {
+  test('behavior: calls completeCheckout with challenge data', async () => {
+    let receivedParams: Record<string, unknown> | undefined
+
+    const charge = whop.charge({
+      completeCheckout: async (params) => {
+        receivedParams = params as unknown as Record<string, unknown>
+        return 'pay_test_123'
+      },
+    })
+
+    const challenge = await createChallenge()
+    await charge.createCredential({ challenge, context: {} })
+
+    expect(receivedParams).toBeDefined()
+    expect(receivedParams!.amount).toBe(5.0)
+    expect(receivedParams!.currency).toBe('usd')
+    expect(typeof receivedParams!.purchaseUrl).toBe('string')
+  })
+
+  test('behavior: produces valid credential string', async () => {
+    const charge = whop.charge({
+      completeCheckout: async () => 'pay_test_456',
+    })
+
+    const challenge = await createChallenge()
+    const credential = await charge.createCredential({ challenge, context: {} })
+
+    expect(credential).toMatch(/^Payment /)
+
+    const parsed = Credential.deserialize(credential)
+    expect(parsed.payload).toMatchObject({ paymentId: 'pay_test_456' })
+  })
+
+  test('behavior: includes externalId in credential payload', async () => {
+    const charge = whop.charge({
+      completeCheckout: async () => 'pay_test_789',
+      externalId: 'order_abc',
+    })
+
+    const challenge = await createChallenge()
+    const credential = await charge.createCredential({ challenge, context: {} })
+    const parsed = Credential.deserialize(credential)
+    expect(parsed.payload).toMatchObject({
+      paymentId: 'pay_test_789',
+      externalId: 'order_abc',
+    })
+  })
+
+  test('behavior: context paymentId skips completeCheckout', async () => {
+    const completeCheckout = vi.fn(async () => 'should_not_be_called')
+
+    const charge = whop.charge({ completeCheckout })
+
+    const challenge = await createChallenge()
+    const credential = await charge.createCredential({
+      challenge,
+      context: { paymentId: 'pay_already_paid' },
+    })
+
+    expect(completeCheckout).not.toHaveBeenCalled()
+    const parsed = Credential.deserialize(credential)
+    expect(parsed.payload).toMatchObject({ paymentId: 'pay_already_paid' })
+  })
+
+  test('behavior: Mppx.create with whop works through createCredential', async () => {
+    const mppx = Mppx.create({
+      methods: [
+        whop({
+          completeCheckout: async () => 'pay_mppx_test',
+        }),
+      ],
+      polyfill: false,
+    })
+
+    const challenge = await createChallenge()
+    const response = new Response(null, {
+      status: 402,
+      headers: {
+        'WWW-Authenticate': Challenge.serialize(challenge),
+      },
+    })
+
+    const credential = await mppx.createCredential(response)
+    expect(credential).toMatch(/^Payment /)
+
+    const parsed = Credential.deserialize(credential)
+    expect(parsed.payload).toMatchObject({ paymentId: 'pay_mppx_test' })
+  })
+})

--- a/src/whop/client/Charge.ts
+++ b/src/whop/client/Charge.ts
@@ -1,0 +1,119 @@
+import * as Credential from '../../Credential.js'
+import * as Method from '../../Method.js'
+import * as z from '../../zod.js'
+import * as Methods from '../Methods.js'
+
+/**
+ * Creates a Whop charge method intent for usage on the client.
+ *
+ * Accepts a `completeCheckout` callback that handles the Whop checkout
+ * flow — opening the purchase URL, waiting for the user to pay, and
+ * returning the resulting payment ID.
+ *
+ * @example
+ * ```ts
+ * import { whop } from 'mppx/client'
+ *
+ * // Browser: open Whop checkout in a popup
+ * const charge = whop.charge({
+ *   completeCheckout: async ({ purchaseUrl }) => {
+ *     const popup = window.open(purchaseUrl, 'whop-checkout', 'width=500,height=700')
+ *     return new Promise((resolve) => {
+ *       window.addEventListener('message', (e) => {
+ *         if (e.data?.paymentId) resolve(e.data.paymentId)
+ *       })
+ *     })
+ *   },
+ * })
+ * ```
+ *
+ * @example
+ * ```ts
+ * // CLI: open browser and wait for callback
+ * const charge = whop.charge({
+ *   completeCheckout: async ({ purchaseUrl }) => {
+ *     const open = await import('open')
+ *     await open.default(purchaseUrl)
+ *     // poll your callback server for the payment ID
+ *     return await pollForPayment()
+ *   },
+ * })
+ * ```
+ */
+export function charge(parameters: charge.Parameters) {
+  const { completeCheckout, externalId } = parameters
+
+  return Method.toClient(Methods.charge, {
+    context: z.object({
+      /** If the caller already has a payment ID (e.g. returning user), skip checkout. */
+      paymentId: z.optional(z.string()),
+    }),
+
+    async createCredential({ challenge, context }) {
+      // Fast path: caller already completed payment externally
+      if (context?.paymentId) {
+        return Credential.serialize({
+          challenge,
+          payload: {
+            paymentId: context.paymentId,
+            ...(externalId ? { externalId } : {}),
+          },
+        })
+      }
+
+      // Get purchase URL from the challenge's opaque/meta field
+      const purchaseUrl = challenge.opaque?.purchase_url
+      if (!purchaseUrl) {
+        throw new Error(
+          'No purchase_url in challenge. The server must include a Whop checkout URL in the challenge meta.',
+        )
+      }
+
+      const paymentId = await completeCheckout({
+        amount: challenge.request.amount as number,
+        challengeId: challenge.id,
+        currency: challenge.request.currency as string,
+        purchaseUrl,
+      })
+
+      return Credential.serialize({
+        challenge,
+        payload: {
+          paymentId,
+          ...(externalId ? { externalId } : {}),
+        },
+      })
+    },
+  })
+}
+
+export declare namespace charge {
+  type Parameters = {
+    /**
+     * Callback that completes the Whop checkout flow.
+     *
+     * Receives the Whop purchase URL and payment details.
+     * Must open the checkout (popup, redirect, browser, etc.),
+     * wait for the user to complete payment, and return the
+     * Whop payment ID.
+     *
+     * In a browser: open iframe/popup, listen for redirect/postMessage.
+     * In a CLI: open default browser, poll a callback endpoint.
+     * In an agent: use browser automation or prompt the user.
+     */
+    completeCheckout: (parameters: CompleteCheckoutParameters) => Promise<string>
+    /** Optional client-side external reference ID for the credential payload. */
+    externalId?: string | undefined
+  }
+
+  type CompleteCheckoutParameters = {
+    /** Payment amount in decimal units (e.g., 5.00 for $5). */
+    amount: number
+    /** The challenge ID, useful for correlating callbacks. */
+    challengeId: string
+    /** ISO currency code (e.g., "usd"). */
+    currency: string
+    /** Whop checkout URL. Direct the user here to complete payment. */
+    purchaseUrl: string
+  }
+}

--- a/src/whop/client/Methods.ts
+++ b/src/whop/client/Methods.ts
@@ -1,0 +1,31 @@
+import { charge as charge_ } from './Charge.js'
+
+/**
+ * Creates a Whop `charge` client method.
+ *
+ * @example
+ * ```ts
+ * import { Mppx, whop } from 'mppx/client'
+ *
+ * const mppx = Mppx.create({
+ *   methods: [
+ *     whop({
+ *       completeCheckout: async ({ purchaseUrl }) => {
+ *         window.open(purchaseUrl)
+ *         return await waitForPaymentId()
+ *       },
+ *     }),
+ *   ],
+ * })
+ * ```
+ */
+export function whop(parameters: whop.Parameters) {
+  return [charge_(parameters)] as const
+}
+
+export namespace whop {
+  export type Parameters = charge_.Parameters
+
+  /** Creates a Whop `charge` client method for checkout-based payments. */
+  export const charge = charge_
+}

--- a/src/whop/client/index.ts
+++ b/src/whop/client/index.ts
@@ -1,0 +1,2 @@
+export { charge } from './Charge.js'
+export { whop } from './Methods.js'

--- a/src/whop/index.ts
+++ b/src/whop/index.ts
@@ -1,0 +1,1 @@
+export * as Methods from './Methods.js'

--- a/src/whop/internal/types.ts
+++ b/src/whop/internal/types.ts
@@ -1,0 +1,28 @@
+/**
+ * Duck-typed interface for the Whop SDK (@whop/sdk).
+ * Matches the subset used by mppx for server-side payment verification
+ * and checkout configuration creation.
+ *
+ * Uses loose signatures so any Whop SDK version is assignable.
+ */
+export type WhopClient = {
+  payments: {
+    retrieve(id: string): Promise<WhopPayment>
+  }
+  checkoutConfigurations: {
+    create(...args: any[]): Promise<WhopCheckoutConfig>
+  }
+}
+
+export type WhopPayment = {
+  id: string
+  status: string
+  total: number
+  subtotal: number
+  currency: string
+}
+
+export type WhopCheckoutConfig = {
+  id: string
+  purchase_url: string
+}

--- a/src/whop/server/Charge.test.ts
+++ b/src/whop/server/Charge.test.ts
@@ -1,0 +1,257 @@
+import { Challenge, Credential } from 'mppx'
+import { Mppx, whop } from 'mppx/server'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import * as Http from '~test/Http.js'
+import type { WhopClient } from '../internal/types.js'
+
+const realm = 'api.example.com'
+const secretKey = 'test-secret-key'
+
+let httpServer: Awaited<ReturnType<typeof Http.createServer>> | undefined
+
+afterEach(() => httpServer?.close())
+
+function createMockWhopClient(
+  overrides?: Partial<{ status: string; total: number; id: string; throws: boolean }>,
+): { client: WhopClient; retrieve: ReturnType<typeof vi.fn> } {
+  const { status = 'paid', total = 5.0, id = 'pay_mock_123', throws = false } = overrides ?? {}
+  const retrieve = vi.fn(async () => {
+    if (throws) throw new Error('Whop API error')
+    return { id, status, total, subtotal: total, currency: 'usd' }
+  })
+  return {
+    client: {
+      payments: { retrieve },
+      checkoutConfigurations: {
+        create: vi.fn(async () => ({
+          id: 'ch_mock',
+          purchase_url: 'https://whop.com/checkout/test',
+        })),
+      },
+    },
+    retrieve,
+  }
+}
+
+describe('whop.charge with client', () => {
+  test('default: verifies payment via client.payments.retrieve', async () => {
+    const { client, retrieve } = createMockWhopClient()
+
+    const server = Mppx.create({
+      methods: [whop({ client, companyId: 'biz_test', currency: 'usd' })],
+      realm,
+      secretKey,
+    })
+
+    httpServer = await Http.createServer(async (req, res) => {
+      const result = await Mppx.toNodeListener(
+        server.charge({
+          amount: 5.0,
+          meta: { purchase_url: 'https://whop.com/checkout/test' },
+        }),
+      )(req, res)
+      if (result.status === 402) return
+      res.end('OK')
+    })
+
+    const response = await fetch(httpServer.url)
+    expect(response.status).toBe(402)
+
+    const challenge = Challenge.fromResponse(response)
+    const credential = Credential.from({
+      challenge,
+      payload: { paymentId: 'pay_test_token' },
+    })
+
+    const paidResponse = await fetch(httpServer.url, {
+      headers: { Authorization: Credential.serialize(credential) },
+    })
+    expect(paidResponse.status).toBe(200)
+    expect(retrieve).toHaveBeenCalledWith('pay_test_token')
+  })
+
+  test('behavior: rejects when payment status is not paid', async () => {
+    const { client } = createMockWhopClient({ status: 'open' })
+
+    const server = Mppx.create({
+      methods: [whop({ client, companyId: 'biz_test', currency: 'usd' })],
+      realm,
+      secretKey,
+    })
+
+    httpServer = await Http.createServer(async (req, res) => {
+      const result = await Mppx.toNodeListener(
+        server.charge({
+          amount: 5.0,
+          meta: { purchase_url: 'https://whop.com/checkout/test' },
+        }),
+      )(req, res)
+      if (result.status === 402) return
+      res.end('OK')
+    })
+
+    const response = await fetch(httpServer.url)
+    const challenge = Challenge.fromResponse(response)
+    const credential = Credential.from({
+      challenge,
+      payload: { paymentId: 'pay_pending' },
+    })
+
+    const paidResponse = await fetch(httpServer.url, {
+      headers: { Authorization: Credential.serialize(credential) },
+    })
+    expect(paidResponse.status).toBe(402)
+    const body = (await paidResponse.json()) as { detail: string }
+    expect(body.detail).toContain('Whop payment status: open')
+  })
+
+  test('behavior: rejects when amount does not match', async () => {
+    const { client } = createMockWhopClient({ total: 99.0 })
+
+    const server = Mppx.create({
+      methods: [whop({ client, companyId: 'biz_test', currency: 'usd' })],
+      realm,
+      secretKey,
+    })
+
+    httpServer = await Http.createServer(async (req, res) => {
+      const result = await Mppx.toNodeListener(
+        server.charge({
+          amount: 5.0,
+          meta: { purchase_url: 'https://whop.com/checkout/test' },
+        }),
+      )(req, res)
+      if (result.status === 402) return
+      res.end('OK')
+    })
+
+    const response = await fetch(httpServer.url)
+    const challenge = Challenge.fromResponse(response)
+    const credential = Credential.from({
+      challenge,
+      payload: { paymentId: 'pay_wrong_amount' },
+    })
+
+    const paidResponse = await fetch(httpServer.url, {
+      headers: { Authorization: Credential.serialize(credential) },
+    })
+    expect(paidResponse.status).toBe(402)
+    const body = (await paidResponse.json()) as { detail: string }
+    expect(body.detail).toContain('Payment amount mismatch')
+  })
+
+  test('behavior: rejects when client throws', async () => {
+    const { client } = createMockWhopClient({ throws: true })
+
+    const server = Mppx.create({
+      methods: [whop({ client, companyId: 'biz_test', currency: 'usd' })],
+      realm,
+      secretKey,
+    })
+
+    httpServer = await Http.createServer(async (req, res) => {
+      const result = await Mppx.toNodeListener(
+        server.charge({
+          amount: 5.0,
+          meta: { purchase_url: 'https://whop.com/checkout/test' },
+        }),
+      )(req, res)
+      if (result.status === 402) return
+      res.end('OK')
+    })
+
+    const response = await fetch(httpServer.url)
+    const challenge = Challenge.fromResponse(response)
+    const credential = Credential.from({
+      challenge,
+      payload: { paymentId: 'pay_failing' },
+    })
+
+    const paidResponse = await fetch(httpServer.url, {
+      headers: { Authorization: Credential.serialize(credential) },
+    })
+    expect(paidResponse.status).toBe(402)
+  })
+
+  test('behavior: receipt contains payment reference', async () => {
+    const { client } = createMockWhopClient({ id: 'pay_custom_ref' })
+
+    const server = Mppx.create({
+      methods: [whop({ client, companyId: 'biz_test', currency: 'usd' })],
+      realm,
+      secretKey,
+    })
+
+    const handle = server.charge({
+      amount: 5.0,
+      meta: { purchase_url: 'https://whop.com/checkout/test' },
+    })
+
+    const firstResult = await handle(new Request('https://example.com'))
+    expect(firstResult.status).toBe(402)
+    if (firstResult.status !== 402) throw new Error()
+
+    const challenge = Challenge.fromResponse(firstResult.challenge)
+    const credential = Credential.from({
+      challenge,
+      payload: { paymentId: 'pay_custom_ref' },
+    })
+
+    const result = await handle(
+      new Request('https://example.com', {
+        headers: { Authorization: Credential.serialize(credential) },
+      }),
+    )
+    expect(result.status).toBe(200)
+    if (result.status !== 200) throw new Error()
+
+    const wrapped = result.withReceipt(Response.json({ ok: true }))
+    const receiptHeader = wrapped.headers.get('Payment-Receipt')
+    expect(receiptHeader).toBeTruthy()
+
+    const decoded = JSON.parse(
+      Buffer.from(receiptHeader!, 'base64url').toString(),
+    ) as { reference: string; method: string }
+    expect(decoded.reference).toBe('pay_custom_ref')
+    expect(decoded.method).toBe('whop')
+  })
+
+  test('behavior: includes externalId in receipt', async () => {
+    const { client } = createMockWhopClient()
+
+    const server = Mppx.create({
+      methods: [whop({ client, companyId: 'biz_test', currency: 'usd' })],
+      realm,
+      secretKey,
+    })
+
+    const handle = server.charge({
+      amount: 5.0,
+      meta: { purchase_url: 'https://whop.com/checkout/test' },
+    })
+
+    const firstResult = await handle(new Request('https://example.com'))
+    if (firstResult.status !== 402) throw new Error()
+
+    const challenge = Challenge.fromResponse(firstResult.challenge)
+    const credential = Credential.from({
+      challenge,
+      payload: { paymentId: 'pay_ext_test', externalId: 'order_xyz' },
+    })
+
+    const result = await handle(
+      new Request('https://example.com', {
+        headers: { Authorization: Credential.serialize(credential) },
+      }),
+    )
+    expect(result.status).toBe(200)
+    if (result.status !== 200) throw new Error()
+
+    const wrapped = result.withReceipt(Response.json({ ok: true }))
+    const receiptHeader = wrapped.headers.get('Payment-Receipt')
+    const decoded = JSON.parse(
+      Buffer.from(receiptHeader!, 'base64url').toString(),
+    ) as { externalId: string }
+    expect(decoded.externalId).toBe('order_xyz')
+  })
+})

--- a/src/whop/server/Charge.ts
+++ b/src/whop/server/Charge.ts
@@ -1,0 +1,223 @@
+import {
+  PaymentExpiredError,
+  VerificationFailedError,
+} from '../../Errors.js'
+import type { OneOf } from '../../internal/types.js'
+import * as Method from '../../Method.js'
+import type { WhopClient, WhopCheckoutConfig, WhopPayment } from '../internal/types.js'
+import * as Methods from '../Methods.js'
+
+/**
+ * Creates a Whop charge method intent for usage on the server.
+ *
+ * Verifies payment by retrieving the Whop payment via the public API.
+ * The checkout configuration (purchase URL) must be created by the
+ * handler and passed via `meta: { purchase_url }` so the client can
+ * complete payment.
+ *
+ * @example
+ * ```ts
+ * import { Mppx, whop } from 'mppx/server'
+ *
+ * const mppx = Mppx.create({
+ *   methods: [
+ *     whop({
+ *       apiKey: process.env.WHOP_API_KEY!,
+ *       companyId: 'biz_xxx',
+ *       currency: 'usd',
+ *     }),
+ *   ],
+ * })
+ *
+ * app.get('/api/resource', async (req) => {
+ *   const checkout = await whop.createCheckout({
+ *     apiKey: process.env.WHOP_API_KEY!,
+ *     companyId: 'biz_xxx',
+ *     amount: 5.0,
+ *     currency: 'usd',
+ *   })
+ *
+ *   const result = await mppx.charge({
+ *     amount: 5.0,
+ *     meta: { purchase_url: checkout.purchase_url },
+ *   })(req)
+ *
+ *   if (result.status === 402) return result.challenge
+ *   return result.withReceipt(new Response('OK'))
+ * })
+ * ```
+ */
+export function charge<const parameters extends charge.Parameters>(parameters: parameters) {
+  const { amount, companyId, currency, description } = parameters
+
+  const client = 'client' in parameters ? parameters.client : undefined
+  const apiKey = 'apiKey' in parameters ? parameters.apiKey : undefined
+
+  type Defaults = charge.DeriveDefaults<parameters>
+  return Method.toServer<typeof Methods.charge, Defaults>(Methods.charge, {
+    defaults: { amount, companyId, currency, description } as unknown as Defaults,
+
+    async verify({ credential }) {
+      const { challenge } = credential
+
+      if (challenge.expires && new Date(challenge.expires) < new Date())
+        throw new PaymentExpiredError({ expires: challenge.expires })
+
+      const parsed = Methods.charge.schema.credential.payload.safeParse(credential.payload)
+      if (!parsed.success)
+        throw new Error('Invalid credential payload: missing or malformed paymentId')
+      const { paymentId, externalId } = parsed.data as {
+        paymentId: string
+        externalId?: string
+      }
+
+      // Retrieve payment from Whop's public API
+      const payment = client
+        ? await client.payments.retrieve(paymentId)
+        : await fetchPayment(apiKey!, paymentId)
+
+      // Verify payment status
+      if (payment.status !== 'paid' && payment.status !== 'succeeded') {
+        throw new VerificationFailedError({
+          reason: `Whop payment status: ${payment.status}`,
+        })
+      }
+
+      // Verify amount matches
+      const expectedAmount = challenge.request.amount as number
+      if (payment.total !== expectedAmount) {
+        throw new VerificationFailedError({
+          reason: `Payment amount mismatch: got ${payment.total}, expected ${expectedAmount}`,
+        })
+      }
+
+      return {
+        method: 'whop',
+        status: 'success',
+        timestamp: new Date().toISOString(),
+        reference: paymentId,
+        ...(externalId ? { externalId } : {}),
+      } as const
+    },
+  })
+}
+
+export declare namespace charge {
+  type Defaults = Method.RequestDefaults<typeof Methods.charge>
+
+  type Parameters = {
+    /** Payment amount in decimal units (e.g., 5.00 for $5). */
+    amount?: number | undefined
+    /** Merchant's Whop company ID (biz_xxx). */
+    companyId: string
+    /** ISO currency code (e.g., "usd"). */
+    currency?: string | undefined
+    /** Optional human-readable description. */
+    description?: string | undefined
+  } & OneOf<
+    | { /** Pre-configured Whop SDK instance. */ client: WhopClient }
+    | { /** Whop API key (Company or App API key). */ apiKey: string }
+  >
+
+  type DeriveDefaults<parameters extends Parameters> = Pick<
+    parameters,
+    Extract<keyof parameters, keyof Defaults>
+  >
+}
+
+/**
+ * Creates a Whop checkout configuration. Call this in your handler
+ * and pass the `purchase_url` via `meta` so the client can complete payment.
+ *
+ * @example
+ * ```ts
+ * import { whop } from 'mppx/server'
+ *
+ * const checkout = await whop.createCheckout({
+ *   apiKey: process.env.WHOP_API_KEY!,
+ *   companyId: 'biz_xxx',
+ *   amount: 5.0,
+ *   currency: 'usd',
+ *   redirectUrl: 'https://mysite.com/payment-complete',
+ * })
+ *
+ * const result = await mppx.charge({
+ *   amount: 5.0,
+ *   meta: { purchase_url: checkout.purchase_url },
+ * })(req)
+ * ```
+ */
+export async function createCheckout(parameters: createCheckout.Parameters): Promise<WhopCheckoutConfig> {
+  if ('client' in parameters && parameters.client) {
+    try {
+      return await parameters.client.checkoutConfigurations.create({
+        company_id: parameters.companyId,
+        plan: {
+          initial_price: parameters.amount,
+          plan_type: 'one_time',
+          currency: parameters.currency ?? 'usd',
+        },
+        ...(parameters.description && {
+          metadata: { description: parameters.description },
+        }),
+        ...(parameters.redirectUrl && { redirect_url: parameters.redirectUrl }),
+      })
+    } catch {
+      throw new Error('Failed to create Whop checkout configuration')
+    }
+  }
+
+  const apiKey = 'apiKey' in parameters ? parameters.apiKey : undefined
+  if (!apiKey) throw new Error('Either client or apiKey is required')
+
+  const body: Record<string, unknown> = {
+    company_id: parameters.companyId,
+    plan: {
+      initial_price: parameters.amount,
+      plan_type: 'one_time',
+      currency: parameters.currency ?? 'usd',
+    },
+  }
+  if (parameters.description) body.metadata = { description: parameters.description }
+  if (parameters.redirectUrl) body.redirect_url = parameters.redirectUrl
+
+  const response = await fetch('https://api.whop.com/api/v1/checkout_configurations', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  })
+
+  if (!response.ok) throw new Error('Failed to create Whop checkout configuration')
+  return (await response.json()) as WhopCheckoutConfig
+}
+
+export declare namespace createCheckout {
+  type Parameters = {
+    /** Payment amount in decimal units (e.g., 5.00 for $5). */
+    amount: number
+    /** Merchant's Whop company ID (biz_xxx). */
+    companyId: string
+    /** ISO currency code. @default "usd" */
+    currency?: string | undefined
+    /** Optional description stored in checkout metadata. */
+    description?: string | undefined
+    /** URL to redirect after checkout. Payment ID appended as query param. */
+    redirectUrl?: string | undefined
+  } & OneOf<
+    | { client: WhopClient }
+    | { apiKey: string }
+  >
+}
+
+/** Retrieves a payment using a raw API key and fetch. */
+async function fetchPayment(apiKey: string, paymentId: string): Promise<WhopPayment> {
+  const response = await fetch(`https://api.whop.com/api/v1/payments/${paymentId}`, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  })
+  if (!response.ok)
+    throw new VerificationFailedError({ reason: 'Failed to retrieve Whop payment' })
+  return (await response.json()) as WhopPayment
+}

--- a/src/whop/server/Methods.ts
+++ b/src/whop/server/Methods.ts
@@ -1,0 +1,30 @@
+import { charge as charge_ } from './Charge.js'
+
+/**
+ * Creates a Whop `charge` method for usage on the server.
+ *
+ * @example
+ * ```ts
+ * import { Mppx, whop } from 'mppx/server'
+ *
+ * const mppx = Mppx.create({
+ *   methods: [
+ *     whop({
+ *       apiKey: process.env.WHOP_API_KEY!,
+ *       companyId: 'biz_xxx',
+ *       currency: 'usd',
+ *     }),
+ *   ],
+ * })
+ * ```
+ */
+export function whop<const parameters extends whop.Parameters>(parameters: parameters) {
+  return [whop.charge(parameters)] as const
+}
+
+export namespace whop {
+  export type Parameters = charge_.Parameters
+
+  /** Creates a Whop `charge` method for checkout-based payments. */
+  export const charge = charge_
+}

--- a/src/whop/server/index.ts
+++ b/src/whop/server/index.ts
@@ -1,0 +1,2 @@
+export { charge, createCheckout } from './Charge.js'
+export { whop } from './Methods.js'

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,9 @@ const alias = {
   'mppx/stripe': path.resolve(import.meta.dirname, 'src/stripe'),
   'mppx/stripe/client': path.resolve(import.meta.dirname, 'src/stripe/client'),
   'mppx/stripe/server': path.resolve(import.meta.dirname, 'src/stripe/server'),
+  'mppx/whop': path.resolve(import.meta.dirname, 'src/whop'),
+  'mppx/whop/client': path.resolve(import.meta.dirname, 'src/whop/client'),
+  'mppx/whop/server': path.resolve(import.meta.dirname, 'src/whop/server'),
   mppx: path.resolve(import.meta.dirname, 'src'),
   '~test': path.resolve(import.meta.dirname, 'test'),
 }


### PR DESCRIPTION
## Summary

- Adds `whop/charge` as a third payment method alongside `tempo` and `stripe`
- Uses Whop's existing public API — **no Whop backend changes required**
- Server creates a checkout configuration, client completes payment via Whop Checkout, server verifies via `payments.retrieve()`
- Includes client SDK, server SDK, CLI plugin, proxy service, working example, and 20 passing tests

## How it works

```
Agent → GET /resource → 402 (challenge with Whop checkout URL)
Agent → opens checkout, user pays → gets payment ID
Agent → retries with payment ID as credential
Server → verifies via Whop API → 200 + receipt
```

### Server
```ts
import { Mppx, whop } from 'mppx/server'

const mppx = Mppx.create({
  methods: [whop({ apiKey: process.env.WHOP_API_KEY!, companyId: 'biz_xxx' })],
})
```

### Client
```ts
import { Mppx, whop } from 'mppx/client'

const mppx = Mppx.create({
  methods: [whop({ completeCheckout: async ({ purchaseUrl }) => { ... } })],
})
```

### Composable with existing methods
```ts
const mppx = Mppx.create({
  methods: [
    tempo.charge({ currency: USDC, recipient: '0x...' }),
    whop({ apiKey: WHOP_KEY, companyId: 'biz_xxx' }),
  ],
})
```

## Files

| Path | Description |
|------|-------------|
| `src/whop/Methods.ts` | Method definition (name: `whop`, intent: `charge`) |
| `src/whop/client/Charge.ts` | Client credential creation via `completeCheckout` callback |
| `src/whop/server/Charge.ts` | Server verification via Whop `payments.retrieve()` + `createCheckout` utility |
| `src/whop/internal/types.ts` | Duck-typed `WhopClient` interface |
| `src/cli/plugins/whop.ts` | CLI plugin (opens browser, prompts for payment ID) |
| `src/proxy/services/whop.ts` | Whop proxy service definition |
| `examples/whop/` | Working Vite example ($1 fortune cookie) |
| `src/whop/**/*.test.ts` | 20 tests (schema, client, server, receipts) |

## Test plan

- [x] `src/whop/Methods.test.ts` — schema validation (9 tests)
- [x] `src/whop/client/Charge.test.ts` — client credential creation (5 tests)
- [x] `src/whop/server/Charge.test.ts` — server verification, error handling, receipts (6 tests)
- [x] Type-check passes (`pnpm check:types`)
- [x] Example tested locally against live Whop API with real payments