### PR TITLE
fix: increase `maxTotalFee` to 50b

### DIFF
--- a/.changeset/honest-wasps-sniff.md
+++ b/.changeset/honest-wasps-sniff.md
@@ -1,5 +1,5 @@
 ---
-"mppx": patch
+'mppx': patch
 ---
 
 Raised too low fee-payer `maxTotalFee` policy

--- a/.changeset/honest-wasps-sniff.md
+++ b/.changeset/honest-wasps-sniff.md
@@ -1,0 +1,5 @@
+---
+"mppx": patch
+---
+
+Raised too low fee-payer `maxTotalFee` policy

--- a/src/tempo/internal/fee-payer.test.ts
+++ b/src/tempo/internal/fee-payer.test.ts
@@ -322,7 +322,7 @@ describe('prepareSponsoredTransaction', () => {
         transaction: {
           ...baseTransaction,
           gas: 1_500_000n,
-          maxFeePerGas: 10_000_000_000n,
+          maxFeePerGas: 50_000_000_000n,
         } as any,
       }),
     ).toThrow('total fee budget exceeds sponsor policy')

--- a/src/tempo/internal/fee-payer.ts
+++ b/src/tempo/internal/fee-payer.ts
@@ -26,12 +26,16 @@ export const callScopes = [
   [Selectors.approve, Selectors.swapExactAmountOut, Selectors.transferWithMemo],
 ]
 
+/**
+ * maxTotalFee must be high enough to cover `transferWithMemo` and
+ * swap transactions at peak gas prices. Bumped from 0.01 ETH in #327.
+ */
 const policy = {
-  maxGas: 2_000_000n, // 2M gas units
-  maxFeePerGas: 100_000_000_000n, // 100 gwei
-  maxPriorityFeePerGas: 10_000_000_000n, // 10 gwei
-  maxTotalFee: 50_000_000_000_000_000n, // 0.05 ETH
-  maxValidityWindowSeconds: 15 * 60, // 15 minutes
+  maxGas: 2_000_000n,
+  maxFeePerGas: 100_000_000_000n,
+  maxPriorityFeePerGas: 10_000_000_000n,
+  maxTotalFee: 50_000_000_000_000_000n,
+  maxValidityWindowSeconds: 15 * 60,
 } as const
 
 /** Validates that a set of transaction calls matches an allowed fee-payer pattern. */

--- a/src/tempo/internal/fee-payer.ts
+++ b/src/tempo/internal/fee-payer.ts
@@ -27,11 +27,11 @@ export const callScopes = [
 ]
 
 const policy = {
-  maxGas: 2_000_000n,
-  maxFeePerGas: 100_000_000_000n,
-  maxPriorityFeePerGas: 10_000_000_000n,
-  maxTotalFee: 50_000_000_000_000_000n,
-  maxValidityWindowSeconds: 15 * 60,
+  maxGas: 2_000_000n, // 2M gas units
+  maxFeePerGas: 100_000_000_000n, // 100 gwei
+  maxPriorityFeePerGas: 10_000_000_000n, // 10 gwei
+  maxTotalFee: 50_000_000_000_000_000n, // 0.05 ETH
+  maxValidityWindowSeconds: 15 * 60, // 15 minutes
 } as const
 
 /** Validates that a set of transaction calls matches an allowed fee-payer pattern. */

--- a/src/tempo/internal/fee-payer.ts
+++ b/src/tempo/internal/fee-payer.ts
@@ -30,7 +30,7 @@ const policy = {
   maxGas: 2_000_000n,
   maxFeePerGas: 100_000_000_000n,
   maxPriorityFeePerGas: 10_000_000_000n,
-  maxTotalFee: 10_000_000_000_000_000n,
+  maxTotalFee: 50_000_000_000_000_000n,
   maxValidityWindowSeconds: 15 * 60,
 } as const
 


### PR DESCRIPTION
user report

> After upgrading from 0.5.5 to 0.5.10, tempo.charge() with feePayer: true fails on Moderato (testnet) with:
> FeePayerValidationError: fee-sponsored transaction total fee budget exceeds sponsor policy gas: 626497 maxFeePerGas: 24000000000 totalFee: 15035928000000000
> The hardcoded maxTotalFee is 10_000_000_000_000_000 (0.01 ETH). A standard transferWithMemo estimates ~626k gas at 24 gwei, totaling 0.015 - 50% over the cap.
> This worked on 0.5.5 (no policy check existed). Is 626k gas expected for a memo transfer on Tempo? Or is the policy cap too low?