### PR TITLE
Add Sei payment method

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,21 @@
       "src": "./src/stripe/server/index.ts",
       "default": "./dist/stripe/server/index.js"
     },
+    "./sei": {
+      "types": "./dist/sei/index.d.ts",
+      "src": "./src/sei/index.ts",
+      "default": "./dist/sei/index.js"
+    },
+    "./sei/client": {
+      "types": "./dist/sei/client/index.d.ts",
+      "src": "./src/sei/client/index.ts",
+      "default": "./dist/sei/client/index.js"
+    },
+    "./sei/server": {
+      "types": "./dist/sei/server/index.d.ts",
+      "src": "./src/sei/server/index.ts",
+      "default": "./dist/sei/server/index.js"
+    },
     "./tempo": {
       "types": "./dist/tempo/index.d.ts",
       "src": "./src/tempo/index.ts",

--- a/src/client/Methods.ts
+++ b/src/client/Methods.ts
@@ -1,3 +1,4 @@
+export { sei } from '../sei/client/index.js'
 export { stripe } from '../stripe/client/index.js'
 export { tempo } from '../tempo/client/index.js'
 export { session } from '../tempo/client/Session.js'

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,4 +1,4 @@
 export * as Expires from '../Expires.js'
-export { session, stripe, tempo } from './Methods.js'
+export { sei, session, stripe, tempo } from './Methods.js'
 export * as Mppx from './Mppx.js'
 export * as Transport from './Transport.js'

--- a/src/sei/Methods.ts
+++ b/src/sei/Methods.ts
@@ -1,0 +1,38 @@
+import { parseUnits } from 'viem'
+
+import * as Method from '../Method.js'
+import * as z from '../zod.js'
+
+/**
+ * Sei charge intent for one-time ERC-20 token transfers.
+ */
+export const charge = Method.from({
+  name: 'sei',
+  intent: 'charge',
+  schema: {
+    credential: {
+      payload: z.discriminatedUnion('type', [
+        z.object({ hash: z.hash(), type: z.literal('hash') }),
+        z.object({ signature: z.signature(), type: z.literal('transaction') }),
+      ]),
+    },
+    request: z.pipe(
+      z.object({
+        amount: z.amount(),
+        chainId: z.optional(z.number()),
+        currency: z.string(),
+        decimals: z.number(),
+        description: z.optional(z.string()),
+        externalId: z.optional(z.string()),
+        recipient: z.optional(z.string()),
+      }),
+      z.transform(({ amount, chainId, decimals, ...rest }) => ({
+        ...rest,
+        amount: parseUnits(amount, decimals).toString(),
+        ...(chainId !== undefined
+          ? { methodDetails: { chainId } }
+          : {}),
+      })),
+    ),
+  },
+})

--- a/src/sei/client/Charge.ts
+++ b/src/sei/client/Charge.ts
@@ -1,0 +1,105 @@
+import { type Address, encodeFunctionData, parseAbi } from 'viem'
+import { prepareTransactionRequest, sendTransaction, signTransaction } from 'viem/actions'
+
+import * as Credential from '../../Credential.js'
+import * as Method from '../../Method.js'
+import * as Account from '../../viem/Account.js'
+import * as Client from '../../viem/Client.js'
+import * as z from '../../zod.js'
+import * as defaults from '../internal/defaults.js'
+import { sei } from '../internal/chains.js'
+import * as Methods from '../Methods.js'
+
+const erc20Abi = parseAbi([
+  'function transfer(address to, uint256 amount) returns (bool)',
+])
+
+/**
+ * Creates a Sei charge method intent for usage on the client.
+ *
+ * @example
+ * ```ts
+ * import { sei } from 'mppx/client'
+ * import { privateKeyToAccount } from 'viem/accounts'
+ *
+ * const charge = sei.charge({
+ *   account: privateKeyToAccount('0x...'),
+ * })
+ * ```
+ */
+export function charge(parameters: charge.Parameters = {}) {
+  const getClient = Client.getResolver({
+    chain: sei,
+    getClient: parameters.getClient,
+    rpcUrl: defaults.rpcUrl,
+  })
+  const getAccount = Account.getResolver({ account: parameters.account })
+
+  return Method.toClient(Methods.charge, {
+    context: z.object({
+      account: z.optional(z.custom<Account.getResolver.Parameters['account']>()),
+      mode: z.optional(z.enum(['push', 'pull'])),
+    }),
+
+    async createCredential({ challenge, context }) {
+      const chainId = challenge.request.methodDetails?.chainId
+      const client = await getClient({ chainId })
+      const account = getAccount(client, context)
+
+      const mode =
+        context?.mode ?? parameters.mode ?? (account.type === 'json-rpc' ? 'push' : 'pull')
+
+      const { request } = challenge
+      const { amount } = request
+      const currency = request.currency as Address
+      const recipient = request.recipient as Address
+
+      const data = encodeFunctionData({
+        abi: erc20Abi,
+        functionName: 'transfer',
+        args: [recipient, BigInt(amount)],
+      })
+
+      if (mode === 'push') {
+        const hash = await sendTransaction(client, {
+          account,
+          to: currency,
+          data,
+        })
+        return Credential.serialize({
+          challenge,
+          payload: { hash, type: 'hash' },
+          source: `did:pkh:eip155:${chainId}:${account.address}`,
+        })
+      }
+
+      const prepared = await prepareTransactionRequest(client, {
+        account,
+        to: currency,
+        data,
+      })
+      const signature = await signTransaction(client, prepared as never)
+
+      return Credential.serialize({
+        challenge,
+        payload: { signature, type: 'transaction' },
+        source: `did:pkh:eip155:${chainId}:${account.address}`,
+      })
+    },
+  })
+}
+
+export declare namespace charge {
+  type Parameters = {
+    /**
+     * Controls how the charge transaction is submitted.
+     *
+     * - `'push'`: Client broadcasts the transaction and sends the tx hash to the server.
+     * - `'pull'`: Client signs the transaction and sends the serialized tx to the server for broadcast.
+     *
+     * @default `'push'` for JSON-RPC accounts, `'pull'` for local accounts.
+     */
+    mode?: 'push' | 'pull' | undefined
+  } & Account.getResolver.Parameters &
+    Client.getResolver.Parameters
+}

--- a/src/sei/client/Methods.ts
+++ b/src/sei/client/Methods.ts
@@ -1,0 +1,24 @@
+import { charge as charge_ } from './Charge.js'
+
+/**
+ * Creates a Sei `charge` client method from shared parameters.
+ *
+ * @example
+ * ```ts
+ * import { Mppx, sei } from 'mppx/client'
+ *
+ * const mppx = Mppx.create({
+ *   methods: [sei({ account })],
+ * })
+ * ```
+ */
+export function sei(parameters: sei.Parameters = {}) {
+  return [charge_(parameters)] as const
+}
+
+export namespace sei {
+  export type Parameters = charge_.Parameters
+
+  /** Creates a Sei `charge` client method for one-time ERC-20 token transfers. */
+  export const charge = charge_
+}

--- a/src/sei/client/index.ts
+++ b/src/sei/client/index.ts
@@ -1,0 +1,2 @@
+export { charge } from './Charge.js'
+export { sei } from './Methods.js'

--- a/src/sei/index.ts
+++ b/src/sei/index.ts
@@ -1,0 +1,1 @@
+export * as Methods from './Methods.js'

--- a/src/sei/internal/chains.ts
+++ b/src/sei/internal/chains.ts
@@ -1,0 +1,26 @@
+import { type Chain, defineChain } from 'viem'
+
+export const sei = defineChain({
+  id: 1329,
+  name: 'Sei',
+  nativeCurrency: { name: 'Sei', symbol: 'SEI', decimals: 18 },
+  rpcUrls: {
+    default: { http: ['https://evm-rpc.sei-apis.com'] },
+  },
+  blockExplorers: {
+    default: { name: 'Seitrace', url: 'https://seitrace.com' },
+  },
+}) satisfies Chain
+
+export const seiTestnet = defineChain({
+  id: 713715,
+  name: 'Sei Testnet',
+  nativeCurrency: { name: 'Sei', symbol: 'SEI', decimals: 18 },
+  rpcUrls: {
+    default: { http: ['https://evm-rpc-testnet.sei-apis.com'] },
+  },
+  blockExplorers: {
+    default: { name: 'Seitrace', url: 'https://seitrace-testnet.com' },
+  },
+  testnet: true,
+}) satisfies Chain

--- a/src/sei/internal/defaults.ts
+++ b/src/sei/internal/defaults.ts
@@ -1,0 +1,41 @@
+import type { ValueOf } from '../../internal/types.js'
+
+export const chainId = {
+  mainnet: 1329,
+  testnet: 713715,
+} as const
+export type ChainId = ValueOf<typeof chainId>
+
+/** Token addresses. */
+export const tokens = {
+  /** USDC token address. */
+  usdc: '0x3894085Ef7Ff0f0aeDf52E2A2704928d1Ec074F1',
+  /** USDT token address. */
+  usdt: '0xB75D0B03c06A926e488e2659DF1A861F860bD3d1',
+} as const
+
+/** Chain ID → default currency. */
+export const currency = {
+  [chainId.mainnet]: tokens.usdc,
+  [chainId.testnet]: tokens.usdc,
+} as const satisfies Record<ChainId, string>
+
+/** Default RPC URLs for each Sei chain. */
+export const rpcUrl = {
+  [chainId.mainnet]: 'https://evm-rpc.sei-apis.com',
+  [chainId.testnet]: 'https://evm-rpc-testnet.sei-apis.com',
+} as const satisfies Record<ChainId, string>
+
+/** Default token decimals for Sei stablecoins. */
+export const decimals = 6
+
+/** Resolves the default currency. */
+export function resolveCurrency(parameters: {
+  /** Chain ID. */
+  chainId?: number | undefined
+  /** Whether in testnet mode. */
+  testnet?: boolean | undefined
+}): string {
+  const id = parameters.chainId ?? (parameters.testnet ? chainId.testnet : chainId.mainnet)
+  return currency[id as keyof typeof currency] ?? tokens.usdc
+}

--- a/src/sei/internal/types.ts
+++ b/src/sei/internal/types.ts
@@ -1,0 +1,6 @@
+export type DeriveDefaults<parameters, defaults> = Pick<
+  parameters,
+  Extract<keyof parameters, keyof defaults>
+> &
+  (parameters extends { account: string } ? { recipient: string } : {}) &
+  (parameters extends { recipient: string } ? { recipient: string } : {})

--- a/src/sei/server/Charge.ts
+++ b/src/sei/server/Charge.ts
@@ -1,0 +1,280 @@
+import {
+  type Address,
+  type TransactionReceipt,
+  decodeEventLog,
+  getAddress,
+  keccak256,
+  parseAbi,
+} from 'viem'
+import { getTransactionReceipt, sendRawTransaction } from 'viem/actions'
+
+import { PaymentExpiredError } from '../../Errors.js'
+import type { LooseOmit } from '../../internal/types.js'
+import * as Method from '../../Method.js'
+import * as Store from '../../Store.js'
+import * as Client from '../../viem/Client.js'
+import * as defaults from '../internal/defaults.js'
+import { sei } from '../internal/chains.js'
+import type * as types from '../internal/types.js'
+import * as Methods from '../Methods.js'
+
+const erc20Abi = parseAbi([
+  'event Transfer(address indexed from, address indexed to, uint256 value)',
+])
+
+/**
+ * Creates a Sei charge method intent for usage on the server.
+ *
+ * @example
+ * ```ts
+ * import { sei } from 'mppx/server'
+ *
+ * const charge = sei.charge()
+ * ```
+ */
+export function charge<const parameters extends charge.Parameters>(
+  parameters: parameters = {} as parameters,
+) {
+  const {
+    amount,
+    currency = defaults.resolveCurrency(parameters),
+    decimals = defaults.decimals,
+    description,
+    externalId,
+    recipient,
+    waitForConfirmation = true,
+  } = parameters
+  const store = (parameters.store ?? Store.memory()) as Store.Store<charge.StoreItemMap>
+
+  const getClient = Client.getResolver({
+    chain: sei,
+    getClient: parameters.getClient,
+    rpcUrl: defaults.rpcUrl,
+  })
+
+  type Defaults = charge.DeriveDefaults<parameters>
+  return Method.toServer<typeof Methods.charge, Defaults>(Methods.charge, {
+    defaults: {
+      amount,
+      currency,
+      decimals,
+      description,
+      externalId,
+      recipient,
+    } as unknown as Defaults,
+
+    async request({ request }) {
+      const chainId = await (async () => {
+        if (request.chainId) return request.chainId
+        if (parameters.testnet) return defaults.chainId.testnet
+        return (await getClient({})).chain?.id
+      })()
+
+      const client = await (async () => {
+        try {
+          return await getClient({ chainId })
+        } catch {
+          throw new Error(`No client configured with chainId ${chainId}.`)
+        }
+      })()
+      if (client.chain?.id !== chainId)
+        throw new Error(`Client not configured with chainId ${chainId}.`)
+
+      return {
+        ...request,
+        chainId,
+      }
+    },
+
+    async verify({ credential, request }) {
+      const { challenge } = credential
+      const { chainId } = request
+
+      const client = await getClient({ chainId })
+
+      const { request: challengeRequest } = challenge
+      const { amount } = challengeRequest
+      const expires = challenge.expires
+
+      const currency = challengeRequest.currency as Address
+      const recipient = challengeRequest.recipient as Address
+
+      if (expires && new Date(expires) < new Date()) throw new PaymentExpiredError({ expires })
+
+      const payload = credential.payload
+
+      switch (payload.type) {
+        case 'hash': {
+          const hash = payload.hash as `0x${string}`
+          await assertHashUnused(store, hash)
+
+          const receipt = await getTransactionReceipt(client, { hash })
+
+          assertTransferLog(receipt, {
+            amount,
+            currency,
+            recipient,
+          })
+
+          await markHashUsed(store, hash)
+
+          return toReceipt(receipt)
+        }
+
+        case 'transaction': {
+          const serializedTransaction = payload.signature as `0x${string}`
+
+          const hash = keccak256(serializedTransaction)
+          await assertHashUnused(store, hash)
+          await markHashUsed(store, hash)
+
+          const reference = await sendRawTransaction(client, {
+            serializedTransaction,
+          })
+
+          if (waitForConfirmation) {
+            const receipt = await getTransactionReceipt(client, { hash: reference })
+
+            assertTransferLog(receipt, {
+              amount,
+              currency,
+              recipient,
+            })
+
+            if (receipt.transactionHash.toLowerCase() !== hash.toLowerCase()) {
+              await assertHashUnused(store, receipt.transactionHash)
+              await markHashUsed(store, receipt.transactionHash)
+            }
+
+            return toReceipt(receipt)
+          }
+
+          if (reference.toLowerCase() !== hash.toLowerCase()) {
+            await assertHashUnused(store, reference)
+            await markHashUsed(store, reference)
+          }
+          return {
+            method: 'sei',
+            status: 'success',
+            timestamp: new Date().toISOString(),
+            reference,
+          } as const
+        }
+
+        default:
+          throw new Error(`Unsupported credential type "${(payload as { type: string }).type}".`)
+      }
+    },
+  })
+}
+
+export declare namespace charge {
+  type StoreItemMap = { [key: `mppx:charge:${string}`]: number }
+
+  type Defaults = LooseOmit<Method.RequestDefaults<typeof Methods.charge>, 'recipient'>
+
+  type Parameters = {
+    /** Testnet mode. */
+    testnet?: boolean | undefined
+    /** Recipient address. */
+    recipient?: Address | undefined
+    /**
+     * Store for transaction hash replay protection.
+     *
+     * Use a shared store in multi-instance deployments so consumed hashes are
+     * visible across all server instances.
+     */
+    store?: Store.Store | undefined
+    /**
+     * Whether to wait for the charge transaction to confirm on-chain before
+     * responding. @default true
+     */
+    waitForConfirmation?: boolean | undefined
+  } & Client.getResolver.Parameters &
+    Defaults
+
+  type DeriveDefaults<parameters extends Parameters> = types.DeriveDefaults<
+    parameters,
+    Defaults
+  > & {
+    decimals: number
+  }
+}
+
+/** @internal */
+function assertTransferLog(
+  receipt: TransactionReceipt,
+  parameters: {
+    amount: string
+    currency: Address
+    recipient: Address
+  },
+): void {
+  const { amount, currency, recipient } = parameters
+
+  const match = receipt.logs.find((log) => {
+    if (log.address.toLowerCase() !== currency.toLowerCase()) return false
+    try {
+      const event = decodeEventLog({ abi: erc20Abi, data: log.data, topics: log.topics })
+      if (event.eventName !== 'Transfer') return false
+      return (
+        getAddress(event.args.to) === getAddress(recipient) &&
+        event.args.value.toString() === amount
+      )
+    } catch {
+      return false
+    }
+  })
+
+  if (!match)
+    throw new MismatchError('Payment verification failed: no matching transfer found.', {
+      amount,
+      currency,
+      recipient,
+    })
+}
+
+/** @internal */
+function getHashStoreKey(hash: `0x${string}`): `mppx:charge:${string}` {
+  return `mppx:charge:${hash.toLowerCase()}`
+}
+
+/** @internal */
+async function assertHashUnused(
+  store: Store.Store<charge.StoreItemMap>,
+  hash: `0x${string}`,
+): Promise<void> {
+  const seen = await store.get(getHashStoreKey(hash))
+  if (seen !== null) throw new Error('Transaction hash has already been used.')
+}
+
+/** @internal */
+async function markHashUsed(
+  store: Store.Store<charge.StoreItemMap>,
+  hash: `0x${string}`,
+): Promise<void> {
+  await store.put(getHashStoreKey(hash), Date.now())
+}
+
+/** @internal */
+function toReceipt(receipt: TransactionReceipt) {
+  const { status, transactionHash } = receipt
+  if (status !== 'success') {
+    throw new Error(`Transaction reverted: ${transactionHash}`)
+  }
+  return {
+    method: 'sei',
+    status: 'success',
+    timestamp: new Date().toISOString(),
+    reference: transactionHash,
+  } as const
+}
+
+/** @internal */
+class MismatchError extends Error {
+  override readonly name = 'MismatchError'
+
+  constructor(reason: string, details: Record<string, string>) {
+    super([reason, ...Object.entries(details).map(([k, v]) => `  - ${k}: ${v}`)].join('\n'))
+  }
+}

--- a/src/sei/server/Methods.ts
+++ b/src/sei/server/Methods.ts
@@ -1,0 +1,24 @@
+import { charge as charge_ } from './Charge.js'
+
+/**
+ * Creates a Sei `charge` method from shared parameters.
+ *
+ * @example
+ * ```ts
+ * import { Mppx, sei } from 'mppx/server'
+ *
+ * const mppx = Mppx.create({
+ *   methods: [sei({ recipient: '0x...' })],
+ * })
+ * ```
+ */
+export function sei<const parameters extends sei.Parameters>(parameters?: parameters) {
+  return [sei.charge(parameters)] as const
+}
+
+export namespace sei {
+  export type Parameters = charge_.Parameters
+
+  /** Creates a Sei `charge` method for one-time ERC-20 token transfers. */
+  export const charge = charge_
+}

--- a/src/sei/server/index.ts
+++ b/src/sei/server/index.ts
@@ -1,0 +1,2 @@
+export { charge } from './Charge.js'
+export { sei } from './Methods.js'

--- a/src/server/Methods.ts
+++ b/src/server/Methods.ts
@@ -1,2 +1,3 @@
+export { sei } from '../sei/server/index.js'
 export { stripe } from '../stripe/server/index.js'
 export { tempo } from '../tempo/server/index.js'

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,6 +1,6 @@
 export * as Expires from '../Expires.js'
 export * as Store from '../Store.js'
-export { stripe, tempo } from './Methods.js'
+export { sei, stripe, tempo } from './Methods.js'
 export * as Mppx from './Mppx.js'
 export * as NodeListener from './NodeListener.js'
 export * as Request from './Request.js'


### PR DESCRIPTION
Adds Sei as a payment method with charge intent support.

Sei is an EVM-compatible L1 with sub-second finality. Uses standard ERC-20 transfers and EIP-1559 transactions — no custom transaction types needed.

Chain IDs: 1329 (mainnet), 713715 (testnet).
Default token: USDC (0x3894085Ef7Ff0f0aeDf52E2A2704928d1Ec074F1).