### PR TITLE
ci: speed up workflows with caching and dedup

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -11,6 +11,7 @@ runs:
       uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
       with:
         node-version: '24.5'
+        cache: 'pnpm'
 
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,5 +1,8 @@
 name: Prerelease
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -60,11 +60,36 @@ jobs:
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies
 
-      - name: Pre-pull Tempo image
-        run: docker pull ghcr.io/tempoxyz/tempo:${VITE_TEMPO_TAG}
+      - name: Cache Playwright browsers
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install Playwright browsers
-        run: pnpm exec playwright install --with-deps chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install chromium
+
+      - name: Install Playwright system deps
+        run: pnpm exec playwright install-deps chromium
+
+      - name: Cache Tempo Docker image
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        id: docker-cache
+        with:
+          path: /tmp/tempo-image.tar
+          key: tempo-image-${{ env.VITE_TEMPO_TAG }}
+
+      - name: Load cached Tempo image
+        if: steps.docker-cache.outputs.cache-hit == 'true'
+        run: docker load -i /tmp/tempo-image.tar
+
+      - name: Pull and cache Tempo image
+        if: steps.docker-cache.outputs.cache-hit != 'true'
+        run: |
+          docker pull ghcr.io/tempoxyz/tempo:${VITE_TEMPO_TAG}
+          docker save ghcr.io/tempoxyz/tempo:${VITE_TEMPO_TAG} -o /tmp/tempo-image.tar
 
       - name: Run tests
         run: |


### PR DESCRIPTION
## Changes

* dedup pre-release runs 
* cache the pnpm store
* cache playwright
* cache docker img