### PR TITLE
examples: add xquik — X (Twitter) data via MPP

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -10,6 +10,7 @@ Standalone, runnable examples demonstrating the mppx HTTP 402 payment flow.
 | [session/multi-fetch](./session/multi-fetch/) | Multiple paid requests over a single payment channel |
 | [session/sse](./session/sse/) | Pay-per-token LLM streaming with SSE |
 | [stripe](./stripe/) | Stripe SPT charge with automatic client |
+| [xquik](./xquik/) | X (Twitter) data lookups — charge + session intents on a real API |
 
 ## Running Examples
 

--- a/examples/xquik/README.md
+++ b/examples/xquik/README.md
@@ -1,0 +1,46 @@
+# Xquik
+
+Look up X (Twitter) tweets, users, and articles without an API key — pay per call via MPP.
+
+[Xquik](https://xquik.com) exposes 7 MPP-eligible endpoints for real-time X data. This example demonstrates both `charge` (fixed per-call) and `session` (per-result) payment intents.
+
+```bash
+npx gitpick wevm/mppx/examples/xquik
+pnpm i
+pnpm dev
+```
+
+## What it does
+
+1. **Tweet lookup** (charge, $0.0003/call) — fetch a tweet by ID with engagement metrics
+2. **Tweet search** (session, $0.0003/tweet) — search tweets by query, pay per result
+3. **User lookup** (charge, $0.00036/call) — look up an X user profile by username
+
+## Test with mppx CLI
+
+```bash
+pnpm mppx https://xquik.com/api/v1/x/tweets/1893456789012345678
+pnpm mppx "https://xquik.com/api/v1/x/tweets/search?q=AI+agents&limit=5"
+pnpm mppx https://xquik.com/api/v1/x/users/xquikcom
+```
+
+## All MPP-eligible Xquik endpoints
+
+| Endpoint | Price | Intent |
+|----------|-------|--------|
+| `GET /api/v1/x/tweets/{id}` | $0.0003/call | charge |
+| `GET /api/v1/x/tweets/search` | $0.0003/tweet | session |
+| `GET /api/v1/x/users/{username}` | $0.00036/call | charge |
+| `GET /api/v1/x/followers/check` | $0.002/call | charge |
+| `GET /api/v1/x/articles/{tweetId}` | $0.002/call | charge |
+| `POST /api/v1/x/media/download` | $0.0003/media | session |
+| `GET /api/v1/trends` | $0.0009/call | charge |
+
+## OpenClaw plugin
+
+For AI agents, install the [TweetClaw](https://www.npmjs.com/package/@xquik/tweetclaw) OpenClaw plugin with MPP support:
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+openclaw config set plugins.entries.tweetclaw.config.tempoPrivateKey '0xYOUR_KEY'
+```

--- a/examples/xquik/package.json
+++ b/examples/xquik/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "xquik",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "dev": "tsx src/client.ts"
+  },
+  "dependencies": {
+    "mppx": "latest",
+    "tsx": "latest",
+    "typescript": "latest",
+    "viem": "latest"
+  }
+}

--- a/examples/xquik/src/client.ts
+++ b/examples/xquik/src/client.ts
@@ -1,0 +1,64 @@
+import { Mppx, tempo } from 'mppx/client'
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
+import { createClient, http } from 'viem'
+import { tempoModerato } from 'viem/chains'
+import { Actions } from 'viem/tempo'
+
+const XQUIK_BASE = 'https://xquik.com/api/v1'
+
+// Create a funded testnet account
+const account = privateKeyToAccount(
+  (process.env.TEMPO_PRIVATE_KEY as `0x${string}`) ?? generatePrivateKey(),
+)
+
+const client = createClient({
+  chain: tempoModerato,
+  pollingInterval: 1_000,
+  transport: http(),
+})
+
+console.log('Funding testnet account...')
+await Actions.faucet.fundSync(client, { account })
+console.log(`Account: ${account.address}\n`)
+
+// Initialize MPP — patches global fetch to auto-handle 402 challenges
+const mppx = Mppx.create({
+  methods: [tempo({ account })],
+})
+
+// 1. Tweet lookup (charge: $0.0003/call)
+console.log('--- Tweet Lookup (charge) ---')
+const tweetRes = await mppx.fetch(`${XQUIK_BASE}/x/tweets/1893456789012345678`)
+if (tweetRes.ok) {
+  const data = (await tweetRes.json()) as { tweet: { text: string; likeCount: number } }
+  console.log(`Tweet: ${data.tweet.text}`)
+  console.log(`Likes: ${data.tweet.likeCount}\n`)
+} else {
+  console.log(`Tweet lookup failed: ${tweetRes.status}\n`)
+}
+
+// 2. User lookup (charge: $0.00036/call)
+console.log('--- User Lookup (charge) ---')
+const userRes = await mppx.fetch(`${XQUIK_BASE}/x/users/xquikcom`)
+if (userRes.ok) {
+  const user = (await userRes.json()) as { username: string; name: string; followers: number }
+  console.log(`User: @${user.username} (${user.name})`)
+  console.log(`Followers: ${user.followers}\n`)
+} else {
+  console.log(`User lookup failed: ${userRes.status}\n`)
+}
+
+// 3. Tweet search (session: $0.0003/tweet)
+console.log('--- Tweet Search (session) ---')
+const searchRes = await mppx.fetch(
+  `${XQUIK_BASE}/x/tweets/search?${new URLSearchParams({ q: 'AI agents', limit: '3' })}`,
+)
+if (searchRes.ok) {
+  const data = (await searchRes.json()) as { tweets: Array<{ text: string }>; total: number }
+  console.log(`Found ${data.total} tweets:`)
+  for (const tweet of data.tweets) {
+    console.log(`  - ${tweet.text.slice(0, 80)}...`)
+  }
+} else {
+  console.log(`Search failed: ${searchRes.status}`)
+}

--- a/examples/xquik/tsconfig.json
+++ b/examples/xquik/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

- Adds an `xquik` example demonstrating MPP against a real production API ([xquik.com](https://xquik.com))
- Shows both `charge` (tweet/user lookup) and `session` (tweet search) payment intents
- Covers 3 of the 7 MPP-eligible Xquik endpoints with runnable code
- Updates the examples README table

## Why

The existing examples use mock/demo APIs. This adds a real-world example where agents can look up X (Twitter) tweets, users, and articles — paying per call via Tempo without any API key or account.

Xquik's 7 MPP endpoints: tweet lookup ($0.0003), tweet search ($0.0003/tweet), user lookup ($0.00036), follower check ($0.002), article ($0.002), media download ($0.0003/media), trends ($0.0009).

## Test plan

- [ ] Run `npx gitpick wevm/mppx/examples/xquik && pnpm i && pnpm dev`
- [ ] Verify tweet lookup, user lookup, and search work with testnet account
- [ ] Test with `pnpm mppx https://xquik.com/api/v1/x/users/xquikcom`

🤖 Generated with [Claude Code](https://claude.com/claude-code)