### PR TITLE
fix: fail at session() initialization when account is missing

### DIFF
--- a/.changeset/session-require-account.md
+++ b/.changeset/session-require-account.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+`tempo.session()` now throws immediately at initialization if no viem `Account` is provided, instead of failing later with an opaque error during channel close. The error message includes an example fix.

--- a/src/client/internal/Fetch.test.ts
+++ b/src/client/internal/Fetch.test.ts
@@ -16,6 +16,7 @@ const server = Mppx_server.create({
   methods: [
     tempo_server({
       getClient: () => client,
+      account: accounts[0],
     }),
   ],
   realm,

--- a/src/middlewares/express.test.ts
+++ b/src/middlewares/express.test.ts
@@ -29,7 +29,7 @@ describe('charge', () => {
       tempo_server({
         getClient: () => client,
         currency: asset,
-        recipient: accounts[0].address,
+        account: accounts[0],
       }),
     ],
     secretKey,
@@ -97,7 +97,7 @@ describe('session', () => {
       methods: [
         tempo_server.session({
           getClient: () => client,
-          recipient: accounts[0].address,
+          account: accounts[0],
           currency: asset,
           escrowContract,
         }),
@@ -123,10 +123,10 @@ describe('session', () => {
       methods: [
         tempo_server.session({
           getClient: () => client,
-          recipient: accounts[0].address,
+          account: accounts[0],
           currency: asset,
           escrowContract,
-          feePayer: accounts[0],
+          feePayer: true,
         }),
       ],
       secretKey,
@@ -165,7 +165,7 @@ describe('payment', () => {
       tempo_server({
         getClient: () => client,
         currency: asset,
-        recipient: accounts[0].address,
+        account: accounts[0],
       }),
     ],
     secretKey,

--- a/src/middlewares/hono.test.ts
+++ b/src/middlewares/hono.test.ts
@@ -29,7 +29,7 @@ describe('charge', () => {
       tempo_server.charge({
         getClient: () => client,
         currency: asset,
-        recipient: accounts[0].address,
+        account: accounts[0],
       }),
     ],
     secretKey,
@@ -90,7 +90,7 @@ describe('session', () => {
       methods: [
         tempo_server.session({
           getClient: () => client,
-          recipient: accounts[0].address,
+          account: accounts[0],
           currency: asset,
           escrowContract,
         }),
@@ -116,10 +116,10 @@ describe('session', () => {
       methods: [
         tempo_server.session({
           getClient: () => client,
-          recipient: accounts[0].address,
+          account: accounts[0],
           currency: asset,
           escrowContract,
-          feePayer: accounts[0],
+          feePayer: true,
         }),
       ],
       secretKey,

--- a/src/middlewares/nextjs.test.ts
+++ b/src/middlewares/nextjs.test.ts
@@ -42,7 +42,7 @@ describe('charge', () => {
       tempo_server.charge({
         getClient: () => client,
         currency: asset,
-        recipient: accounts[0].address,
+        account: accounts[0],
       }),
     ],
     secretKey,
@@ -105,7 +105,7 @@ describe('session', () => {
       methods: [
         tempo_server.session({
           getClient: () => client,
-          recipient: accounts[0].address,
+          account: accounts[0],
           currency: asset,
           escrowContract,
         }),
@@ -130,10 +130,10 @@ describe('session', () => {
       methods: [
         tempo_server.session({
           getClient: () => client,
-          recipient: accounts[0].address,
+          account: accounts[0],
           currency: asset,
           escrowContract,
-          feePayer: accounts[0],
+          feePayer: true,
         }),
       ],
       secretKey,

--- a/src/server/Mppx.test.ts
+++ b/src/server/Mppx.test.ts
@@ -9,6 +9,7 @@ const secretKey = 'test-secret-key'
 
 const method = tempo({
   getClient: () => client,
+  account: accounts[0],
 })
 
 describe('create', () => {

--- a/src/tempo/server/Session.test.ts
+++ b/src/tempo/server/Session.test.ts
@@ -35,6 +35,7 @@ import { signVoucher } from '../session/Voucher.js'
 import { charge, session, settle } from './Session.js'
 
 const payer = accounts[2]
+const recipientAccount = accounts[0]
 const recipient = accounts[0].address
 const currency = asset
 
@@ -61,7 +62,7 @@ describe.runIf(isLocalnet)('session', () => {
     return session({
       store: rawStore,
       getClient: () => client,
-      account: recipient,
+      account: recipientAccount,
       currency,
       escrowContract,
       chainId: chain.id,
@@ -1237,27 +1238,29 @@ describe.runIf(isLocalnet)('session', () => {
       expect(ch!.finalized).toBe(true)
     })
 
-    test('close throws when client has no account', async () => {
-      const { channelId, serializedTransaction } = await createSignedOpenTransaction(10000000n)
-      const server = createServer({
-        getClient: () => createClient({ chain, transport: http() }),
-      })
-      await openServerChannel(server, channelId, serializedTransaction)
+    test('session() throws at initialization when no account provided', () => {
+      expect(() =>
+        session({
+          store: rawStore,
+          getClient: () => client,
+          account: recipient as Address,
+          currency,
+          escrowContract,
+          chainId: chain.id,
+        } as session.Parameters),
+      ).toThrow('tempo.session() requires an `account`')
+    })
 
-      await expect(
-        server.verify({
-          credential: {
-            challenge: makeChallenge({ id: 'challenge-2', channelId }),
-            payload: {
-              action: 'close' as const,
-              channelId,
-              cumulativeAmount: '1000000',
-              signature: await signTestVoucher(channelId, 1000000n),
-            },
-          },
-          request: makeRequest(),
-        }),
-      ).rejects.toThrow('Cannot close channel: no account available')
+    test('session() throws at initialization with no account at all', () => {
+      expect(() =>
+        session({
+          store: rawStore,
+          getClient: () => client,
+          currency,
+          escrowContract,
+          chainId: chain.id,
+        } as session.Parameters),
+      ).toThrow('tempo.session() requires an `account`')
     })
   })
 
@@ -2254,6 +2257,7 @@ describe('monotonicity and TOCTOU (unit tests)', () => {
 })
 
 describe('session default currency resolution', () => {
+  const mockAccount = accounts[0]
   const mockClient = createClient({ transport: http('http://localhost:1') })
   const mockMainnetClient = createClient({
     chain: {
@@ -2278,7 +2282,7 @@ describe('session default currency resolution', () => {
     const server = session({
       store: Store.memory(),
       getClient: () => mockClient,
-      account: '0x0000000000000000000000000000000000000001',
+      account: mockAccount,
       escrowContract: '0x0000000000000000000000000000000000000002',
     } as session.Parameters)
     expect(server.defaults?.currency).toBe('0x20C000000000000000000000b9537d11c60E8b50')
@@ -2288,7 +2292,7 @@ describe('session default currency resolution', () => {
     const server = session({
       store: Store.memory(),
       getClient: () => mockClient,
-      account: '0x0000000000000000000000000000000000000001',
+      account: mockAccount,
       escrowContract: '0x0000000000000000000000000000000000000002',
       testnet: true,
     } as session.Parameters)
@@ -2299,7 +2303,7 @@ describe('session default currency resolution', () => {
     const server = session({
       store: Store.memory(),
       getClient: () => mockClient,
-      account: '0x0000000000000000000000000000000000000001',
+      account: mockAccount,
       escrowContract: '0x0000000000000000000000000000000000000002',
       chainId: 69420,
     } as session.Parameters)
@@ -2310,7 +2314,7 @@ describe('session default currency resolution', () => {
     const server = session({
       store: Store.memory(),
       getClient: () => mockClient,
-      account: '0x0000000000000000000000000000000000000001',
+      account: mockAccount,
       currency: '0xcustom',
       escrowContract: '0x0000000000000000000000000000000000000002',
       chainId: 4217,
@@ -2323,7 +2327,7 @@ describe('session default currency resolution', () => {
     const server = session({
       store: Store.memory(),
       getClient: () => mockClient,
-      account: '0x0000000000000000000000000000000000000001',
+      account: mockAccount,
       escrowContract: '0x0000000000000000000000000000000000000002',
       chainId: 42431,
     } as session.Parameters)
@@ -2336,7 +2340,7 @@ describe('session default currency resolution', () => {
         tempo_server.session({
           store: Store.memory(),
           getClient: () => mockMainnetClient,
-          account: '0x0000000000000000000000000000000000000001',
+          account: mockAccount,
           escrowContract: '0x0000000000000000000000000000000000000002',
           chainId: 4217,
           testnet: false,
@@ -2363,7 +2367,7 @@ describe('session default currency resolution', () => {
         tempo_server.session({
           store: Store.memory(),
           getClient: () => mockTestnetClient,
-          account: '0x0000000000000000000000000000000000000001',
+          account: mockAccount,
           escrowContract: '0x0000000000000000000000000000000000000002',
           testnet: true,
         }),
@@ -2390,7 +2394,7 @@ describe('session default currency resolution', () => {
         tempo_server.session({
           store: Store.memory(),
           getClient: () => mockTestnetClient,
-          account: '0x0000000000000000000000000000000000000001',
+          account: mockAccount,
           escrowContract: '0x0000000000000000000000000000000000000002',
           chainId: 69420,
         }),
@@ -2416,7 +2420,7 @@ describe('session default currency resolution', () => {
         tempo_server.session({
           store: Store.memory(),
           getClient: () => mockClient,
-          account: '0x0000000000000000000000000000000000000001',
+          account: mockAccount,
           currency: '0xcustom',
           escrowContract: '0x0000000000000000000000000000000000000002',
           chainId: 4217,

--- a/src/tempo/server/Session.ts
+++ b/src/tempo/server/Session.ts
@@ -101,6 +101,11 @@ export function session<const parameters extends session.Parameters>(p?: paramet
 
   const { account, recipient, feePayer, feePayerUrl } = Account.resolve(parameters)
 
+  if (!account)
+    throw new Error(
+      'tempo.session() requires an `account` (viem Account, e.g. privateKeyToAccount("0x...")). An address string is not sufficient — the server needs a signing account for on-chain channel close and settlement.',
+    )
+
   const getClient = Client.getResolver({
     chain: tempo_chain,
     feePayerUrl,

--- a/src/tempo/session/Chain.ts
+++ b/src/tempo/session/Chain.ts
@@ -132,7 +132,7 @@ export async function closeOnChain(
   const resolved = account ?? client.account
   if (!resolved)
     throw new Error(
-      'Cannot close channel: no account available. Provide an `account` in the session config or a `getClient` that returns an account-bearing client.',
+      'Cannot close channel: no account available. Pass an `account` (viem Account, e.g. privateKeyToAccount("0x...")) to tempo.session(), or provide a `getClient` that returns an account-bearing client.',
     )
   const args = [voucher.channelId, voucher.cumulativeAmount, voucher.signature] as const
   if (feePayer) {


### PR DESCRIPTION
## Problem

When `tempo.session()` is configured without a viem `Account`, the server starts up fine but fails later with an opaque error during a channel close request:

```
Cannot close channel: no account available. Provide an `account` in the session config or a `getClient` that returns an account-bearing client.
```

## Fix

Now `session()` throws **immediately at initialization** with a clear, actionable message:

```
tempo.session() requires an `account` (viem Account, e.g. privateKeyToAccount("0x...")).
An address string is not sufficient — the server needs a signing account for on-chain
channel close and settlement.
```

Companion docs PR: https://github.com/tempoxyz/mpp/pull/460