### PR TITLE
fix: add client-side challenge expiration validation

### DIFF
--- a/src/client/Mppx.ts
+++ b/src/client/Mppx.ts
@@ -1,4 +1,5 @@
 import type * as Challenge from '../Challenge.js'
+import * as Errors from '../Errors.js'
 import type * as Method from '../Method.js'
 import type * as z from '../zod.js'
 import * as Fetch from './internal/Fetch.js'
@@ -80,6 +81,11 @@ export function create<
     transport,
     async createCredential(response: Transport.ResponseOf<transport>, context?: unknown) {
       const challenge = transport.getChallenge(response as never) as Challenge.Challenge
+
+      // Validate challenge expiration before creating credential (client-side early rejection)
+      if (challenge.expires && new Date(challenge.expires) < new Date()) {
+        throw new Errors.PaymentExpiredError({ expires: challenge.expires })
+      }
 
       const mi = methods.find((m) => m.name === challenge.method && m.intent === challenge.intent)
       if (!mi)

--- a/src/client/internal/Fetch.ts
+++ b/src/client/internal/Fetch.ts
@@ -1,4 +1,5 @@
 import * as Challenge from '../../Challenge.js'
+import * as Errors from '../../Errors.js'
 import type * as Method from '../../Method.js'
 import type * as z from '../../zod.js'
 
@@ -71,6 +72,9 @@ export function from<const methods extends readonly Method.AnyClient[]>(
       throw new Error(
         `No method found for challenges: ${challenges.map((c) => `${c.method}.${c.intent}`).join(', ')}. Available: ${methods.map((m) => `${m.name}.${m.intent}`).join(', ')}`,
       )
+
+    // Validate challenge expiration before creating credential (client-side early rejection)
+    validateChallengeExpiration(challenge)
 
     const onChallengeCredential = onChallenge
       ? await onChallenge(challenge, {
@@ -237,6 +241,13 @@ function validateCredentialHeaderValue(credential: string): void {
   if (!credential.trim()) throw new Error('Credential header value must be non-empty')
   if (credential.includes('\r') || credential.includes('\n')) {
     throw new Error('Credential header value contains illegal newline characters')
+  }
+}
+
+/** @internal Validates that a challenge has not expired. */
+function validateChallengeExpiration(challenge: Challenge.Challenge): void {
+  if (challenge.expires && new Date(challenge.expires) < new Date()) {
+    throw new Errors.PaymentExpiredError({ expires: challenge.expires })
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #198

## Problem

When a client receives a Challenge with an `expires` timestamp that has already passed, the client still attempts to create a credential and make the payment. This results in:

1. Wasted user time - wallet interactions that will be rejected
2. Unnecessary network round-trips
3. User confusion (why did my payment fail?)

The server already validates expiration (`src/server/Mppx.ts:359-367`), but by then the client has already connected wallet and signed transactions.

## Solution

Adds client-side expiration validation at two code paths:

1. **`Fetch.from()`** - auto-402 interceptor, after challenge matching
2. **`Mppx.createCredential()`** - manual API, after challenge parsing

Both throw `PaymentExpiredError` (already defined in `Errors.ts`) when `challenge.expires` is set and in the past.

## Changes

```ts
// src/client/internal/Fetch.ts - after finding matching challenge
validateChallengeExpiration(challenge)

// src/client/Mppx.ts - in createCredential()
if (challenge.expires && new Date(challenge.expires) < new Date()) {
  throw new Errors.PaymentExpiredError({ expires: challenge.expires })
}
```

## Testing

```ts
// Expired challenge
const challenge = { expires: "2025-01-01T00:00:00Z", ... }
await mppx.createCredential(response)
// Throws: PaymentExpiredError: Payment expired at 2025-01-01T00:00:00Z.
```

## Impact

- Type: UX improvement
- Risk: Low - fails faster with clearer error
- Breaking: No - just changes when the error is thrown