### PR TITLE
test: widen fee-payer server coverage

### DIFF
--- a/src/middlewares/elysia.test.ts
+++ b/src/middlewares/elysia.test.ts
@@ -2,11 +2,14 @@ import * as http from 'node:http'
 
 import { Elysia } from 'elysia'
 import { Receipt } from 'mppx'
-import { Mppx as Mppx_client, tempo as tempo_client } from 'mppx/client'
+import { Mppx as Mppx_client, session as sessionIntent, tempo as tempo_client } from 'mppx/client'
 import { Mppx, discovery } from 'mppx/elysia'
 import { tempo as tempo_server } from 'mppx/server'
-import { describe, expect, test } from 'vp/test'
-import { accounts, asset, client } from '~test/tempo/viem.js'
+import type { Address } from 'viem'
+import { Addresses } from 'viem/tempo'
+import { beforeAll, describe, expect, test } from 'vp/test'
+import { deployEscrow } from '~test/tempo/session.js'
+import { accounts, asset, client, fundAccount } from '~test/tempo/viem.js'
 
 function createServer(app: Elysia<any, any, any, any, any, any, any>) {
   return new Promise<{ url: string; close: () => void }>((resolve) => {
@@ -34,13 +37,14 @@ function createServer(app: Elysia<any, any, any, any, any, any, any>) {
 
 const secretKey = 'test-secret-key'
 
-describe('charge', () => {
+function createChargeHarness(feePayer: boolean) {
   const mppx = Mppx.create({
     methods: [
       tempo_server.charge({
         getClient: () => client,
         currency: asset,
         recipient: accounts[0].address,
+        ...(feePayer ? { feePayer: true } : {}),
       }),
     ],
     secretKey,
@@ -56,7 +60,13 @@ describe('charge', () => {
     ],
   })
 
+  return { fetch, mppx }
+}
+
+describe('charge', () => {
   test('returns 402 when no credential', async () => {
+    const { mppx } = createChargeHarness(false)
+
     const app = new Elysia().guard({ beforeHandle: mppx.charge({ amount: '1' }) }, (app) =>
       app.get('/', () => ({ fortune: 'You will be rich' })),
     )
@@ -70,6 +80,8 @@ describe('charge', () => {
   })
 
   test('returns 200 with receipt on valid payment', async () => {
+    const { fetch, mppx } = createChargeHarness(false)
+
     const app = new Elysia().guard({ beforeHandle: mppx.charge({ amount: '1' }) }, (app) =>
       app.get('/', () => ({ fortune: 'You will be rich' })),
     )
@@ -88,7 +100,24 @@ describe('charge', () => {
     server.close()
   })
 
+  test('fee payer: returns 200 with receipt on valid payment', async () => {
+    const { fetch, mppx } = createChargeHarness(true)
+
+    const app = new Elysia().guard({ beforeHandle: mppx.charge({ amount: '1' }) }, (app) =>
+      app.get('/', () => ({ fortune: 'You will be rich' })),
+    )
+
+    const server = await createServer(app)
+    const response = await fetch(server.url)
+    expect(response.status).toBe(200)
+    expect(Receipt.fromResponse(response).status).toBe('success')
+
+    server.close()
+  })
+
   test('serves /openapi.json from discovery plugin', async () => {
+    const { mppx } = createChargeHarness(false)
+
     const app = new Elysia().use(
       discovery(mppx, {
         info: { title: 'Elysia API', version: '1.0.0' },
@@ -109,6 +138,100 @@ describe('charge', () => {
       intent: 'charge',
       method: 'tempo',
     })
+
+    server.close()
+  })
+})
+
+describe('session', () => {
+  let escrowContract: Address
+
+  function createSessionHarness(feePayer: boolean) {
+    const mppx = Mppx.create({
+      methods: [
+        tempo_server.session({
+          getClient: () => client,
+          account: accounts[0],
+          currency: asset,
+          escrowContract,
+          ...(feePayer ? { feePayer: accounts[1] } : {}),
+        } as any),
+      ],
+      secretKey,
+    })
+
+    const { fetch } = Mppx_client.create({
+      polyfill: false,
+      methods: [
+        sessionIntent({
+          account: accounts[2],
+          deposit: '10',
+          getClient: () => client,
+        }),
+      ],
+    })
+
+    return { fetch, mppx }
+  }
+
+  beforeAll(async () => {
+    escrowContract = await deployEscrow()
+    await fundAccount({ address: accounts[1].address, token: Addresses.pathUsd })
+    await fundAccount({ address: accounts[1].address, token: asset })
+    await fundAccount({ address: accounts[2].address, token: Addresses.pathUsd })
+    await fundAccount({ address: accounts[2].address, token: asset })
+  })
+
+  test('returns 402 when no credential', async () => {
+    const { mppx } = createSessionHarness(false)
+
+    const app = new Elysia().guard(
+      { beforeHandle: mppx.session({ amount: '1', currency: asset, unitType: 'token' }) },
+      (app) => app.get('/', () => ({ data: 'streamed' })),
+    )
+
+    const server = await createServer(app)
+    const response = await globalThis.fetch(server.url)
+    expect(response.status).toBe(402)
+    expect(response.headers.get('WWW-Authenticate')).toContain('Payment')
+
+    server.close()
+  })
+
+  test('returns 200 with receipt on valid payment', async () => {
+    const { fetch, mppx } = createSessionHarness(false)
+
+    const app = new Elysia().guard(
+      { beforeHandle: mppx.session({ amount: '1', currency: asset, unitType: 'token' }) },
+      (app) => app.get('/', () => ({ data: 'streamed' })),
+    )
+
+    const server = await createServer(app)
+    const response = await fetch(server.url)
+    expect(response.status).toBe(200)
+
+    const body = await response.json()
+    expect(body).toEqual({ data: 'streamed' })
+
+    const receipt = Receipt.fromResponse(response)
+    expect(receipt.status).toBe('success')
+    expect(receipt.method).toBe('tempo')
+
+    server.close()
+  })
+
+  test('fee payer: returns 200 with receipt on valid payment', async () => {
+    const { fetch, mppx } = createSessionHarness(true)
+
+    const app = new Elysia().guard(
+      { beforeHandle: mppx.session({ amount: '1', currency: asset, unitType: 'token' }) },
+      (app) => app.get('/', () => ({ data: 'streamed' })),
+    )
+
+    const server = await createServer(app)
+    const response = await fetch(server.url)
+    expect(response.status).toBe(200)
+    expect(Receipt.fromResponse(response).status).toBe('success')
 
     server.close()
   })

--- a/src/middlewares/express.test.ts
+++ b/src/middlewares/express.test.ts
@@ -23,13 +23,14 @@ function createServer(app: express.Express) {
 
 const secretKey = 'test-secret-key'
 
-describe('charge', () => {
+function createChargeHarness(feePayer: boolean) {
   const mppx = Mppx.create({
     methods: [
       tempo_server({
         getClient: () => client,
         currency: asset,
         account: accounts[0],
+        ...(feePayer ? { feePayer: true } : {}),
       }),
     ],
     secretKey,
@@ -45,7 +46,39 @@ describe('charge', () => {
     ],
   })
 
+  return { fetch, mppx }
+}
+
+function createCoreChargeHarness(feePayer: boolean) {
+  const mppx = Mppx_server.create({
+    methods: [
+      tempo_server({
+        getClient: () => client,
+        currency: asset,
+        account: accounts[0],
+        ...(feePayer ? { feePayer: true } : {}),
+      }),
+    ],
+    secretKey,
+  })
+
+  const { fetch } = Mppx_client.create({
+    polyfill: false,
+    methods: [
+      tempo_client({
+        account: accounts[1],
+        getClient: () => client,
+      }),
+    ],
+  })
+
+  return { fetch, mppx }
+}
+
+describe('charge', () => {
   test('returns 402 when no credential', async () => {
+    const { mppx } = createChargeHarness(false)
+
     const app = express()
     app.get('/', mppx.charge({ amount: '1' }), (_req, res) => {
       res.json({ fortune: 'You will be rich' })
@@ -60,6 +93,8 @@ describe('charge', () => {
   })
 
   test('returns 200 with receipt on valid payment', async () => {
+    const { fetch, mppx } = createChargeHarness(false)
+
     const app = express()
     app.get('/', mppx.charge({ amount: '1' }), (_req, res) => {
       res.json({ fortune: 'You will be rich' })
@@ -82,7 +117,25 @@ describe('charge', () => {
     server.close()
   })
 
+  test('fee payer: returns 200 with receipt on valid payment', async () => {
+    const { fetch, mppx } = createChargeHarness(true)
+
+    const app = express()
+    app.get('/', mppx.charge({ amount: '1' }), (_req, res) => {
+      res.json({ fortune: 'You will be rich' })
+    })
+
+    const server = await createServer(app)
+    const response = await fetch(server.url)
+    expect(response.status).toBe(200)
+    expect(Receipt.fromResponse(response).status).toBe('success')
+
+    server.close()
+  })
+
   test('serves /openapi.json from a handler-derived route config', async () => {
+    const { mppx } = createChargeHarness(false)
+
     const app = express()
     const pay = mppx.charge({ amount: '1' })
     app.get('/', pay, (_req, res) => {
@@ -114,13 +167,7 @@ describe('charge', () => {
 describe('session', () => {
   let escrowContract: Address
 
-  beforeAll(async () => {
-    escrowContract = await deployEscrow()
-    await fundAccount({ address: accounts[2].address, token: Addresses.pathUsd })
-    await fundAccount({ address: accounts[2].address, token: asset })
-  })
-
-  test('returns 402 when no credential', async () => {
+  function createSessionHarness(feePayer: boolean) {
     const mppx = Mppx.create({
       methods: [
         tempo_server.session({
@@ -128,34 +175,8 @@ describe('session', () => {
           account: accounts[0],
           currency: asset,
           escrowContract,
-        }),
-      ],
-      secretKey,
-    })
-
-    const app = express()
-    app.get('/', mppx.session({ amount: '1', unitType: 'token' }), (_req, res) => {
-      res.json({ data: 'streamed' })
-    })
-
-    const server = await createServer(app)
-    const response = await globalThis.fetch(server.url)
-    expect(response.status).toBe(402)
-    expect(response.headers.get('WWW-Authenticate')).toContain('Payment')
-
-    server.close()
-  })
-
-  test('returns 200 with receipt on valid payment', async () => {
-    const mppx = Mppx.create({
-      methods: [
-        tempo_server.session({
-          getClient: () => client,
-          account: accounts[0],
-          currency: asset,
-          escrowContract,
-          feePayer: true,
-        }),
+          ...(feePayer ? { feePayer: accounts[1] } : {}),
+        } as any),
       ],
       secretKey,
     })
@@ -171,8 +192,38 @@ describe('session', () => {
       ],
     })
 
+    return { fetch, mppx }
+  }
+
+  beforeAll(async () => {
+    escrowContract = await deployEscrow()
+    await fundAccount({ address: accounts[1].address, token: Addresses.pathUsd })
+    await fundAccount({ address: accounts[1].address, token: asset })
+    await fundAccount({ address: accounts[2].address, token: Addresses.pathUsd })
+    await fundAccount({ address: accounts[2].address, token: asset })
+  })
+
+  test('returns 402 when no credential', async () => {
+    const { mppx } = createSessionHarness(false)
+
     const app = express()
-    app.get('/', mppx.session({ amount: '1', unitType: 'token' }), (_req, res) => {
+    app.get('/', mppx.session({ amount: '1', currency: asset, unitType: 'token' }), (_req, res) => {
+      res.json({ data: 'streamed' })
+    })
+
+    const server = await createServer(app)
+    const response = await globalThis.fetch(server.url)
+    expect(response.status).toBe(402)
+    expect(response.headers.get('WWW-Authenticate')).toContain('Payment')
+
+    server.close()
+  })
+
+  test('returns 200 with receipt on valid payment', async () => {
+    const { fetch, mppx } = createSessionHarness(false)
+
+    const app = express()
+    app.get('/', mppx.session({ amount: '1', currency: asset, unitType: 'token' }), (_req, res) => {
       res.json({ data: 'streamed' })
     })
 
@@ -185,31 +236,28 @@ describe('session', () => {
 
     server.close()
   })
+
+  test('fee payer: returns 200 with receipt on valid payment', async () => {
+    const { fetch, mppx } = createSessionHarness(true)
+
+    const app = express()
+    app.get('/', mppx.session({ amount: '1', currency: asset, unitType: 'token' }), (_req, res) => {
+      res.json({ data: 'streamed' })
+    })
+
+    const server = await createServer(app)
+    const response = await fetch(server.url)
+    expect(response.status).toBe(200)
+    expect(Receipt.fromResponse(response).status).toBe('success')
+
+    server.close()
+  })
 })
 
 describe('payment', () => {
-  const mppx = Mppx_server.create({
-    methods: [
-      tempo_server({
-        getClient: () => client,
-        currency: asset,
-        account: accounts[0],
-      }),
-    ],
-    secretKey,
-  })
-
-  const { fetch } = Mppx_client.create({
-    polyfill: false,
-    methods: [
-      tempo_client({
-        account: accounts[1],
-        getClient: () => client,
-      }),
-    ],
-  })
-
   test('returns 402 when no credential', async () => {
+    const { mppx } = createCoreChargeHarness(false)
+
     const app = express()
     app.get('/', payment(mppx.charge, { amount: '1' }), (_req, res) => {
       res.json({ fortune: 'You will be rich' })
@@ -224,6 +272,8 @@ describe('payment', () => {
   })
 
   test('returns 200 with receipt on valid payment', async () => {
+    const { fetch, mppx } = createCoreChargeHarness(false)
+
     const app = express()
     app.get('/', payment(mppx.charge, { amount: '1' }), (_req, res) => {
       res.json({ fortune: 'You will be rich' })
@@ -242,6 +292,22 @@ describe('payment', () => {
     const receipt = Receipt.fromResponse(response)
     expect(receipt.status).toBe('success')
     expect(receipt.method).toBe('tempo')
+
+    server.close()
+  })
+
+  test('fee payer: returns 200 with receipt on valid payment', async () => {
+    const { fetch, mppx } = createCoreChargeHarness(true)
+
+    const app = express()
+    app.get('/', payment(mppx.charge, { amount: '1' }), (_req, res) => {
+      res.json({ fortune: 'You will be rich' })
+    })
+
+    const server = await createServer(app)
+    const response = await fetch(server.url)
+    expect(response.status).toBe(200)
+    expect(Receipt.fromResponse(response).status).toBe('success')
 
     server.close()
   })

--- a/src/middlewares/hono.test.ts
+++ b/src/middlewares/hono.test.ts
@@ -23,13 +23,14 @@ function createServer(app: Hono) {
 
 const secretKey = 'test-secret-key'
 
-describe('charge', () => {
+function createChargeHarness(feePayer: boolean) {
   const mppx = Mppx.create({
     methods: [
       tempo_server.charge({
         getClient: () => client,
         currency: asset,
         account: accounts[0],
+        ...(feePayer ? { feePayer: true } : {}),
       }),
     ],
     secretKey,
@@ -45,7 +46,13 @@ describe('charge', () => {
     ],
   })
 
+  return { fetch, mppx }
+}
+
+describe('charge', () => {
   test('returns 402 when no credential', async () => {
+    const { mppx } = createChargeHarness(false)
+
     const app = new Hono()
     app.get('/', mppx.charge({ amount: '1' }), (c) => c.json({ fortune: 'You will be rich' }))
 
@@ -58,6 +65,8 @@ describe('charge', () => {
   })
 
   test('returns 200 with receipt on valid payment', async () => {
+    const { fetch, mppx } = createChargeHarness(false)
+
     const app = new Hono()
     app.get('/', mppx.charge({ amount: '1' }), (c) => c.json({ fortune: 'You will be rich' }))
 
@@ -75,7 +84,23 @@ describe('charge', () => {
     server.close()
   })
 
+  test('fee payer: returns 200 with receipt on valid payment', async () => {
+    const { fetch, mppx } = createChargeHarness(true)
+
+    const app = new Hono()
+    app.get('/', mppx.charge({ amount: '1' }), (c) => c.json({ fortune: 'You will be rich' }))
+
+    const server = await createServer(app)
+    const response = await fetch(server.url)
+    expect(response.status).toBe(200)
+    expect(Receipt.fromResponse(response).status).toBe('success')
+
+    server.close()
+  })
+
   test('serves /openapi.json via auto discovery', async () => {
+    const { mppx } = createChargeHarness(false)
+
     const app = new Hono()
     app.get('/', mppx.charge({ amount: '1' }), (c) => c.json({ fortune: 'You will be rich' }))
     discovery(app, mppx, { auto: true, info: { title: 'Auto API', version: '2.0.0' } })
@@ -101,13 +126,7 @@ describe('charge', () => {
 describe('session', () => {
   let escrowContract: Address
 
-  beforeAll(async () => {
-    escrowContract = await deployEscrow()
-    await fundAccount({ address: accounts[2].address, token: Addresses.pathUsd })
-    await fundAccount({ address: accounts[2].address, token: asset })
-  })
-
-  test('returns 402 when no credential', async () => {
+  function createSessionHarness(feePayer: boolean) {
     const mppx = Mppx.create({
       methods: [
         tempo_server.session({
@@ -115,34 +134,8 @@ describe('session', () => {
           account: accounts[0],
           currency: asset,
           escrowContract,
-        }),
-      ],
-      secretKey,
-    })
-
-    const app = new Hono()
-    app.get('/', mppx.session({ amount: '1', unitType: 'token' }), (c) =>
-      c.json({ data: 'streamed' }),
-    )
-
-    const server = await createServer(app)
-    const response = await globalThis.fetch(server.url)
-    expect(response.status).toBe(402)
-    expect(response.headers.get('WWW-Authenticate')).toContain('Payment')
-
-    server.close()
-  })
-
-  test('returns 200 with receipt on valid payment', async () => {
-    const mppx = Mppx.create({
-      methods: [
-        tempo_server.session({
-          getClient: () => client,
-          account: accounts[0],
-          currency: asset,
-          escrowContract,
-          feePayer: true,
-        }),
+          ...(feePayer ? { feePayer: accounts[1] } : {}),
+        } as any),
       ],
       secretKey,
     })
@@ -158,8 +151,38 @@ describe('session', () => {
       ],
     })
 
+    return { fetch, mppx }
+  }
+
+  beforeAll(async () => {
+    escrowContract = await deployEscrow()
+    await fundAccount({ address: accounts[1].address, token: Addresses.pathUsd })
+    await fundAccount({ address: accounts[1].address, token: asset })
+    await fundAccount({ address: accounts[2].address, token: Addresses.pathUsd })
+    await fundAccount({ address: accounts[2].address, token: asset })
+  })
+
+  test('returns 402 when no credential', async () => {
+    const { mppx } = createSessionHarness(false)
+
     const app = new Hono()
-    app.get('/', mppx.session({ amount: '1', unitType: 'token' }), (c) =>
+    app.get('/', mppx.session({ amount: '1', currency: asset, unitType: 'token' }), (c) =>
+      c.json({ data: 'streamed' }),
+    )
+
+    const server = await createServer(app)
+    const response = await globalThis.fetch(server.url)
+    expect(response.status).toBe(402)
+    expect(response.headers.get('WWW-Authenticate')).toContain('Payment')
+
+    server.close()
+  })
+
+  test('returns 200 with receipt on valid payment', async () => {
+    const { fetch, mppx } = createSessionHarness(false)
+
+    const app = new Hono()
+    app.get('/', mppx.session({ amount: '1', currency: asset, unitType: 'token' }), (c) =>
       c.json({ data: 'streamed' }),
     )
 
@@ -169,6 +192,22 @@ describe('session', () => {
 
     const body = await response.json()
     expect(body).toEqual({ data: 'streamed' })
+
+    server.close()
+  })
+
+  test('fee payer: returns 200 with receipt on valid payment', async () => {
+    const { fetch, mppx } = createSessionHarness(true)
+
+    const app = new Hono()
+    app.get('/', mppx.session({ amount: '1', currency: asset, unitType: 'token' }), (c) =>
+      c.json({ data: 'streamed' }),
+    )
+
+    const server = await createServer(app)
+    const response = await fetch(server.url)
+    expect(response.status).toBe(200)
+    expect(Receipt.fromResponse(response).status).toBe('success')
 
     server.close()
   })

--- a/src/middlewares/nextjs.test.ts
+++ b/src/middlewares/nextjs.test.ts
@@ -36,13 +36,14 @@ function createServer(handler: (request: Request) => Promise<Response> | Respons
 
 const secretKey = 'test-secret-key'
 
-describe('charge', () => {
+function createChargeHarness(feePayer: boolean) {
   const mppx = Mppx.create({
     methods: [
       tempo_server.charge({
         getClient: () => client,
         currency: asset,
         account: accounts[0],
+        ...(feePayer ? { feePayer: true } : {}),
       }),
     ],
     secretKey,
@@ -58,7 +59,13 @@ describe('charge', () => {
     ],
   })
 
+  return { fetch, mppx }
+}
+
+describe('charge', () => {
   test('returns 402 when no credential', async () => {
+    const { mppx } = createChargeHarness(false)
+
     const handler = mppx.charge({ amount: '1' })(() =>
       Response.json({ fortune: 'You will be rich' }),
     )
@@ -72,6 +79,8 @@ describe('charge', () => {
   })
 
   test('returns 200 with receipt on valid payment', async () => {
+    const { fetch, mppx } = createChargeHarness(false)
+
     const handler = mppx.charge({ amount: '1' })(() =>
       Response.json({ fortune: 'You will be rich' }),
     )
@@ -90,7 +99,24 @@ describe('charge', () => {
     server.close()
   })
 
+  test('fee payer: returns 200 with receipt on valid payment', async () => {
+    const { fetch, mppx } = createChargeHarness(true)
+
+    const handler = mppx.charge({ amount: '1' })(() =>
+      Response.json({ fortune: 'You will be rich' }),
+    )
+
+    const server = await createServer(handler)
+    const response = await fetch(server.url)
+    expect(response.status).toBe(200)
+    expect(Receipt.fromResponse(response).status).toBe('success')
+
+    server.close()
+  })
+
   test('serves /openapi.json from a handler-derived route config', async () => {
+    const { mppx } = createChargeHarness(false)
+
     const pay = mppx.charge({ amount: '1' })
     const server = await createServer(
       discovery(mppx, {
@@ -119,13 +145,7 @@ describe('charge', () => {
 describe('session', () => {
   let escrowContract: Address
 
-  beforeAll(async () => {
-    escrowContract = await deployEscrow()
-    await fundAccount({ address: accounts[2].address, token: Addresses.pathUsd })
-    await fundAccount({ address: accounts[2].address, token: asset })
-  })
-
-  test('returns 402 when no credential', async () => {
+  function createSessionHarness(feePayer: boolean) {
     const mppx = Mppx.create({
       methods: [
         tempo_server.session({
@@ -133,33 +153,8 @@ describe('session', () => {
           account: accounts[0],
           currency: asset,
           escrowContract,
-        }),
-      ],
-      secretKey,
-    })
-
-    const handler = mppx.session({ amount: '1', unitType: 'token' })(() =>
-      Response.json({ data: 'streamed' }),
-    )
-
-    const server = await createServer(handler)
-    const response = await globalThis.fetch(server.url)
-    expect(response.status).toBe(402)
-    expect(response.headers.get('WWW-Authenticate')).toContain('Payment')
-
-    server.close()
-  })
-
-  test('returns 200 with receipt on valid payment', async () => {
-    const mppx = Mppx.create({
-      methods: [
-        tempo_server.session({
-          getClient: () => client,
-          account: accounts[0],
-          currency: asset,
-          escrowContract,
-          feePayer: true,
-        }),
+          ...(feePayer ? { feePayer: accounts[1] } : {}),
+        } as any),
       ],
       secretKey,
     })
@@ -175,7 +170,36 @@ describe('session', () => {
       ],
     })
 
-    const handler = mppx.session({ amount: '1', unitType: 'token' })(() =>
+    return { fetch, mppx }
+  }
+
+  beforeAll(async () => {
+    escrowContract = await deployEscrow()
+    await fundAccount({ address: accounts[1].address, token: Addresses.pathUsd })
+    await fundAccount({ address: accounts[1].address, token: asset })
+    await fundAccount({ address: accounts[2].address, token: Addresses.pathUsd })
+    await fundAccount({ address: accounts[2].address, token: asset })
+  })
+
+  test('returns 402 when no credential', async () => {
+    const { mppx } = createSessionHarness(false)
+
+    const handler = mppx.session({ amount: '1', currency: asset, unitType: 'token' })(() =>
+      Response.json({ data: 'streamed' }),
+    )
+
+    const server = await createServer(handler)
+    const response = await globalThis.fetch(server.url)
+    expect(response.status).toBe(402)
+    expect(response.headers.get('WWW-Authenticate')).toContain('Payment')
+
+    server.close()
+  })
+
+  test('returns 200 with receipt on valid payment', async () => {
+    const { fetch, mppx } = createSessionHarness(false)
+
+    const handler = mppx.session({ amount: '1', currency: asset, unitType: 'token' })(() =>
       Response.json({ data: 'streamed' }),
     )
 
@@ -189,6 +213,21 @@ describe('session', () => {
     const receipt = Receipt.fromResponse(response)
     expect(receipt.status).toBe('success')
     expect(receipt.method).toBe('tempo')
+
+    server.close()
+  })
+
+  test('fee payer: returns 200 with receipt on valid payment', async () => {
+    const { fetch, mppx } = createSessionHarness(true)
+
+    const handler = mppx.session({ amount: '1', currency: asset, unitType: 'token' })(() =>
+      Response.json({ data: 'streamed' }),
+    )
+
+    const server = await createServer(handler)
+    const response = await fetch(server.url)
+    expect(response.status).toBe(200)
+    expect(Receipt.fromResponse(response).status).toBe('success')
 
     server.close()
   })

--- a/test/tempo/session.ts
+++ b/test/tempo/session.ts
@@ -146,6 +146,7 @@ export async function signOpenChannel(params: {
   deposit: bigint
   salt: Hex
   authorizedSigner?: Address
+  feePayer?: boolean
 }): Promise<{ channelId: Hex; serializedTransaction: Hex }> {
   const { escrow, payer, payee, token, deposit, salt } = params
   const authorizedSigner = params.authorizedSigner ?? zeroAddress
@@ -177,6 +178,7 @@ export async function signOpenChannel(params: {
       { to: token, data: approveData },
       { to: escrow, data: openData },
     ],
+    ...(params.feePayer ? { feePayer: true, feeToken: token } : {}),
   } as never)
   prepared.gas = prepared.gas! + 5_000n
 
@@ -191,6 +193,7 @@ export async function signTopUpChannel(params: {
   channelId: Hex
   token: Address
   amount: bigint
+  feePayer?: boolean
 }): Promise<{ serializedTransaction: Hex }> {
   const { escrow, payer, channelId, token, amount } = params
 
@@ -211,6 +214,7 @@ export async function signTopUpChannel(params: {
       { to: token, data: approveData },
       { to: escrow, data: topUpData },
     ],
+    ...(params.feePayer ? { feePayer: true, feeToken: token } : {}),
   } as never)
   prepared.gas = prepared.gas! + 5_000n
 


### PR DESCRIPTION
## Summary
- widen fee-payer coverage in the Tempo session server suite across direct and fee-payer modes
- teach the shared session test transaction helpers to build fee-payer open and top-up transactions
- reduce middleware adapter coverage to one fee-payer smoke test per surface while keeping exhaustive fee-payer behavior in the core session and charge suites
