### PR TITLE
feat: add token-gate feature - grant free access to ERC-20/ERC-721 token holders on mppx-protected routes

### DIFF
--- a/examples/token-gate/src/server.ts
+++ b/examples/token-gate/src/server.ts
@@ -1,0 +1,107 @@
+/**
+ * Token-gate example server.
+ *
+ * Token holders (ERC-721 NFT on Base) get free access to the protected route.
+ * Non-holders go through the normal Tempo payment flow.
+ *
+ * The payer's address is read from `credential.source` — no extra client-side
+ * signing is required beyond the standard payment credential.
+ *
+ * Run:
+ *   MPPX_RPC_URL=... NFT_CONTRACT=0x... node --import tsx src/server.ts
+ */
+
+import { Mppx, tempo } from 'mppx/server'
+import { tokenGate } from 'mppx/token-gate'
+import { Receipt } from 'mppx'
+import { createClient, http } from 'viem'
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
+import { base } from 'viem/chains'
+import { tempoModerato } from 'viem/chains'
+import { Actions } from 'viem/tempo'
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const account = privateKeyToAccount(generatePrivateKey())
+const currency = '0x20c0000000000000000000000000000000000000' as const // pathUSD
+
+const NFT_CONTRACT = (process.env.NFT_CONTRACT ?? '0x0000000000000000000000000000000000000001') as `0x${string}`
+
+// ---------------------------------------------------------------------------
+// Build token-gated tempo charge method
+// ---------------------------------------------------------------------------
+
+const tempoCharge = tempo({
+  currency,
+  feePayer: true,
+  recipient: account.address,
+  testnet: true,
+})
+
+const gatedCharge = tokenGate(tempoCharge, {
+  contracts: [
+    {
+      address: NFT_CONTRACT,
+      chain: base,
+      type: 'ERC-721',
+    },
+  ],
+  // cacheTtlSeconds: 300 (default — 5 min)
+})
+
+// ---------------------------------------------------------------------------
+// Server
+// ---------------------------------------------------------------------------
+
+const mppx = Mppx.create({ methods: [gatedCharge] })
+
+export async function handler(request: Request): Promise<Response | null> {
+  const url = new URL(request.url)
+
+  // Health — always free
+  if (url.pathname === '/api/health') {
+    return Response.json({ status: 'ok' })
+  }
+
+  // Protected — free for NFT holders, paid for everyone else
+  if (url.pathname === '/api/data') {
+    const result = await mppx.charge({
+      amount: '0.01',
+      description: 'Exclusive data — free for NFT holders',
+    })(request)
+
+    if (result.status === 402) return result.challenge
+
+    const response = Response.json({ data: 'exclusive content' })
+    const wrapped = result.withReceipt(response)
+
+    // Log whether access was free (token-gated) or paid
+    const receiptHeader = wrapped.headers.get('Payment-Receipt')
+    if (receiptHeader) {
+      const receipt = Receipt.deserialize(receiptHeader)
+      const via = receipt.reference === 'token-gate:free' ? 'free (token holder)' : `paid (${receipt.reference})`
+      console.log(`[access] /api/data — ${via}`)
+    }
+
+    return wrapped
+  }
+
+  return null
+}
+
+// ---------------------------------------------------------------------------
+// Startup
+// ---------------------------------------------------------------------------
+
+const client = createClient({
+  chain: tempoModerato,
+  pollingInterval: 1_000,
+  transport: http(process.env.MPPX_RPC_URL),
+})
+
+await Actions.faucet.fundSync(client, { account })
+console.log(`[server] recipient: ${account.address}`)
+console.log(`[server] NFT contract: ${NFT_CONTRACT}`)
+console.log(`[server] token holders get free access to /api/data`)

--- a/package.json
+++ b/package.json
@@ -144,6 +144,11 @@
       "types": "./dist/middlewares/elysia.d.ts",
       "src": "./src/middlewares/elysia.ts",
       "default": "./dist/middlewares/elysia.js"
+    },
+    "./token-gate": {
+      "types": "./dist/token-gate.d.ts",
+      "src": "./src/token-gate.ts",
+      "default": "./dist/token-gate.js"
     }
   },
   "peerDependencies": {

--- a/src/token-gate.test.ts
+++ b/src/token-gate.test.ts
@@ -1,0 +1,436 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { clearTokenGateCache, parseDid, tokenGate } from './token-gate.js'
+import type { TokenContract } from './token-gate.js'
+import type * as Method from './Method.js'
+import type * as Receipt from './Receipt.js'
+import type * as Credential from './Credential.js'
+import type * as Challenge from './Challenge.js'
+
+// ---------------------------------------------------------------------------
+// viem mock
+// ---------------------------------------------------------------------------
+
+const mockReadContract = vi.fn()
+
+vi.mock('viem', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('viem')>()
+  return {
+    ...actual,
+    createPublicClient: () => ({ readContract: mockReadContract }),
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const BASE_CHAIN = { id: 8453, name: 'Base', rpcUrls: { default: { http: ['https://mainnet.base.org'] } } } as const
+
+const ERC20_CONTRACT: TokenContract = {
+  address: '0xToken000000000000000000000000000000000001',
+  chain: BASE_CHAIN as never,
+  type: 'ERC-20',
+  minBalance: 100n,
+}
+
+const ERC721_CONTRACT: TokenContract = {
+  address: '0xNFT0000000000000000000000000000000000001',
+  chain: BASE_CHAIN as never,
+  type: 'ERC-721',
+}
+
+const ERC721_SPECIFIC: TokenContract = {
+  address: '0xNFT0000000000000000000000000000000000001',
+  chain: BASE_CHAIN as never,
+  type: 'ERC-721',
+  tokenId: 42n,
+}
+
+const TEST_ADDRESS = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266' as `0x${string}`
+const TEST_DID = `did:pkh:eip155:8453:${TEST_ADDRESS}`
+
+function makeChallenge(): Challenge.Challenge {
+  return {
+    id: 'test-challenge-id',
+    realm: 'api.example.com',
+    method: 'tempo',
+    intent: 'charge',
+    request: { amount: '0.01' },
+  }
+}
+
+function makeCredential(source?: string): Credential.Credential {
+  return {
+    challenge: makeChallenge(),
+    payload: { signature: '0xdeadbeef', type: 'hash' as const },
+    ...(source !== undefined && { source }),
+  }
+}
+
+function makeFreeReceipt(methodName = 'tempo'): Receipt.Receipt {
+  return {
+    method: methodName,
+    reference: 'token-gate:free',
+    status: 'success',
+    timestamp: expect.any(String) as unknown as string,
+  }
+}
+
+/** Builds a minimal Method.Server for testing. */
+function makeServer(
+  name = 'tempo',
+  intent = 'charge',
+  verifyResult: Receipt.Receipt | Error = {
+    method: name,
+    reference: '0xpaid',
+    status: 'success',
+    timestamp: new Date().toISOString(),
+  },
+): Method.Server {
+  const verify = vi.fn(async () => {
+    if (verifyResult instanceof Error) throw verifyResult
+    return verifyResult
+  })
+  return {
+    name,
+    intent,
+    schema: {
+      credential: { payload: {} as never },
+      request: {} as never,
+    },
+    verify,
+  } as unknown as Method.Server
+}
+
+// ---------------------------------------------------------------------------
+// parseDid
+// ---------------------------------------------------------------------------
+
+describe('parseDid', () => {
+  test('behavior: parses valid EIP-155 DID', () => {
+    expect(parseDid(`did:pkh:eip155:1:${TEST_ADDRESS}`)).toBe(TEST_ADDRESS)
+  })
+
+  test('behavior: parses DID with different chainId', () => {
+    expect(parseDid(TEST_DID)).toBe(TEST_ADDRESS)
+  })
+
+  test('behavior: returns null for non-eip155 DID', () => {
+    expect(parseDid('did:pkh:solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9')).toBeNull()
+  })
+
+  test('behavior: returns null for malformed DID (too few parts)', () => {
+    expect(parseDid('did:pkh:eip155:1')).toBeNull()
+  })
+
+  test('behavior: returns null for empty string', () => {
+    expect(parseDid('')).toBeNull()
+  })
+
+  test('behavior: returns null when address missing 0x prefix', () => {
+    expect(parseDid('did:pkh:eip155:1:f39Fd6e51aad88F6F4ce6aB8827279cffFb92266')).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// tokenGate — fallthrough cases
+// ---------------------------------------------------------------------------
+
+describe('tokenGate — fallthrough', () => {
+  beforeEach(() => {
+    clearTokenGateCache()
+    mockReadContract.mockReset()
+  })
+
+  test('behavior: falls through when credential has no source', async () => {
+    const server = makeServer()
+    const gated = tokenGate(server, { contracts: [ERC20_CONTRACT] })
+    const credential = makeCredential() // no source
+
+    await gated.verify({ credential, request: { amount: '0.01' } })
+
+    expect(server.verify).toHaveBeenCalledOnce()
+    expect(mockReadContract).not.toHaveBeenCalled()
+  })
+
+  test('behavior: falls through for unparseable DID', async () => {
+    const server = makeServer()
+    const gated = tokenGate(server, { contracts: [ERC20_CONTRACT] })
+    const credential = makeCredential('not-a-did')
+
+    await gated.verify({ credential, request: { amount: '0.01' } })
+
+    expect(server.verify).toHaveBeenCalledOnce()
+    expect(mockReadContract).not.toHaveBeenCalled()
+  })
+
+  test('behavior: falls through for non-eip155 DID', async () => {
+    const server = makeServer()
+    const gated = tokenGate(server, { contracts: [ERC20_CONTRACT] })
+    const credential = makeCredential('did:pkh:solana:mainnet:5eykt4UsFv8P8')
+
+    await gated.verify({ credential, request: { amount: '0.01' } })
+
+    expect(server.verify).toHaveBeenCalledOnce()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// tokenGate — holder path (free receipt)
+// ---------------------------------------------------------------------------
+
+describe('tokenGate — holder', () => {
+  beforeEach(() => {
+    clearTokenGateCache()
+    mockReadContract.mockReset()
+  })
+
+  test('behavior: returns free receipt for ERC-20 holder', async () => {
+    mockReadContract.mockResolvedValue(1000n) // balance >= minBalance (100n)
+
+    const server = makeServer()
+    const gated = tokenGate(server, { contracts: [ERC20_CONTRACT] })
+    const credential = makeCredential(TEST_DID)
+
+    const receipt = await gated.verify({ credential, request: { amount: '0.01' } })
+
+    expect(receipt).toMatchObject(makeFreeReceipt('tempo'))
+    expect(server.verify).not.toHaveBeenCalled()
+  })
+
+  test('behavior: receipt method matches server.name', async () => {
+    mockReadContract.mockResolvedValue(1n)
+
+    const server = makeServer('stripe', 'charge')
+    const gated = tokenGate(server, { contracts: [ERC721_CONTRACT] })
+    const credential = makeCredential(TEST_DID)
+
+    const receipt = await gated.verify({ credential, request: { amount: '0.01' } })
+
+    expect(receipt.method).toBe('stripe')
+    expect(receipt.reference).toBe('token-gate:free')
+  })
+
+  test('behavior: returns free receipt for ERC-721 balanceOf holder', async () => {
+    mockReadContract.mockResolvedValue(3n) // holds 3 NFTs
+
+    const server = makeServer()
+    const gated = tokenGate(server, { contracts: [ERC721_CONTRACT] })
+    const credential = makeCredential(TEST_DID)
+
+    const receipt = await gated.verify({ credential, request: { amount: '0.01' } })
+
+    expect(receipt.reference).toBe('token-gate:free')
+  })
+
+  test('behavior: returns free receipt for ERC-721 ownerOf match', async () => {
+    mockReadContract.mockResolvedValue(TEST_ADDRESS) // ownerOf returns payer address
+
+    const server = makeServer()
+    const gated = tokenGate(server, { contracts: [ERC721_SPECIFIC] })
+    const credential = makeCredential(TEST_DID)
+
+    const receipt = await gated.verify({ credential, request: { amount: '0.01' } })
+
+    expect(receipt.reference).toBe('token-gate:free')
+    expect(mockReadContract).toHaveBeenCalledWith(
+      expect.objectContaining({ functionName: 'ownerOf', args: [42n] }),
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// tokenGate — non-holder path (fallthrough to verify)
+// ---------------------------------------------------------------------------
+
+describe('tokenGate — non-holder', () => {
+  beforeEach(() => {
+    clearTokenGateCache()
+    mockReadContract.mockReset()
+  })
+
+  test('behavior: delegates to original verify when balance is 0', async () => {
+    mockReadContract.mockResolvedValue(0n)
+
+    const server = makeServer()
+    const gated = tokenGate(server, { contracts: [ERC20_CONTRACT] })
+    const credential = makeCredential(TEST_DID)
+
+    await gated.verify({ credential, request: { amount: '0.01' } })
+
+    expect(server.verify).toHaveBeenCalledOnce()
+  })
+
+  test('behavior: delegates to original verify when balance is below minBalance', async () => {
+    mockReadContract.mockResolvedValue(50n) // below minBalance of 100n
+
+    const server = makeServer()
+    const gated = tokenGate(server, { contracts: [ERC20_CONTRACT] })
+    const credential = makeCredential(TEST_DID)
+
+    await gated.verify({ credential, request: { amount: '0.01' } })
+
+    expect(server.verify).toHaveBeenCalledOnce()
+  })
+
+  test('behavior: delegates when ownerOf returns different address', async () => {
+    mockReadContract.mockResolvedValue('0x000000000000000000000000000000000000dead')
+
+    const server = makeServer()
+    const gated = tokenGate(server, { contracts: [ERC721_SPECIFIC] })
+    const credential = makeCredential(TEST_DID)
+
+    await gated.verify({ credential, request: { amount: '0.01' } })
+
+    expect(server.verify).toHaveBeenCalledOnce()
+  })
+
+  test('behavior: ownerOf revert treated as non-holder', async () => {
+    mockReadContract.mockRejectedValue(new Error('execution reverted'))
+
+    const server = makeServer()
+    const gated = tokenGate(server, { contracts: [ERC721_SPECIFIC] })
+    const credential = makeCredential(TEST_DID)
+
+    await gated.verify({ credential, request: { amount: '0.01' } })
+
+    expect(server.verify).toHaveBeenCalledOnce()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// matchMode
+// ---------------------------------------------------------------------------
+
+describe('tokenGate — matchMode', () => {
+  beforeEach(() => {
+    clearTokenGateCache()
+    mockReadContract.mockReset()
+  })
+
+  test('behavior: matchMode any — one holder is enough', async () => {
+    // First contract: not a holder. Second contract: holder.
+    mockReadContract
+      .mockResolvedValueOnce(0n)   // ERC-20: not holder
+      .mockResolvedValueOnce(5n)   // ERC-721: holder
+
+    const server = makeServer()
+    const gated = tokenGate(server, {
+      contracts: [ERC20_CONTRACT, ERC721_CONTRACT],
+      matchMode: 'any',
+    })
+    const credential = makeCredential(TEST_DID)
+
+    const receipt = await gated.verify({ credential, request: { amount: '0.01' } })
+
+    expect(receipt.reference).toBe('token-gate:free')
+  })
+
+  test('behavior: matchMode all — must hold all contracts', async () => {
+    mockReadContract
+      .mockResolvedValueOnce(1000n) // ERC-20: holder
+      .mockResolvedValueOnce(0n)    // ERC-721: not holder
+
+    const server = makeServer()
+    const gated = tokenGate(server, {
+      contracts: [ERC20_CONTRACT, ERC721_CONTRACT],
+      matchMode: 'all',
+    })
+    const credential = makeCredential(TEST_DID)
+
+    await gated.verify({ credential, request: { amount: '0.01' } })
+
+    expect(server.verify).toHaveBeenCalledOnce()
+  })
+
+  test('behavior: matchMode all — holder of all grants free access', async () => {
+    mockReadContract
+      .mockResolvedValueOnce(1000n) // ERC-20: holder
+      .mockResolvedValueOnce(2n)    // ERC-721: holder
+
+    const server = makeServer()
+    const gated = tokenGate(server, {
+      contracts: [ERC20_CONTRACT, ERC721_CONTRACT],
+      matchMode: 'all',
+    })
+    const credential = makeCredential(TEST_DID)
+
+    const receipt = await gated.verify({ credential, request: { amount: '0.01' } })
+
+    expect(receipt.reference).toBe('token-gate:free')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cache
+// ---------------------------------------------------------------------------
+
+describe('tokenGate — cache', () => {
+  beforeEach(() => {
+    clearTokenGateCache()
+    mockReadContract.mockReset()
+  })
+
+  test('behavior: second call uses cached result (no extra readContract)', async () => {
+    mockReadContract.mockResolvedValue(1000n)
+
+    const server = makeServer()
+    const gated = tokenGate(server, { contracts: [ERC20_CONTRACT] })
+    const credential = makeCredential(TEST_DID)
+
+    await gated.verify({ credential, request: { amount: '0.01' } })
+    await gated.verify({ credential, request: { amount: '0.01' } })
+
+    expect(mockReadContract).toHaveBeenCalledOnce()
+  })
+
+  test('behavior: clearTokenGateCache forces fresh readContract call', async () => {
+    mockReadContract.mockResolvedValue(1000n)
+
+    const server = makeServer()
+    const gated = tokenGate(server, { contracts: [ERC20_CONTRACT] })
+    const credential = makeCredential(TEST_DID)
+
+    await gated.verify({ credential, request: { amount: '0.01' } })
+    clearTokenGateCache()
+    await gated.verify({ credential, request: { amount: '0.01' } })
+
+    expect(mockReadContract).toHaveBeenCalledTimes(2)
+  })
+
+  test('behavior: expired cache entry triggers fresh readContract call', async () => {
+    mockReadContract.mockResolvedValue(1000n)
+
+    const server = makeServer()
+    // Very short TTL: 0 seconds
+    const gated = tokenGate(server, { contracts: [ERC20_CONTRACT], cacheTtlSeconds: 0 })
+    const credential = makeCredential(TEST_DID)
+
+    await gated.verify({ credential, request: { amount: '0.01' } })
+    await gated.verify({ credential, request: { amount: '0.01' } })
+
+    expect(mockReadContract).toHaveBeenCalledTimes(2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Preserves server shape
+// ---------------------------------------------------------------------------
+
+describe('tokenGate — server shape', () => {
+  test('behavior: preserves all original server fields', () => {
+    const server = makeServer()
+    const gated = tokenGate(server, { contracts: [ERC20_CONTRACT] })
+
+    expect(gated.name).toBe(server.name)
+    expect(gated.intent).toBe(server.intent)
+    expect(gated.schema).toBe(server.schema)
+  })
+
+  test('behavior: replaces only verify', () => {
+    const server = makeServer()
+    const gated = tokenGate(server, { contracts: [ERC20_CONTRACT] })
+
+    expect(gated.verify).not.toBe(server.verify)
+  })
+})

--- a/src/token-gate.ts
+++ b/src/token-gate.ts
@@ -1,0 +1,306 @@
+/**
+ * Token-gate utility for mppx.
+ *
+ * Wraps any `Method.Server` and grants free access to ERC-20/ERC-721 token
+ * holders by checking on-chain balance inside the `verify` hook. The payer's
+ * address is extracted from `credential.source` (DID format), so no extra
+ * client-side signing is required.
+ *
+ * @example
+ * ```ts
+ * import { tokenGate } from 'mppx/token-gate'
+ * import { base } from 'viem/chains'
+ *
+ * const gatedCharge = tokenGate(tempoCharge, {
+ *   contracts: [{ address: '0xYourNFT', chain: base, type: 'ERC-721' }],
+ * })
+ *
+ * const mppx = Mppx.create({ methods: [gatedCharge], secretKey: '...' })
+ * app.get('/premium', mppx.charge({ amount: '$0.01' }), handler)
+ * ```
+ */
+
+import { createPublicClient, http } from 'viem'
+import type { Chain, PublicClient } from 'viem'
+import type * as Method from './Method.js'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * An ERC-20 or ERC-721 token contract to check for holder status.
+ */
+export type TokenContract = {
+  /** Contract address on the EVM chain. */
+  address: `0x${string}`
+  /** viem chain object (e.g. `base`, `mainnet`). */
+  chain: Chain
+  /** Token standard. */
+  type: 'ERC-20' | 'ERC-721'
+  /** Minimum balance required. Defaults to `1n`. For ERC-20 this is in the token's smallest unit. */
+  minBalance?: bigint | undefined
+  /** Specific ERC-721 token ID. When set, uses `ownerOf()` instead of `balanceOf()`. */
+  tokenId?: bigint | undefined
+}
+
+/**
+ * Options for `tokenGate`.
+ */
+export type TokenGateOptions = {
+  /** Token contracts to check. */
+  contracts: TokenContract[]
+  /**
+   * Whether the address must hold at least one contract (`'any'`) or all
+   * contracts (`'all'`). Defaults to `'any'`.
+   */
+  matchMode?: 'any' | 'all' | undefined
+  /**
+   * How long to cache on-chain ownership results in seconds.
+   * Defaults to `300` (5 minutes).
+   */
+  cacheTtlSeconds?: number | undefined
+}
+
+// ---------------------------------------------------------------------------
+// ABIs
+// ---------------------------------------------------------------------------
+
+/** balanceOf(address) → uint256 */
+const BALANCE_OF_ABI = [
+  {
+    name: 'balanceOf',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [{ name: 'owner', type: 'address' }],
+    outputs: [{ name: '', type: 'uint256' }],
+  },
+] as const
+
+/** ownerOf(tokenId) → address */
+const OWNER_OF_ABI = [
+  {
+    name: 'ownerOf',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [{ name: 'tokenId', type: 'uint256' }],
+    outputs: [{ name: '', type: 'address' }],
+  },
+] as const
+
+// ---------------------------------------------------------------------------
+// Caches
+// ---------------------------------------------------------------------------
+
+interface CacheEntry {
+  isHolder: boolean
+  expiresAt: number
+}
+
+/** In-memory ownership cache, keyed by `address:chainId:contractAddress[:tokenId]`. */
+const ownershipCache = new Map<string, CacheEntry>()
+
+/** Per-chain viem public clients, keyed by chainId. */
+const publicClientCache = new Map<number, PublicClient>()
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Parses a DID-PKH string and returns the EVM address, or `null` if the DID
+ * is absent, malformed, or not an EIP-155 (EVM) DID.
+ *
+ * @param source - DID string, e.g. `"did:pkh:eip155:8453:0xABC..."`
+ * @returns The `0x`-prefixed address, or `null`.
+ */
+export function parseDid(source: string): `0x${string}` | null {
+  const parts = source.split(':')
+  // Expected: ["did", "pkh", "eip155", chainId, address]
+  if (parts.length !== 5) return null
+  if (parts[0] !== 'did' || parts[1] !== 'pkh' || parts[2] !== 'eip155') return null
+  const address = parts[4]
+  if (!address || !address.startsWith('0x')) return null
+  return address as `0x${string}`
+}
+
+/**
+ * Returns a cached viem public client for the given chain.
+ *
+ * @param chain - viem chain object
+ * @returns Public client for the chain
+ */
+function getPublicClient(chain: Chain): PublicClient {
+  const existing = publicClientCache.get(chain.id)
+  if (existing) return existing
+  const client = createPublicClient({ chain, transport: http() })
+  publicClientCache.set(chain.id, client)
+  return client
+}
+
+/**
+ * Checks whether a single contract grants holder status to the address.
+ *
+ * @param address - EVM wallet address to check
+ * @param contract - Token contract definition
+ * @param cacheTtlMs - Cache TTL in milliseconds
+ * @returns True if the address holds the required tokens
+ */
+async function checkContract(
+  address: `0x${string}`,
+  contract: TokenContract,
+  cacheTtlMs: number,
+): Promise<boolean> {
+  const tokenIdSuffix = contract.tokenId !== undefined ? `:${contract.tokenId}` : ''
+  const cacheKey = `${address.toLowerCase()}:${contract.chain.id}:${contract.address.toLowerCase()}${tokenIdSuffix}`
+
+  const cached = ownershipCache.get(cacheKey)
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.isHolder
+  }
+
+  const client = getPublicClient(contract.chain)
+  let isHolder: boolean
+
+  if (contract.type === 'ERC-721' && contract.tokenId !== undefined) {
+    try {
+      const owner = (await client.readContract({
+        address: contract.address,
+        abi: OWNER_OF_ABI,
+        functionName: 'ownerOf',
+        args: [contract.tokenId],
+      })) as `0x${string}`
+      isHolder = owner.toLowerCase() === address.toLowerCase()
+    } catch {
+      // ownerOf reverts for non-existent tokens
+      isHolder = false
+    }
+  } else {
+    const minBalance = contract.minBalance ?? 1n
+    const balance = (await client.readContract({
+      address: contract.address,
+      abi: BALANCE_OF_ABI,
+      functionName: 'balanceOf',
+      args: [address],
+    })) as bigint
+    isHolder = balance >= minBalance
+  }
+
+  ownershipCache.set(cacheKey, { isHolder, expiresAt: Date.now() + cacheTtlMs })
+  return isHolder
+}
+
+/**
+ * Checks on-chain token ownership for the given address across all contracts.
+ *
+ * @param address - EVM wallet address
+ * @param contracts - Token contracts to check
+ * @param matchMode - `'any'` (default) or `'all'`
+ * @param cacheTtlMs - Cache TTL in milliseconds
+ * @returns True if the address qualifies as a token holder
+ */
+async function checkOwnership(
+  address: `0x${string}`,
+  contracts: TokenContract[],
+  matchMode: 'any' | 'all',
+  cacheTtlMs: number,
+): Promise<boolean> {
+  if (contracts.length === 0) return false
+
+  if (matchMode === 'all') {
+    for (const contract of contracts) {
+      if (!(await checkContract(address, contract, cacheTtlMs))) return false
+    }
+    return true
+  }
+
+  for (const contract of contracts) {
+    if (await checkContract(address, contract, cacheTtlMs)) return true
+  }
+  return false
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Wraps a `Method.Server` and grants free access to token holders.
+ *
+ * The payer's address is extracted from `credential.source` (a DID-PKH string
+ * embedded in the credential). If the address holds the required tokens, a
+ * free receipt is returned instead of settling payment. Non-holders and
+ * credentials without a `source` field fall through to the original `verify`.
+ *
+ * On-chain results are cached in-process for 5 minutes by default
+ * (configurable via `cacheTtlSeconds`).
+ *
+ * @param server - The method server to wrap (e.g. a tempo charge server).
+ * @param options - Token contracts and cache options.
+ * @returns A new `Method.Server` with token-gate logic in `verify`.
+ *
+ * @example
+ * ```ts
+ * import { tokenGate } from 'mppx/token-gate'
+ * import { base } from 'viem/chains'
+ *
+ * const gatedCharge = tokenGate(tempoCharge, {
+ *   contracts: [{ address: '0xYourNFT', chain: base, type: 'ERC-721' }],
+ * })
+ * ```
+ */
+export function tokenGate<
+  const method extends Method.Method,
+  const defaults extends Method.RequestDefaults<method>,
+  const transportOverride,
+>(
+  server: Method.Server<method, defaults, transportOverride>,
+  options: TokenGateOptions,
+): Method.Server<method, defaults, transportOverride> {
+  const { contracts, matchMode = 'any', cacheTtlSeconds = 300 } = options
+  const cacheTtlMs = cacheTtlSeconds * 1000
+
+  return {
+    ...server,
+    verify: async (params) => {
+      const { credential } = params
+
+      // No source field — fall through to normal payment
+      if (!credential.source) {
+        return server.verify(params)
+      }
+
+      // Parse DID to extract EVM address
+      const address = parseDid(credential.source)
+      if (!address) {
+        // Unparseable or non-EVM DID — fall through
+        return server.verify(params)
+      }
+
+      // Check on-chain ownership (cached)
+      const isHolder = await checkOwnership(address, contracts, matchMode, cacheTtlMs)
+
+      if (isHolder) {
+        // Token holder — grant free access
+        return {
+          method: server.name,
+          reference: 'token-gate:free',
+          status: 'success',
+          timestamp: new Date().toISOString(),
+        }
+      }
+
+      // Not a holder — normal payment
+      return server.verify(params)
+    },
+  }
+}
+
+/**
+ * Clears the in-memory ownership and public client caches.
+ * Useful for testing or when you need to force fresh on-chain lookups.
+ */
+export function clearTokenGateCache(): void {
+  ownershipCache.clear()
+  publicClientCache.clear()
+}


### PR DESCRIPTION
## Description

Adds a `tokenGate()` utility that wraps any `Method.Server` and grants free access to on-chain token holders, with no client-side changes required.

### How it works

mppx already embeds the payer's identity in every payment credential as a DID string (`credential.source: "did:pkh:eip155:8453:0xABC..."`). `tokenGate` reads that address, checks on-chain ownership via viem, and short-circuits the payment flow for holders — no extra client signing needed.

1. Request arrives with a payment credential
2. `tokenGate` extracts the payer address from `credential.source`
3. On-chain ownership is checked via `balanceOf` (ERC-20 / ERC-721) or `ownerOf` (specific token ID)
4. **Token holder** → free receipt returned (`reference: "token-gate:free"`)
5. **Non-holder** → delegates to the original `verify` (normal payment proceeds)

Credentials without a `source` field or with a non-EVM DID fall through transparently.

### Usage

```ts
import { tokenGate } from 'mppx/token-gate'
import { base } from 'viem/chains'

const gatedCharge = tokenGate(tempoCharge, {
  contracts: [{ address: '0xYourNFT', chain: base, type: 'ERC-721' }],
})

const mppx = Mppx.create({ methods: [gatedCharge] })
```

Works with any framework (Hono, Express, Elysia, Next.js) and any payment method (tempo, stripe) — it operates at the `Method.Server` level, so no middleware changes are needed.

### Options

| Option | Type | Default | Description |
|---|---|---|---|
| `contracts` | `TokenContract[]` | — | ERC-20 or ERC-721 contracts to check |
| `matchMode` | `'any' \| 'all'` | `'any'` | Whether the holder must own any or all contracts |
| `cacheTtlSeconds` | `number` | `300` | In-process ownership cache TTL |

`TokenContract` fields: `address`, `chain`, `type`, optional `minBalance` (default `1n`), optional `tokenId` (ERC-721 — uses `ownerOf` instead of `balanceOf`).

### Distinguishing free vs paid access

The `Payment-Receipt` header's `reference` field identifies how access was granted:

```ts
const receipt = Receipt.fromResponse(response)
const via = receipt.reference === 'token-gate:free'
  ? 'free (token holder)'
  : `paid (${receipt.reference})`
```

### Changes

- `src/token-gate.ts` — `tokenGate()`, `parseDid()`, `clearTokenGateCache()`
- `src/token-gate.test.ts` — 25 tests (DID parsing, holder/non-holder paths, ERC-20/ERC-721, `matchMode`, cache TTL, server shape)
- `examples/token-gate/src/server.ts` — NFT-gated route example
- `package.json` — `"mppx/token-gate"` export added