### PR TITLE
feat: proof credential type for zero-dollar auth

### DIFF
--- a/src/tempo/Methods.ts
+++ b/src/tempo/Methods.ts
@@ -26,6 +26,7 @@ export const charge = Method.from({
       payload: z.discriminatedUnion('type', [
         z.object({ hash: z.hash(), type: z.literal('hash') }),
         z.object({ signature: z.signature(), type: z.literal('transaction') }),
+        z.object({ signature: z.signature(), type: z.literal('proof') }),
       ]),
     },
     request: z.pipe(

--- a/src/tempo/client/Charge.ts
+++ b/src/tempo/client/Charge.ts
@@ -1,6 +1,11 @@
 import type * as Hex from 'ox/Hex'
 import type { Address } from 'viem'
-import { prepareTransactionRequest, sendCallsSync, signTransaction } from 'viem/actions'
+import {
+  prepareTransactionRequest,
+  sendCallsSync,
+  signTypedData,
+  signTransaction,
+} from 'viem/actions'
 import { tempo as tempo_chain } from 'viem/chains'
 import { Actions } from 'viem/tempo'
 
@@ -13,6 +18,7 @@ import * as Attribution from '../Attribution.js'
 import * as AutoSwap from '../internal/auto-swap.js'
 import * as Charge_internal from '../internal/charge.js'
 import * as defaults from '../internal/defaults.js'
+import * as Proof from '../internal/proof.js'
 import * as Methods from '../Methods.js'
 
 /**
@@ -49,11 +55,28 @@ export function charge(parameters: charge.Parameters = {}) {
       const client = await getClient({ chainId })
       const account = getAccount(client, context)
 
+      const { request } = challenge
+      const { amount, methodDetails } = request
+
+      // Zero-amount: sign EIP-712 typed data instead of creating a transaction.
+      if (BigInt(amount) === 0n) {
+        const signature = await signTypedData(client, {
+          account,
+          domain: Proof.domain(chainId!),
+          types: Proof.types,
+          primaryType: 'Proof',
+          message: Proof.message(challenge.id),
+        })
+        return Credential.serialize({
+          challenge,
+          payload: { signature, type: 'proof' },
+          source: Proof.proofSource({ address: account.address, chainId: chainId! }),
+        })
+      }
+
       const mode =
         context?.mode ?? parameters.mode ?? (account.type === 'json-rpc' ? 'push' : 'pull')
 
-      const { request } = challenge
-      const { amount, methodDetails } = request
       const currency = request.currency as Address
 
       if (parameters.expectedRecipients) {

--- a/src/tempo/internal/proof.test.ts
+++ b/src/tempo/internal/proof.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'vp/test'
+
+import * as Proof from './proof.js'
+
+describe('Proof', () => {
+  test('types has Proof with challengeId field', () => {
+    expect(Proof.types).toEqual({
+      Proof: [{ name: 'challengeId', type: 'string' }],
+    })
+  })
+
+  test('domain returns EIP-712 domain with name, version, chainId', () => {
+    const d = Proof.domain(42431)
+    expect(d).toEqual({ name: 'MPP', version: '1', chainId: 42431 })
+  })
+
+  test('domain uses provided chainId', () => {
+    expect(Proof.domain(1).chainId).toBe(1)
+    expect(Proof.domain(99999).chainId).toBe(99999)
+  })
+
+  test('message wraps challengeId', () => {
+    expect(Proof.message('abc123')).toEqual({ challengeId: 'abc123' })
+  })
+
+  test('proofSource constructs did:pkh DID', () => {
+    expect(Proof.proofSource({ address: '0x1234567890abcdef', chainId: 42431 })).toBe(
+      'did:pkh:eip155:42431:0x1234567890abcdef',
+    )
+  })
+
+  test('proofSource preserves address casing', () => {
+    const address = '0xAbCdEf1234567890AbCdEf1234567890AbCdEf12'
+    expect(Proof.proofSource({ address, chainId: 1 })).toBe(`did:pkh:eip155:1:${address}`)
+  })
+})

--- a/src/tempo/internal/proof.ts
+++ b/src/tempo/internal/proof.ts
@@ -1,0 +1,19 @@
+/** EIP-712 typed data types for proof credentials. */
+export const types = {
+  Proof: [{ name: 'challengeId', type: 'string' }],
+} as const
+
+/** Constructs the EIP-712 domain for a proof credential. */
+export function domain(chainId: number) {
+  return { name: 'MPP', version: '1', chainId } as const
+}
+
+/** Constructs the EIP-712 message for a proof credential. */
+export function message(challengeId: string) {
+  return { challengeId } as const
+}
+
+/** Constructs the expected `did:pkh` source DID for a proof credential. */
+export function proofSource(parameters: { address: string; chainId: number }): string {
+  return `did:pkh:eip155:${parameters.chainId}:${parameters.address}`
+}

--- a/src/tempo/server/Charge.test.ts
+++ b/src/tempo/server/Charge.test.ts
@@ -5,7 +5,12 @@ import type { Hex } from 'ox'
 import { TxEnvelopeTempo } from 'ox/tempo'
 import { Handler } from 'tempo.ts/server'
 import { createClient, custom, encodeFunctionData, parseUnits } from 'viem'
-import { getTransactionReceipt, prepareTransactionRequest, signTransaction } from 'viem/actions'
+import {
+  getTransactionReceipt,
+  prepareTransactionRequest,
+  signTypedData,
+  signTransaction,
+} from 'viem/actions'
 import { Abis, Account, Actions, Addresses, Secp256k1, Tick, Transaction } from 'viem/tempo'
 import { beforeAll, describe, expect, test } from 'vp/test'
 import * as Http from '~test/Http.js'
@@ -14,6 +19,7 @@ import { accounts, asset, chain, client, fundAccount } from '~test/tempo/viem.js
 
 import * as Store from '../../Store.js'
 import * as Attribution from '../Attribution.js'
+import * as Proof from '../internal/proof.js'
 import { signVoucher } from '../session/Voucher.js'
 
 const realm = 'api.example.com'
@@ -1915,6 +1921,361 @@ describe('tempo', () => {
         expect(receipt.method).toBe('tempo')
         expect(receipt.reference).toBeDefined()
       }
+
+      httpServer.close()
+    })
+  })
+
+  describe('intent: charge; type: proof (zero-dollar auth)', () => {
+    test('default: end-to-end zero-dollar auth via SDK', async () => {
+      const mppx = Mppx_client.create({
+        polyfill: false,
+        methods: [
+          tempo_client({
+            account: accounts[1],
+            getClient: () => client,
+          }),
+        ],
+      })
+
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await Mppx_server.toNodeListener(
+          server.charge({ amount: '0', decimals: 6 }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
+      })
+
+      const response = await mppx.fetch(httpServer.url)
+      expect(response.status).toBe(200)
+
+      const receipt = Receipt.fromResponse(response)
+      expect(receipt.status).toBe('success')
+      expect(receipt.method).toBe('tempo')
+      expect(receipt.reference).toBeDefined()
+
+      httpServer.close()
+    })
+
+    test('behavior: proof credential contains valid source DID', async () => {
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await Mppx_server.toNodeListener(
+          server.charge({ amount: '0', decimals: 6 }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
+      })
+
+      const response1 = await fetch(httpServer.url)
+      expect(response1.status).toBe(402)
+
+      const challenge = Challenge.fromResponse(response1, {
+        methods: [tempo_client.charge()],
+      })
+
+      const signature = await signTypedData(client, {
+        account: accounts[1],
+        domain: Proof.domain(chain.id),
+        types: Proof.types,
+        primaryType: 'Proof',
+        message: Proof.message(challenge.id),
+      })
+
+      const credential = Credential.from({
+        challenge,
+        payload: { signature, type: 'proof' as const },
+        source: `did:pkh:eip155:${chain.id}:${accounts[1].address}`,
+      })
+
+      const response2 = await fetch(httpServer.url, {
+        headers: { Authorization: Credential.serialize(credential) },
+      })
+      expect(response2.status).toBe(200)
+
+      httpServer.close()
+    })
+
+    test('behavior: rejects proof with wrong signer', async () => {
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await Mppx_server.toNodeListener(
+          server.charge({ amount: '0', decimals: 6 }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
+      })
+
+      const response1 = await fetch(httpServer.url)
+      const challenge = Challenge.fromResponse(response1, {
+        methods: [tempo_client.charge()],
+      })
+
+      // Sign with accounts[2] but claim source is accounts[1]
+      const signature = await signTypedData(client, {
+        account: accounts[2],
+        domain: Proof.domain(chain.id),
+        types: Proof.types,
+        primaryType: 'Proof',
+        message: Proof.message(challenge.id),
+      })
+
+      const credential = Credential.from({
+        challenge,
+        payload: { signature, type: 'proof' as const },
+        source: `did:pkh:eip155:${chain.id}:${accounts[1].address}`,
+      })
+
+      const response2 = await fetch(httpServer.url, {
+        headers: { Authorization: Credential.serialize(credential) },
+      })
+      expect(response2.status).toBe(402)
+
+      httpServer.close()
+    })
+
+    test('behavior: rejects proof without source', async () => {
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await Mppx_server.toNodeListener(
+          server.charge({ amount: '0', decimals: 6 }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
+      })
+
+      const response1 = await fetch(httpServer.url)
+      const challenge = Challenge.fromResponse(response1, {
+        methods: [tempo_client.charge()],
+      })
+
+      const signature = await signTypedData(client, {
+        account: accounts[1],
+        domain: Proof.domain(chain.id),
+        types: Proof.types,
+        primaryType: 'Proof',
+        message: Proof.message(challenge.id),
+      })
+
+      const credential = Credential.from({
+        challenge,
+        payload: { signature, type: 'proof' as const },
+        // no source
+      })
+
+      const response2 = await fetch(httpServer.url, {
+        headers: { Authorization: Credential.serialize(credential) },
+      })
+      expect(response2.status).toBe(402)
+
+      httpServer.close()
+    })
+
+    test('behavior: rejects transaction payload for zero-amount', async () => {
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await Mppx_server.toNodeListener(
+          server.charge({ amount: '0', decimals: 6 }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
+      })
+
+      const response1 = await fetch(httpServer.url)
+      const challenge = Challenge.fromResponse(response1, {
+        methods: [tempo_client.charge()],
+      })
+
+      const credential = Credential.from({
+        challenge,
+        payload: { signature: '0xdead', type: 'transaction' as const },
+        source: `did:pkh:eip155:${chain.id}:${accounts[1].address}`,
+      })
+
+      const response2 = await fetch(httpServer.url, {
+        headers: { Authorization: Credential.serialize(credential) },
+      })
+      expect(response2.status).toBe(402)
+      const body = (await response2.json()) as { detail: string }
+      expect(body.detail).toContain('Zero-amount challenges require a proof credential.')
+
+      httpServer.close()
+    })
+
+    test('behavior: rejects hash payload for zero-amount', async () => {
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await Mppx_server.toNodeListener(
+          server.charge({ amount: '0', decimals: 6 }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
+      })
+
+      const response1 = await fetch(httpServer.url)
+      const challenge = Challenge.fromResponse(response1, {
+        methods: [tempo_client.charge()],
+      })
+
+      const credential = Credential.from({
+        challenge,
+        payload: {
+          hash: '0x0000000000000000000000000000000000000000000000000000000000000001',
+          type: 'hash' as const,
+        },
+        source: `did:pkh:eip155:${chain.id}:${accounts[1].address}`,
+      })
+
+      const response2 = await fetch(httpServer.url, {
+        headers: { Authorization: Credential.serialize(credential) },
+      })
+      expect(response2.status).toBe(402)
+      const body = (await response2.json()) as { detail: string }
+      expect(body.detail).toContain('Zero-amount challenges require a proof credential.')
+
+      httpServer.close()
+    })
+
+    test('behavior: rejects proof payload for non-zero amount', async () => {
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await Mppx_server.toNodeListener(
+          server.charge({ amount: '1', decimals: 6 }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
+      })
+
+      const response1 = await fetch(httpServer.url)
+      const challenge = Challenge.fromResponse(response1, {
+        methods: [tempo_client.charge()],
+      })
+
+      const signature = await signTypedData(client, {
+        account: accounts[1],
+        domain: Proof.domain(chain.id),
+        types: Proof.types,
+        primaryType: 'Proof',
+        message: Proof.message(challenge.id),
+      })
+
+      const credential = Credential.from({
+        challenge,
+        payload: { signature, type: 'proof' as const },
+        source: `did:pkh:eip155:${chain.id}:${accounts[1].address}`,
+      })
+
+      const response2 = await fetch(httpServer.url, {
+        headers: { Authorization: Credential.serialize(credential) },
+      })
+      expect(response2.status).toBe(402)
+      const body = (await response2.json()) as { detail: string }
+      expect(body.detail).toContain('Proof credentials are only valid for zero-amount challenges.')
+
+      httpServer.close()
+    })
+
+    test('behavior: receipt reference is the challenge ID', async () => {
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await Mppx_server.toNodeListener(
+          server.charge({ amount: '0', decimals: 6 }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
+      })
+
+      const response1 = await fetch(httpServer.url)
+      const challenge = Challenge.fromResponse(response1, {
+        methods: [tempo_client.charge()],
+      })
+
+      const signature = await signTypedData(client, {
+        account: accounts[1],
+        domain: Proof.domain(chain.id),
+        types: Proof.types,
+        primaryType: 'Proof',
+        message: Proof.message(challenge.id),
+      })
+
+      const credential = Credential.from({
+        challenge,
+        payload: { signature, type: 'proof' as const },
+        source: `did:pkh:eip155:${chain.id}:${accounts[1].address}`,
+      })
+
+      const response2 = await fetch(httpServer.url, {
+        headers: { Authorization: Credential.serialize(credential) },
+      })
+      expect(response2.status).toBe(200)
+      const receipt = Receipt.fromResponse(response2)
+      expect(receipt.reference).toBe(challenge.id)
+
+      httpServer.close()
+    })
+
+    test('behavior: rejects proof signed with wrong chainId domain', async () => {
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await Mppx_server.toNodeListener(
+          server.charge({ amount: '0', decimals: 6 }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
+      })
+
+      const response1 = await fetch(httpServer.url)
+      const challenge = Challenge.fromResponse(response1, {
+        methods: [tempo_client.charge()],
+      })
+
+      // Sign with a different chainId in the EIP-712 domain
+      const signature = await signTypedData(client, {
+        account: accounts[1],
+        domain: Proof.domain(99999),
+        types: Proof.types,
+        primaryType: 'Proof',
+        message: Proof.message(challenge.id),
+      })
+
+      const credential = Credential.from({
+        challenge,
+        payload: { signature, type: 'proof' as const },
+        source: `did:pkh:eip155:${chain.id}:${accounts[1].address}`,
+      })
+
+      const response2 = await fetch(httpServer.url, {
+        headers: { Authorization: Credential.serialize(credential) },
+      })
+      expect(response2.status).toBe(402)
+
+      httpServer.close()
+    })
+
+    test('behavior: rejects proof with malformed source DID', async () => {
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await Mppx_server.toNodeListener(
+          server.charge({ amount: '0', decimals: 6 }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
+      })
+
+      const response1 = await fetch(httpServer.url)
+      const challenge = Challenge.fromResponse(response1, {
+        methods: [tempo_client.charge()],
+      })
+
+      const signature = await signTypedData(client, {
+        account: accounts[1],
+        domain: Proof.domain(chain.id),
+        types: Proof.types,
+        primaryType: 'Proof',
+        message: Proof.message(challenge.id),
+      })
+
+      const credential = Credential.from({
+        challenge,
+        payload: { signature, type: 'proof' as const },
+        source: 'not-a-valid-did',
+      })
+
+      const response2 = await fetch(httpServer.url, {
+        headers: { Authorization: Credential.serialize(credential) },
+      })
+      expect(response2.status).toBe(402)
 
       httpServer.close()
     })

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -4,6 +4,7 @@ import {
   sendRawTransaction,
   sendRawTransactionSync,
   signTransaction,
+  verifyTypedData,
   call as viem_call,
 } from 'viem/actions'
 import { tempo as tempo_chain } from 'viem/chains'
@@ -19,6 +20,7 @@ import * as TempoAddress from '../internal/address.js'
 import * as Charge_internal from '../internal/charge.js'
 import * as defaults from '../internal/defaults.js'
 import * as FeePayer from '../internal/fee-payer.js'
+import * as Proof from '../internal/proof.js'
 import * as Selectors from '../internal/selectors.js'
 import type * as types from '../internal/types.js'
 import * as Methods from '../Methods.js'
@@ -123,6 +125,10 @@ export function charge<const parameters extends charge.Parameters>(
       const memo = methodDetails?.memo as `0x${string}` | undefined
 
       const payload = credential.payload
+      const isZeroAmount = BigInt(amount) === 0n
+
+      if (isZeroAmount && payload.type !== 'proof')
+        throw new MismatchError('Zero-amount challenges require a proof credential.', {})
 
       switch (payload.type) {
         case 'hash': {
@@ -140,6 +146,38 @@ export function charge<const parameters extends charge.Parameters>(
           await markHashUsed(store, hash)
 
           return toReceipt(receipt)
+        }
+
+        case 'proof': {
+          if (!isZeroAmount)
+            throw new MismatchError(
+              'Proof credentials are only valid for zero-amount challenges.',
+              {},
+            )
+
+          const expectedSource = credential.source
+          if (!expectedSource)
+            throw new MismatchError('Proof credential must include a source.', {})
+
+          const sourceAddress = expectedSource.split(':').pop() as `0x${string}`
+          const resolvedChainId = challenge.request.methodDetails?.chainId ?? chainId!
+
+          const valid = await verifyTypedData(client, {
+            address: sourceAddress,
+            domain: Proof.domain(resolvedChainId),
+            types: Proof.types,
+            primaryType: 'Proof',
+            message: Proof.message(challenge.id),
+            signature: payload.signature as `0x${string}`,
+          })
+          if (!valid) throw new MismatchError('Proof signature does not match source.', {})
+
+          return {
+            method: 'tempo',
+            status: 'success',
+            timestamp: new Date().toISOString(),
+            reference: challenge.id,
+          } as const
         }
 
         case 'transaction': {


### PR DESCRIPTION
## Summary

Adds a new `proof` credential payload type that uses EIP-191 signed messages instead of real transactions for zero-amount identity flows.

This builds upon existing "zero dollar auth" flows by removing a griefing vector in which a server could cause users to burn 0.001 USD in cases where the end-user was the feePayer. 