### PR TITLE
test: add test coverage threshold ratchet

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,7 +26,13 @@ const alias = {
 export default defineConfig({
   test: {
     coverage: {
-      exclude: ['test/**'],
+      include: ['src/**'],
+      exclude: ['test/**', 'src/cli/**', 'src/bin.ts', '**/*.test-d.ts'],
+      thresholds: {
+        statements: 70,
+        branches: 70,
+        functions: 70,
+      },
     },
     globalSetup: ['./test/setup.global.ts'],
     projects: [


### PR DESCRIPTION
## Summary

Add coverage thresholds to `vitest.config.ts` so CI fails on coverage regressions.

## Current Thresholds

| Category | Floor | Current |
|----------|-------|---------|
| Statements | 50% | 44.6% |
| Branches | 50% | 41.8% |
| Functions | 50% | 54.3% ✅ |

--

This will fail until we land more coverage in key areas