### PR TITLE
ci: add 10s test timeout to prevent hanging CI runs

### DIFF
--- a/test/setup.global.ts
+++ b/test/setup.global.ts
@@ -1,9 +1,9 @@
 import { nodeEnv } from './config.js'
 import { createServer, port } from './tempo/prool.js'
 
-const defaultStartAttempts = 5
+const defaultStartAttempts = 3
 const defaultStartRetryDelayMs = 3_000
-const defaultStartRequestTimeoutMs = 120_000
+const defaultStartRequestTimeoutMs = 30_000
 
 function parsePositiveInt(value: string | undefined, fallback: number) {
   if (!value) return fallback

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,6 +42,7 @@ export default defineConfig({
           globals: true,
           retry: 3,
           setupFiles: ['./test/setup.ts'],
+          testTimeout: 10_000,
           hookTimeout: 60_000,
         },
       },
@@ -53,6 +54,7 @@ export default defineConfig({
           globals: true,
           retry: 3,
           setupFiles: ['./test/setup.ts'],
+          testTimeout: 10_000,
           hookTimeout: 60_000,
         },
       },
@@ -73,6 +75,7 @@ export default defineConfig({
           include: ['src/**/*.browser.test.ts'],
           globals: true,
           retry: 1,
+          testTimeout: 10_000,
           browser: {
             enabled: true,
             headless: true,


### PR DESCRIPTION
Adds `testTimeout: 10_000` to all three vitest projects (node, cli, browser).

**Problem:** CI shard 1/3 was [hanging indefinitely](https://github.com/wevm/mppx/actions/runs/23668024565/job/68954795130) because the default vitest `testTimeout` is 5s but combined with `retry: 3`, a truly stuck async call (e.g. `waitForTransactionReceipt`) can hang forever since the timeout doesn't always cancel in-flight promises.