### PR TITLE
feat: add OWS wallet support via owsAccount()

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,11 @@
       "src": "./src/tempo/index.ts",
       "default": "./dist/tempo/index.js"
     },
+    "./ows": {
+      "types": "./dist/ows.d.ts",
+      "src": "./src/ows.ts",
+      "default": "./dist/ows.js"
+    },
     "./hono": {
       "types": "./dist/middlewares/hono.d.ts",
       "src": "./src/middlewares/hono.ts",
@@ -148,10 +153,14 @@
     "elysia": ">=1",
     "express": ">=5",
     "hono": ">=4",
+    "@open-wallet-standard/core": ">=1.0.0",
     "viem": ">=2.47.5"
   },
   "peerDependenciesMeta": {
     "@modelcontextprotocol/sdk": {
+      "optional": true
+    },
+    "@open-wallet-standard/core": {
       "optional": true
     },
     "elysia": {

--- a/src/ows.ts
+++ b/src/ows.ts
@@ -1,0 +1,44 @@
+import { privateKeyToAccount } from 'viem/accounts'
+import type { Account } from 'viem'
+
+/**
+ * Create a viem Account from an OWS wallet.
+ *
+ * Decrypts the EVM signing key from the OWS vault and wraps it
+ * as a viem LocalAccount for use with `tempo()`.
+ *
+ * @example
+ * ```ts
+ * import { owsAccount } from 'mppx/ows'
+ * import { tempo } from 'mppx/tempo'
+ *
+ * const account = owsAccount('my-wallet')
+ * const [charge] = tempo({ account })
+ * ```
+ */
+export function owsAccount(walletNameOrId: string, vaultPath?: string): Account {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { exportWallet } = require('@open-wallet-standard/core') as {
+    exportWallet: (nameOrId: string, passphrase?: string, vaultPath?: string) => string
+  }
+
+  const exported = exportWallet(walletNameOrId, undefined, vaultPath)
+
+  let privateKey: `0x${string}`
+
+  try {
+    const keys = JSON.parse(exported)
+    const hex = keys.secp256k1 ?? ''
+    privateKey = (hex.startsWith('0x') ? hex : `0x${hex}`) as `0x${string}`
+  } catch {
+    // Mnemonic — use deriveAddress to get the key
+    const { deriveAddress } = require('@open-wallet-standard/core') as {
+      deriveAddress: (mnemonic: string, chain: string) => { address: string; private_key?: string; privateKey?: string }
+    }
+    const info = deriveAddress(exported, 'evm')
+    const hex = info.private_key ?? info.privateKey ?? ''
+    privateKey = (hex.startsWith('0x') ? hex : `0x${hex}`) as `0x${string}`
+  }
+
+  return privateKeyToAccount(privateKey)
+}


### PR DESCRIPTION
## Summary

Adds `owsAccount(walletNameOrId)` — creates a viem Account from an [OWS](https://openwallet.sh) encrypted vault. Use with `tempo()` for headless signing without raw keys.

## Usage

```typescript
import { owsAccount } from 'mppx/ows'
import { tempo } from 'mppx/tempo'

// Before: raw key in code
const [charge] = tempo({ account: privateKeyToAccount('0x...') })

// After: key stays encrypted until needed
const [charge] = tempo({ account: owsAccount('my-wallet') })
```

Requires: `npm install @open-wallet-standard/core`

## Changes

| File | What |
|------|------|
| `package.json` | Added `./ows` export, `@open-wallet-standard/core` as optional peer dep |
| `src/ows.ts` | **New** — `owsAccount()` adapter |

No changes to existing code paths. OWS dependency is optional (peer dep).

Note: `ows` is added as an optional peer dependency to match the existing pattern (`@modelcontextprotocol/sdk`, `hono`, `express`, `elysia`). Happy to make it a regular dependency if the team prefers OWS as a first-party integration.