### PR TITLE
test: gate on-chain session tests behind localnet check

### DIFF
--- a/src/tempo/client/ChannelOps.test.ts
+++ b/src/tempo/client/ChannelOps.test.ts
@@ -3,8 +3,11 @@ import { type Address, createClient } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { Addresses } from 'viem/tempo'
 import { beforeAll, describe, expect, test } from 'vitest'
+import { nodeEnv } from '~test/config.js'
 import { deployEscrow, openChannel } from '~test/tempo/session.js'
 import { accounts, asset, chain, client, fundAccount, http } from '~test/tempo/viem.js'
+
+const isLocalnet = nodeEnv === 'localnet'
 
 import type { Challenge } from '../../Challenge.js'
 import * as Credential from '../../Credential.js'
@@ -166,7 +169,7 @@ describe('createClosePayload', () => {
   })
 })
 
-describe('createOpenPayload', () => {
+describe.runIf(isLocalnet)('createOpenPayload', () => {
   const payer = accounts[2]
   const payee = accounts[1].address
   const currency = asset
@@ -250,7 +253,7 @@ describe('createOpenPayload', () => {
   })
 })
 
-describe('tryRecoverChannel', () => {
+describe.runIf(isLocalnet)('tryRecoverChannel', () => {
   const payer = accounts[3]
   const payee = accounts[1].address
   const currency = asset

--- a/src/tempo/client/Session.test.ts
+++ b/src/tempo/client/Session.test.ts
@@ -2,8 +2,11 @@ import { type Address, createClient, type Hex, http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { Addresses } from 'viem/tempo'
 import { beforeAll, describe, expect, test } from 'vitest'
+import { nodeEnv } from '~test/config.js'
 import { deployEscrow, openChannel } from '~test/tempo/session.js'
 import { accounts, asset, chain, client, fundAccount } from '~test/tempo/viem.js'
+
+const isLocalnet = nodeEnv === 'localnet'
 
 import * as Challenge from '../../Challenge.js'
 import * as Credential from '../../Credential.js'
@@ -201,7 +204,7 @@ describe('session (pure)', () => {
   })
 })
 
-describe('session (on-chain)', () => {
+describe.runIf(isLocalnet)('session (on-chain)', () => {
   const payer = accounts[2]
   const payee = accounts[1].address
   let escrowContract: Address

--- a/src/tempo/server/Session.test.ts
+++ b/src/tempo/server/Session.test.ts
@@ -5,6 +5,9 @@ import { type Address, createClient, type Hex } from 'viem'
 import { waitForTransactionReceipt } from 'viem/actions'
 import { Addresses } from 'viem/tempo'
 import { beforeAll, beforeEach, describe, expect, test } from 'vitest'
+import { nodeEnv } from '~test/config.js'
+
+const isLocalnet = nodeEnv === 'localnet'
 import {
   deployEscrow,
   requestCloseChannel,
@@ -40,12 +43,13 @@ let escrowContract: Address
 let saltCounter = 0
 
 beforeAll(async () => {
+  if (!isLocalnet) return
   escrowContract = await deployEscrow()
   await fundAccount({ address: payer.address, token: Addresses.pathUsd })
   await fundAccount({ address: payer.address, token: currency })
 })
 
-describe('session', () => {
+describe.runIf(isLocalnet)('session', () => {
   let rawStore: Store.Store
   let store: ChannelStore.ChannelStore
 

--- a/src/tempo/session/Chain.test.ts
+++ b/src/tempo/session/Chain.test.ts
@@ -2,6 +2,7 @@ import { type Address, encodeFunctionData, erc20Abi, type Hex } from 'viem'
 import { waitForTransactionReceipt } from 'viem/actions'
 import { Addresses, Transaction } from 'viem/tempo'
 import { beforeAll, describe, expect, test } from 'vitest'
+import { nodeEnv } from '~test/config.js'
 import {
   closeChannelOnChain,
   deployEscrow,
@@ -21,6 +22,8 @@ import {
   verifyTopUpTransaction,
 } from './Chain.js'
 import { signVoucher } from './Voucher.js'
+
+const isLocalnet = nodeEnv === 'localnet'
 
 const UINT128_MAX = 2n ** 128n - 1n
 
@@ -70,7 +73,7 @@ describe('assertUint128 (via settleOnChain / closeOnChain)', () => {
   })
 })
 
-describe('on-chain', () => {
+describe.runIf(isLocalnet)('on-chain', () => {
   const payer = accounts[2]
   const recipient = accounts[0].address
   const currency = asset


### PR DESCRIPTION
## Summary

Gate session tests that require a running Tempo node behind `describe.runIf(isLocalnet)` so pure unit tests can run in CI without a localnet dependency.

## Changes

| File | Change |
|------|--------|
| `server/Session.test.ts` | Guard `beforeAll(deployEscrow)` + wrap main `describe('session')` with `runIf`. `respond`, `monotonicity`, `default currency`, and `SSE` type tests now run everywhere. |
| `client/Session.test.ts` | Gate `describe('session (on-chain)')`. Pure tests unchanged. |
| `client/ChannelOps.test.ts` | Gate `createOpenPayload` and `tryRecoverChannel`. |
| `session/Chain.test.ts` | Gate `describe('on-chain')`. `assertUint128` unchanged. |
| `test/session-test-plan.md` | Coverage plan with unit/integration classification. |