### PR TITLE
fix(client): normalize headers in SessionManager.sse()

### DIFF
--- a/src/tempo/client/SessionManager.ts
+++ b/src/tempo/client/SessionManager.ts
@@ -154,10 +154,18 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
     async sse(input, init) {
       const { onReceipt, signal, ...fetchInit } = init ?? {}
 
+      // Normalize headers to a plain object so that Headers instances
+      // (whose properties are not enumerable) are not lost when spread.
+      const normalized: Record<string, string> = {}
+      const h = fetchInit.headers
+      if (h instanceof Headers) h.forEach((v, k) => (normalized[k] = v))
+      else if (Array.isArray(h)) for (const [k, v] of h) normalized[k] = v
+      else if (h) Object.assign(normalized, h)
+
       const sseInit = {
         ...fetchInit,
         headers: {
-          ...fetchInit.headers,
+          ...normalized,
           Accept: 'text/event-stream',
         },
         ...(signal ? { signal } : {}),


### PR DESCRIPTION
## Problem

`SessionManager.sse()` spreads `fetchInit.headers` directly into a new object:

```typescript
headers: {
  ...fetchInit.headers,
  Accept: 'text/event-stream',
},
```

When `fetchInit.headers` is a `Headers` instance (the standard Web API type), spreading it produces an empty object because `Headers` properties are not enumerable. This silently drops all client-provided headers, including `Content-Type`.

## Impact

Any client passing a `Headers` instance (rather than a plain object) loses all custom headers on SSE requests. This affects `Content-Type`, `Authorization`, and any other headers the caller sets. The regular `fetch` retry path in `Fetch.ts` already handles this correctly via `normalizeHeaders()`.

## Fix

Normalize headers to a plain object before spreading, handling all three header formats (`Headers` instance, array of tuples, plain object) - the same logic already used in `Fetch.ts:normalizeHeaders()`.

## Reproduction

```typescript
const session = tempo.session({ account, maxDeposit: '1' })
const stream = await session.sse('https://api.example.com/v1/completions', {
  method: 'POST',
  headers: new Headers({ 'Content-Type': 'application/json' }),
  body: JSON.stringify({ model: 'test', stream: true }),
})
// Server receives request without Content-Type header
```