### PR TITLE
feat: Accept-Payment negotiation and security bumps

### DIFF
--- a/.changeset/accept-payment-preferences.md
+++ b/.changeset/accept-payment-preferences.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Add typed `paymentPreferences` support that emits `Accept-Payment` on client requests and filters composed server challenges accordingly.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@changesets/cli": "^2.30.0",
     "@hono/node-server": "1.19.13",
-    "@modelcontextprotocol/sdk": "^1.25.3",
+    "@modelcontextprotocol/sdk": "1.27.1",
     "@playwright/test": "^1.58.2",
     "@types/express": "^5.0.6",
     "@types/node": "^25.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,8 +50,8 @@ importers:
         specifier: 1.19.13
         version: 1.19.13(hono@4.12.12)
       '@modelcontextprotocol/sdk':
-        specifier: 1.26.0
-        version: 1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+        specifier: 1.27.1
+        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.58.2
@@ -769,6 +769,16 @@ packages:
 
   '@modelcontextprotocol/sdk@1.26.0':
     resolution: {integrity: sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
+  '@modelcontextprotocol/sdk@1.27.1':
+    resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -4306,6 +4316,31 @@ snapshots:
       - supports-color
 
   '@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.13(hono@4.12.12)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.3.1(express@5.2.1)
+      hono: 4.12.12
+      jose: 6.2.1
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.1(zod@4.3.6)
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  '@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.13(hono@4.12.12)
       ajv: 8.18.0

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -2,6 +2,7 @@ import { spawnSync } from 'node:child_process'
 import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 import { parseUnits } from 'viem'
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
@@ -14,6 +15,7 @@ import { accounts, asset, chain, client, fundAccount } from '~test/tempo/viem.js
 
 import * as Challenge from '../Challenge.js'
 import * as Credential from '../Credential.js'
+import * as Method from '../Method.js'
 import * as Receipt from '../Receipt.js'
 import * as Mppx_server from '../server/Mppx.js'
 import { toNodeListener } from '../server/Mppx.js'
@@ -21,6 +23,7 @@ import * as Store from '../Store.js'
 import { stripe as stripe_server } from '../stripe/server/Methods.js'
 import { tempo } from '../tempo/server/Methods.js'
 import type { SessionCredentialPayload } from '../tempo/session/Types.js'
+import * as z from '../zod.js'
 import cli from './cli.js'
 
 const testPrivateKey = generatePrivateKey()
@@ -76,6 +79,24 @@ async function serve(argv: string[], options?: { env?: Record<string, string | u
     }
   }
   return { output, stderr, exitCode }
+}
+
+function createMockChargeMethod(name: string) {
+  return Method.from({
+    name,
+    intent: 'charge',
+    schema: {
+      credential: {
+        payload: z.object({ token: z.string() }),
+      },
+      request: z.object({
+        amount: z.string(),
+        currency: z.string(),
+        decimals: z.number(),
+        recipient: z.string(),
+      }),
+    },
+  })
 }
 
 describe('discover validate', () => {
@@ -326,6 +347,198 @@ describe('basic charge (examples/basic)', () => {
       expect(output).toContain('paid')
     } finally {
       httpServer.close()
+    }
+  })
+
+  test('selects a later supported challenge when the first offer is unsupported', async () => {
+    const unsupportedMethod = Method.toServer(createMockChargeMethod('unknown'), {
+      async verify() {
+        return {
+          method: 'unknown',
+          reference: 'unknown-ref',
+          status: 'success' as const,
+          timestamp: new Date().toISOString(),
+        }
+      },
+    })
+    const tempoMethod = tempo.charge({ getClient: () => client })
+
+    const server = Mppx_server.create({
+      methods: [unsupportedMethod, tempoMethod],
+      realm: 'cli-test-multi-offer',
+      secretKey: 'cli-test-secret',
+    })
+
+    const httpServer = await Http.createServer(async (req, res) => {
+      const result = await toNodeListener(
+        server.compose(
+          [
+            unsupportedMethod,
+            {
+              amount: '1',
+              currency: asset,
+              decimals: 6,
+              expires: new Date(Date.now() + 60_000).toISOString(),
+              recipient: accounts[0].address,
+            },
+          ],
+          [
+            tempoMethod,
+            {
+              amount: '1',
+              currency: asset,
+              decimals: 6,
+              expires: new Date(Date.now() + 60_000).toISOString(),
+              recipient: accounts[0].address,
+            },
+          ],
+        ),
+      )(req, res)
+      if (result.status === 402) return
+      res.end('paid-from-second-offer')
+    })
+
+    try {
+      const { output, exitCode } = await serve([httpServer.url, '--rpc-url', rpcUrl, '-s'], {
+        env: { MPPX_PRIVATE_KEY: testPrivateKey },
+      })
+
+      expect(exitCode).toBeUndefined()
+      expect(output).toContain('paid-from-second-offer')
+    } finally {
+      httpServer.close()
+    }
+  })
+
+  test('config methods emit Accept-Payment and select the preferred challenge', async () => {
+    const alphaMethod = Method.toServer(createMockChargeMethod('alpha'), {
+      async verify({ envelope }) {
+        if (!envelope) throw new Error('expected envelope')
+        if ((envelope.credential.payload as { token: string }).token !== 'alpha-token') {
+          throw new Error('expected alpha credential')
+        }
+
+        return {
+          method: 'alpha',
+          reference: 'alpha-ref',
+          status: 'success' as const,
+          timestamp: new Date().toISOString(),
+        }
+      },
+    })
+    const betaMethod = Method.toServer(createMockChargeMethod('beta'), {
+      async verify({ envelope }) {
+        if (!envelope) throw new Error('expected envelope')
+        if ((envelope.credential.payload as { token: string }).token !== 'beta-token') {
+          throw new Error('expected beta credential')
+        }
+
+        return {
+          method: 'beta',
+          reference: 'beta-ref',
+          status: 'success' as const,
+          timestamp: new Date().toISOString(),
+        }
+      },
+    })
+
+    const server = Mppx_server.create({
+      methods: [betaMethod, alphaMethod],
+      realm: 'cli-test-config-offers',
+      secretKey: 'cli-test-secret',
+    })
+
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mppx-cli-config-'))
+    const configPath = path.join(configDir, 'mppx.config.mjs')
+    const mppxModuleUrl = pathToFileURL(path.join(process.cwd(), 'src/index.ts')).href
+    const cliModuleUrl = pathToFileURL(path.join(process.cwd(), 'src/cli/config.ts')).href
+    fs.writeFileSync(
+      configPath,
+      `
+import { Credential, Method, z } from '${mppxModuleUrl}'
+import { defineConfig } from '${cliModuleUrl}'
+
+const alpha = Method.toClient(Method.from({
+  name: 'alpha',
+  intent: 'charge',
+  schema: {
+    credential: { payload: z.object({ token: z.string() }) },
+    request: z.object({ amount: z.string(), currency: z.string(), decimals: z.number(), recipient: z.string() }),
+  },
+}), {
+  async createCredential({ challenge }) {
+    return Credential.serialize({ challenge, payload: { token: 'alpha-token' } })
+  },
+})
+
+const beta = Method.toClient(Method.from({
+  name: 'beta',
+  intent: 'charge',
+  schema: {
+    credential: { payload: z.object({ token: z.string() }) },
+    request: z.object({ amount: z.string(), currency: z.string(), decimals: z.number(), recipient: z.string() }),
+  },
+}), {
+  async createCredential({ challenge }) {
+    return Credential.serialize({ challenge, payload: { token: 'beta-token' } })
+  },
+})
+
+export default defineConfig({
+  methods: [beta, alpha],
+  paymentPreferences: ({ alpha, beta }) => ({
+    [alpha.charge]: 1,
+    [beta.charge]: 0.2,
+  }),
+})
+      `.trim(),
+    )
+
+    let acceptPaymentHeader: string | undefined
+    let authorization: string | undefined
+    const httpServer = await Http.createServer(async (req, res) => {
+      if (!req.headers.authorization)
+        acceptPaymentHeader = req.headers['accept-payment'] as string | undefined
+      else authorization = req.headers.authorization
+
+      const result = await toNodeListener(
+        server.compose(
+          [
+            betaMethod,
+            {
+              amount: '1',
+              currency: asset,
+              decimals: 6,
+              expires: new Date(Date.now() + 60_000).toISOString(),
+              recipient: accounts[0].address,
+            },
+          ],
+          [
+            alphaMethod,
+            {
+              amount: '1',
+              currency: asset,
+              decimals: 6,
+              expires: new Date(Date.now() + 60_000).toISOString(),
+              recipient: accounts[0].address,
+            },
+          ],
+        ),
+      )(req, res)
+      if (result.status === 402) return
+      res.end('paid-from-config-preference')
+    })
+
+    try {
+      const { output, exitCode } = await serve([httpServer.url, '--config', configPath, '-s'])
+
+      expect(exitCode).toBeUndefined()
+      expect(output).toContain('paid-from-config-preference')
+      expect(acceptPaymentHeader).toBe('beta/charge;q=0.2, alpha/charge')
+      expect(Credential.deserialize(authorization!).payload).toEqual({ token: 'alpha-token' })
+    } finally {
+      httpServer.close()
+      fs.rmSync(configDir, { recursive: true, force: true })
     }
   })
 
@@ -1118,6 +1331,71 @@ describe('sign', () => {
     const { exitCode, output } = await serve(['sign', '--challenge', challenge])
     expect(exitCode).toBe(2)
     expect(output).toContain('Unsupported payment method')
+  })
+
+  test('paymentPreferences opt-out is not bypassed by CLI fallback selection', async () => {
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mppx-sign-config-'))
+    const configPath = path.join(configDir, 'mppx.config.mjs')
+    const mppxModuleUrl = pathToFileURL(path.join(process.cwd(), 'src/index.ts')).href
+    const cliModuleUrl = pathToFileURL(path.join(process.cwd(), 'src/cli/config.ts')).href
+    fs.writeFileSync(
+      configPath,
+      `
+import { Credential, Method, z } from '${mppxModuleUrl}'
+import { defineConfig } from '${cliModuleUrl}'
+
+const alpha = Method.toClient(Method.from({
+  name: 'alpha',
+  intent: 'charge',
+  schema: {
+    credential: { payload: z.object({ token: z.string() }) },
+    request: z.object({ amount: z.string() }),
+  },
+}), {
+  async createCredential({ challenge }) {
+    return Credential.serialize({ challenge, payload: { token: 'alpha-token' } })
+  },
+})
+
+export default defineConfig({
+  methods: [alpha],
+  paymentPreferences: ({ alpha }) => ({
+    [alpha.charge]: 0,
+  }),
+})
+      `.trim(),
+    )
+
+    const challenge =
+      'Payment id="x", realm="x", method="alpha", intent="charge", request="eyJhbW91bnQiOiIxIn0"'
+
+    try {
+      const { exitCode, output } = await serve([
+        'sign',
+        '--challenge',
+        challenge,
+        '--config',
+        configPath,
+      ])
+      expect(exitCode).toBe(2)
+      expect(output).toContain('Unsupported payment method')
+    } finally {
+      fs.rmSync(configDir, { recursive: true, force: true })
+    }
+  })
+
+  test('selects a later supported challenge from a merged challenge value', async () => {
+    const merged = [
+      'Payment id="x", realm="x", method="unknown", intent="charge", request="e30"',
+      validChallenge,
+    ].join(', ')
+
+    const { output, exitCode } = await serve(['sign', '--challenge', merged, '--rpc-url', rpcUrl], {
+      env: { MPPX_PRIVATE_KEY: testPrivateKey },
+    })
+
+    expect(exitCode).toBeUndefined()
+    expect(output.trim()).toMatch(/^Payment\s+\S+/)
   })
 
   test('error: no account for tempo', async () => {

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -13,7 +13,7 @@ import { normalizeHeaders } from '../client/internal/Fetch.js'
 import * as Mppx from '../client/Mppx.js'
 import { validate as validateDiscovery } from '../discovery/Validate.js'
 import { createDefaultStore, createKeychain, resolveAccountName } from './account.js'
-import { loadConfig, resolvePlugin } from './internal.js'
+import { loadConfig, resolveAcceptPayment, selectChallenge } from './internal.js'
 import type { Plugin } from './plugins/plugin.js'
 import { readTempoKeystore, resolveTempoAccount } from './plugins/tempo.js'
 import {
@@ -128,6 +128,13 @@ const cli = Cli.create('mppx', {
         headers[header.slice(0, index).trim()] = header.slice(index + 1).trim()
       }
     }
+    const acceptPayment = resolveAcceptPayment(loaded?.config)
+    if (
+      acceptPayment &&
+      !Object.keys(headers).some((key) => key.toLowerCase() === 'accept-payment')
+    ) {
+      headers['Accept-Payment'] = acceptPayment
+    }
 
     const url = (() => {
       const hasProtocol = /^https?:\/\//.test(c.args.url)
@@ -200,8 +207,26 @@ const cli = Cli.create('mppx', {
         return
       }
 
-      const challenge = Challenge.fromResponse(challengeResponse)
-      const { plugin, method: configMethod } = resolvePlugin(challenge, loaded?.config)
+      const selected = selectChallenge(
+        Challenge.fromResponseList(challengeResponse),
+        loaded?.config,
+      )
+      if (!selected) {
+        const offers = Challenge.fromResponseList(challengeResponse)
+          .map((challenge) => `${challenge.method}/${challenge.intent}`)
+          .join(', ')
+        return c.error({
+          code: 'UNSUPPORTED_METHOD',
+          message: `Unsupported payment method. Server offers: ${offers}. Add it to mppx.config.ts using defineConfig().`,
+          exitCode: 2,
+        })
+      }
+
+      const { challenge, plugin, method: configMethod } = selected
+      const selectedChallengeResponse = new Response(null, {
+        status: 402,
+        headers: { 'WWW-Authenticate': Challenge.serialize(challenge) },
+      })
 
       let tokenSymbol = (challenge.request.currency as string | undefined) ?? ''
       let tokenDecimals = (challenge.request.decimals as number | undefined) ?? 6
@@ -297,23 +322,17 @@ const cli = Cli.create('mppx', {
       // Create credential
       let credential: string
       if (pluginResult?.createCredential)
-        credential = await pluginResult.createCredential(challengeResponse)
+        credential = await pluginResult.createCredential(selectedChallengeResponse)
       else if (pluginResult) {
         const mppx = Mppx.create({ methods: pluginResult.methods, polyfill: false })
         credential = await mppx.createCredential(
-          challengeResponse,
+          selectedChallengeResponse,
           pluginResult.credentialContext as undefined,
         )
       } else if (configMethod) {
         const mppx = Mppx.create({ methods: [configMethod], polyfill: false })
-        credential = await mppx.createCredential(challengeResponse)
-      } else {
-        return c.error({
-          code: 'UNSUPPORTED_METHOD',
-          message: `Unsupported payment method: ${challenge.method}/${challenge.intent}. Add it to mppx.config.ts using defineConfig().`,
-          exitCode: 2,
-        })
-      }
+        credential = await mppx.createCredential(selectedChallengeResponse)
+      } else throw new Error('unreachable')
 
       // Send credential and get response
       const credentialHeaders = {
@@ -815,9 +834,9 @@ const sign = Cli.create('sign', {
       })
     }
 
-    let challenge: Challenge.Challenge
+    let challenges: Challenge.Challenge[]
     try {
-      challenge = Challenge.deserialize(raw)
+      challenges = Challenge.deserializeList(raw)
     } catch (err) {
       return c.error({
         code: 'INVALID_CHALLENGE',
@@ -832,7 +851,19 @@ const sign = Cli.create('sign', {
     }
 
     const loaded = await loadConfig(c.options.config)
-    const { plugin, method: configMethod } = resolvePlugin(challenge, loaded?.config)
+    const selected = selectChallenge(challenges, loaded?.config)
+    if (!selected) {
+      const offers = challenges
+        .map((challenge) => `${challenge.method}/${challenge.intent}`)
+        .join(', ')
+      return c.error({
+        code: 'UNSUPPORTED_METHOD',
+        message: `Unsupported payment method. Server offers: ${offers}. Add it to mppx.config.ts using defineConfig().`,
+        exitCode: 2,
+      })
+    }
+
+    const { challenge, plugin, method: configMethod } = selected
     const methodOpts = parseMethodOpts(c.options.methodOpt)
 
     const wwwAuth = Challenge.serialize(challenge)

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -28,17 +28,23 @@ import type { Plugin } from './plugins/plugin.js'
  * })
  * ```
  */
-export function defineConfig(config: defineConfig.Config): defineConfig.Config {
+export function defineConfig<const methods extends Mppx.Methods | undefined = undefined>(
+  config: defineConfig.Config<methods>,
+): defineConfig.Config<methods> {
   return config
 }
 
 export declare namespace defineConfig {
-  type Config = {
+  type Config<methods extends Mppx.Methods | undefined = undefined> = {
     /** Array of methods to use. */
-    methods?: Mppx.create.Config['methods'] | undefined
+    methods?: methods
+    /** Optional payment preferences for configured client methods. */
+    paymentPreferences?: methods extends Mppx.Methods
+      ? Mppx.create.Config<methods>['paymentPreferences']
+      : undefined
     /** Array of plugins to use. */
     plugins?: Plugin[] | undefined
   }
 }
 
-export type Config = defineConfig.Config
+export type Config = defineConfig.Config<Mppx.Methods>

--- a/src/cli/internal.ts
+++ b/src/cli/internal.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 
 import type * as Challenge from '../Challenge.js'
+import * as AcceptPayment from '../internal/AcceptPayment.js'
 import type * as Method from '../Method.js'
 import type { Config } from './config.js'
 import { stripe as stripePlugin, tempo as tempoPlugin } from './plugins/index.js'
@@ -13,19 +14,74 @@ export function resolvePlugin(
   challenge: Challenge.Challenge,
   config?: { plugins?: Plugin[] | undefined; methods?: any },
 ): { plugin?: Plugin | undefined; method?: Method.AnyClient | undefined } {
-  const configPlugin = config?.plugins?.find((p) => p.method === challenge.method)
+  const configPlugin = config?.plugins?.find((p) => supportsPlugin(p, challenge))
   if (configPlugin) return { plugin: configPlugin }
 
-  const builtin = builtinPlugins.find((p) => p.method === challenge.method)
+  const builtin = builtinPlugins.find((p) => supportsPlugin(p, challenge))
   if (builtin) return { plugin: builtin }
 
-  const configMethods = config?.methods?.flat() as Method.AnyClient[] | undefined
+  const configMethods = flattenConfigMethods(config)
   const matched = configMethods?.find(
     (m) => m.name === challenge.method && m.intent === challenge.intent,
   )
   if (matched) return { method: matched }
 
   return {}
+}
+
+export function selectChallenge(
+  challenges: readonly Challenge.Challenge[],
+  config?: Config | undefined,
+):
+  | ({ challenge: Challenge.Challenge } & {
+      plugin?: Plugin | undefined
+      method?: Method.AnyClient | undefined
+    })
+  | undefined {
+  const configMethods = flattenConfigMethods(config)
+  if (configMethods?.length) {
+    const resolvedPreferences = AcceptPayment.resolve(
+      configMethods,
+      config?.paymentPreferences as AcceptPayment.Config<typeof configMethods> | undefined,
+    )
+    const selected = AcceptPayment.selectChallenge(
+      challenges,
+      configMethods,
+      resolvedPreferences.entries,
+    )
+    if (selected) {
+      return { challenge: selected.challenge, ...resolvePlugin(selected.challenge, config) }
+    }
+
+    return undefined
+  }
+
+  for (const challenge of challenges) {
+    const resolved = resolvePlugin(challenge, config)
+    if (resolved.plugin || resolved.method) return { challenge, ...resolved }
+  }
+
+  return undefined
+}
+
+export function resolveAcceptPayment(config?: Config | undefined): string | undefined {
+  const methods = flattenConfigMethods(config)
+  if (!methods?.length) return undefined
+
+  return AcceptPayment.resolve(
+    methods,
+    config?.paymentPreferences as AcceptPayment.Config<typeof methods> | undefined,
+  ).header
+}
+
+export function flattenConfigMethods(
+  config?: Pick<Config, 'methods'> | undefined,
+): Method.AnyClient[] | undefined {
+  return Array.isArray(config?.methods) ? (config.methods.flat() as Method.AnyClient[]) : undefined
+}
+
+function supportsPlugin(plugin: Plugin, challenge: Challenge.Challenge): boolean {
+  return plugin.supports ? plugin.supports(challenge) : plugin.method === challenge.method
 }
 
 const CONFIG_NAMES = ['mppx.config.ts', 'mppx.config.js', 'mppx.config.mjs'] as const

--- a/src/cli/plugins/plugin.ts
+++ b/src/cli/plugins/plugin.ts
@@ -9,6 +9,9 @@ export interface Plugin {
   /** Payment method name (e.g., 'tempo', 'stripe') */
   method: string
 
+  /** Optional predicate for challenge support when a plugin does not support every intent for its method. */
+  supports?(challenge: Challenge.Challenge): boolean
+
   /**
    * Resolve account, client, and display info for a challenge.
    * Returns methods for credential creation.

--- a/src/cli/plugins/stripe.ts
+++ b/src/cli/plugins/stripe.ts
@@ -7,6 +7,9 @@ import { createPlugin } from './plugin.js'
 export function stripe() {
   return createPlugin({
     method: 'stripe',
+    supports(challenge) {
+      return challenge.method === 'stripe' && challenge.intent === 'charge'
+    },
 
     async setup({ challenge, methodOpts }) {
       const challengeRequest = challenge.request as Record<string, unknown>

--- a/src/cli/plugins/tempo.ts
+++ b/src/cli/plugins/tempo.ts
@@ -46,6 +46,9 @@ export function tempo() {
 
   return createPlugin({
     method: 'tempo',
+    supports(challenge) {
+      return challenge.method === 'tempo' && ['charge', 'session'].includes(challenge.intent)
+    },
 
     async setup({ challenge, options, methodOpts }) {
       const accountName = resolveAccountName(options.account)

--- a/src/client/Mppx.test-d.ts
+++ b/src/client/Mppx.test-d.ts
@@ -46,6 +46,23 @@ describe('create.Config', () => {
 
     expectTypeOf<Config>().toHaveProperty('methods')
   })
+
+  test('paymentPreferences callback exposes typed method keys', () => {
+    const mppx = Mppx.create({
+      methods: [tempo({ account: {} as Account })],
+      paymentPreferences: ({ tempo }) => {
+        expectTypeOf(tempo.charge).toEqualTypeOf<'tempo/charge'>()
+        expectTypeOf(tempo.session).toEqualTypeOf<'tempo/session'>()
+
+        return {
+          [tempo.charge]: 0.5,
+          [tempo.session]: 0,
+        }
+      },
+    })
+
+    expectTypeOf(mppx.fetch).toBeFunction()
+  })
 })
 
 describe('Method.toClient', () => {
@@ -98,6 +115,22 @@ describe('Mppx with context', () => {
 
     expectTypeOf(mppx.createCredential).toBeFunction()
     expectTypeOf(mppx.createCredential).returns.toMatchTypeOf<Promise<string>>()
+  })
+
+  test('createCredential accepts an optional Accept-Payment override', () => {
+    const method = charge({
+      account: {} as Account,
+    })
+
+    const mppx = Mppx.create({ methods: [method] })
+
+    const createCredential: (
+      response: Response,
+      context?: Parameters<typeof mppx.createCredential>[1],
+      options?: Parameters<typeof mppx.createCredential>[2],
+    ) => Promise<string> = mppx.createCredential
+
+    expectTypeOf(createCredential).toBeFunction()
   })
 })
 

--- a/src/client/Mppx.test.ts
+++ b/src/client/Mppx.test.ts
@@ -130,7 +130,7 @@ describe('createCredential', () => {
     })
 
     await expect(mppx.createCredential(response)).rejects.toThrow(
-      'No method found for "unknown.charge". Available: tempo.charge, tempo.session',
+      'No method found for challenges: unknown.charge. Available: tempo.charge, tempo.session',
     )
   })
 
@@ -184,6 +184,135 @@ describe('createCredential', () => {
     const parsed = Credential.deserialize(credential)
 
     expect(parsed.payload).toEqual({ signature: '0xstripe', type: 'transaction' })
+    expect(parsed.challenge.method).toBe('stripe')
+  })
+
+  test('behavior: selects the preferred challenge from a multi-challenge response', async () => {
+    const stripeCharge = Method.from({
+      name: 'stripe',
+      intent: 'charge',
+      schema: {
+        credential: {
+          payload: Methods.charge.schema.credential.payload,
+        },
+        request: Methods.charge.schema.request,
+      },
+    })
+
+    const stripe = Method.toClient(stripeCharge, {
+      async createCredential({ challenge }) {
+        return Credential.serialize({
+          challenge,
+          payload: { signature: '0xstripe', type: 'transaction' },
+        })
+      },
+    })
+
+    const mppx = Mppx.create({
+      polyfill: false,
+      methods: [tempo({ account: accounts[1], getClient: () => client }), stripe],
+      paymentPreferences: ({ stripe }) => ({
+        [stripe.charge]: 0.5,
+      }),
+    })
+
+    const tempoChallenge = Challenge.fromMethod(Methods.charge, {
+      realm,
+      secretKey,
+      expires: new Date(Date.now() + 60_000).toISOString(),
+      request: {
+        amount: '1000',
+        currency: '0x1234567890123456789012345678901234567890',
+        decimals: 6,
+        recipient: '0x1234567890123456789012345678901234567890',
+      },
+    })
+    const stripeChallenge = Challenge.from({
+      id: 'stripe-challenge-id',
+      realm,
+      method: 'stripe',
+      intent: 'charge',
+      request: {
+        amount: '2000',
+        currency: '0xabcd',
+        recipient: '0xefgh',
+      },
+    })
+
+    const response = new Response(null, {
+      status: 402,
+      headers: {
+        'WWW-Authenticate': `${Challenge.serialize(stripeChallenge)}, ${Challenge.serialize(tempoChallenge)}`,
+      },
+    })
+
+    const credential = await mppx.createCredential(response)
+    const parsed = Credential.deserialize(credential)
+
+    expect(parsed.challenge.method).toBe('tempo')
+  })
+
+  test('behavior: createCredential accepts a request-local Accept-Payment override', async () => {
+    const stripeCharge = Method.from({
+      name: 'stripe',
+      intent: 'charge',
+      schema: {
+        credential: {
+          payload: Methods.charge.schema.credential.payload,
+        },
+        request: Methods.charge.schema.request,
+      },
+    })
+
+    const stripe = Method.toClient(stripeCharge, {
+      async createCredential({ challenge }) {
+        return Credential.serialize({
+          challenge,
+          payload: { signature: '0xstripe', type: 'transaction' },
+        })
+      },
+    })
+
+    const mppx = Mppx.create({
+      polyfill: false,
+      methods: [tempo({ account: accounts[1], getClient: () => client }), stripe],
+    })
+
+    const tempoChallenge = Challenge.fromMethod(Methods.charge, {
+      realm,
+      secretKey,
+      expires: new Date(Date.now() + 60_000).toISOString(),
+      request: {
+        amount: '1000',
+        currency: '0x1234567890123456789012345678901234567890',
+        decimals: 6,
+        recipient: '0x1234567890123456789012345678901234567890',
+      },
+    })
+    const stripeChallenge = Challenge.from({
+      id: 'stripe-challenge-id',
+      realm,
+      method: 'stripe',
+      intent: 'charge',
+      request: {
+        amount: '2000',
+        currency: '0xabcd',
+        recipient: '0xefgh',
+      },
+    })
+
+    const response = new Response(null, {
+      status: 402,
+      headers: {
+        'WWW-Authenticate': `${Challenge.serialize(stripeChallenge)}, ${Challenge.serialize(tempoChallenge)}`,
+      },
+    })
+
+    const credential = await mppx.createCredential(response, undefined, {
+      acceptPayment: 'stripe/charge, tempo/charge;q=0.1',
+    })
+    const parsed = Credential.deserialize(credential)
+
     expect(parsed.challenge.method).toBe('stripe')
   })
 

--- a/src/client/Mppx.ts
+++ b/src/client/Mppx.ts
@@ -1,4 +1,5 @@
 import type * as Challenge from '../Challenge.js'
+import * as AcceptPayment from '../internal/AcceptPayment.js'
 import type * as Method from '../Method.js'
 import type * as z from '../zod.js'
 import * as Fetch from './internal/Fetch.js'
@@ -25,6 +26,7 @@ export type Mppx<
   createCredential: (
     response: Transport.ResponseOf<transport>,
     context?: AnyContextFor<FlattenMethods<methods>> | undefined,
+    options?: createCredential.Options | undefined,
   ) => Promise<string>
 }
 
@@ -61,11 +63,13 @@ export function create<
   const rawFetch = config.fetch ?? globalThis.fetch
 
   const methods = config.methods.flat() as unknown as FlattenMethods<methods>
+  const acceptPayment = AcceptPayment.resolve(methods, config.paymentPreferences)
 
   const resolvedOnChallenge = onChallenge as Fetch.from.Config<
     FlattenMethods<methods>
   >['onChallenge']
   const config_fetch = {
+    acceptPayment,
     ...(config.fetch && { fetch: config.fetch }),
     ...(resolvedOnChallenge && { onChallenge: resolvedOnChallenge }),
     methods,
@@ -78,14 +82,23 @@ export function create<
     rawFetch,
     methods,
     transport,
-    async createCredential(response: Transport.ResponseOf<transport>, context?: unknown) {
-      const challenge = transport.getChallenge(response as never) as Challenge.Challenge
+    async createCredential(
+      response: Transport.ResponseOf<transport>,
+      context?: unknown,
+      options?: createCredential.Options,
+    ) {
+      const challenges = transport.getChallenges
+        ? transport.getChallenges(response as never)
+        : [transport.getChallenge(response as never)]
+      const preferences = resolveChallengePreferences(acceptPayment.entries, options?.acceptPayment)
 
-      const mi = methods.find((m) => m.name === challenge.method && m.intent === challenge.intent)
-      if (!mi)
+      const selected = AcceptPayment.selectChallenge(challenges, methods, preferences)
+      if (!selected)
         throw new Error(
-          `No method found for "${challenge.method}.${challenge.intent}". Available: ${methods.map((m) => `${m.name}.${m.intent}`).join(', ')}`,
+          `No method found for challenges: ${challenges.map((challenge) => `${challenge.method}.${challenge.intent}`).join(', ')}. Available: ${methods.map((m) => `${m.name}.${m.intent}`).join(', ')}`,
         )
+
+      const { challenge, method: mi } = selected
 
       const parsedContext =
         mi.context && context !== undefined ? mi.context.parse(context) : undefined
@@ -96,6 +109,13 @@ export function create<
           : ({ challenge } as never),
       )
     },
+  }
+}
+
+export declare namespace createCredential {
+  type Options = {
+    /** Request-local Accept-Payment override for manual rawFetch + createCredential flows. */
+    acceptPayment?: string | readonly AcceptPayment.Entry[] | undefined
   }
 }
 
@@ -133,6 +153,8 @@ export declare namespace create {
           },
         ) => Promise<string | undefined>)
       | undefined
+    /** Client-declared supported payment methods, keyed by typed `method/intent` strings. */
+    paymentPreferences?: AcceptPayment.Config<FlattenMethods<methods>> | undefined
     /** Array of methods to use. Accepts individual clients or tuples (e.g. from `tempo()`). */
     methods: methods
     /** Whether to polyfill `globalThis.fetch` with the payment-aware wrapper. @default true */
@@ -168,3 +190,11 @@ type FlattenMethods<methods extends Methods> = methods extends readonly [
       ? readonly [head, ...FlattenMethods<tail>]
       : never
   : readonly []
+
+function resolveChallengePreferences(
+  fallback: readonly AcceptPayment.Entry[],
+  override?: string | readonly AcceptPayment.Entry[] | undefined,
+): readonly AcceptPayment.Entry[] {
+  if (!override) return fallback
+  return typeof override === 'string' ? AcceptPayment.parse(override) : override
+}

--- a/src/client/Transport.test.ts
+++ b/src/client/Transport.test.ts
@@ -57,20 +57,18 @@ describe('http', () => {
         },
       })
 
-      expect(transport.getChallenge(response)).toMatchInlineSnapshot(`
-        {
-          "expires": "2025-01-01T00:00:00.000Z",
-          "id": "0hnrySRDqWfttlDIJpuxV4mJsRJIS7d7RjnufuonJOE",
-          "intent": "charge",
-          "method": "tempo",
-          "realm": "api.example.com",
-          "request": {
-            "amount": "1000",
-            "currency": "0x20c0000000000000000000000000000000000001",
-            "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00",
-          },
-        }
-      `)
+      expect(transport.getChallenge(response)).toMatchObject({
+        expires: '2025-01-01T00:00:00.000Z',
+        id: expect.any(String),
+        intent: 'charge',
+        method: 'tempo',
+        realm: 'api.example.com',
+        request: {
+          amount: '1000',
+          currency: '0x20c0000000000000000000000000000000000001',
+          recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00',
+        },
+      })
     })
 
     test('throws for non-402 response', () => {
@@ -78,6 +76,24 @@ describe('http', () => {
       const response = new Response(null, { status: 200 })
 
       expect(() => transport.getChallenge(response)).toThrow()
+    })
+  })
+
+  describe('getChallenges', () => {
+    test('returns all HTTP challenges', () => {
+      const transport = Transport.http()
+      const alternate = { ...challenge, id: 'alternate', method: 'stripe' as const }
+      const response = new Response(null, {
+        status: 402,
+        headers: {
+          'WWW-Authenticate': `${Challenge.serialize(challenge)}, ${Challenge.serialize(alternate)}`,
+        },
+      })
+
+      expect(transport.getChallenges?.(response).map((entry) => entry.id)).toEqual([
+        challenge.id,
+        'alternate',
+      ])
     })
   })
 
@@ -89,9 +105,7 @@ describe('http', () => {
       const result = transport.setCredential({}, serialized)
       const headers = result.headers as Headers
 
-      expect(headers.get('Authorization')).toMatchInlineSnapshot(
-        `"Payment eyJjaGFsbGVuZ2UiOnsiZXhwaXJlcyI6IjIwMjUtMDEtMDFUMDA6MDA6MDAuMDAwWiIsImlkIjoiMGhucnlTUkRxV2Z0dGxESUpwdXhWNG1Kc1JKSVM3ZDdSam51ZnVvbkpPRSIsImludGVudCI6ImNoYXJnZSIsIm1ldGhvZCI6InRlbXBvIiwicmVhbG0iOiJhcGkuZXhhbXBsZS5jb20iLCJyZXF1ZXN0IjoiZXlKaGJXOTFiblFpT2lJeE1EQXdJaXdpWTNWeWNtVnVZM2tpT2lJd2VESXdZekF3TURBd01EQXdNREF3TURBd01EQXdNREF3TURBd01EQXdNREF3TURBd01EQXdNREVpTENKeVpXTnBjR2xsYm5RaU9pSXdlRGMwTW1Rek5VTmpOall6TkVNd05UTXlPVEkxWVROaU9EUTBRbU01WlRjMU9UVm1PR1pGTURBaWZRIn0sInBheWxvYWQiOnsic2lnbmF0dXJlIjoiMHhhYmMxMjMiLCJ0eXBlIjoidHJhbnNhY3Rpb24ifX0"`,
-      )
+      expect(headers.get('Authorization')).toBe(serialized)
     })
 
     test('preserves existing headers', () => {
@@ -178,20 +192,18 @@ describe('mcp', () => {
         },
       }
 
-      expect(transport.getChallenge(response)).toMatchInlineSnapshot(`
-        {
-          "expires": "2025-01-01T00:00:00.000Z",
-          "id": "0hnrySRDqWfttlDIJpuxV4mJsRJIS7d7RjnufuonJOE",
-          "intent": "charge",
-          "method": "tempo",
-          "realm": "api.example.com",
-          "request": {
-            "amount": "1000",
-            "currency": "0x20c0000000000000000000000000000000000001",
-            "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00",
-          },
-        }
-      `)
+      expect(transport.getChallenge(response)).toMatchObject({
+        expires: '2025-01-01T00:00:00.000Z',
+        id: expect.any(String),
+        intent: 'charge',
+        method: 'tempo',
+        realm: 'api.example.com',
+        request: {
+          amount: '1000',
+          currency: '0x20c0000000000000000000000000000000000001',
+          recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00',
+        },
+      })
     })
 
     test('throws for success response', () => {
@@ -224,39 +236,60 @@ describe('mcp', () => {
     })
   })
 
+  describe('getChallenges', () => {
+    test('returns all MCP challenges', () => {
+      const transport = Transport.mcp()
+      const response: Mcp.Response = {
+        jsonrpc: '2.0',
+        id: 1,
+        error: {
+          code: Mcp.paymentRequiredCode,
+          message: 'Payment Required',
+          data: {
+            httpStatus: 402,
+            challenges: [challenge, { ...challenge, id: 'alternate', method: 'stripe' }],
+          },
+        },
+      }
+
+      expect(transport.getChallenges?.(response).map((entry) => entry.id)).toEqual([
+        challenge.id,
+        'alternate',
+      ])
+    })
+  })
+
   describe('setCredential', () => {
     test('default', () => {
       const transport = Transport.mcp()
       const serialized = Credential.serialize(credential)
 
-      expect(transport.setCredential(mcpRequest, serialized)).toMatchInlineSnapshot(`
-        {
-          "method": "tools/call",
-          "params": {
-            "_meta": {
-              "org.paymentauth/credential": {
-                "challenge": {
-                  "expires": "2025-01-01T00:00:00.000Z",
-                  "id": "0hnrySRDqWfttlDIJpuxV4mJsRJIS7d7RjnufuonJOE",
-                  "intent": "charge",
-                  "method": "tempo",
-                  "realm": "api.example.com",
-                  "request": {
-                    "amount": "1000",
-                    "currency": "0x20c0000000000000000000000000000000000001",
-                    "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00",
-                  },
-                },
-                "payload": {
-                  "signature": "0xabc123",
-                  "type": "transaction",
+      expect(transport.setCredential(mcpRequest, serialized)).toMatchObject({
+        method: 'tools/call',
+        params: {
+          _meta: {
+            'org.paymentauth/credential': {
+              challenge: {
+                expires: '2025-01-01T00:00:00.000Z',
+                id: expect.any(String),
+                intent: 'charge',
+                method: 'tempo',
+                realm: 'api.example.com',
+                request: {
+                  amount: '1000',
+                  currency: '0x20c0000000000000000000000000000000000001',
+                  recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00',
                 },
               },
+              payload: {
+                signature: '0xabc123',
+                type: 'transaction',
+              },
             },
-            "name": "test-tool",
           },
-        }
-      `)
+          name: 'test-tool',
+        },
+      })
     })
 
     test('preserves existing _meta', () => {

--- a/src/client/Transport.ts
+++ b/src/client/Transport.ts
@@ -13,6 +13,8 @@ export type Transport<in out request = unknown, in out response = unknown> = {
   name: string
   /** Checks if a response indicates payment is required. */
   isPaymentRequired: (response: response) => boolean
+  /** Extracts all challenges from a payment-required response, when the transport supports multiple offers. */
+  getChallenges?: (response: response) => Challenge.Challenge[]
   /** Extracts the challenge from a payment-required response. */
   getChallenge: (response: response) => Challenge.Challenge
   /** Attaches a credential to a request. */
@@ -64,6 +66,10 @@ export function http() {
       return response.status === 402
     },
 
+    getChallenges(response) {
+      return Challenge.fromResponseList(response)
+    },
+
     getChallenge(response) {
       return Challenge.fromResponse(response)
     },
@@ -89,6 +95,13 @@ export function mcp() {
 
     isPaymentRequired(response) {
       return 'error' in response && response.error?.code === Mcp.paymentRequiredCode
+    },
+
+    getChallenges(response) {
+      if (!('error' in response) || !response.error) throw new Error('Response is not an error.')
+      const challenges = response.error.data?.challenges
+      if (!challenges?.length) throw new Error('No challenge in error response.')
+      return challenges
     },
 
     getChallenge(response) {

--- a/src/client/internal/Fetch.browser.test.ts
+++ b/src/client/internal/Fetch.browser.test.ts
@@ -22,6 +22,10 @@ function make402() {
   })
 }
 
+function toHeaders(headers: unknown): Headers {
+  return new Headers((headers ?? {}) as HeadersInit)
+}
+
 /** Returns a fetch wrapper and the init captured from the 402 retry call. */
 function setup() {
   const calls: (RequestInit | undefined)[] = []
@@ -38,7 +42,7 @@ function setup() {
     /** Headers sent on the retry (second) request. */
     retryHeaders: async (input: RequestInfo | URL, init?: RequestInit) => {
       await fetch(input, init)
-      return (calls[1] as Record<string, unknown>)?.headers as Record<string, string>
+      return toHeaders((calls[1] as Record<string, unknown>)?.headers)
     },
   }
 }
@@ -49,9 +53,9 @@ describe('Fetch.from: browser header normalization', () => {
     const h = await retryHeaders('https://example.com', {
       headers: new Headers({ 'X-Custom': 'value', 'Content-Type': 'application/json' }),
     })
-    expect(h['x-custom']).toBe('value')
-    expect(h['content-type']).toBe('application/json')
-    expect(h.Authorization).toBe('credential')
+    expect(h.get('x-custom')).toBe('value')
+    expect(h.get('content-type')).toBe('application/json')
+    expect(h.get('authorization')).toBe('credential')
   })
 
   test('preserves header tuples', async () => {
@@ -62,9 +66,9 @@ describe('Fetch.from: browser header normalization', () => {
         ['Accept', 'application/json'],
       ],
     })
-    expect(h['X-Custom']).toBe('value')
-    expect(h.Accept).toBe('application/json')
-    expect(h.Authorization).toBe('credential')
+    expect(h.get('x-custom')).toBe('value')
+    expect(h.get('accept')).toBe('application/json')
+    expect(h.get('authorization')).toBe('credential')
   })
 
   test('replaces authorization case-insensitively', async () => {
@@ -72,22 +76,21 @@ describe('Fetch.from: browser header normalization', () => {
     const h = await retryHeaders('https://example.com', {
       headers: { authorization: 'Bearer stale', 'X-Custom': 'value' },
     })
-    expect(h.authorization).toBeUndefined()
-    expect(h.Authorization).toBe('credential')
-    expect(h['X-Custom']).toBe('value')
+    expect(h.get('authorization')).toBe('credential')
+    expect(h.get('x-custom')).toBe('value')
   })
 
   test('preserves plain object headers', async () => {
     const { retryHeaders } = setup()
     const h = await retryHeaders('https://example.com', { headers: { 'X-Custom': 'val' } })
-    expect(h['X-Custom']).toBe('val')
-    expect(h.Authorization).toBe('credential')
+    expect(h.get('x-custom')).toBe('val')
+    expect(h.get('authorization')).toBe('credential')
   })
 
   test('adds Authorization when no headers provided', async () => {
     const { retryHeaders } = setup()
     const h = await retryHeaders('https://example.com')
-    expect(h.Authorization).toBe('credential')
+    expect(h.get('authorization')).toBe('credential')
   })
 })
 

--- a/src/client/internal/Fetch.test.ts
+++ b/src/client/internal/Fetch.test.ts
@@ -350,7 +350,7 @@ function make402(overrides?: { method?: string; intent?: string }) {
 }
 
 describe('Fetch.from: init passthrough (non-402)', () => {
-  test('passes unmodified init to underlying fetch for non-402 responses', async () => {
+  test('preserves init object identity while adding Accept-Payment', async () => {
     const receivedInits: (RequestInit | undefined)[] = []
     const mockFetch: typeof globalThis.fetch = async (_input, init) => {
       receivedInits.push(init)
@@ -371,6 +371,9 @@ describe('Fetch.from: init passthrough (non-402)', () => {
     await fetch('https://example.com/ws-upgrade', customInit)
 
     expect(receivedInits[0]).toBe(customInit)
+    const headers = new Headers(receivedInits[0]?.headers)
+    expect(headers.get('X-Custom')).toBe('value')
+    expect(headers.get('Accept-Payment')).toBe('test/test')
   })
 
   test('preserves extra properties on init for non-402 responses', async () => {
@@ -395,7 +398,8 @@ describe('Fetch.from: init passthrough (non-402)', () => {
 
     const received = receivedInits[0]!
     expect(received.method).toBe('GET')
-    expect((received.headers as Record<string, string>).Authorization).toBe('Bearer token123')
+    expect(new Headers(received.headers).get('Authorization')).toBe('Bearer token123')
+    expect(new Headers(received.headers).get('Accept-Payment')).toBe('test/test')
     expect(received.signal).toBe(customInit.signal)
   })
 
@@ -412,7 +416,7 @@ describe('Fetch.from: init passthrough (non-402)', () => {
     })
 
     await fetch('https://example.com/api')
-    expect(receivedInits[0]).toBeUndefined()
+    expect(new Headers(receivedInits[0]?.headers).get('Accept-Payment')).toBe('test/test')
   })
 
   test('passes init with context through untouched', async () => {
@@ -431,9 +435,153 @@ describe('Fetch.from: init passthrough (non-402)', () => {
     await fetch('https://example.com/api', customInit as any)
 
     expect(receivedInits[0]).toBe(customInit)
+    expect((receivedInits[0] as Record<string, unknown>).context).toEqual({ account: '0xabc' })
+    expect(new Headers(receivedInits[0]?.headers).get('Accept-Payment')).toBe('test/test')
   })
 
-  test('preserves object identity across all non-402 status codes', async () => {
+  test('preserves Request-carried headers when injecting Accept-Payment', async () => {
+    const receivedInputs: (RequestInfo | URL)[] = []
+    const receivedInits: (RequestInit | undefined)[] = []
+    const mockFetch: typeof globalThis.fetch = async (input, init) => {
+      receivedInputs.push(input)
+      receivedInits.push(init)
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [noopMethod],
+    })
+
+    const request = new Request('https://example.com/api', {
+      headers: { Authorization: 'Bearer token123', 'X-Custom': 'value' },
+    })
+
+    await fetch(request)
+
+    expect(receivedInputs[0]).toBe(request)
+    const headers = new Headers(receivedInits[0]?.headers)
+    expect(headers.get('Authorization')).toBe('Bearer token123')
+    expect(headers.get('X-Custom')).toBe('value')
+    expect(headers.get('Accept-Payment')).toBe('test/test')
+  })
+
+  test('does not overwrite an explicit Accept-Payment header', async () => {
+    const receivedInits: (RequestInit | undefined)[] = []
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      receivedInits.push(init)
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [noopMethod],
+    })
+
+    await fetch('https://example.com/api', {
+      headers: { 'Accept-Payment': 'custom/charge;q=0.5' },
+    })
+
+    expect(new Headers(receivedInits[0]?.headers).get('Accept-Payment')).toBe('custom/charge;q=0.5')
+  })
+
+  test('uses an explicit Accept-Payment header to reprioritize challenge selection', async () => {
+    let callCount = 0
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      callCount++
+      if (callCount === 1) {
+        expect(new Headers(init?.headers).get('Accept-Payment')).toBe(
+          'stripe/charge, tempo/charge;q=0.1',
+        )
+
+        return new Response(null, {
+          status: 402,
+          headers: {
+            'WWW-Authenticate': [
+              'Payment id="tempo", realm="test", method="tempo", intent="charge", request="eyJhbW91bnQiOiIxIn0"',
+              'Payment id="stripe", realm="test", method="stripe", intent="charge", request="eyJhbW91bnQiOiIxIn0"',
+            ].join(', '),
+          },
+        })
+      }
+
+      expect(new Headers(init?.headers).get('Authorization')).toBe('stripe-credential')
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [
+        {
+          name: 'tempo',
+          intent: 'charge',
+          context: undefined,
+          createCredential: async () => 'tempo-credential',
+        },
+        {
+          name: 'stripe',
+          intent: 'charge',
+          context: undefined,
+          createCredential: async () => 'stripe-credential',
+        },
+      ] as const,
+    })
+
+    const response = await fetch('https://example.com/api', {
+      headers: { 'Accept-Payment': 'stripe/charge, tempo/charge;q=0.1' },
+    })
+    expect(response.status).toBe(200)
+  })
+
+  test('applies an explicit method opt-out before broader wildcard preferences', async () => {
+    let callCount = 0
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      callCount++
+      if (callCount === 1) {
+        expect(new Headers(init?.headers).get('Accept-Payment')).toBe(
+          'tempo/*;q=1, tempo/charge;q=0, stripe/*;q=0.5',
+        )
+
+        return new Response(null, {
+          status: 402,
+          headers: {
+            'WWW-Authenticate': [
+              'Payment id="tempo", realm="test", method="tempo", intent="charge", request="eyJhbW91bnQiOiIxIn0"',
+              'Payment id="stripe", realm="test", method="stripe", intent="charge", request="eyJhbW91bnQiOiIxIn0"',
+            ].join(', '),
+          },
+        })
+      }
+
+      expect(new Headers(init?.headers).get('Authorization')).toBe('stripe-credential')
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [
+        {
+          name: 'tempo',
+          intent: 'charge',
+          context: undefined,
+          createCredential: async () => 'tempo-credential',
+        },
+        {
+          name: 'stripe',
+          intent: 'charge',
+          context: undefined,
+          createCredential: async () => 'stripe-credential',
+        },
+      ] as const,
+    })
+
+    const response = await fetch('https://example.com/api', {
+      headers: { 'Accept-Payment': 'tempo/*;q=1, tempo/charge;q=0, stripe/*;q=0.5' },
+    })
+    expect(response.status).toBe(200)
+  })
+
+  test('preserves non-header init fields across all non-402 status codes', async () => {
     for (const status of [200, 201, 204, 301, 400, 401, 403, 404, 500, 503]) {
       const receivedInits: (RequestInit | undefined)[] = []
       const mockFetch: typeof globalThis.fetch = async (_input, init) => {
@@ -448,7 +596,8 @@ describe('Fetch.from: init passthrough (non-402)', () => {
 
       const customInit = { method: 'GET' }
       await fetch('https://example.com/api', customInit)
-      expect(receivedInits[0]).toBe(customInit)
+      expect(receivedInits[0]?.method).toBe(customInit.method)
+      expect(new Headers(receivedInits[0]?.headers).get('Accept-Payment')).toBe('test/test')
     }
   })
 })
@@ -521,10 +670,11 @@ describe('Fetch.from: 402 retry path', () => {
     })
 
     const retryInit = calls[1]!.init as Record<string, unknown>
-    const headers = retryInit.headers as Record<string, string>
-    expect(headers['X-Custom']).toBe('value')
-    expect(headers['Content-Type']).toBe('application/json')
-    expect(headers.Authorization).toBe('credential')
+    const headers = new Headers(retryInit.headers as HeadersInit)
+    expect(headers.get('X-Custom')).toBe('value')
+    expect(headers.get('Content-Type')).toBe('application/json')
+    expect(headers.get('Accept-Payment')).toBe('test/test')
+    expect(headers.get('Authorization')).toBe('credential')
   })
 
   test('preserves method and other init properties on retry', async () => {
@@ -575,7 +725,154 @@ describe('Fetch.from: 402 retry path', () => {
 
     expect(calls).toHaveLength(2)
     const retryInit = calls[1]!.init as Record<string, unknown>
-    expect(retryInit.headers).toEqual({ Authorization: 'credential' })
+    const headers = new Headers(retryInit.headers as HeadersInit)
+    expect(headers.get('Accept-Payment')).toBe('test/test')
+    expect(headers.get('Authorization')).toBe('credential')
+  })
+
+  test('preserves Request-carried headers on retry after injecting Accept-Payment', async () => {
+    let callCount = 0
+    const calls: { init: RequestInit | undefined; input: RequestInfo | URL }[] = []
+    const mockFetch: typeof globalThis.fetch = async (input, init) => {
+      calls.push({ init, input })
+      callCount++
+      if (callCount === 1) return make402()
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [noopMethod],
+    })
+
+    const request = new Request('https://example.com/api', {
+      headers: { Authorization: 'Bearer token123', 'X-Custom': 'value' },
+    })
+
+    await fetch(request)
+
+    expect(calls[0]?.input).toBe(request)
+    expect(calls[1]?.input).toBe(request)
+    const headers = new Headers(calls[1]?.init?.headers)
+    expect(headers.get('X-Custom')).toBe('value')
+    expect(headers.get('Accept-Payment')).toBe('test/test')
+    expect(headers.get('Authorization')).toBe('credential')
+  })
+
+  test('selects the highest-ranked supported challenge', async () => {
+    let callCount = 0
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      callCount++
+      if (callCount === 1) {
+        expect(new Headers(init?.headers).get('Accept-Payment')).toBe(
+          'tempo/charge, stripe/charge;q=0.5',
+        )
+
+        return new Response(null, {
+          status: 402,
+          headers: {
+            'WWW-Authenticate': [
+              'Payment id="stripe", realm="test", method="stripe", intent="charge", request="eyJhbW91bnQiOiIxIn0"',
+              'Payment id="tempo", realm="test", method="tempo", intent="charge", request="eyJhbW91bnQiOiIxIn0"',
+            ].join(', '),
+          },
+        })
+      }
+
+      expect(new Headers(init?.headers).get('Authorization')).toBe('tempo-credential')
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [
+        {
+          name: 'tempo',
+          intent: 'charge',
+          context: undefined,
+          createCredential: async () => 'tempo-credential',
+        },
+        {
+          name: 'stripe',
+          intent: 'charge',
+          context: undefined,
+          createCredential: async () => 'stripe-credential',
+        },
+      ] as const,
+      acceptPayment: {
+        definition: { 'stripe/charge': 0.5 },
+        entries: [
+          { intent: 'charge', method: 'tempo', q: 1, index: 0 },
+          { intent: 'charge', method: 'stripe', q: 0.5, index: 1 },
+        ],
+        header: 'tempo/charge, stripe/charge;q=0.5',
+        keys: {
+          stripe: { charge: 'stripe/charge' },
+          tempo: { charge: 'tempo/charge' },
+        },
+      },
+    })
+
+    const response = await fetch('https://example.com/api')
+    expect(response.status).toBe(200)
+  })
+
+  test('falls back to configured preferences when explicit Accept-Payment is invalid', async () => {
+    let callCount = 0
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      callCount++
+      if (callCount === 1) {
+        expect(new Headers(init?.headers).get('Accept-Payment')).toBe('not a valid header')
+
+        return new Response(null, {
+          status: 402,
+          headers: {
+            'WWW-Authenticate': [
+              'Payment id="stripe", realm="test", method="stripe", intent="charge", request="eyJhbW91bnQiOiIxIn0"',
+              'Payment id="tempo", realm="test", method="tempo", intent="charge", request="eyJhbW91bnQiOiIxIn0"',
+            ].join(', '),
+          },
+        })
+      }
+
+      expect(new Headers(init?.headers).get('Authorization')).toBe('tempo-credential')
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [
+        {
+          name: 'tempo',
+          intent: 'charge',
+          context: undefined,
+          createCredential: async () => 'tempo-credential',
+        },
+        {
+          name: 'stripe',
+          intent: 'charge',
+          context: undefined,
+          createCredential: async () => 'stripe-credential',
+        },
+      ] as const,
+      acceptPayment: {
+        definition: { 'stripe/charge': 0.5 },
+        entries: [
+          { intent: 'charge', method: 'tempo', q: 1, index: 0 },
+          { intent: 'charge', method: 'stripe', q: 0.5, index: 1 },
+        ],
+        header: 'tempo/charge, stripe/charge;q=0.5',
+        keys: {
+          stripe: { charge: 'stripe/charge' },
+          tempo: { charge: 'tempo/charge' },
+        },
+      },
+    })
+
+    const response = await fetch('https://example.com/api', {
+      headers: { 'Accept-Payment': 'not a valid header' },
+    })
+    expect(response.status).toBe(200)
   })
 
   test('throws when no matching method for 402 challenge', async () => {

--- a/src/client/internal/Fetch.ts
+++ b/src/client/internal/Fetch.ts
@@ -1,4 +1,5 @@
 import * as Challenge from '../../Challenge.js'
+import * as AcceptPayment from '../../internal/AcceptPayment.js'
 import type * as Method from '../../Method.js'
 import type * as z from '../../zod.js'
 
@@ -37,40 +38,41 @@ let originalFetch: typeof globalThis.fetch | undefined
 export function from<const methods extends readonly Method.AnyClient[]>(
   config: from.Config<methods>,
 ): from.Fetch<methods> {
-  const { fetch = globalThis.fetch, methods, onChallenge } = config
+  const { acceptPayment, fetch = globalThis.fetch, methods, onChallenge } = config
+  const resolvedAcceptPayment = acceptPayment ?? AcceptPayment.resolve(methods)
   // Always operate on the true underlying fetch to avoid wrapper-on-wrapper stacking,
   // which can duplicate retries and make restore semantics fragile.
   const baseFetch = unwrapFetch(fetch)
 
   const wrappedFetch = async (input: RequestInfo | URL, init?: from.RequestInit<methods>) => {
-    // Pass init through untouched to preserve object identity for non-402 responses.
-    const response = await baseFetch(input, init)
+    const callerHeaders = getCallerHeaders(input, init?.headers)
+    const hasExplicitAcceptPayment = callerHeaders.has('Accept-Payment')
+    const paymentPreferences = resolvePaymentPreferences(callerHeaders, resolvedAcceptPayment)
+    const initialRequest = prepareInitialRequest(
+      input,
+      init,
+      callerHeaders,
+      paymentPreferences.header,
+      hasExplicitAcceptPayment,
+    )
+    const response = await baseFetch(initialRequest.input, initialRequest.init)
 
     if (response.status !== 402) return response
 
     // Only extract context for payment handling after confirming 402.
     const context = (init as Record<string, unknown> | undefined)?.context
-    const { context: _, ...fetchInit } = (init ?? {}) as Record<string, unknown>
+    const { context: _, ...fetchInit } = (initialRequest.init ?? {}) as Record<string, unknown>
 
     // Parse all challenges from the response (supports merged WWW-Authenticate headers).
-    // Match in client preference order: iterate the client's methods array and pick the
-    // first method that has a matching challenge, so the client controls priority.
     const challenges = Challenge.fromResponseList(response)
 
-    let challenge: Challenge.Challenge | undefined
-    let mi: (typeof methods)[number] | undefined
-    for (const m of methods) {
-      const match = challenges.find((c) => c.method === m.name && c.intent === m.intent)
-      if (match) {
-        challenge = match
-        mi = m
-        break
-      }
-    }
-    if (!challenge || !mi)
+    const selected = AcceptPayment.selectChallenge(challenges, methods, paymentPreferences.entries)
+    if (!selected)
       throw new Error(
         `No method found for challenges: ${challenges.map((c) => `${c.method}.${c.intent}`).join(', ')}. Available: ${methods.map((m) => `${m.name}.${m.intent}`).join(', ')}`,
       )
+
+    const { challenge, method: mi } = selected
 
     const onChallengeCredential = onChallenge
       ? await onChallenge(challenge, {
@@ -81,9 +83,9 @@ export function from<const methods extends readonly Method.AnyClient[]>(
     const credential = onChallengeCredential ?? (await resolveCredential(challenge, mi, context))
     validateCredentialHeaderValue(credential)
 
-    return baseFetch(input, {
+    return baseFetch(initialRequest.input, {
       ...fetchInit,
-      headers: withAuthorizationHeader(fetchInit.headers, credential),
+      headers: withAuthorizationHeader(initialRequest.headers, credential),
     })
   }
 
@@ -104,6 +106,8 @@ type AnyContextFor<methods extends readonly Method.AnyClient[]> = {
 
 export declare namespace from {
   type Config<methods extends readonly Method.AnyClient[] = readonly Method.AnyClient[]> = {
+    /** Resolved `Accept-Payment` header and selection preferences. */
+    acceptPayment?: AcceptPayment.Resolved<methods> | undefined
     /** Custom fetch function to wrap. Defaults to `globalThis.fetch`. */
     fetch?: typeof globalThis.fetch
     /** Array of methods to use. */
@@ -219,6 +223,47 @@ function withAuthorizationHeader(headers: unknown, credential: string): Record<s
 }
 
 /** @internal */
+function prepareInitialRequest<methods extends readonly Method.AnyClient[]>(
+  input: RequestInfo | URL,
+  init: from.RequestInit<methods> | undefined,
+  callerHeaders: Headers,
+  header: string,
+  hasExplicitAcceptPayment: boolean,
+): { headers: Headers; init: from.RequestInit<methods> | undefined; input: RequestInfo | URL } {
+  const shouldInjectAcceptPayment = Boolean(header) && !hasExplicitAcceptPayment
+  if (!shouldInjectAcceptPayment) return { headers: callerHeaders, init, input }
+
+  const headers = new Headers(input instanceof Request ? input.headers : undefined)
+  callerHeaders.forEach((value, key) => {
+    headers.set(key, value)
+  })
+  headers.set('Accept-Payment', header)
+
+  if (init) {
+    // Preserve init identity for callers like websocket upgrade helpers that
+    // depend on the original RequestInit object reaching the underlying fetch.
+    ;(init as from.RequestInit<methods> & { headers?: HeadersInit }).headers = headers
+    return {
+      headers,
+      init,
+      input,
+    }
+  }
+
+  return {
+    headers,
+    init: shouldInjectAcceptPayment ? ({ headers } as from.RequestInit<methods>) : undefined,
+    input,
+  }
+}
+
+/** @internal */
+function getCallerHeaders(input: RequestInfo | URL, headers: HeadersInit | undefined): Headers {
+  if (headers) return new Headers(headers)
+  return new Headers(input instanceof Request ? input.headers : undefined)
+}
+
+/** @internal */
 function unwrapFetch(fetch: typeof globalThis.fetch): typeof globalThis.fetch {
   let current = fetch as WrappedFetch
   while (current[MPPX_FETCH_WRAPPER]) {
@@ -250,4 +295,25 @@ async function resolveCredential(
   return mi.createCredential(
     parsedContext !== undefined ? { challenge, context: parsedContext } : ({ challenge } as never),
   )
+}
+
+function resolvePaymentPreferences<methods extends readonly Method.AnyClient[]>(
+  headers: Headers,
+  acceptPayment: AcceptPayment.Resolved<methods>,
+): AcceptPayment.Resolved<methods> {
+  const header = headers.get('Accept-Payment')
+  if (!header) return acceptPayment
+
+  try {
+    return {
+      ...acceptPayment,
+      entries: AcceptPayment.parse(header),
+      header,
+    }
+  } catch {
+    // Fail open for explicit malformed headers: preserve the caller's header on
+    // the wire, but continue automatic challenge selection with configured
+    // defaults instead of throwing from the wrapper.
+    return acceptPayment
+  }
 }

--- a/src/internal/AcceptPayment.test.ts
+++ b/src/internal/AcceptPayment.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, test } from 'vp/test'
+
+import * as AcceptPayment from './AcceptPayment.js'
+
+function stripIndex(entry: AcceptPayment.Entry) {
+  const { index: _index, ...rest } = entry
+  return rest
+}
+
+describe('AcceptPayment', () => {
+  test('resolve builds a typed header from methods and overrides', () => {
+    const resolved = AcceptPayment.resolve(
+      [
+        { name: 'tempo', intent: 'charge' },
+        { name: 'tempo', intent: 'session' },
+        { name: 'stripe', intent: 'charge' },
+      ] as const,
+      ({ tempo, stripe }) => ({
+        [stripe.charge]: 0.5,
+        [tempo.session]: 0,
+      }),
+    )
+
+    expect(resolved.header).toBe('tempo/charge, tempo/session;q=0, stripe/charge;q=0.5')
+    expect(resolved.keys.tempo.charge).toBe('tempo/charge')
+    expect(resolved.keys.tempo.session).toBe('tempo/session')
+    expect(resolved.keys.stripe.charge).toBe('stripe/charge')
+  })
+
+  test('parse supports q-values and wildcards', () => {
+    expect(
+      AcceptPayment.parse('tempo/*, stripe/charge;q=0.5, */session;q=0').map(stripIndex),
+    ).toEqual([
+      { intent: '*', method: 'tempo', q: 1 },
+      { intent: 'charge', method: 'stripe', q: 0.5 },
+      { intent: 'session', method: '*', q: 0 },
+    ])
+  })
+
+  test('parse raw header vectors into normalized entries', () => {
+    const vectors = [
+      {
+        header: 'tempo/charge',
+        entries: [{ intent: 'charge', method: 'tempo', q: 1 }],
+        normalized: 'tempo/charge',
+      },
+      {
+        header: ' stripe/charge ; q = 0.25 , */session ; q=0 ',
+        entries: [
+          { intent: 'charge', method: 'stripe', q: 0.25 },
+          { intent: 'session', method: '*', q: 0 },
+        ],
+        normalized: 'stripe/charge;q=0.25, */session;q=0',
+      },
+      {
+        header: 'tempo/*;q=1, tempo/charge;q=0, stripe/*;q=0.5',
+        entries: [
+          { intent: '*', method: 'tempo', q: 1 },
+          { intent: 'charge', method: 'tempo', q: 0 },
+          { intent: '*', method: 'stripe', q: 0.5 },
+        ],
+        normalized: 'tempo/*, tempo/charge;q=0, stripe/*;q=0.5',
+      },
+    ] as const
+
+    for (const { entries, header, normalized } of vectors) {
+      const parsed = AcceptPayment.parse(header)
+      expect(parsed.map(stripIndex)).toEqual(entries)
+      expect(AcceptPayment.serialize(parsed)).toBe(normalized)
+    }
+  })
+
+  test('parse rejects empty and malformed headers', () => {
+    expect(() => AcceptPayment.parse('')).toThrow('Accept-Payment header is empty.')
+    expect(() => AcceptPayment.parse('tempo')).toThrow('Invalid Accept-Payment entry: tempo')
+    expect(() => AcceptPayment.parse('Tempo/charge')).toThrow(
+      'Invalid Accept-Payment method: Tempo',
+    )
+    expect(() => AcceptPayment.parse('tempo/charge;q')).toThrow(
+      'Invalid Accept-Payment parameter: q',
+    )
+    expect(() => AcceptPayment.parse('tempo/charge;q=1.001')).toThrow('Expected an HTTP qvalue')
+  })
+
+  test('rank prefers higher q then preserves offer order for ties', () => {
+    const offers = [
+      { method: 'tempo', intent: 'charge' },
+      { method: 'stripe', intent: 'charge' },
+      { method: 'tempo', intent: 'session' },
+    ]
+    const preferences = AcceptPayment.parse(
+      'stripe/charge;q=0.5, tempo/charge;q=0.9, tempo/session;q=0.9',
+    )
+
+    expect(AcceptPayment.rank(offers, preferences)).toEqual([
+      { method: 'tempo', intent: 'charge' },
+      { method: 'tempo', intent: 'session' },
+      { method: 'stripe', intent: 'charge' },
+    ])
+  })
+
+  test('rank prefers more specific wildcard matches', () => {
+    const preferences = AcceptPayment.parse('tempo/*;q=0.5, tempo/session;q=0.5, */*;q=0.1')
+
+    expect(AcceptPayment.rank([{ method: 'tempo', intent: 'session' }], preferences)).toEqual([
+      { method: 'tempo', intent: 'session' },
+    ])
+  })
+
+  test('rank applies the most specific match before q-value filtering', () => {
+    const preferences = AcceptPayment.parse('tempo/*;q=1, tempo/charge;q=0, stripe/*;q=0.5')
+
+    expect(
+      AcceptPayment.rank(
+        [
+          { method: 'tempo', intent: 'charge' },
+          { method: 'stripe', intent: 'charge' },
+        ],
+        preferences,
+      ),
+    ).toEqual([{ method: 'stripe', intent: 'charge' }])
+  })
+
+  test('rank excludes offers matched only by q=0 preferences', () => {
+    const preferences = AcceptPayment.parse('tempo/charge;q=0, stripe/*;q=0.1')
+
+    expect(
+      AcceptPayment.rank(
+        [
+          { method: 'tempo', intent: 'charge' },
+          { method: 'stripe', intent: 'session' },
+        ],
+        preferences,
+      ),
+    ).toEqual([{ method: 'stripe', intent: 'session' }])
+  })
+
+  test('selectChallenge returns the best supported offer', () => {
+    const selected = AcceptPayment.selectChallenge(
+      [
+        { id: '1', intent: 'charge', method: 'stripe', realm: 'test', request: {} },
+        { id: '2', intent: 'session', method: 'tempo', realm: 'test', request: {} },
+      ],
+      [
+        { name: 'tempo', intent: 'session' },
+        { name: 'stripe', intent: 'charge' },
+      ] as const,
+      AcceptPayment.parse('stripe/charge;q=0.5, tempo/session;q=0.9'),
+    )
+
+    expect(selected?.challenge.id).toBe('2')
+    expect(selected?.method).toEqual({ name: 'tempo', intent: 'session' })
+  })
+
+  test('selectChallenge honors a specific opt-out over a broader wildcard', () => {
+    const selected = AcceptPayment.selectChallenge(
+      [
+        { id: '1', intent: 'charge', method: 'tempo', realm: 'test', request: {} },
+        { id: '2', intent: 'charge', method: 'stripe', realm: 'test', request: {} },
+      ],
+      [
+        { name: 'tempo', intent: 'charge' },
+        { name: 'stripe', intent: 'charge' },
+      ] as const,
+      AcceptPayment.parse('tempo/*;q=1, tempo/charge;q=0, stripe/*;q=0.5'),
+    )
+
+    expect(selected?.challenge.id).toBe('2')
+    expect(selected?.method).toEqual({ name: 'stripe', intent: 'charge' })
+  })
+
+  test('selectChallenge returns undefined when supported offers are disabled', () => {
+    const selected = AcceptPayment.selectChallenge(
+      [
+        { id: '1', intent: 'charge', method: 'tempo', realm: 'test', request: {} },
+        { id: '2', intent: 'charge', method: 'stripe', realm: 'test', request: {} },
+      ],
+      [{ name: 'tempo', intent: 'charge' }] as const,
+      AcceptPayment.parse('tempo/charge;q=0, stripe/charge'),
+    )
+
+    expect(selected).toBeUndefined()
+  })
+
+  test('throws for unknown payment preference keys', () => {
+    expect(() =>
+      AcceptPayment.resolve(
+        [{ name: 'tempo', intent: 'charge' }] as const,
+        {
+          'stripe/charge': 1,
+        } as never,
+      ),
+    ).toThrow('Unknown payment preference "stripe/charge"')
+  })
+
+  test('throws for invalid configured q-values', () => {
+    expect(() =>
+      AcceptPayment.resolve([{ name: 'tempo', intent: 'charge' }] as const, {
+        'tempo/charge': 0.3333,
+      }),
+    ).toThrow('Expected at most 3 decimal places')
+  })
+
+  test('throws for non-finite configured q-values', () => {
+    expect(() =>
+      AcceptPayment.resolve([{ name: 'tempo', intent: 'charge' }] as const, {
+        'tempo/charge': Number.POSITIVE_INFINITY,
+      }),
+    ).toThrow('Expected a finite number')
+  })
+})

--- a/src/internal/AcceptPayment.ts
+++ b/src/internal/AcceptPayment.ts
@@ -1,0 +1,304 @@
+import type * as Challenge from '../Challenge.js'
+
+type MethodLike = {
+  intent: string
+  name: string
+}
+
+/** Typed `method/intent` key for a configured payment capability. */
+export type Key<methods extends readonly MethodLike[]> = methods[number] extends infer mi
+  ? mi extends { name: infer name extends string; intent: infer intent extends string }
+    ? `${name}/${intent}`
+    : never
+  : never
+
+/** Method keys grouped by method name for ergonomic config callbacks. */
+export type KeyTree<methods extends readonly MethodLike[]> = {
+  [name in methods[number]['name']]: {
+    [mi in Extract<
+      methods[number],
+      { name: name }
+    > as mi['intent']]: `${mi['name']}/${mi['intent']}`
+  }
+}
+
+/** Per-capability q-values keyed by typed `method/intent` strings. */
+export type Definition<methods extends readonly MethodLike[]> = Partial<
+  Record<Key<methods>, number>
+>
+
+/**
+ * Accept-Payment configuration.
+ *
+ * Callers may provide a plain definition map or a callback that receives a
+ * typed key tree for authoring preferences without string literals.
+ */
+export type Config<methods extends readonly MethodLike[]> =
+  | Definition<methods>
+  | ((keys: KeyTree<methods>) => Definition<methods>)
+
+/** Parsed Accept-Payment entry with its original declaration order. */
+export type Entry = {
+  intent: string | '*'
+  method: string | '*'
+  q: number
+  index: number
+}
+
+/** Resolved negotiation data derived from client methods and config. */
+export type Resolved<methods extends readonly MethodLike[]> = {
+  definition: Definition<methods>
+  entries: Entry[]
+  header: string
+  keys: KeyTree<methods>
+}
+
+type Match = Entry & { specificity: number }
+
+/** Builds the typed key tree used by callback-style preference config. */
+export function buildKeys<const methods extends readonly MethodLike[]>(
+  methods: methods,
+): KeyTree<methods> {
+  const keys: Record<string, Record<string, string>> = {}
+
+  for (const method of methods) {
+    const group = (keys[method.name] ??= {})
+    group[method.intent] = keyOf(method)
+  }
+
+  return keys as KeyTree<methods>
+}
+
+/** Resolves configured payment preferences into a header string and parsed entries. */
+export function resolve<const methods extends readonly MethodLike[]>(
+  methods: methods,
+  config?: Config<methods>,
+): Resolved<methods> {
+  const keys = buildKeys(methods)
+  const definition = resolveDefinition(methods, keys, config)
+  const entries = methods.map((method, index) => ({
+    intent: method.intent,
+    method: method.name,
+    q: definition[keyOf(method) as Key<methods>] ?? 1,
+    index,
+  }))
+
+  return {
+    definition,
+    entries,
+    header: serialize(entries),
+    keys,
+  }
+}
+
+/** Parses an `Accept-Payment` header into normalized preference entries. */
+export function parse(header: string): Entry[] {
+  const parts = header
+    .split(/\s*,\s*/)
+    .map((part) => part.trim())
+    .filter(Boolean)
+
+  if (parts.length === 0) throw new Error('Accept-Payment header is empty.')
+
+  return parts.map((part, index) => parseEntry(part, index))
+}
+
+/** Serializes preference entries to an `Accept-Payment` header value. */
+export function serialize(entries: readonly Omit<Entry, 'index'>[] | readonly Entry[]): string {
+  return entries
+    .map(({ method, intent, q }) => {
+      const value = `${method}/${intent}`
+      return q === 1 ? value : `${value};q=${formatQ(q)}`
+    })
+    .join(', ')
+}
+
+/**
+ * Orders offered payment methods by the best matching client preference.
+ *
+ * More specific matches win before comparing q-values, so an explicit opt-out
+ * like `tempo/charge;q=0` overrides a broader wildcard such as `tempo/*;q=1`.
+ */
+export function rank<const offer extends { intent: string; method: string }>(
+  offers: readonly offer[],
+  preferences: readonly Entry[],
+): offer[] {
+  return offers
+    .map((offer, index) => {
+      const match = bestMatch(offer, preferences)
+      return match && match.q > 0 ? { match, offer, index } : undefined
+    })
+    .filter((candidate): candidate is NonNullable<typeof candidate> => Boolean(candidate))
+    .sort((left, right) => right.match.q - left.match.q || left.index - right.index)
+    .map(({ offer }) => offer)
+}
+
+/** Selects the best supported challenge from a set of server offers. */
+export function selectChallenge<const methods extends readonly MethodLike[]>(
+  challenges: readonly Challenge.Challenge[],
+  methods: methods,
+  preferences: readonly Entry[],
+):
+  | {
+      challenge: Challenge.Challenge
+      method: methods[number]
+    }
+  | undefined {
+  const methodByKey = new Map<string, methods[number]>()
+  for (const method of methods) {
+    const key = keyOf(method)
+    if (!methodByKey.has(key)) methodByKey.set(key, method)
+  }
+
+  const ranked = rank(
+    challenges.filter((challenge) => methodByKey.has(keyOf(challenge))),
+    preferences,
+  )
+  const challenge = ranked[0]
+  if (!challenge) return undefined
+
+  return {
+    challenge,
+    method: methodByKey.get(keyOf(challenge))!,
+  }
+}
+
+/** Returns the canonical `method/intent` key for a method or challenge-like value. */
+export function keyOf(value: { intent: string; method?: string; name?: string }): string {
+  const method = value.method ?? value.name
+  if (!method) throw new Error('Missing payment method name.')
+  return `${method}/${value.intent}`
+}
+
+function bestMatch(
+  offer: { intent: string; method: string },
+  preferences: readonly Entry[],
+): Match | undefined {
+  let best: Match | undefined
+
+  for (const preference of preferences) {
+    if (!matches(offer, preference)) continue
+
+    const candidate = { ...preference, specificity: specificity(preference) }
+    if (
+      !best ||
+      candidate.specificity > best.specificity ||
+      (candidate.specificity === best.specificity && candidate.q > best.q) ||
+      (candidate.specificity === best.specificity &&
+        candidate.q === best.q &&
+        candidate.index < best.index)
+    ) {
+      best = candidate
+    }
+  }
+
+  return best
+}
+
+function matches(
+  offer: { intent: string; method: string },
+  preference: Pick<Entry, 'intent' | 'method'>,
+): boolean {
+  return (
+    (preference.method === '*' || preference.method === offer.method) &&
+    (preference.intent === '*' || preference.intent === offer.intent)
+  )
+}
+
+function specificity(preference: Pick<Entry, 'intent' | 'method'>): number {
+  return Number(preference.method !== '*') + Number(preference.intent !== '*')
+}
+
+function parseEntry(part: string, index: number): Entry {
+  const match =
+    /^(?<method>[^/;\s]+|\*)\s*\/\s*(?<intent>[^/;\s]+|\*)(?<params>(?:\s*;\s*.+)?)$/u.exec(part)
+  const method = match?.groups?.method
+  const intent = match?.groups?.intent
+
+  if (!method || !intent) {
+    throw new Error(`Invalid Accept-Payment entry: ${part}`)
+  }
+
+  assertToken(method, 'method')
+  assertToken(intent, 'intent')
+
+  let q = 1
+  for (const param of splitParameters(match.groups?.params)) {
+    if (!param) continue
+
+    const parameterMatch = /^(?<name>[A-Za-z0-9_-]+)\s*=\s*(?<value>\S+)$/u.exec(param)
+    const name = parameterMatch?.groups?.name
+    const rawValue = parameterMatch?.groups?.value
+
+    if (!name || !rawValue) {
+      throw new Error(`Invalid Accept-Payment parameter: ${param}`)
+    }
+    if (name !== 'q') continue
+    q = parseHeaderQ(rawValue, `Accept-Payment entry "${part}"`)
+  }
+
+  return { intent, method, q, index }
+}
+
+function splitParameters(value?: string): string[] {
+  return value ? value.split(/\s*;\s*/).filter(Boolean) : []
+}
+
+function resolveDefinition<const methods extends readonly MethodLike[]>(
+  methods: methods,
+  keys: KeyTree<methods>,
+  config?: Config<methods>,
+): Definition<methods> {
+  if (!config) return {} as Definition<methods>
+
+  const raw = typeof config === 'function' ? config(keys) : config
+  const allowed = new Set(methods.map((method) => keyOf(method)))
+  const normalized: Record<string, number> = {}
+
+  for (const [key, value] of Object.entries(raw ?? {})) {
+    if (!allowed.has(key)) {
+      throw new Error(`Unknown payment preference "${key}". Available: ${[...allowed].join(', ')}`)
+    }
+    normalized[key] = parseQ(value, `payment preference "${key}"`)
+  }
+
+  return normalized as Definition<methods>
+}
+
+function parseQ(value: unknown, context: string): number {
+  if (typeof value !== 'number' || Number.isNaN(value) || !Number.isFinite(value)) {
+    throw new Error(`Invalid q-value for ${context}. Expected a finite number.`)
+  }
+  return assertQ(value, context)
+}
+
+function parseHeaderQ(value: string, context: string): number {
+  if (!/^0(?:\.\d{0,3})?$|^1(?:\.0{0,3})?$/.test(value)) {
+    throw new Error(`Invalid q-value for ${context}. Expected an HTTP qvalue.`)
+  }
+  return assertQ(Number(value), context)
+}
+
+function assertQ(value: number, context: string): number {
+  if (value < 0 || value > 1) {
+    throw new Error(`Invalid q-value for ${context}. Expected a value between 0 and 1.`)
+  }
+  const rounded = Math.round(value * 1000)
+  if (Math.abs(value * 1000 - rounded) > 1e-9) {
+    throw new Error(`Invalid q-value for ${context}. Expected at most 3 decimal places.`)
+  }
+  return rounded / 1000
+}
+
+function formatQ(value: number): string {
+  return value
+    .toFixed(3)
+    .replace(/\.0+$/, '')
+    .replace(/(\.\d*?)0+$/, '$1')
+}
+
+function assertToken(value: string, label: string): void {
+  if (value !== '*' && !/^[a-z0-9-]+$/.test(value)) {
+    throw new Error(`Invalid Accept-Payment ${label}: ${value}`)
+  }
+}

--- a/src/mcp-sdk/client/McpClient.ts
+++ b/src/mcp-sdk/client/McpClient.ts
@@ -3,6 +3,7 @@ import type { McpError } from '@modelcontextprotocol/sdk/types.js'
 
 import type * as Challenge from '../../Challenge.js'
 import * as Credential from '../../Credential.js'
+import * as AcceptPayment from '../../internal/AcceptPayment.js'
 import * as core_Mcp from '../../Mcp.js'
 import type * as Method from '../../Method.js'
 import type * as z from '../../zod.js'
@@ -51,6 +52,7 @@ export function wrap<
   const methods extends readonly Method.AnyClient[],
 >(client: client, config: wrap.Config<methods>): wrap.McpClient<client, methods> {
   const { methods } = config
+  const paymentPreferences = AcceptPayment.resolve(methods)
 
   return {
     ...client,
@@ -76,11 +78,12 @@ export function wrap<
         const challenges = (error.data as { challenges?: Challenge.Challenge[] })?.challenges
         if (!challenges?.length) throw error
 
-        // Select first challenge that matches an installed method intent
-        const challenge = challenges.find((c) =>
-          methods.some((m) => m.name === c.method && m.intent === c.intent),
+        const selected = AcceptPayment.selectChallenge(
+          challenges,
+          methods,
+          paymentPreferences.entries,
         )
-        if (!challenge) {
+        if (!selected) {
           const available = challenges.map((c) => `${c.method}.${c.intent}`).join(', ')
           const installed = methods.map((m) => `${m.name}.${m.intent}`).join(', ')
           throw new Error(
@@ -89,7 +92,10 @@ export function wrap<
           )
         }
 
-        const credential = await createCredential(challenge, { context, methods })
+        const credential = await createCredential(selected.challenge, {
+          context,
+          methods,
+        })
         const parsed = Credential.deserialize(credential)
 
         const retryResult = await client.callTool(

--- a/src/server/Mppx.test.ts
+++ b/src/server/Mppx.test.ts
@@ -127,6 +127,50 @@ describe('request handler', () => {
     expect(body.detail).not.toContain('rpc.example.com')
   })
 
+  test('returns 402 when challenge ID mismatch', async () => {
+    const wrongChallenge = Challenge.from({
+      id: 'wrong-id',
+      intent: 'charge',
+      method: 'tempo',
+      realm,
+      request: { amount: '1000', currency: asset, recipient: accounts[0].address },
+    })
+    const credential = Credential.from({
+      challenge: wrongChallenge,
+      payload: { signature: '0x123', type: 'transaction' },
+    })
+
+    const request = new Request('https://example.com/resource', {
+      headers: { Authorization: Credential.serialize(credential) },
+    })
+
+    const result = await Mppx.create({ methods: [method], realm, secretKey }).charge({
+      amount: '1000',
+      currency: asset,
+      expires: new Date(Date.now() + 60_000).toISOString(),
+      recipient: accounts[0].address,
+    })(request)
+
+    expect(result.status).toBe(402)
+    if (result.status !== 402) throw new Error()
+
+    const body = (await result.challenge.json()) as object
+    expect({
+      ...body,
+      challengeId: '[challengeId]',
+      instance: '[instance]',
+    }).toMatchInlineSnapshot(`
+      {
+        "challengeId": "[challengeId]",
+        "detail": "Challenge "wrong-id" is invalid: challenge was not issued by this server.",
+        "instance": "[instance]",
+        "status": 402,
+        "title": "Invalid Challenge",
+        "type": "https://paymentauth.org/problems/invalid-challenge",
+      }
+    `)
+  })
+
   test('captures each transport request once and threads the verified envelope additively', async () => {
     const requestMethod = Method.from({
       name: 'mock',
@@ -230,50 +274,6 @@ describe('request handler', () => {
     expect(respondEnvelope?.capturedRequest).toBe(requestCapturedRequest)
     expect(receiptEnvelope?.capturedRequest).toBe(requestCapturedRequest)
     expect(receiptEnvelope?.challenge.id).toBe(credential.challenge.id)
-  })
-
-  test('returns 402 when challenge ID mismatch', async () => {
-    const wrongChallenge = Challenge.from({
-      id: 'wrong-id',
-      intent: 'charge',
-      method: 'tempo',
-      realm,
-      request: { amount: '1000', currency: asset, recipient: accounts[0].address },
-    })
-    const credential = Credential.from({
-      challenge: wrongChallenge,
-      payload: { signature: '0x123', type: 'transaction' },
-    })
-
-    const request = new Request('https://example.com/resource', {
-      headers: { Authorization: Credential.serialize(credential) },
-    })
-
-    const result = await Mppx.create({ methods: [method], realm, secretKey }).charge({
-      amount: '1000',
-      currency: asset,
-      expires: new Date(Date.now() + 60_000).toISOString(),
-      recipient: accounts[0].address,
-    })(request)
-
-    expect(result.status).toBe(402)
-    if (result.status !== 402) throw new Error()
-
-    const body = (await result.challenge.json()) as object
-    expect({
-      ...body,
-      challengeId: '[challengeId]',
-      instance: '[instance]',
-    }).toMatchInlineSnapshot(`
-      {
-        "challengeId": "[challengeId]",
-        "detail": "Challenge "wrong-id" is invalid: challenge was not issued by this server.",
-        "instance": "[instance]",
-        "status": 402,
-        "title": "Invalid Challenge",
-        "type": "https://paymentauth.org/problems/invalid-challenge",
-      }
-    `)
   })
 
   test('returns 402 when credential is from a different route (cross-route scope confusion)', async () => {
@@ -980,6 +980,103 @@ describe('compose', () => {
     const wwwAuth = result.challenge.headers.get('WWW-Authenticate')!
     expect(wwwAuth).toContain('method="alpha"')
     expect(wwwAuth).toContain('method="beta"')
+  })
+
+  test('filters compose challenges using Accept-Payment', async () => {
+    const mppx = Mppx.create({ methods: [alphaMethod, betaMethod], realm, secretKey })
+
+    const result = await mppx.compose(
+      [alphaMethod, challengeOpts],
+      [betaMethod, challengeOpts],
+    )(
+      new Request('https://example.com/resource', {
+        headers: { 'Accept-Payment': 'beta/charge' },
+      }),
+    )
+
+    expect(result.status).toBe(402)
+    if (result.status !== 402) throw new Error()
+
+    const challenges = Challenge.fromResponseList(result.challenge)
+    expect(challenges).toHaveLength(1)
+    expect(challenges[0]?.method).toBe('beta')
+  })
+
+  test('orders compose challenges by Accept-Payment q-value', async () => {
+    const mppx = Mppx.create({ methods: [alphaMethod, betaMethod], realm, secretKey })
+
+    const result = await mppx.compose(
+      [alphaMethod, challengeOpts],
+      [betaMethod, challengeOpts],
+    )(
+      new Request('https://example.com/resource', {
+        headers: { 'Accept-Payment': 'beta/charge;q=0.9, alpha/charge;q=0.3' },
+      }),
+    )
+
+    expect(result.status).toBe(402)
+    if (result.status !== 402) throw new Error()
+
+    const challenges = Challenge.fromResponseList(result.challenge)
+    expect(challenges.map((challenge) => challenge.method)).toEqual(['beta', 'alpha'])
+  })
+
+  test('applies a specific Accept-Payment opt-out before broader wildcards', async () => {
+    const mppx = Mppx.create({ methods: [alphaMethod, betaMethod], realm, secretKey })
+
+    const result = await mppx.compose(
+      [alphaMethod, challengeOpts],
+      [betaMethod, challengeOpts],
+    )(
+      new Request('https://example.com/resource', {
+        headers: { 'Accept-Payment': 'alpha/*;q=1, alpha/charge;q=0, beta/*;q=0.5' },
+      }),
+    )
+
+    expect(result.status).toBe(402)
+    if (result.status !== 402) throw new Error()
+
+    const challenges = Challenge.fromResponseList(result.challenge)
+    expect(challenges).toHaveLength(1)
+    expect(challenges[0]?.method).toBe('beta')
+  })
+
+  test('falls back to all compose challenges when Accept-Payment has no matches', async () => {
+    const mppx = Mppx.create({ methods: [alphaMethod, betaMethod], realm, secretKey })
+
+    const result = await mppx.compose(
+      [alphaMethod, challengeOpts],
+      [betaMethod, challengeOpts],
+    )(
+      new Request('https://example.com/resource', {
+        headers: { 'Accept-Payment': 'gamma/charge' },
+      }),
+    )
+
+    expect(result.status).toBe(402)
+    if (result.status !== 402) throw new Error()
+
+    const challenges = Challenge.fromResponseList(result.challenge)
+    expect(challenges.map((challenge) => challenge.method)).toEqual(['alpha', 'beta'])
+  })
+
+  test('falls back to all compose challenges when Accept-Payment is invalid', async () => {
+    const mppx = Mppx.create({ methods: [alphaMethod, betaMethod], realm, secretKey })
+
+    const result = await mppx.compose(
+      [alphaMethod, challengeOpts],
+      [betaMethod, challengeOpts],
+    )(
+      new Request('https://example.com/resource', {
+        headers: { 'Accept-Payment': 'not a valid header' },
+      }),
+    )
+
+    expect(result.status).toBe(402)
+    if (result.status !== 402) throw new Error()
+
+    const challenges = Challenge.fromResponseList(result.challenge)
+    expect(challenges.map((challenge) => challenge.method)).toEqual(['alpha', 'beta'])
   })
 
   test('dispatches to matching handler when credential matches alpha', async () => {

--- a/src/server/Mppx.ts
+++ b/src/server/Mppx.ts
@@ -5,8 +5,9 @@ import * as Challenge from '../Challenge.js'
 import * as Credential from '../Credential.js'
 import * as Errors from '../Errors.js'
 import * as Expires from '../Expires.js'
+import * as AcceptPayment from '../internal/AcceptPayment.js'
 import * as Env from '../internal/env.js'
-import * as Method from '../Method.js'
+import type * as Method from '../Method.js'
 import * as PaymentRequest from '../PaymentRequest.js'
 import type * as Receipt from '../Receipt.js'
 import type * as z from '../zod.js'
@@ -447,22 +448,22 @@ function createMethodFn(parameters: createMethodFn.Parameters): createMethodFn.R
           withReceipt<response>(response?: response) {
             if (managementResponse) {
               return transport.respondReceipt({
+                challengeId: credential.challenge.id,
                 credential,
                 envelope,
                 input,
                 receipt: receiptData,
                 response: managementResponse as never,
-                challengeId: credential.challenge.id,
               }) as response
             }
             if (!response) throw new Error('withReceipt() requires a response argument')
             return transport.respondReceipt({
+              challengeId: credential.challenge.id,
               credential,
               envelope,
               input,
               receipt: receiptData,
               response: response as never,
-              challengeId: credential.challenge.id,
             }) as response
           },
         }
@@ -883,37 +884,57 @@ export function compose(
     // No credential — call all handlers and merge 402 challenges.
     const results = await Promise.all(handlers.map((h) => h(input)))
 
+    const challengeEntries = (() => {
+      const entries: {
+        handler: ConfiguredHandler
+        challenge: Challenge.Challenge
+        result: Extract<MethodFn.Response<Transport.Http>, { status: 402 }>
+      }[] = []
+
+      for (let i = 0; i < handlers.length; i++) {
+        const result = results[i]
+        if (result?.status !== 402) continue
+
+        const response = result.challenge as Response
+        const wwwAuth = response.headers.get('WWW-Authenticate')
+        if (!wwwAuth) continue
+
+        entries.push({
+          handler: handlers[i] as ConfiguredHandler,
+          challenge: Challenge.deserialize(wwwAuth),
+          result,
+        })
+      }
+
+      const acceptPayment = input.headers.get('Accept-Payment')
+      if (!acceptPayment) return entries
+
+      try {
+        const ranked = AcceptPayment.rank(
+          entries.map((entry) => entry.challenge),
+          AcceptPayment.parse(acceptPayment),
+        )
+        if (ranked.length === 0) return entries
+
+        const entriesById = new Map(entries.map((entry) => [entry.challenge.id, entry] as const))
+        return ranked.map((challenge) => entriesById.get(challenge.id)!)
+      } catch {
+        return entries
+      }
+    })()
+
     // Merge WWW-Authenticate headers from all 402 responses.
     const mergedHeaders = new Headers()
     mergedHeaders.set('Cache-Control', 'no-store')
 
-    for (const result of results) {
-      if (result.status !== 402) continue
-      const response = result.challenge as Response
+    for (const entry of challengeEntries) {
+      const response = entry.result.challenge as Response
       const wwwAuth = response.headers.get('WWW-Authenticate')
       if (wwwAuth) mergedHeaders.append('WWW-Authenticate', wwwAuth)
     }
 
     // Collect html-enabled handlers and their challenges
-    const htmlEntries = (() => {
-      const entries: {
-        handler: ConfiguredHandler
-        challenge: Challenge.Challenge
-      }[] = []
-      for (let i = 0; i < handlers.length; i++) {
-        const meta = (handlers[i] as ConfiguredHandler)._internal
-        if (!meta?.html) continue
-        const result = results[i]
-        if (result?.status !== 402) continue
-        const wwwAuth = result.challenge.headers.get('WWW-Authenticate')
-        if (!wwwAuth) continue
-        entries.push({
-          handler: handlers[i] as ConfiguredHandler,
-          challenge: Challenge.deserialize(wwwAuth),
-        })
-      }
-      return entries
-    })()
+    const htmlEntries = challengeEntries.filter((entry) => entry.handler._internal?.html)
 
     const wantsHtml = input.headers.get('Accept')?.includes('text/html')
     if (wantsHtml && htmlEntries.length > 0) {
@@ -962,10 +983,9 @@ export function compose(
 
     // Non-HTML fallback: use first handler's body
     let body: string | null = null
-    for (const result of results) {
-      if (result.status !== 402) continue
+    for (const entry of challengeEntries) {
       if (!body) {
-        const response = result.challenge as Response
+        const response = entry.result.challenge as Response
         const contentType = response.headers.get('Content-Type')
         if (contentType) mergedHeaders.set('Content-Type', contentType)
         body = await response.text()

--- a/src/tempo/client/SessionManager.test.ts
+++ b/src/tempo/client/SessionManager.test.ts
@@ -225,13 +225,10 @@ describe('Session', () => {
         // drain
       }
 
-      const calledHeaders = (mockFetch.mock.calls[0]![1] as RequestInit).headers as Record<
-        string,
-        string
-      >
-      expect(calledHeaders['content-type']).toBe('application/json')
-      expect(calledHeaders['x-custom']).toBe('value')
-      expect(calledHeaders.Accept).toBe('text/event-stream')
+      const calledHeaders = new Headers((mockFetch.mock.calls[0]![1] as RequestInit).headers)
+      expect(calledHeaders.get('content-type')).toBe('application/json')
+      expect(calledHeaders.get('x-custom')).toBe('value')
+      expect(calledHeaders.get('accept')).toBe('text/event-stream')
     })
   })
 


### PR DESCRIPTION
Rebased stack of security dependency pins and Accept-Payment capability negotiation onto main.

### Changes

1. **fix: pin @modelcontextprotocol/sdk to 1.27.1** — Pin MCP SDK to avoid breaking changes.

2. **feat: negotiate payment capabilities with Accept-Payment (#308)** — Implements Accept-Payment negotiation from https://github.com/tempoxyz/mpp-specs/pull/231. Adds capability negotiation across client, server, and CLI so a client can advertise supported payment methods, a server can offer multiple challenges, and the client deterministically picks the best match using HTTP-style `q` values, wildcards, and specificity precedence.