### PR TITLE
ci: cap test runtime job at 10 minutes

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -48,6 +48,7 @@ jobs:
   test:
     name: Test Runtime
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       # GitHub-hosted runners are ephemeral, so we can skip the Ryuk sidecar
       # and avoid Docker Hub rate limits on testcontainers/ryuk pulls.


### PR DESCRIPTION
## Summary
- add `timeout-minutes: 10` to the `Verify / Test Runtime` job in [`.github/workflows/verify.yml`](file:///Users/brendanryan/tempo/mppx/.github/workflows/verify.yml)

## Why
We had a stuck `Main / Verify / Test Runtime` run that sat for hours before being cancelled. This job should never run indefinitely, and 10 minutes is comfortably above the normal successful runtime while still failing fast when the workflow wedges.