### PR TITLE
ci: shard test suite across 3 parallel runners

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -40,8 +40,12 @@ jobs:
         run: pnpm dev && pnpm check:types && pnpm check:types:examples
 
   test:
-    name: Test Runtime
+    name: Test Runtime (${{ matrix.shard }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        shard: [1/3, 2/3, 3/3]
     env:
       VITE_TEMPO_TAG: sha-20aecec
     steps:
@@ -71,6 +75,6 @@ jobs:
           eval "$(dbus-launch --sh-syntax)"
           eval "$(printf '\n' | gnome-keyring-daemon --unlock)"
           eval "$(printf '\n' | gnome-keyring-daemon --start)"
-          pnpm run test --bail=1
+          pnpm run test --bail=1 --shard=${{ matrix.shard }}
         env:
           CI: true


### PR DESCRIPTION
Splits the Test Runtime job into 3 parallel shards using Vitest's `--shard` flag and a GitHub Actions matrix strategy.