### PR TITLE
chore: replace pr-audit workflow with inline curl event publish

### DIFF
--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -16,7 +16,7 @@ jobs:
           echo "${{ secrets.EVENTS_KEY }}" > ${{ runner.temp }}/key
           echo "${{ secrets.EVENTS_CERT }}" > ${{ runner.temp }}/cert
 
-          curl -sf -o /dev/null -X POST ${{ secrets.EVENTS_ARGS }} \
+          HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' -X POST ${{ secrets.EVENTS_ARGS }} \
             -H "Content-Type: application/json" \
             --key ${{ runner.temp }}/key \
             --cert ${{ runner.temp }}/cert \
@@ -27,4 +27,9 @@ jobs:
                 "pr_number": ${{ github.event.pull_request.number }},
                 "sha": "${{ github.event.pull_request.head.sha }}"
               }
-            }'
+            }')
+          echo "HTTP status: $HTTP_CODE"
+          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+            echo "::error::Event publish failed with HTTP $HTTP_CODE"
+            exit 1
+          fi


### PR DESCRIPTION
Replaces the two-job permission-gate workflow with a single-job reth-style inline workflow that publishes events via direct curl with mTLS.

**Changes:**
- Removes the `gate` job (permission check via GitHub API)
- Removes the reusable workflow call to `tempoxyz/gh-actions`
- Uses direct `curl` with `EVENTS_KEY`, `EVENTS_CERT`, and `EVENTS_ARGS` secrets
- Logs HTTP status code on failure for debugging

**Requires:** `EVENTS_KEY`, `EVENTS_CERT`, and `EVENTS_ARGS` secrets configured in the wevm org or mppx repo settings.