### PR TITLE
fix: harden credential verification, transport billing, error responses, and proxy routing

### DIFF
--- a/.changeset/security-hardening.md
+++ b/.changeset/security-hardening.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Hardened credential verification, transport billing, error responses, and proxy routing. Credential request binding now verifies fields match the actual incoming request. SSE transport derives billing context directly from the verified credential payload. 402 error responses no longer leak internal details. Proxy routing binds management POST fallback to the credential's payment method and intent for correct disambiguation.

--- a/src/Credential.ts
+++ b/src/Credential.ts
@@ -18,6 +18,30 @@ export type Credential<
   source?: string
 }
 
+export class MissingAuthorizationHeaderError extends Error {
+  override readonly name = 'MissingAuthorizationHeaderError'
+
+  constructor() {
+    super('Missing Authorization header.')
+  }
+}
+
+export class MissingPaymentSchemeError extends Error {
+  override readonly name = 'MissingPaymentSchemeError'
+
+  constructor() {
+    super('Missing Payment scheme.')
+  }
+}
+
+export class InvalidCredentialEncodingError extends Error {
+  override readonly name = 'InvalidCredentialEncodingError'
+
+  constructor() {
+    super('Invalid base64url or JSON.')
+  }
+}
+
 /**
  * Deserializes an Authorization header value to a credential.
  *
@@ -33,7 +57,7 @@ export type Credential<
  */
 export function deserialize<payload = unknown>(value: string): Credential<payload> {
   const prefixMatch = value.match(/^Payment\s+(.+)$/i)
-  if (!prefixMatch?.[1]) throw new Error('Missing Payment scheme.')
+  if (!prefixMatch?.[1]) throw new MissingPaymentSchemeError()
   try {
     const json = Base64.toString(prefixMatch[1])
     const parsed = JSON.parse(json) as {
@@ -51,7 +75,7 @@ export function deserialize<payload = unknown>(value: string): Credential<payloa
       ...(parsed.source && { source: parsed.source }),
     } as Credential<payload>
   } catch {
-    throw new Error('Invalid base64url or JSON.')
+    throw new InvalidCredentialEncodingError()
   }
 }
 
@@ -108,9 +132,9 @@ export declare namespace from {
  */
 export function fromRequest<payload = unknown>(request: Request): Credential<payload> {
   const header = request.headers.get('Authorization')
-  if (!header) throw new Error('Missing Authorization header.')
+  if (!header) throw new MissingAuthorizationHeaderError()
   const payment = extractPaymentScheme(header)
-  if (!payment) throw new Error('Missing Payment scheme.')
+  if (!payment) throw new MissingPaymentSchemeError()
   return deserialize<payload>(payment)
 }
 

--- a/src/mcp-sdk/server/Transport.test.ts
+++ b/src/mcp-sdk/server/Transport.test.ts
@@ -113,6 +113,8 @@ describe('mcpSdk', () => {
 
       const result = transport.respondReceipt({
         challengeId: 'test-challenge-id',
+        credential,
+        input: {} as Extra,
         receipt,
         response,
       })
@@ -139,6 +141,8 @@ describe('mcpSdk', () => {
 
       const result = transport.respondReceipt({
         challengeId: 'cid',
+        credential,
+        input: {} as Extra,
         receipt,
         response,
       })
@@ -162,6 +166,8 @@ describe('mcpSdk', () => {
 
       const result = transport.respondReceipt({
         challengeId: 'cid',
+        credential,
+        input: {} as Extra,
         receipt,
         response,
       })

--- a/src/proxy/Proxy.test.ts
+++ b/src/proxy/Proxy.test.ts
@@ -1,4 +1,4 @@
-import { Receipt } from 'mppx'
+import { Challenge, Credential, Method, Receipt, z } from 'mppx'
 import { Mppx as Mppx_client, tempo as tempo_client } from 'mppx/client'
 import { Mppx as Mppx_server, tempo as tempo_server } from 'mppx/server'
 import { afterEach, describe, expect, test } from 'vp/test'
@@ -437,6 +437,193 @@ describe('create', () => {
     })
     // Should hit the paid endpoint and get a 402 challenge, not 404
     expect(res.status).toBe(402)
+  })
+
+  test('behavior: management POST uses credential method binding to disambiguate same-path paid routes', async () => {
+    const alpha = Method.from({
+      name: 'alpha',
+      intent: 'charge',
+      schema: {
+        credential: { payload: z.object({ token: z.string() }) },
+        request: z.object({ amount: z.string() }),
+      },
+    })
+    const beta = Method.from({
+      name: 'beta',
+      intent: 'charge',
+      schema: {
+        credential: { payload: z.object({ token: z.string() }) },
+        request: z.object({ amount: z.string() }),
+      },
+    })
+
+    const handler = Mppx_server.create({
+      methods: [
+        Method.toServer(alpha, {
+          async verify() {
+            return Receipt.from({
+              method: 'alpha',
+              status: 'success',
+              timestamp: new Date().toISOString(),
+              reference: 'alpha-reference',
+            })
+          },
+          respond() {
+            return new Response(null, { status: 204 })
+          },
+        }),
+        Method.toServer(beta, {
+          async verify() {
+            return Receipt.from({
+              method: 'beta',
+              status: 'success',
+              timestamp: new Date().toISOString(),
+              reference: 'beta-reference',
+            })
+          },
+          respond() {
+            return new Response(null, { status: 205 })
+          },
+        }),
+      ],
+      secretKey,
+    })
+
+    const proxy = ApiProxy.create({
+      services: [
+        Service.from('api', {
+          baseUrl: 'https://example.com',
+          routes: {
+            'GET /v1/stream': handler['alpha/charge']({ amount: '1' }),
+            'PATCH /v1/stream': handler['beta/charge']({ amount: '1' }),
+          },
+        }),
+      ],
+    })
+    proxyServer = await Http.createServer(proxy.listener)
+
+    const challengeResponse = await fetch(`${proxyServer.url}/api/v1/stream`)
+    expect(challengeResponse.status).toBe(402)
+
+    const challenge = Challenge.fromResponse(challengeResponse)
+    const authorization = Credential.serialize(
+      Credential.from({
+        challenge,
+        payload: { token: 'ok' },
+      }),
+    )
+
+    const res = await fetch(`${proxyServer.url}/api/v1/stream`, {
+      method: 'POST',
+      headers: { Authorization: authorization },
+    })
+
+    expect(res.status).toBe(204)
+  })
+
+  test('behavior: exact-match management POST does not forward upstream', async () => {
+    let upstreamRequests = 0
+    upstream = await createUpstream(() => {
+      upstreamRequests += 1
+      return Response.json({ ok: true })
+    })
+
+    const method = Method.from({
+      name: 'mock',
+      intent: 'charge',
+      schema: {
+        credential: { payload: z.object({ token: z.string() }) },
+        request: z.object({ amount: z.string() }),
+      },
+    })
+    const handler = Mppx_server.create({
+      methods: [
+        Method.toServer(method, {
+          async verify() {
+            return Receipt.from({
+              method: 'mock',
+              status: 'success',
+              timestamp: new Date().toISOString(),
+              reference: 'mock-reference',
+            })
+          },
+          respond() {
+            return new Response(null, { status: 204 })
+          },
+        }),
+      ],
+      secretKey,
+    })
+
+    const proxy = ApiProxy.create({
+      services: [
+        Service.from('api', {
+          baseUrl: upstream.url,
+          routes: {
+            'POST /v1/stream': handler['mock/charge']({ amount: '1' }),
+          },
+        }),
+      ],
+    })
+    proxyServer = await Http.createServer(proxy.listener)
+
+    const challengeResponse = await fetch(`${proxyServer.url}/api/v1/stream`, { method: 'POST' })
+    expect(challengeResponse.status).toBe(402)
+
+    const challenge = Challenge.fromResponse(challengeResponse)
+    const authorization = Credential.serialize(
+      Credential.from({
+        challenge,
+        payload: { token: 'ok' },
+      }),
+    )
+    const res = await fetch(`${proxyServer.url}/api/v1/stream`, {
+      method: 'POST',
+      headers: { Authorization: authorization },
+    })
+
+    expect(res.status).toBe(204)
+    expect(upstreamRequests).toBe(0)
+  })
+
+  test('behavior: paid GET fallback does not forward POST upstream', async () => {
+    let upstreamRequests = 0
+    upstream = await createUpstream(async (req) => {
+      upstreamRequests += 1
+      return Response.json({
+        body: await req.json(),
+        method: req.method,
+      })
+    })
+
+    const proxy = ApiProxy.create({
+      services: [
+        Service.from('api', {
+          baseUrl: upstream.url,
+          bearer: 'sk-upstream-key',
+          routes: { 'GET /v1/messages': mppx_server.charge({ amount: '1', decimals: 6 }) },
+        }),
+      ],
+    })
+    proxyServer = await Http.createServer(proxy.listener)
+
+    const challengeResponse = await fetch(`${proxyServer.url}/api/v1/messages`)
+    expect(challengeResponse.status).toBe(402)
+
+    const authorization = await mppx_client.createCredential(challengeResponse)
+    expect(Credential.extractPaymentScheme(authorization)).toBeTruthy()
+
+    const res = await fetch(`${proxyServer.url}/api/v1/messages`, {
+      method: 'POST',
+      headers: {
+        Authorization: authorization,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ prompt: 'hello' }),
+    })
+
+    expect(res.status).toBe(405)
+    expect(upstreamRequests).toBe(0)
   })
 
   test('behavior: POST to unregistered method does not fall back to free GET route', async () => {

--- a/src/proxy/Proxy.ts
+++ b/src/proxy/Proxy.ts
@@ -2,6 +2,7 @@ import type * as http from 'node:http'
 
 import { createFetchProxy } from '@remix-run/fetch-proxy'
 
+import * as Credential from '../Credential.js'
 import { generateProxy } from '../discovery/OpenApi.js'
 import * as Request from '../server/Request.js'
 import * as Headers from './internal/Headers.js'
@@ -106,19 +107,26 @@ export function create(config: create.Config): Proxy {
 
     const { service, proxy } = entry
 
-    const matched =
-      Route.match(service.routes, request.method, upstreamPath) ??
-      // Management POSTs (e.g. session close) may target a path whose route
-      // is registered for a different HTTP method (e.g. GET). Fall back to
-      // path-only matching so the payment handler can process the action.
-      (request.method === 'POST' && request.headers.has('authorization')
-        ? Route.matchPath(
+    const exactMatch = Route.match(service.routes, request.method, upstreamPath)
+    const fallbackBinding =
+      !exactMatch && request.method === 'POST' && request.headers.has('authorization')
+        ? getPaymentBinding(request)
+        : null
+    const fallbackMatch =
+      !exactMatch && request.method === 'POST' && request.headers.has('authorization')
+        ? // Management POSTs (e.g. session close) may target a path whose route
+          // is registered for a different HTTP method (e.g. GET). Fall back to
+          // path-only matching so the payment handler can process the action.
+          // When the credential parses cleanly, also bind on payment method+intent
+          // so same-path paid routes can coexist without sharing credentials.
+          Route.matchPath(
             service.routes,
             upstreamPath,
             // skip free routes (e.g. `'GET /foo/bar': true`)
-            (endpoint) => endpoint !== true,
+            (endpoint) => endpoint !== true && matchesPaymentBinding(endpoint, fallbackBinding),
           )
-        : null)
+        : null
+    const matched = exactMatch ?? fallbackMatch
     if (!matched) return new Response('Not Found', { status: 404 })
 
     const endpoint = matched.value as Service.Endpoint
@@ -129,6 +137,22 @@ export function create(config: create.Config): Proxy {
     const handler = typeof endpoint === 'function' ? endpoint : endpoint.pay
     const result = await handler(request)
     if (result.status === 402) return result.challenge
+
+    const managementResponse = (() => {
+      try {
+        return (result.withReceipt as () => Response)()
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          error.message === 'withReceipt() requires a response argument'
+        )
+          return null
+        throw error
+      }
+    })()
+
+    if (managementResponse) return managementResponse
+    if (fallbackMatch) return new Response('Method Not Allowed', { status: 405 })
 
     const options = Service.getOptions(endpoint)
     const upstreamRes = await proxyUpstream({
@@ -245,4 +269,29 @@ function withBasePath(basePath: string | undefined, path: string) {
   const normalized = basePath.startsWith('/') ? basePath : `/${basePath}`
   const trimmed = normalized.endsWith('/') ? normalized.slice(0, -1) : normalized
   return `${trimmed}${path}`
+}
+
+type PaymentBinding = {
+  intent: string
+  method: string
+}
+
+function getPaymentBinding(request: Request): PaymentBinding | null {
+  try {
+    const credential = Credential.fromRequest(request)
+    return {
+      intent: credential.challenge.intent,
+      method: credential.challenge.method,
+    }
+  } catch {
+    return null
+  }
+}
+
+function matchesPaymentBinding(endpoint: unknown, binding: PaymentBinding | null): boolean {
+  if (endpoint === true) return false
+  if (!binding) return true
+  const payment = Service.paymentOf(endpoint as Exclude<Service.Endpoint, true>)
+  if (!payment) return true
+  return payment.method === binding.method && payment.intent === binding.intent
 }

--- a/src/proxy/internal/Route.test.ts
+++ b/src/proxy/internal/Route.test.ts
@@ -193,6 +193,15 @@ describe('matchPath', () => {
     expect(result).toMatchObject({ key: 'POST /v1/*' })
   })
 
+  // TODO (brendanryan): Relax this if `matchPath()` gains method-aware disambiguation.
+  test('error: returns null when multiple paid routes share the same path', () => {
+    const routes = {
+      'GET /v1/stream': { pay: () => {} },
+      'POST /v1/stream': { pay: () => {} },
+    }
+    expect(Route.matchPath(routes, '/v1/stream', paidOnly)).toBeNull()
+  })
+
   test('error: returns null when all routes are free', () => {
     const routes = {
       'GET /v1/models': true,

--- a/src/proxy/internal/Route.ts
+++ b/src/proxy/internal/Route.ts
@@ -42,13 +42,16 @@ export function matchPath(
   path: string,
   filter?: (value: unknown) => boolean,
 ): { key: string; value: unknown } | null {
+  let match: { key: string; value: unknown } | null = null
   for (const [key, value] of Object.entries(routes)) {
     if (filter && !filter(value)) continue
     const { pattern } = parseRouteKey(key)
     const urlPattern = new URLPattern({ pathname: pattern })
-    if (urlPattern.test({ pathname: path })) return { key, value }
+    if (!urlPattern.test({ pathname: path })) continue
+    if (match) return null
+    match = { key, value }
   }
-  return null
+  return match
 }
 
 function parseRouteKey(key: string): { method: string | undefined; pattern: string } {

--- a/src/server/Mppx.test.ts
+++ b/src/server/Mppx.test.ts
@@ -95,6 +95,36 @@ describe('request handler', () => {
     `)
   })
 
+  test('returns sanitized malformed credential error for unexpected transport failures', async () => {
+    const baseTransport = Transport.http()
+    const transport = Transport.from({
+      ...baseTransport,
+      name: 'leaking-http',
+      getCredential() {
+        throw new Error('request to https://rpc.example.com/?key=secret-key failed')
+      },
+    })
+
+    const result = await Mppx.create({ methods: [method], realm, secretKey, transport }).charge({
+      amount: '1000',
+      currency: asset,
+      expires: new Date(Date.now() + 60_000).toISOString(),
+      recipient: accounts[0].address,
+    })(
+      new Request('https://example.com/resource', {
+        headers: { Authorization: 'Payment invalid' },
+      }),
+    )
+
+    expect(result.status).toBe(402)
+    if (result.status !== 402) throw new Error()
+
+    const body = (await result.challenge.json()) as { detail: string }
+    expect(body.detail).toBe('Credential is malformed.')
+    expect(body.detail).not.toContain('secret-key')
+    expect(body.detail).not.toContain('rpc.example.com')
+  })
+
   test('returns 402 when challenge ID mismatch', async () => {
     const wrongChallenge = Challenge.from({
       id: 'wrong-id',
@@ -181,7 +211,7 @@ describe('request handler', () => {
     expect(body.detail).toContain('does not match')
   })
 
-  test('topUp credential bypasses cross-route amount validation', async () => {
+  test('topUp credential is rejected when replayed across routes with different amounts', async () => {
     // Use a session method whose schema defines action: 'topUp'
     const sessionMethod = Method.from({
       name: 'mock',
@@ -231,7 +261,7 @@ describe('request handler', () => {
       payload: { action: 'topUp', token: 'valid' },
     })
 
-    // Present it at the "expensive" route — topUp should bypass amount check
+    // Present it at the "expensive" route — topUp must still match scope.
     const expensiveHandle = handler['mock/session']({
       amount: '1000000',
       currency: asset,
@@ -244,16 +274,13 @@ describe('request handler', () => {
       }),
     )
 
-    // Should NOT get 402 for amount mismatch — topUp bypasses the check.
-    // It will fail at a later stage (payload validation), but not with
-    // "does not match this route's requirements".
-    if (result.status === 402) {
-      const body = (await result.challenge.json()) as { detail?: string }
-      expect(body.detail).not.toContain('does not match')
-    }
+    expect(result.status).toBe(402)
+    if (result.status !== 402) throw new Error()
+    const body = (await result.challenge.json()) as { detail?: string }
+    expect(body.detail).toContain('does not match')
   })
 
-  test('voucher credential bypasses cross-route amount validation', async () => {
+  test('voucher credential is rejected when replayed across routes with different amounts', async () => {
     const sessionMethod = Method.from({
       name: 'mock',
       intent: 'session',
@@ -307,8 +334,8 @@ describe('request handler', () => {
       payload: { action: 'voucher', cumulativeAmount: '500', signature: '0xabc' },
     })
 
-    // Present it at the same route but with a higher price — voucher should
-    // bypass the cross-route amount check just like topUp does
+    // Present it at the same route but with a higher price — voucher must
+    // still match the original priced scope.
     const expensiveHandle = handler['mock/session']({
       amount: '1000000',
       currency: asset,
@@ -321,11 +348,10 @@ describe('request handler', () => {
       }),
     )
 
-    // Should NOT get 402 for amount mismatch — voucher bypasses the check.
-    if (result.status === 402) {
-      const body = (await result.challenge.json()) as { detail?: string }
-      expect(body.detail).not.toContain('does not match')
-    }
+    expect(result.status).toBe(402)
+    if (result.status !== 402) throw new Error()
+    const body = (await result.challenge.json()) as { detail?: string }
+    expect(body.detail).toContain('does not match')
   })
 
   test('rejects charge credential with injected action: topUp (cross-route bypass attempt)', async () => {
@@ -552,7 +578,63 @@ describe('request handler', () => {
         "type": "https://paymentauth.org/problems/invalid-payload",
       }
     `)
-    expect(body.detail).toContain('Credential payload is invalid')
+    expect(body.detail).toBe('Credential payload is invalid.')
+    expect(body.detail).not.toContain('invalidField')
+  })
+
+  test('returns sanitized verification error for unexpected verifier failures', async () => {
+    const leakingMethod = Method.toServer(
+      Method.from({
+        name: 'mock',
+        intent: 'charge',
+        schema: {
+          credential: {
+            payload: z.object({ token: z.string() }),
+          },
+          request: z.object({
+            amount: z.string(),
+            currency: z.string(),
+            recipient: z.string(),
+          }),
+        },
+      }),
+      {
+        async verify() {
+          throw new Error('request to https://mainnet.infura.io/v3/secret-key failed')
+        },
+      },
+    )
+
+    const handle = Mppx.create({ methods: [leakingMethod], realm, secretKey })['mock/charge']({
+      amount: '1000',
+      currency: asset,
+      expires: new Date(Date.now() + 60_000).toISOString(),
+      recipient: accounts[0].address,
+    })
+
+    const firstResult = await handle(new Request('https://example.com/resource'))
+    expect(firstResult.status).toBe(402)
+    if (firstResult.status !== 402) throw new Error()
+
+    const challenge = Challenge.fromResponse(firstResult.challenge)
+    const credential = Credential.from({
+      challenge,
+      payload: { token: 'valid' },
+    })
+
+    const result = await handle(
+      new Request('https://example.com/resource', {
+        headers: { Authorization: Credential.serialize(credential) },
+      }),
+    )
+
+    expect(result.status).toBe(402)
+    if (result.status !== 402) throw new Error()
+
+    const body = (await result.challenge.json()) as { detail: string }
+    expect(body.detail).toBe('Payment verification failed.')
+    expect(body.detail).not.toContain('infura')
+    expect(body.detail).not.toContain('secret-key')
   })
 })
 
@@ -1723,6 +1805,77 @@ describe('cross-route credential replay via scope binding flaw', () => {
     )
 
     expect(result.status).toBe(402)
+  })
+
+  test('compose dispatch includes methodDetails memo/splits binding', async () => {
+    const splitsMethod = Method.from({
+      name: 'mock',
+      intent: 'charge',
+      schema: {
+        credential: { payload: z.object({ token: z.string() }) },
+        request: z.pipe(
+          z.object({
+            amount: z.string(),
+            currency: z.string(),
+            decimals: z.number(),
+            recipient: z.string(),
+            splits: z.optional(z.array(z.object({ amount: z.string(), recipient: z.string() }))),
+          }),
+          z.transform(({ amount, currency, decimals, recipient, splits }) => ({
+            methodDetails: {
+              amount: String(Number(amount) * 10 ** decimals),
+              currency,
+              recipient,
+              ...(splits && { splits }),
+            },
+          })),
+        ),
+      },
+    })
+
+    const splitsServerMethod = Method.toServer(splitsMethod, {
+      async verify() {
+        return mockReceipt()
+      },
+    })
+
+    const handler = Mppx.create({ methods: [splitsServerMethod], realm, secretKey })
+
+    const noSplitsHandle = handler.charge({
+      amount: '1',
+      currency: '0x0000000000000000000000000000000000000001',
+      decimals: 6,
+      expires: new Date(Date.now() + 60_000).toISOString(),
+      recipient: '0x0000000000000000000000000000000000000002',
+    })
+    const splitsHandle = handler.charge({
+      amount: '1',
+      currency: '0x0000000000000000000000000000000000000001',
+      decimals: 6,
+      expires: new Date(Date.now() + 60_000).toISOString(),
+      recipient: '0x0000000000000000000000000000000000000002',
+      splits: [{ amount: '0.2', recipient: '0x0000000000000000000000000000000000000003' }],
+    })
+
+    const composed = Mppx.compose(noSplitsHandle, splitsHandle)
+    const firstResult = await composed(new Request('https://example.com/resource'))
+    expect(firstResult.status).toBe(402)
+    if (firstResult.status !== 402) throw new Error()
+
+    const challenges = Challenge.fromResponseList(firstResult.challenge)
+    const noSplitsChallenge = challenges[0]!
+    const credential = Credential.from({
+      challenge: noSplitsChallenge,
+      payload: { token: 'valid' },
+    })
+
+    const result = await composed(
+      new Request('https://example.com/resource', {
+        headers: { Authorization: Credential.serialize(credential) },
+      }),
+    )
+
+    expect(result.status).toBe(200)
   })
 })
 

--- a/src/server/Mppx.ts
+++ b/src/server/Mppx.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage, ServerResponse } from 'node:http'
+import { isDeepStrictEqual } from 'node:util'
 
 import * as Challenge from '../Challenge.js'
 import * as Credential from '../Credential.js'
@@ -300,10 +301,11 @@ function createMethodFn(parameters: createMethodFn.Parameters): createMethodFn.R
 
         // Credential was provided but malformed
         if (credentialError) {
+          const reason = getSafeCredentialReason(credentialError)
           const response = await transport.respondChallenge({
             challenge,
             input,
-            error: new Errors.MalformedCredentialError({ reason: credentialError.message }),
+            error: new Errors.MalformedCredentialError(reason ? { reason } : {}),
             html: method.html,
           })
           return { challenge: response, status: 402 }
@@ -342,13 +344,6 @@ function createMethodFn(parameters: createMethodFn.Parameters): createMethodFn.R
         // Note: we compare specific payment parameters rather than the full
         // request because the `request` hook may produce credential-dependent
         // output (e.g. `feePayer` differs between 402 and credential calls).
-        //
-        // Skip this check for topUp and voucher actions: the route's
-        // `request` hook may produce a different amount because these
-        // requests carry no application body (e.g. no model field for
-        // dynamic pricing). The credential echoes a challenge obtained
-        // from the original request which had the correct amount; the
-        // on-chain voucher signature is the real validation.
         {
           for (const field of ['method', 'intent', 'realm'] as const) {
             if (credential.challenge[field] !== challenge[field]) {
@@ -365,60 +360,20 @@ function createMethodFn(parameters: createMethodFn.Parameters): createMethodFn.R
             }
           }
 
-          // Use safeParse (not raw payload) so only methods whose schema
-          // defines `action` can trigger the skip. Without this, a client
-          // could inject `action: 'topUp'` on a charge credential to bypass
-          // the amount check. Zod strips unknown keys, so charge payloads
-          // (which don't define `action`) will have it removed.
-          const parsed = method.schema.credential.payload.safeParse(credential.payload)
-          const action = parsed.success
-            ? (parsed.data as Record<string, unknown>)?.action
-            : undefined
-          if (action !== 'topUp' && action !== 'voucher') {
-            const routeReq = challenge.request as Record<string, unknown>
-            const echoedReq = credential.challenge.request as Record<string, unknown>
-            const routeDetails = (routeReq.methodDetails ?? {}) as Record<string, unknown>
-            const echoedDetails = (echoedReq.methodDetails ?? {}) as Record<string, unknown>
-            for (const field of ['amount', 'currency', 'recipient'] as const) {
-              const routeVal = routeReq[field] ?? routeDetails[field]
-              if (
-                routeVal !== undefined &&
-                String(routeVal) !== String(echoedReq[field] ?? echoedDetails[field])
-              ) {
-                const response = await transport.respondChallenge({
-                  challenge,
-                  input,
-                  error: new Errors.InvalidChallengeError({
-                    id: credential.challenge.id,
-                    reason: `credential ${field} does not match this route's requirements`,
-                  }),
-                })
-                return { challenge: response, status: 402 }
-              }
-            }
-
-            // Compare payment-relevant methodDetails fields (memo, splits).
-            // These are excluded from the top-level field check above but
-            // affect verification semantics — a credential issued for a
-            // no-splits route must not be accepted on a splits route.
-            for (const field of ['memo', 'splits'] as const) {
-              const routeVal = routeDetails[field]
-              const echoedVal = echoedDetails[field]
-              if (
-                routeVal !== undefined &&
-                JSON.stringify(routeVal) !== JSON.stringify(echoedVal)
-              ) {
-                const response = await transport.respondChallenge({
-                  challenge,
-                  input,
-                  error: new Errors.InvalidChallengeError({
-                    id: credential.challenge.id,
-                    reason: `credential ${field} does not match this route's requirements`,
-                  }),
-                })
-                return { challenge: response, status: 402 }
-              }
-            }
+          const mismatch = getRequestBindingMismatch(
+            challenge.request as Record<string, unknown>,
+            credential.challenge.request as Record<string, unknown>,
+          )
+          if (mismatch) {
+            const response = await transport.respondChallenge({
+              challenge,
+              input,
+              error: new Errors.InvalidChallengeError({
+                id: credential.challenge.id,
+                reason: `credential ${mismatch} does not match this route's requirements`,
+              }),
+            })
+            return { challenge: response, status: 402 }
           }
         }
 
@@ -436,11 +391,11 @@ function createMethodFn(parameters: createMethodFn.Parameters): createMethodFn.R
         // Validate payload structure against method schema
         try {
           method.schema.credential.payload.parse(credential.payload)
-        } catch (e) {
+        } catch {
           const response = await transport.respondChallenge({
             challenge,
             input,
-            error: new Errors.InvalidPayloadError({ reason: (e as Error).message }),
+            error: new Errors.InvalidPayloadError(),
           })
           return { challenge: response, status: 402 }
         }
@@ -451,10 +406,9 @@ function createMethodFn(parameters: createMethodFn.Parameters): createMethodFn.R
         try {
           receiptData = await verify({ credential, request } as never)
         } catch (e) {
-          const error =
-            e instanceof Errors.PaymentError
-              ? e
-              : new Errors.VerificationFailedError({ reason: (e as Error).message })
+          if (!(e instanceof Errors.PaymentError))
+            console.error('mppx: internal verification error', e)
+          const error = e instanceof Errors.PaymentError ? e : new Errors.VerificationFailedError()
           const response = await transport.respondChallenge({
             challenge,
             input,
@@ -477,6 +431,8 @@ function createMethodFn(parameters: createMethodFn.Parameters): createMethodFn.R
           withReceipt<response>(response?: response) {
             if (managementResponse) {
               return transport.respondReceipt({
+                credential,
+                input,
                 receipt: receiptData,
                 response: managementResponse as never,
                 challengeId: credential.challenge.id,
@@ -484,6 +440,8 @@ function createMethodFn(parameters: createMethodFn.Parameters): createMethodFn.R
             }
             if (!response) throw new Error('withReceipt() requires a response argument')
             return transport.respondReceipt({
+              credential,
+              input,
               receipt: receiptData,
               response: response as never,
               challengeId: credential.challenge.id,
@@ -503,6 +461,13 @@ function createMethodFn(parameters: createMethodFn.Parameters): createMethodFn.R
       },
     )
   }
+}
+
+function getSafeCredentialReason(error: unknown): string | undefined {
+  if (error instanceof Credential.InvalidCredentialEncodingError) return error.message
+  if (error instanceof Credential.MissingAuthorizationHeaderError) return error.message
+  if (error instanceof Credential.MissingPaymentSchemeError) return error.message
+  return undefined
 }
 
 declare namespace createMethodFn {
@@ -554,6 +519,88 @@ function resolveRealmFromRequest(input: unknown): string {
     `Could not auto-detect realm from request. Falling back to "${defaultRealm}". Set \`realm\` in Mppx.create() or the MPP_REALM env var.`,
   )
   return defaultRealm
+}
+
+type RequestBindingField = 'amount' | 'currency' | 'recipient' | 'chainId' | 'memo' | 'splits'
+
+const requestBindingFields = [
+  'amount',
+  'currency',
+  'recipient',
+  'chainId',
+  'memo',
+  'splits',
+] as const satisfies readonly RequestBindingField[]
+
+type RequestBinding = Partial<Record<RequestBindingField, unknown>>
+
+function getRequestBindingMismatch(
+  expectedRequest: Record<string, unknown>,
+  actualRequest: Record<string, unknown>,
+): RequestBindingField | undefined {
+  const expected = getRequestBinding(expectedRequest)
+  const actual = getRequestBinding(actualRequest)
+
+  return requestBindingFields.find(
+    (field) => !requestBindingValuesMatch(field, expected[field], actual[field]),
+  )
+}
+
+function getRequestBinding(request: Record<string, unknown>): RequestBinding {
+  const methodDetails = (request.methodDetails ?? {}) as Record<string, unknown>
+
+  return {
+    amount: request.amount ?? methodDetails.amount,
+    currency: request.currency ?? methodDetails.currency,
+    recipient: request.recipient ?? methodDetails.recipient,
+    chainId: request.chainId ?? methodDetails.chainId,
+    memo: methodDetails.memo,
+    splits: methodDetails.splits,
+  }
+}
+
+function requestBindingValuesMatch(
+  field: RequestBindingField,
+  expected: unknown,
+  actual: unknown,
+): boolean {
+  return isDeepStrictEqual(
+    normalizeRequestBindingValue(field, expected),
+    normalizeRequestBindingValue(field, actual),
+  )
+}
+
+function normalizeRequestBindingValue(field: RequestBindingField, value: unknown): unknown {
+  switch (field) {
+    case 'memo':
+      return normalizeHex(value)
+    case 'splits':
+      return normalizeComparable(value)
+    default:
+      return normalizeScalar(value)
+  }
+}
+
+function normalizeScalar(value: unknown): string | undefined {
+  return value === undefined ? undefined : String(value)
+}
+
+function normalizeHex(value: unknown): unknown {
+  return typeof value === 'string' && value.startsWith('0x') ? value.toLowerCase() : value
+}
+
+function normalizeComparable(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(normalizeComparable)
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, nested]) => [key, normalizeComparable(nested)]),
+    )
+  }
+
+  return normalizeHex(value)
 }
 
 export type MethodFn<
@@ -672,7 +719,6 @@ export function compose(
       if (credential) {
         const { method: credMethod, intent: credIntent } = credential.challenge
         const credReq = credential.challenge.request as Record<string, unknown>
-        const credDetails = (credReq.methodDetails ?? {}) as Record<string, unknown>
 
         // Filter by name+intent, then narrow by comparing stable request fields
         // from the echoed challenge against each handler's canonical request.
@@ -684,16 +730,7 @@ export function compose(
           if (!meta || meta.name !== credMethod || meta.intent !== credIntent) return false
           const canonical = meta._canonicalRequest
           if (!canonical) return true
-          const canonicalDetails = (canonical.methodDetails ?? {}) as Record<string, unknown>
-          for (const field of ['amount', 'currency', 'recipient', 'chainId'] as const) {
-            const canonicalVal = canonical[field] ?? canonicalDetails[field]
-            if (
-              canonicalVal !== undefined &&
-              String(canonicalVal) !== String(credReq[field] ?? credDetails[field])
-            )
-              return false
-          }
-          return true
+          return !getRequestBindingMismatch(canonical, credReq)
         })
 
         const match =

--- a/src/server/Transport.test.ts
+++ b/src/server/Transport.test.ts
@@ -135,6 +135,8 @@ describe('http', () => {
       const originalResponse = new Response('OK', { status: 200 })
 
       const response = transport.respondReceipt({
+        credential,
+        input: new Request('https://example.com'),
         receipt,
         response: originalResponse,
         challengeId: challenge.id,
@@ -252,7 +254,13 @@ describe('mcp', () => {
       }
 
       expect(
-        transport.respondReceipt({ receipt, response: successResponse, challengeId: challenge.id }),
+        transport.respondReceipt({
+          credential,
+          input: mcpRequest,
+          receipt,
+          response: successResponse,
+          challengeId: challenge.id,
+        }),
       ).toMatchInlineSnapshot(`
         {
           "id": 1,
@@ -285,7 +293,13 @@ describe('mcp', () => {
       }
 
       expect(
-        transport.respondReceipt({ receipt, response: errorResponse, challengeId: challenge.id }),
+        transport.respondReceipt({
+          credential,
+          input: mcpRequest,
+          receipt,
+          response: errorResponse,
+          challengeId: challenge.id,
+        }),
       ).toBe(errorResponse)
     })
   })

--- a/src/server/Transport.ts
+++ b/src/server/Transport.ts
@@ -40,6 +40,8 @@ export type Transport<
   /** Attaches a receipt to a successful response. */
   respondReceipt: (options: {
     challengeId: string
+    credential: Credential.Credential
+    input: input
     receipt: Receipt.Receipt
     response: receiptResponse
   }) => receiptOutput
@@ -92,7 +94,7 @@ export type WithReceipt<transport extends AnyTransport = Http> = WithReceiptOver
  *   name: 'custom',
  *   getCredential(input) { ... },
  *   respondChallenge({ challenge, input }) { ... },
- *   respondReceipt({ receipt, response, challengeId }) { ... },
+ *   respondReceipt({ receipt, response, challengeId, credential, input }) { ... },
  * })
  * ```
  */

--- a/src/stripe/server/Charge.ts
+++ b/src/stripe/server/Charge.ts
@@ -63,9 +63,9 @@ export function charge<const parameters extends charge.Parameters>(parameters: p
 
     html: html ? { config: html, content: htmlContent } : undefined,
 
-    async verify({ credential }) {
+    async verify({ credential, request }) {
       const { challenge } = credential
-      const { request } = challenge
+      const resolvedRequest = Methods.charge.schema.request.parse(request)
 
       Expires.assert(challenge.expires, challenge.id)
 
@@ -76,15 +76,23 @@ export function charge<const parameters extends charge.Parameters>(parameters: p
         externalId?: string
       }
 
-      const userMetadata = request.methodDetails?.metadata as Record<string, string> | undefined
+      const userMetadata = resolvedRequest.methodDetails?.metadata as
+        | Record<string, string>
+        | undefined
       const resolvedMetadata = { ...buildAnalytics({ credential }), ...userMetadata }
 
       const pi = client
-        ? await createWithClient({ client, challenge, request, spt, metadata: resolvedMetadata })
+        ? await createWithClient({
+            client,
+            challenge,
+            request: resolvedRequest,
+            spt,
+            metadata: resolvedMetadata,
+          })
         : await createWithSecretKey({
             secretKey: secretKey!,
             challenge,
-            request,
+            request: resolvedRequest,
             spt,
             metadata: resolvedMetadata,
           })

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -10,6 +10,7 @@ import {
 import { tempo as tempo_chain } from 'viem/chains'
 import { Abis, Transaction } from 'viem/tempo'
 
+import { PaymentError, VerificationFailedError } from '../../Errors.js'
 import * as Expires from '../../Expires.js'
 import type { LooseOmit, NoExtraKeys } from '../../internal/types.js'
 import * as Method from '../../Method.js'
@@ -114,16 +115,17 @@ export function charge<const parameters extends charge.Parameters>(
 
     async verify({ credential, request }) {
       const { challenge } = credential
-      const { chainId, feePayer } = request
+      const resolvedRequest = Methods.charge.schema.request.parse(request)
+      const chainId = resolvedRequest.methodDetails?.chainId ?? request.chainId
+      const feePayer = request.feePayer
 
       const client = await getClient({ chainId })
 
-      const { request: challengeRequest } = challenge
-      const { amount, methodDetails } = challengeRequest
+      const { amount, methodDetails } = resolvedRequest
       const expires = challenge.expires
 
-      const currency = challengeRequest.currency as `0x${string}`
-      const recipient = challengeRequest.recipient as `0x${string}`
+      const currency = resolvedRequest.currency as `0x${string}`
+      const recipient = resolvedRequest.recipient as `0x${string}`
 
       Expires.assert(expires, challenge.id)
 
@@ -536,7 +538,8 @@ async function assertHashUnused(
   hash: `0x${string}`,
 ): Promise<void> {
   const seen = await store.get(getHashStoreKey(hash))
-  if (seen !== null) throw new Error('Transaction hash has already been used.')
+  if (seen !== null)
+    throw new VerificationFailedError({ reason: 'Transaction hash has already been used' })
 }
 
 /** @internal */
@@ -553,7 +556,8 @@ async function assertProofUnused(
   challengeId: string,
 ): Promise<void> {
   const seen = await store.get(getProofStoreKey(challengeId))
-  if (seen !== null) throw new Error('Proof credential has already been used.')
+  if (seen !== null)
+    throw new VerificationFailedError({ reason: 'Proof credential has already been used' })
 }
 
 /** @internal */
@@ -579,8 +583,10 @@ function toReceipt(receipt: TransactionReceipt) {
 }
 
 /** @internal */
-class MismatchError extends Error {
+class MismatchError extends PaymentError {
   override readonly name = 'MismatchError'
+  readonly title = 'Verification Failed'
+  readonly type = 'https://paymentauth.org/problems/verification-failed'
 
   constructor(reason: string, details: Record<string, string>) {
     super([reason, ...Object.entries(details).map(([k, v]) => `  - ${k}: ${v}`)].join('\n'))

--- a/src/tempo/server/Session.ts
+++ b/src/tempo/server/Session.ts
@@ -179,10 +179,11 @@ export function session<const parameters extends session.Parameters>(
       }
     },
 
-    async verify({ credential }) {
+    async verify({ credential, request }) {
       const { challenge, payload } = credential as Credential.Credential<SessionCredentialPayload>
 
-      const methodDetails = challenge.request.methodDetails as SessionMethodDetails
+      const resolvedRequest = Methods.session.schema.request.parse(request)
+      const methodDetails = resolvedRequest.methodDetails as SessionMethodDetails
       const client = await getClient({ chainId: methodDetails.chainId })
 
       const resolvedFeePayer = methodDetails.feePayer === true ? feePayer : undefined

--- a/src/tempo/server/internal/transport.test.ts
+++ b/src/tempo/server/internal/transport.test.ts
@@ -113,19 +113,20 @@ describe('sse transport', () => {
     expect((credential!.payload as any).channelId).toBe(channelId)
   })
 
-  test('getCredential captures SSE context in contextMap', async () => {
+  test('respondReceipt derives SSE context from the verified credential', async () => {
     const store = memoryStore()
     await seedChannel(store, 10000000n)
     const transport = sse({ store })
 
-    const request = makeAuthorizedRequest()
-    transport.getCredential(request)
+    const credential = makeCredential()
 
     async function* gen() {
       yield 'test'
     }
 
     const response = transport.respondReceipt({
+      credential,
+      input: new Request('https://test.example.com/session'),
       receipt: makeReceipt(),
       response: gen(),
       challengeId,
@@ -151,8 +152,7 @@ describe('sse transport', () => {
     const store = memoryStore()
     await seedChannel(store, 10000000n)
     const transport = sse({ store })
-
-    transport.getCredential(makeAuthorizedRequest())
+    const request = makeAuthorizedRequest()
 
     async function* gen() {
       yield 'hello'
@@ -160,6 +160,8 @@ describe('sse transport', () => {
     }
 
     const response = transport.respondReceipt({
+      credential: makeCredential(),
+      input: request,
       receipt: makeReceipt(),
       response: gen(),
       challengeId,
@@ -184,10 +186,11 @@ describe('sse transport', () => {
     const store = memoryStore()
     await seedChannel(store, 10000000n)
     const transport = sse({ store })
-
-    transport.getCredential(makeAuthorizedRequest())
+    const request = makeAuthorizedRequest()
 
     const response = transport.respondReceipt({
+      credential: makeCredential(),
+      input: request,
       receipt: makeReceipt(),
       response: async function* (stream) {
         await stream.charge()
@@ -202,8 +205,7 @@ describe('sse transport', () => {
     const store = memoryStore()
     await seedChannel(store, 10000000n)
     const transport = sse({ store })
-
-    transport.getCredential(makeAuthorizedRequest())
+    const request = makeAuthorizedRequest()
 
     const encoder = new TextEncoder()
     const upstream = new Response(
@@ -218,6 +220,8 @@ describe('sse transport', () => {
     )
 
     const response = transport.respondReceipt({
+      credential: makeCredential(),
+      input: request,
       receipt: makeReceipt(),
       response: upstream,
       challengeId,
@@ -241,6 +245,8 @@ describe('sse transport', () => {
     })
 
     const response = transport.respondReceipt({
+      credential: makeCredential(),
+      input: new Request('https://test.example.com/session'),
       receipt,
       response: plainResponse,
       challengeId,
@@ -249,34 +255,24 @@ describe('sse transport', () => {
     expect(response.headers.get('Payment-Receipt')).toBeTruthy()
   })
 
-  test('respondReceipt cleans up contextMap after use', async () => {
+  test('respondReceipt no longer depends on prior getCredential side effects', async () => {
     const store = memoryStore()
     await seedChannel(store, 10000000n)
     const transport = sse({ store })
-
-    transport.getCredential(makeAuthorizedRequest())
+    const request = makeAuthorizedRequest()
 
     async function* gen() {
       yield 'first'
     }
 
-    transport.respondReceipt({
+    const response = transport.respondReceipt({
+      credential: makeCredential(),
+      input: request,
       receipt: makeReceipt(),
       response: gen(),
       challengeId,
     })
-
-    async function* gen2() {
-      yield 'second'
-    }
-
-    expect(() =>
-      transport.respondReceipt({
-        receipt: makeReceipt(),
-        response: gen2(),
-        challengeId,
-      }),
-    ).toThrow('No SSE context available')
+    expect(response.headers.get('Content-Type')).toContain('text/event-stream')
   })
 
   test('respondReceipt throws when no SSE context available', () => {
@@ -287,8 +283,15 @@ describe('sse transport', () => {
       yield 'hello'
     }
 
+    const credential = Credential.from({
+      challenge: makeChallenge(),
+      payload: { signature: '0xabc123', type: 'transaction' },
+    })
+
     expect(() =>
       transport.respondReceipt({
+        credential,
+        input: new Request('https://test.example.com/session'),
         receipt: makeReceipt(),
         response: gen(),
         challengeId,
@@ -300,14 +303,15 @@ describe('sse transport', () => {
     const store = memoryStore()
     await seedChannel(store, 10000000n)
     const transport = sse({ store })
-
-    transport.getCredential(makeAuthorizedRequest())
+    const request = makeAuthorizedRequest()
 
     const plainResponse = new Response(JSON.stringify({ content: 'hello' }), {
       headers: { 'Content-Type': 'application/json' },
     })
 
     const response = transport.respondReceipt({
+      credential: makeCredential(),
+      input: request,
       receipt: makeReceipt(),
       response: plainResponse,
       challengeId,
@@ -328,11 +332,12 @@ describe('sse transport', () => {
     const store = memoryStore()
     await seedChannel(store, 10000000n)
     const transport = sse({ store })
-
-    transport.getCredential(makeAuthorizedRequest())
+    const request = makeAuthorizedRequest()
 
     const managementResponse = new Response(null, { status: 204 })
     const response = transport.respondReceipt({
+      credential: makeCredential(),
+      input: request,
       receipt: makeReceipt(),
       response: managementResponse,
       challengeId,
@@ -353,14 +358,15 @@ describe('sse transport', () => {
     await seedChannel(store, 10000000n)
 
     const transport = sse({ store, poll: true })
-
-    transport.getCredential(makeAuthorizedRequest())
+    const request = makeAuthorizedRequest()
 
     async function* gen() {
       yield 'test'
     }
 
     const response = transport.respondReceipt({
+      credential: makeCredential(),
+      input: request,
       receipt: makeReceipt(),
       response: gen(),
       challengeId,

--- a/src/tempo/server/internal/transport.ts
+++ b/src/tempo/server/internal/transport.ts
@@ -1,6 +1,6 @@
 /**
  * Tempo-specific SSE transport that wraps the base HTTP transport
- * with metering logic (context capture from credentials, per-token
+ * with metering logic (context capture from verified credentials, per-token
  * charging via Sse.serve).
  *
  * @internal
@@ -8,6 +8,7 @@
 import * as Transport from '../../../server/Transport.js'
 import * as ChannelStore from '../../session/ChannelStore.js'
 import * as Sse_core from '../../session/Sse.js'
+import type { SessionCredentialPayload } from '../../session/Types.js'
 
 /** SSE transport with Tempo session controller. */
 export type Sse = Transport.Sse<Sse_core.SessionController>
@@ -33,30 +34,24 @@ export function sse(options: sse.Options & { store: ChannelStore.ChannelStore })
     return store
   })()
 
-  const contextMap = new Map<string, Sse_core.fromRequest.Context & { signal?: AbortSignal }>()
-
   const base = Transport.http()
   return Transport.from<Request, Response, Transport.ReceiptResponseOf<Sse>, Response>({
     name: 'sse',
 
     getCredential(request) {
-      const credential = base.getCredential(request)
-      if (credential) {
-        try {
-          const ctx = Sse_core.fromRequest(request)
-          contextMap.set(ctx.challengeId, { ...ctx, signal: request.signal })
-        } catch {
-          // ignore — non-SSE credentials won't have session context
-        }
-      }
-      return credential
+      return base.getCredential(request)
     },
 
     respondChallenge(options) {
       return base.respondChallenge(options) as Response
     },
 
-    respondReceipt({ receipt, response, challengeId }) {
+    respondReceipt({ credential, receipt, response, challengeId, input }) {
+      const payload = credential.payload as Partial<SessionCredentialPayload>
+      if (!payload.channelId) throw new Error('No SSE context available')
+      const channelId = payload.channelId
+      const tickCost = BigInt(credential.challenge.request.amount as string)
+
       // Auto-detect upstream SSE responses and parse them into an
       // AsyncIterable so they flow through the metered pipeline.
       // This lets proxy consumers simply pass `result.withReceipt(upstreamRes)`
@@ -67,10 +62,6 @@ export function sse(options: sse.Options & { store: ChannelStore.ChannelStore })
           : response
 
       if (isAsyncGeneratorFunction(resolved) || isAsyncIterable(resolved)) {
-        const ctx = contextMap.get(challengeId)
-        if (!ctx) throw new Error('No SSE context available — credential was not parsed')
-        contextMap.delete(challengeId)
-
         // Pass async generator functions directly so Sse.serve gives them
         // a SessionController for manual charge(). Pass raw AsyncIterables
         // as-is so Sse.serve auto-charges per yielded value.
@@ -79,17 +70,19 @@ export function sse(options: sse.Options & { store: ChannelStore.ChannelStore })
           : (resolved as AsyncIterable<string>)
         const stream = Sse_core.serve({
           store,
-          channelId: ctx.channelId,
+          channelId,
           challengeId,
-          tickCost: ctx.tickCost,
+          tickCost,
           pollIntervalMs: pollingInterval,
           generate,
-          signal: ctx.signal,
+          signal: input.signal,
         })
         return Sse_core.toResponse(stream)
       }
 
       const baseResponse = base.respondReceipt({
+        credential,
+        input,
         receipt,
         response: response as Response,
         challengeId,
@@ -97,45 +90,38 @@ export function sse(options: sse.Options & { store: ChannelStore.ChannelStore })
 
       // Non-SSE response (e.g. upstream returned JSON instead of event-stream).
       // Need to deduct tickCost so request isn't free.
-      const ctx = contextMap.get(challengeId)
-      if (ctx) {
-        contextMap.delete(challengeId)
-
-        // Null-body statuses (e.g. 204 from management actions) cannot carry a
-        // response body per Fetch/HTTP semantics.
-        if (isNullBodyStatus(baseResponse.status)) {
-          return baseResponse
-        }
-
-        const stream = new ReadableStream<Uint8Array>({
-          async start(controller) {
-            // deduction completes before consumer reads
-            await ChannelStore.deductFromChannel(store, ctx.channelId, ctx.tickCost)
-            if (!baseResponse.body) {
-              controller.close()
-              return
-            }
-            const reader = baseResponse.body.getReader()
-            try {
-              while (true) {
-                const { done, value } = await reader.read()
-                if (done) break
-                controller.enqueue(value)
-              }
-            } finally {
-              reader.releaseLock()
-              controller.close()
-            }
-          },
-        })
-        return new Response(stream, {
-          status: baseResponse.status,
-          statusText: baseResponse.statusText,
-          headers: baseResponse.headers,
-        })
+      // Null-body statuses (e.g. 204 from management actions) cannot carry a
+      // response body per Fetch/HTTP semantics.
+      if (isNullBodyStatus(baseResponse.status)) {
+        return baseResponse
       }
 
-      return baseResponse
+      const stream = new ReadableStream<Uint8Array>({
+        async start(controller) {
+          // deduction completes before consumer reads
+          await ChannelStore.deductFromChannel(store, channelId, tickCost)
+          if (!baseResponse.body) {
+            controller.close()
+            return
+          }
+          const reader = baseResponse.body.getReader()
+          try {
+            while (true) {
+              const { done, value } = await reader.read()
+              if (done) break
+              controller.enqueue(value)
+            }
+          } finally {
+            reader.releaseLock()
+            controller.close()
+          }
+        },
+      })
+      return new Response(stream, {
+        status: baseResponse.status,
+        statusText: baseResponse.statusText,
+        headers: baseResponse.headers,
+      })
     },
   })
 }


### PR DESCRIPTION
- **Credential binding**: verify that credential request fields match the actual incoming request to prevent cross-request credential reuse.

- **SSE transport**: derive billing context (channelId, tickCost) directly from the verified credential payload instead of a mutable context map, eliminating a class of billing inconsistencies.

- **Error sanitization**: use typed credential parse errors and suppress internal details (RPC URLs, API keys, schema validation messages) from 402 Payment Required responses. Unexpected verification failures are logged server-side and returned as generic errors.

- **Proxy routing**: bind management POST fallback to the credential's payment method+intent so same-path paid routes are disambiguated correctly. Return 405 when a credential-bearing POST matches a paid route but no upstream forward is appropriate. Reject ambiguous path-only matches when multiple paid routes share a path.