### PR TITLE
ci: remove test sharding

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -40,12 +40,8 @@ jobs:
         run: pnpm dev && pnpm check:types && pnpm check:types:examples
 
   test:
-    name: Test Runtime (${{ matrix.shard }})
+    name: Test Runtime
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        shard: [1/3, 2/3, 3/3]
     env:
       VITE_TEMPO_TAG: sha-20aecec
     steps:
@@ -100,6 +96,6 @@ jobs:
           eval "$(dbus-launch --sh-syntax)"
           eval "$(printf '\n' | gnome-keyring-daemon --unlock)"
           eval "$(printf '\n' | gnome-keyring-daemon --start)"
-          pnpm run test --bail=1 --shard=${{ matrix.shard }}
+          pnpm run test --bail=1
         env:
           CI: true


### PR DESCRIPTION
One of our tests shards is consistently hanging / flaking in CI runs. 

Disabling sharding until we can find a durable fix -- performance improvements aren't worth the flakes here