### PR TITLE
proposal: mppx.challenge and mppx.verifyCredential interface refactor

### DIFF
--- a/src/server/Mppx.test-d.ts
+++ b/src/server/Mppx.test-d.ts
@@ -133,4 +133,37 @@ describe('Mppx type tests', () => {
   test('static Mppx.compose accepts configured handlers', () => {
     expectTypeOf(Mppx.compose).toBeFunction()
   })
+
+  test('challenge namespace has nested accessors matching methods', () => {
+    const mppx = Mppx.create({ methods: [alphaMethod, betaMethod], realm, secretKey })
+
+    expectTypeOf(mppx.challenge).toBeObject()
+    expectTypeOf(mppx.challenge.alpha).toBeObject()
+    expectTypeOf(mppx.challenge.alpha.charge).toBeFunction()
+    expectTypeOf(mppx.challenge.beta).toBeObject()
+    expectTypeOf(mppx.challenge.beta.charge).toBeFunction()
+  })
+
+  test('challenge functions return Challenge type', () => {
+    const mppx = Mppx.create({ methods: [alphaMethod], realm, secretKey })
+
+    const challenge = mppx.challenge.alpha.charge({
+      amount: '100',
+      currency: '0x01',
+      decimals: 6,
+      recipient: '0x02',
+    })
+
+    expectTypeOf(challenge).toHaveProperty('id')
+    expectTypeOf(challenge).toHaveProperty('realm')
+    expectTypeOf(challenge).toHaveProperty('method')
+    expectTypeOf(challenge).toHaveProperty('intent')
+    expectTypeOf(challenge).toHaveProperty('request')
+  })
+
+  test('verifyCredential exists and returns Promise<Receipt>', () => {
+    const mppx = Mppx.create({ methods: [alphaMethod], realm, secretKey })
+
+    expectTypeOf(mppx.verifyCredential).toBeFunction()
+  })
 })

--- a/src/server/Mppx.test-d.ts
+++ b/src/server/Mppx.test-d.ts
@@ -144,7 +144,7 @@ describe('Mppx type tests', () => {
     expectTypeOf(mppx.challenge.beta.charge).toBeFunction()
   })
 
-  test('challenge functions return Challenge type', () => {
+  test('challenge functions return Promise<Challenge>', () => {
     const mppx = Mppx.create({ methods: [alphaMethod], realm, secretKey })
 
     const challenge = mppx.challenge.alpha.charge({
@@ -154,11 +154,14 @@ describe('Mppx type tests', () => {
       recipient: '0x02',
     })
 
-    expectTypeOf(challenge).toHaveProperty('id')
-    expectTypeOf(challenge).toHaveProperty('realm')
-    expectTypeOf(challenge).toHaveProperty('method')
-    expectTypeOf(challenge).toHaveProperty('intent')
-    expectTypeOf(challenge).toHaveProperty('request')
+    expectTypeOf(challenge).toMatchTypeOf<Promise<unknown>>()
+
+    type AwaitedChallenge = Awaited<typeof challenge>
+    expectTypeOf<AwaitedChallenge>().toHaveProperty('id')
+    expectTypeOf<AwaitedChallenge>().toHaveProperty('realm')
+    expectTypeOf<AwaitedChallenge>().toHaveProperty('method')
+    expectTypeOf<AwaitedChallenge>().toHaveProperty('intent')
+    expectTypeOf<AwaitedChallenge>().toHaveProperty('request')
   })
 
   test('verifyCredential exists and returns Promise<Receipt>', () => {

--- a/src/server/Mppx.test.ts
+++ b/src/server/Mppx.test.ts
@@ -1,9 +1,16 @@
 import * as http from 'node:http'
 
 import { Challenge, Credential, Method, z } from 'mppx'
-import { Mppx, Transport, tempo } from 'mppx/server'
+import {
+  Mppx as Mppx_client,
+  session as tempo_session_client,
+  tempo as tempo_client,
+} from 'mppx/client'
+import { Mppx, stripe, Store, Transport, tempo } from 'mppx/server'
+import { getTransactionReceipt } from 'viem/actions'
 import { describe, expect, test } from 'vp/test'
 import * as Http from '~test/Http.js'
+import { deployEscrow } from '~test/tempo/session.js'
 import { accounts, asset, client } from '~test/tempo/viem.js'
 
 const realm = 'api.example.com'
@@ -2947,14 +2954,14 @@ describe('challenge', () => {
     recipient: '0x0000000000000000000000000000000000000002',
   }
 
-  test('mppx.challenge.alpha.charge returns a valid Challenge object', () => {
+  test('mppx.challenge.alpha.charge returns a valid Challenge object', async () => {
     const mppx = Mppx.create({
       methods: [alphaChargeServer, alphaSessionServer, betaChargeServer],
       realm,
       secretKey,
     })
 
-    const challenge = mppx.challenge.alpha.charge(challengeOpts)
+    const challenge = await mppx.challenge.alpha.charge(challengeOpts)
 
     expect(challenge.method).toBe('alpha')
     expect(challenge.intent).toBe('charge')
@@ -2965,14 +2972,14 @@ describe('challenge', () => {
     expect(challenge.id).toBeDefined()
   })
 
-  test('mppx.challenge.alpha.session returns a valid Challenge object', () => {
+  test('mppx.challenge.alpha.session returns a valid Challenge object', async () => {
     const mppx = Mppx.create({
       methods: [alphaChargeServer, alphaSessionServer, betaChargeServer],
       realm,
       secretKey,
     })
 
-    const challenge = mppx.challenge.alpha.session({
+    const challenge = await mppx.challenge.alpha.session({
       amount: '500',
       currency: '0x0000000000000000000000000000000000000001',
       recipient: '0x0000000000000000000000000000000000000002',
@@ -2985,38 +2992,38 @@ describe('challenge', () => {
     expect(challenge.request.unitType).toBe('token')
   })
 
-  test('mppx.challenge.beta.charge returns challenge for a different method', () => {
+  test('mppx.challenge.beta.charge returns challenge for a different method', async () => {
     const mppx = Mppx.create({
       methods: [alphaChargeServer, betaChargeServer],
       realm,
       secretKey,
     })
 
-    const challenge = mppx.challenge.beta.charge(challengeOpts)
+    const challenge = await mppx.challenge.beta.charge(challengeOpts)
 
     expect(challenge.method).toBe('beta')
     expect(challenge.intent).toBe('charge')
   })
 
-  test('challenge ID is HMAC-bound and verifiable', () => {
+  test('challenge ID is HMAC-bound and verifiable', async () => {
     const mppx = Mppx.create({
       methods: [alphaChargeServer],
       realm,
       secretKey,
     })
 
-    const challenge = mppx.challenge.alpha.charge(challengeOpts)
+    const challenge = await mppx.challenge.alpha.charge(challengeOpts)
     expect(Challenge.verify(challenge, { secretKey })).toBe(true)
   })
 
-  test('challenge includes description and meta when provided', () => {
+  test('challenge includes description and meta when provided', async () => {
     const mppx = Mppx.create({
       methods: [alphaChargeServer],
       realm,
       secretKey,
     })
 
-    const challenge = mppx.challenge.alpha.charge({
+    const challenge = await mppx.challenge.alpha.charge({
       ...challengeOpts,
       description: 'Order #123',
       meta: { checkout_id: 'chk_abc' },
@@ -3026,7 +3033,7 @@ describe('challenge', () => {
     expect(challenge.opaque).toEqual({ checkout_id: 'chk_abc' })
   })
 
-  test('challenge applies schema transforms', () => {
+  test('challenge applies schema transforms', async () => {
     // Method with a z.transform that converts decimals
     const transformMethod = Method.from({
       name: 'transform',
@@ -3057,7 +3064,7 @@ describe('challenge', () => {
 
     const mppx = Mppx.create({ methods: [serverMethod], realm, secretKey })
 
-    const challenge = mppx.challenge.transform.charge({
+    const challenge = await mppx.challenge.transform.charge({
       amount: '25.92',
       currency: '0x0000000000000000000000000000000000000001',
       decimals: 6,
@@ -3068,6 +3075,53 @@ describe('challenge', () => {
     expect(challenge.request.amount).toBe('25920000')
   })
 
+  test('challenge awaits async request hooks before creating the challenge', async () => {
+    const asyncMethod = Method.from({
+      name: 'async',
+      intent: 'charge',
+      schema: {
+        credential: { payload: z.object({ token: z.string() }) },
+        request: z.pipe(
+          z.object({
+            amount: z.string(),
+            chainId: z.optional(z.number()),
+            currency: z.string(),
+            decimals: z.number(),
+            recipient: z.string(),
+          }),
+          z.transform(({ amount, chainId, currency, decimals, recipient }) => ({
+            amount: String(Number(amount) * 10 ** decimals),
+            currency,
+            methodDetails: { chainId },
+            recipient,
+          })),
+        ),
+      },
+    })
+
+    const asyncServer = Method.toServer(asyncMethod, {
+      async request({ request }) {
+        await Promise.resolve()
+        return { ...request, chainId: 42431 }
+      },
+      async verify() {
+        return mockReceipt('async')
+      },
+    })
+
+    const mppx = Mppx.create({ methods: [asyncServer], realm, secretKey })
+
+    const challenge = await mppx.challenge.async.charge({
+      amount: '25.92',
+      currency: '0x0000000000000000000000000000000000000001',
+      decimals: 6,
+      recipient: '0x0000000000000000000000000000000000000002',
+    })
+
+    expect(challenge.request.amount).toBe('25920000')
+    expect(challenge.request.methodDetails).toEqual({ chainId: 42431 })
+  })
+
   test('challenge produced by mppx.challenge is accepted by the 402 handler', async () => {
     const mppx = Mppx.create({
       methods: [alphaChargeServer],
@@ -3076,7 +3130,7 @@ describe('challenge', () => {
     })
 
     // Generate challenge via the new API
-    const challenge = mppx.challenge.alpha.charge(challengeOpts)
+    const challenge = await mppx.challenge.alpha.charge(challengeOpts)
 
     // Build a credential from it
     const credential = Credential.from({ challenge, payload: { token: 'valid' } })
@@ -3189,7 +3243,7 @@ describe('verifyCredential', () => {
       secretKey,
     })
 
-    const challenge = mppx.challenge.alpha.charge(challengeOpts)
+    const challenge = await mppx.challenge.alpha.charge(challengeOpts)
     const credential = Credential.from({ challenge, payload: { token: 'valid' } })
     const serialized = Credential.serialize(credential)
 
@@ -3208,7 +3262,7 @@ describe('verifyCredential', () => {
       secretKey,
     })
 
-    const challenge = mppx.challenge.alpha.charge(challengeOpts)
+    const challenge = await mppx.challenge.alpha.charge(challengeOpts)
     const credential = Credential.from({ challenge, payload: { token: 'valid' } })
 
     const receipt = await mppx.verifyCredential(credential)
@@ -3225,7 +3279,7 @@ describe('verifyCredential', () => {
       secretKey,
     })
 
-    const challenge = mppx.challenge.alpha.session({
+    const challenge = await mppx.challenge.alpha.session({
       amount: '500',
       currency: '0x0000000000000000000000000000000000000001',
       recipient: '0x0000000000000000000000000000000000000002',
@@ -3249,7 +3303,7 @@ describe('verifyCredential', () => {
       secretKey,
     })
 
-    const challenge = mppx.challenge.beta.charge(challengeOpts)
+    const challenge = await mppx.challenge.beta.charge(challengeOpts)
     const credential = Credential.from({ challenge, payload: { token: 'valid' } })
 
     const receipt = await mppx.verifyCredential(credential)
@@ -3293,7 +3347,7 @@ describe('verifyCredential', () => {
       secretKey,
     })
 
-    const challenge = mppx.challenge.alpha.charge({
+    const challenge = await mppx.challenge.alpha.charge({
       ...challengeOpts,
       expires: new Date(Date.now() - 1000).toISOString(), // already expired
     })
@@ -3309,7 +3363,7 @@ describe('verifyCredential', () => {
       secretKey,
     })
 
-    const challenge = mppx.challenge.alpha.charge(challengeOpts)
+    const challenge = await mppx.challenge.alpha.charge(challengeOpts)
     const credential = Credential.from({
       challenge,
       payload: { wrong_field: 123 }, // doesn't match z.object({ token: z.string() })
@@ -3385,7 +3439,7 @@ describe('verifyCredential', () => {
     const mppx = Mppx.create({ methods: [serverMethod], realm, secretKey })
 
     // Generate challenge with human-readable amount
-    const challenge = mppx.challenge.transform.charge({
+    const challenge = await mppx.challenge.transform.charge({
       amount: '25.92',
       currency: '0x0000000000000000000000000000000000000001',
       decimals: 6,
@@ -3403,6 +3457,317 @@ describe('verifyCredential', () => {
     expect(receipt.method).toBe('transform')
   })
 
+  test('verifies a credential for a transformed built-in method', async () => {
+    const stripeClient = {
+      paymentIntents: {
+        create: async (input: { amount: number; currency: string }) => {
+          expect(input.amount).toBe(2592)
+          expect(input.currency).toBe('usd')
+
+          return {
+            id: 'pi_123',
+            lastResponse: { headers: {} },
+            status: 'succeeded',
+          }
+        },
+      },
+    }
+
+    const mppx = Mppx.create({
+      methods: [
+        stripe.charge({
+          client: stripeClient as never,
+          currency: 'usd',
+          decimals: 2,
+          networkId: 'internal',
+          paymentMethodTypes: ['card'],
+        }),
+      ],
+      realm,
+      secretKey,
+    })
+
+    const challenge = await mppx.challenge.stripe.charge({
+      amount: '25.92',
+    })
+    const credential = Credential.from({
+      challenge,
+      payload: { spt: 'spt_test' },
+    })
+
+    const receipt = await mppx.verifyCredential(credential)
+
+    expect(receipt.status).toBe('success')
+    expect(receipt.method).toBe('stripe')
+  })
+
+  test('verifies a serialized credential for a transformed built-in method', async () => {
+    const stripeClient = {
+      paymentIntents: {
+        create: async (input: { amount: number; currency: string }) => {
+          expect(input.amount).toBe(2592)
+          expect(input.currency).toBe('usd')
+
+          return {
+            id: 'pi_456',
+            lastResponse: { headers: {} },
+            status: 'succeeded',
+          }
+        },
+      },
+    }
+
+    const mppx = Mppx.create({
+      methods: [
+        stripe.charge({
+          client: stripeClient as never,
+          currency: 'usd',
+          decimals: 2,
+          networkId: 'internal',
+          paymentMethodTypes: ['card'],
+        }),
+      ],
+      realm,
+      secretKey,
+    })
+
+    const challenge = await mppx.challenge.stripe.charge({ amount: '25.92' })
+    const credential = Credential.from({
+      challenge,
+      payload: { spt: 'spt_serialized' },
+    })
+
+    const receipt = await mppx.verifyCredential(Credential.serialize(credential))
+
+    expect(receipt.status).toBe('success')
+    expect(receipt.method).toBe('stripe')
+  })
+
+  test('verifies a zero-amount proof credential created from a real 402 response', async () => {
+    const server = Mppx.create({
+      methods: [
+        tempo.charge({
+          account: accounts[0],
+          currency: asset,
+          getClient: () => client,
+        }),
+      ],
+      realm,
+      secretKey,
+    })
+    const clientMppx = Mppx_client.create({
+      polyfill: false,
+      methods: [
+        tempo_client.charge({
+          account: accounts[1],
+          getClient: () => client,
+        }),
+      ],
+    })
+
+    const httpServer = await Http.createServer(async (req, res) => {
+      const result = await Mppx.toNodeListener(server.charge({ amount: '0' }))(req, res)
+      if (result.status === 402) return
+      res.end('OK')
+    })
+
+    const response = await fetch(httpServer.url)
+    expect(response.status).toBe(402)
+
+    const serializedCredential = await clientMppx.createCredential(response)
+    const proofCredential = Credential.deserialize(serializedCredential)
+    expect(proofCredential.payload).toMatchObject({ type: 'proof' })
+
+    const receipt = await server.verifyCredential(serializedCredential)
+
+    expect(receipt.status).toBe('success')
+    expect(receipt.method).toBe('tempo')
+
+    httpServer.close()
+  })
+
+  test('verifies a sponsored tempo credential created from a real 402 response', async () => {
+    const server = Mppx.create({
+      methods: [
+        tempo.charge({
+          account: accounts[0],
+          currency: asset,
+          feePayer: true,
+          getClient: () => client,
+        }),
+      ],
+      realm,
+      secretKey,
+    })
+    const clientMppx = Mppx_client.create({
+      polyfill: false,
+      methods: [
+        tempo_client.charge({
+          account: accounts[1],
+          getClient: () => client,
+        }),
+      ],
+    })
+
+    const httpServer = await Http.createServer(async (req, res) => {
+      const result = await Mppx.toNodeListener(server.charge({ amount: '1' }))(req, res)
+      if (result.status === 402) return
+      res.end('OK')
+    })
+
+    const response = await fetch(httpServer.url)
+    expect(response.status).toBe(402)
+
+    const serializedCredential = await clientMppx.createCredential(response, { mode: 'pull' })
+    const transactionCredential = Credential.deserialize(serializedCredential)
+    expect(transactionCredential.payload).toMatchObject({ type: 'transaction' })
+
+    const receipt = await server.verifyCredential(serializedCredential)
+
+    expect(receipt.status).toBe('success')
+    expect(receipt.method).toBe('tempo')
+
+    const txReceipt = await getTransactionReceipt(client, {
+      hash: receipt.reference as `0x${string}`,
+    })
+    expect((txReceipt as { feePayer?: string }).feePayer).toBe(accounts[0].address.toLowerCase())
+
+    httpServer.close()
+  })
+
+  test('verifies real session open and voucher credentials created from 402 responses', async () => {
+    const escrowContract = await deployEscrow()
+    const server = Mppx.create({
+      methods: [
+        tempo.session({
+          store: Store.memory(),
+          getClient: () => client,
+          account: accounts[0],
+          currency: asset,
+          escrowContract,
+          chainId: client.chain!.id,
+        }),
+      ],
+      realm,
+      secretKey,
+    })
+    const clientMppx = Mppx_client.create({
+      polyfill: false,
+      methods: [
+        tempo_session_client({
+          account: accounts[1],
+          deposit: '10',
+          getClient: () => client,
+        }),
+      ],
+    })
+
+    const httpServer = await Http.createServer(async (req, res) => {
+      const result = await Mppx.toNodeListener(
+        server.session({ amount: '1', unitType: 'request' }),
+      )(req, res)
+      if (result.status === 402) return
+      res.end('OK')
+    })
+
+    const openChallengeResponse = await fetch(httpServer.url)
+    expect(openChallengeResponse.status).toBe(402)
+
+    const serializedOpenCredential = await clientMppx.createCredential(openChallengeResponse)
+    const openCredential = Credential.deserialize(serializedOpenCredential)
+    expect(openCredential.payload).toMatchObject({ action: 'open' })
+
+    const openReceipt = await server.verifyCredential(serializedOpenCredential)
+
+    expect(openReceipt.status).toBe('success')
+    expect(openReceipt.method).toBe('tempo')
+
+    const voucherChallengeResponse = await fetch(httpServer.url)
+    expect(voucherChallengeResponse.status).toBe(402)
+
+    const serializedVoucherCredential = await clientMppx.createCredential(voucherChallengeResponse)
+    const voucherCredential = Credential.deserialize(serializedVoucherCredential)
+    expect(voucherCredential.payload).toMatchObject({ action: 'voucher' })
+
+    const voucherReceipt = await server.verifyCredential(serializedVoucherCredential)
+
+    expect(voucherReceipt.status).toBe('success')
+    expect(voucherReceipt.method).toBe('tempo')
+    expect(voucherReceipt.reference).toBe(openReceipt.reference)
+
+    httpServer.close()
+  })
+
+  test('verifies a sponsored tempo credential created by the real client', async () => {
+    const server = Mppx.create({
+      methods: [
+        tempo.charge({
+          account: accounts[0],
+          currency: asset,
+          feePayer: true,
+          getClient: () => client,
+        }),
+      ],
+      realm,
+      secretKey,
+    })
+
+    const challenge = await server.challenge.tempo.charge({ amount: '1' })
+    const clientMethod = tempo_client.charge({
+      account: accounts[1],
+      getClient: () => client,
+    })
+    const credential = await clientMethod.createCredential({
+      challenge: challenge as Parameters<typeof clientMethod.createCredential>[0]['challenge'],
+      context: { mode: 'pull' },
+    })
+
+    const receipt = await server.verifyCredential(credential)
+
+    expect(receipt.status).toBe('success')
+    expect(receipt.method).toBe('tempo')
+
+    const txReceipt = await getTransactionReceipt(client, {
+      hash: receipt.reference as `0x${string}`,
+    })
+    expect((txReceipt as { feePayer?: string }).feePayer).toBe(accounts[0].address.toLowerCase())
+  })
+
+  test('verifies a sponsored tempo credential object created by the real client', async () => {
+    const server = Mppx.create({
+      methods: [
+        tempo.charge({
+          account: accounts[0],
+          currency: asset,
+          feePayer: true,
+          getClient: () => client,
+        }),
+      ],
+      realm,
+      secretKey,
+    })
+
+    const challenge = await server.challenge.tempo.charge({ amount: '1' })
+    const clientMethod = tempo_client.charge({
+      account: accounts[1],
+      getClient: () => client,
+    })
+    const serializedCredential = await clientMethod.createCredential({
+      challenge: challenge as Parameters<typeof clientMethod.createCredential>[0]['challenge'],
+      context: { mode: 'pull' },
+    })
+
+    const receipt = await server.verifyCredential(Credential.deserialize(serializedCredential))
+
+    expect(receipt.status).toBe('success')
+    expect(receipt.method).toBe('tempo')
+
+    const txReceipt = await getTransactionReceipt(client, {
+      hash: receipt.reference as `0x${string}`,
+    })
+    expect((txReceipt as { feePayer?: string }).feePayer).toBe(accounts[0].address.toLowerCase())
+  })
+
   test('challenge + verifyCredential round-trip with serialized string', async () => {
     const mppx = Mppx.create({
       methods: [alphaChargeServer, alphaSessionServer],
@@ -3411,7 +3776,7 @@ describe('verifyCredential', () => {
     })
 
     // Generate, serialize, verify — the full UCP flow
-    const challenge = mppx.challenge.alpha.charge(challengeOpts)
+    const challenge = await mppx.challenge.alpha.charge(challengeOpts)
     const credential = Credential.from({ challenge, payload: { token: 'valid' } })
     const serialized = Credential.serialize(credential)
 

--- a/src/server/Mppx.test.ts
+++ b/src/server/Mppx.test.ts
@@ -2861,3 +2861,563 @@ describe('realm auto-detection', () => {
     expect(body.detail).toContain('realm')
   })
 })
+
+// ── mppx.challenge ──────────────────────────────────────────────────────
+
+describe('challenge', () => {
+  const mockCharge = Method.from({
+    name: 'alpha',
+    intent: 'charge',
+    schema: {
+      credential: { payload: z.object({ token: z.string() }) },
+      request: z.object({
+        amount: z.string(),
+        currency: z.string(),
+        decimals: z.number(),
+        recipient: z.string(),
+      }),
+    },
+  })
+
+  const mockSession = Method.from({
+    name: 'alpha',
+    intent: 'session',
+    schema: {
+      credential: {
+        payload: z.discriminatedUnion('action', [
+          z.object({ action: z.literal('open'), token: z.string() }),
+          z.object({ action: z.literal('voucher'), amount: z.string() }),
+        ]),
+      },
+      request: z.object({
+        amount: z.string(),
+        currency: z.string(),
+        recipient: z.string(),
+        unitType: z.string(),
+      }),
+    },
+  })
+
+  const betaCharge = Method.from({
+    name: 'beta',
+    intent: 'charge',
+    schema: {
+      credential: { payload: z.object({ token: z.string() }) },
+      request: z.object({
+        amount: z.string(),
+        currency: z.string(),
+        decimals: z.number(),
+        recipient: z.string(),
+      }),
+    },
+  })
+
+  function mockReceipt(name: string) {
+    return {
+      method: name,
+      reference: `tx-${name}`,
+      status: 'success' as const,
+      timestamp: new Date().toISOString(),
+    }
+  }
+
+  const alphaChargeServer = Method.toServer(mockCharge, {
+    async verify() {
+      return mockReceipt('alpha')
+    },
+  })
+
+  const alphaSessionServer = Method.toServer(mockSession, {
+    async verify() {
+      return mockReceipt('alpha-session')
+    },
+  })
+
+  const betaChargeServer = Method.toServer(betaCharge, {
+    async verify() {
+      return mockReceipt('beta')
+    },
+  })
+
+  const challengeOpts = {
+    amount: '1000',
+    currency: '0x0000000000000000000000000000000000000001',
+    decimals: 6,
+    expires: new Date(Date.now() + 60_000).toISOString(),
+    recipient: '0x0000000000000000000000000000000000000002',
+  }
+
+  test('mppx.challenge.alpha.charge returns a valid Challenge object', () => {
+    const mppx = Mppx.create({
+      methods: [alphaChargeServer, alphaSessionServer, betaChargeServer],
+      realm,
+      secretKey,
+    })
+
+    const challenge = mppx.challenge.alpha.charge(challengeOpts)
+
+    expect(challenge.method).toBe('alpha')
+    expect(challenge.intent).toBe('charge')
+    expect(challenge.realm).toBe(realm)
+    expect(challenge.request.amount).toBe('1000')
+    expect(challenge.request.currency).toBe('0x0000000000000000000000000000000000000001')
+    expect(challenge.request.recipient).toBe('0x0000000000000000000000000000000000000002')
+    expect(challenge.id).toBeDefined()
+  })
+
+  test('mppx.challenge.alpha.session returns a valid Challenge object', () => {
+    const mppx = Mppx.create({
+      methods: [alphaChargeServer, alphaSessionServer, betaChargeServer],
+      realm,
+      secretKey,
+    })
+
+    const challenge = mppx.challenge.alpha.session({
+      amount: '500',
+      currency: '0x0000000000000000000000000000000000000001',
+      recipient: '0x0000000000000000000000000000000000000002',
+      unitType: 'token',
+    })
+
+    expect(challenge.method).toBe('alpha')
+    expect(challenge.intent).toBe('session')
+    expect(challenge.realm).toBe(realm)
+    expect(challenge.request.unitType).toBe('token')
+  })
+
+  test('mppx.challenge.beta.charge returns challenge for a different method', () => {
+    const mppx = Mppx.create({
+      methods: [alphaChargeServer, betaChargeServer],
+      realm,
+      secretKey,
+    })
+
+    const challenge = mppx.challenge.beta.charge(challengeOpts)
+
+    expect(challenge.method).toBe('beta')
+    expect(challenge.intent).toBe('charge')
+  })
+
+  test('challenge ID is HMAC-bound and verifiable', () => {
+    const mppx = Mppx.create({
+      methods: [alphaChargeServer],
+      realm,
+      secretKey,
+    })
+
+    const challenge = mppx.challenge.alpha.charge(challengeOpts)
+    expect(Challenge.verify(challenge, { secretKey })).toBe(true)
+  })
+
+  test('challenge includes description and meta when provided', () => {
+    const mppx = Mppx.create({
+      methods: [alphaChargeServer],
+      realm,
+      secretKey,
+    })
+
+    const challenge = mppx.challenge.alpha.charge({
+      ...challengeOpts,
+      description: 'Order #123',
+      meta: { checkout_id: 'chk_abc' },
+    })
+
+    expect(challenge.description).toBe('Order #123')
+    expect(challenge.opaque).toEqual({ checkout_id: 'chk_abc' })
+  })
+
+  test('challenge applies schema transforms', () => {
+    // Method with a z.transform that converts decimals
+    const transformMethod = Method.from({
+      name: 'transform',
+      intent: 'charge',
+      schema: {
+        credential: { payload: z.object({ token: z.string() }) },
+        request: z.pipe(
+          z.object({
+            amount: z.string(),
+            currency: z.string(),
+            decimals: z.number(),
+            recipient: z.string(),
+          }),
+          z.transform(({ amount, currency, decimals, recipient }) => ({
+            amount: String(Number(amount) * 10 ** decimals),
+            currency,
+            recipient,
+          })),
+        ),
+      },
+    })
+
+    const serverMethod = Method.toServer(transformMethod, {
+      async verify() {
+        return mockReceipt('transform')
+      },
+    })
+
+    const mppx = Mppx.create({ methods: [serverMethod], realm, secretKey })
+
+    const challenge = mppx.challenge.transform.charge({
+      amount: '25.92',
+      currency: '0x0000000000000000000000000000000000000001',
+      decimals: 6,
+      recipient: '0x0000000000000000000000000000000000000002',
+    })
+
+    // Schema transform should apply: 25.92 * 10^6 = 25920000
+    expect(challenge.request.amount).toBe('25920000')
+  })
+
+  test('challenge produced by mppx.challenge is accepted by the 402 handler', async () => {
+    const mppx = Mppx.create({
+      methods: [alphaChargeServer],
+      realm,
+      secretKey,
+    })
+
+    // Generate challenge via the new API
+    const challenge = mppx.challenge.alpha.charge(challengeOpts)
+
+    // Build a credential from it
+    const credential = Credential.from({ challenge, payload: { token: 'valid' } })
+
+    // Present it to the 402 handler
+    const result = await mppx.charge(challengeOpts)(
+      new Request('https://example.com/resource', {
+        headers: { Authorization: Credential.serialize(credential) },
+      }),
+    )
+
+    expect(result.status).toBe(200)
+  })
+})
+
+// ── mppx.verifyCredential ───────────────────────────────────────────────
+
+describe('verifyCredential', () => {
+  const mockCharge = Method.from({
+    name: 'alpha',
+    intent: 'charge',
+    schema: {
+      credential: { payload: z.object({ token: z.string() }) },
+      request: z.object({
+        amount: z.string(),
+        currency: z.string(),
+        decimals: z.number(),
+        recipient: z.string(),
+      }),
+    },
+  })
+
+  const mockSession = Method.from({
+    name: 'alpha',
+    intent: 'session',
+    schema: {
+      credential: {
+        payload: z.discriminatedUnion('action', [
+          z.object({ action: z.literal('open'), token: z.string() }),
+          z.object({ action: z.literal('voucher'), amount: z.string() }),
+        ]),
+      },
+      request: z.object({
+        amount: z.string(),
+        currency: z.string(),
+        recipient: z.string(),
+        unitType: z.string(),
+      }),
+    },
+  })
+
+  const betaCharge = Method.from({
+    name: 'beta',
+    intent: 'charge',
+    schema: {
+      credential: { payload: z.object({ token: z.string() }) },
+      request: z.object({
+        amount: z.string(),
+        currency: z.string(),
+        decimals: z.number(),
+        recipient: z.string(),
+      }),
+    },
+  })
+
+  function mockReceipt(name: string) {
+    return {
+      method: name,
+      reference: `tx-${name}`,
+      status: 'success' as const,
+      timestamp: new Date().toISOString(),
+    }
+  }
+
+  let verifyArgs: Record<string, unknown> | undefined
+
+  const alphaChargeServer = Method.toServer(mockCharge, {
+    async verify({ credential, request }) {
+      verifyArgs = { credential, request }
+      return mockReceipt('alpha')
+    },
+  })
+
+  const alphaSessionServer = Method.toServer(mockSession, {
+    async verify({ credential, request }) {
+      verifyArgs = { credential, request }
+      return mockReceipt('alpha-session')
+    },
+  })
+
+  const betaChargeServer = Method.toServer(betaCharge, {
+    async verify() {
+      return mockReceipt('beta')
+    },
+  })
+
+  const challengeOpts = {
+    amount: '1000',
+    currency: '0x0000000000000000000000000000000000000001',
+    decimals: 6,
+    expires: new Date(Date.now() + 60_000).toISOString(),
+    recipient: '0x0000000000000000000000000000000000000002',
+  }
+
+  test('verifies a serialized credential string (charge)', async () => {
+    verifyArgs = undefined
+    const mppx = Mppx.create({
+      methods: [alphaChargeServer, alphaSessionServer, betaChargeServer],
+      realm,
+      secretKey,
+    })
+
+    const challenge = mppx.challenge.alpha.charge(challengeOpts)
+    const credential = Credential.from({ challenge, payload: { token: 'valid' } })
+    const serialized = Credential.serialize(credential)
+
+    const receipt = await mppx.verifyCredential(serialized)
+
+    expect(receipt.status).toBe('success')
+    expect(receipt.method).toBe('alpha')
+    expect(verifyArgs).toBeDefined()
+  })
+
+  test('verifies a parsed Credential object (charge)', async () => {
+    verifyArgs = undefined
+    const mppx = Mppx.create({
+      methods: [alphaChargeServer],
+      realm,
+      secretKey,
+    })
+
+    const challenge = mppx.challenge.alpha.charge(challengeOpts)
+    const credential = Credential.from({ challenge, payload: { token: 'valid' } })
+
+    const receipt = await mppx.verifyCredential(credential)
+
+    expect(receipt.status).toBe('success')
+    expect(receipt.method).toBe('alpha')
+  })
+
+  test('verifies a credential for session intent', async () => {
+    verifyArgs = undefined
+    const mppx = Mppx.create({
+      methods: [alphaChargeServer, alphaSessionServer],
+      realm,
+      secretKey,
+    })
+
+    const challenge = mppx.challenge.alpha.session({
+      amount: '500',
+      currency: '0x0000000000000000000000000000000000000001',
+      recipient: '0x0000000000000000000000000000000000000002',
+      unitType: 'token',
+    })
+    const credential = Credential.from({
+      challenge,
+      payload: { action: 'open', token: 'valid' },
+    })
+
+    const receipt = await mppx.verifyCredential(credential)
+
+    expect(receipt.status).toBe('success')
+    expect(receipt.method).toBe('alpha-session')
+  })
+
+  test('dispatches to correct method when multiple methods are registered', async () => {
+    const mppx = Mppx.create({
+      methods: [alphaChargeServer, betaChargeServer],
+      realm,
+      secretKey,
+    })
+
+    const challenge = mppx.challenge.beta.charge(challengeOpts)
+    const credential = Credential.from({ challenge, payload: { token: 'valid' } })
+
+    const receipt = await mppx.verifyCredential(credential)
+
+    expect(receipt.method).toBe('beta')
+  })
+
+  test('rejects credential with wrong HMAC (not issued by this server)', async () => {
+    const mppx = Mppx.create({
+      methods: [alphaChargeServer],
+      realm,
+      secretKey,
+    })
+
+    const wrongChallenge = Challenge.from({
+      id: 'tampered-id',
+      intent: 'charge',
+      method: 'alpha',
+      realm,
+      request: {
+        amount: '1000',
+        currency: '0x0000000000000000000000000000000000000001',
+        decimals: 6,
+        recipient: '0x0000000000000000000000000000000000000002',
+      },
+    })
+    const credential = Credential.from({
+      challenge: wrongChallenge,
+      payload: { token: 'valid' },
+    })
+
+    await expect(mppx.verifyCredential(credential)).rejects.toThrow(
+      'challenge was not issued by this server',
+    )
+  })
+
+  test('rejects credential with expired challenge', async () => {
+    const mppx = Mppx.create({
+      methods: [alphaChargeServer],
+      realm,
+      secretKey,
+    })
+
+    const challenge = mppx.challenge.alpha.charge({
+      ...challengeOpts,
+      expires: new Date(Date.now() - 1000).toISOString(), // already expired
+    })
+    const credential = Credential.from({ challenge, payload: { token: 'valid' } })
+
+    await expect(mppx.verifyCredential(credential)).rejects.toThrow()
+  })
+
+  test('rejects credential with invalid payload schema', async () => {
+    const mppx = Mppx.create({
+      methods: [alphaChargeServer],
+      realm,
+      secretKey,
+    })
+
+    const challenge = mppx.challenge.alpha.charge(challengeOpts)
+    const credential = Credential.from({
+      challenge,
+      payload: { wrong_field: 123 }, // doesn't match z.object({ token: z.string() })
+    })
+
+    await expect(mppx.verifyCredential(credential)).rejects.toThrow()
+  })
+
+  test('rejects credential for unregistered method/intent', async () => {
+    const mppx = Mppx.create({
+      methods: [alphaChargeServer],
+      realm,
+      secretKey,
+    })
+
+    // Forge a challenge for an unregistered method using the same secret
+    const challenge = Challenge.from({
+      secretKey,
+      intent: 'charge',
+      method: 'unknown',
+      realm,
+      expires: new Date(Date.now() + 60_000).toISOString(),
+      request: {
+        amount: '1000',
+        currency: '0x0000000000000000000000000000000000000001',
+      },
+    })
+    const credential = Credential.from({ challenge, payload: { token: 'valid' } })
+
+    await expect(mppx.verifyCredential(credential)).rejects.toThrow(
+      'no registered method for unknown/charge',
+    )
+  })
+
+  test('rejects malformed credential string', async () => {
+    const mppx = Mppx.create({
+      methods: [alphaChargeServer],
+      realm,
+      secretKey,
+    })
+
+    await expect(mppx.verifyCredential('not-valid-base64')).rejects.toThrow()
+  })
+
+  test('challenge + verifyCredential round-trip with schema transforms', async () => {
+    const transformMethod = Method.from({
+      name: 'transform',
+      intent: 'charge',
+      schema: {
+        credential: { payload: z.object({ token: z.string() }) },
+        request: z.pipe(
+          z.object({
+            amount: z.string(),
+            currency: z.string(),
+            decimals: z.number(),
+            recipient: z.string(),
+          }),
+          z.transform(({ amount, currency, decimals, recipient }) => ({
+            amount: String(Number(amount) * 10 ** decimals),
+            currency,
+            recipient,
+          })),
+        ),
+      },
+    })
+
+    const serverMethod = Method.toServer(transformMethod, {
+      async verify() {
+        return mockReceipt('transform')
+      },
+    })
+
+    const mppx = Mppx.create({ methods: [serverMethod], realm, secretKey })
+
+    // Generate challenge with human-readable amount
+    const challenge = mppx.challenge.transform.charge({
+      amount: '25.92',
+      currency: '0x0000000000000000000000000000000000000001',
+      decimals: 6,
+      recipient: '0x0000000000000000000000000000000000000002',
+    })
+
+    // Verify the transform was applied
+    expect(challenge.request.amount).toBe('25920000')
+
+    // Build credential and verify end-to-end
+    const credential = Credential.from({ challenge, payload: { token: 'valid' } })
+    const receipt = await mppx.verifyCredential(credential)
+
+    expect(receipt.status).toBe('success')
+    expect(receipt.method).toBe('transform')
+  })
+
+  test('challenge + verifyCredential round-trip with serialized string', async () => {
+    const mppx = Mppx.create({
+      methods: [alphaChargeServer, alphaSessionServer],
+      realm,
+      secretKey,
+    })
+
+    // Generate, serialize, verify — the full UCP flow
+    const challenge = mppx.challenge.alpha.charge(challengeOpts)
+    const credential = Credential.from({ challenge, payload: { token: 'valid' } })
+    const serialized = Credential.serialize(credential)
+
+    // Simulate receiving the credential string from a UCP instrument
+    const receipt = await mppx.verifyCredential(serialized)
+
+    expect(receipt.status).toBe('success')
+  })
+})

--- a/src/server/Mppx.ts
+++ b/src/server/Mppx.ts
@@ -70,7 +70,34 @@ export type Mppx<
       ): (input: Request) => Promise<MethodFn.Response<Transport.Http>>
     }
   : {}) &
-  Handlers<FlattenMethods<methods>, transport>
+  Handlers<FlattenMethods<methods>, transport> & {
+    /**
+     * Generate Challenge objects for registered methods without going through
+     * the HTTP 402 request lifecycle. Uses the same options, defaults, and
+     * schema transforms as the corresponding intent handler.
+     *
+     * @example
+     * ```ts
+     * const challenge = mppx.challenge.tempo.charge({ amount: '25.92' })
+     * ```
+     */
+    challenge: ChallengeHandlers<FlattenMethods<methods>>
+
+    /**
+     * Verify a credential string or object end-to-end: deserialize,
+     * HMAC-check, match to a registered method, validate payload schema,
+     * check expiry, and call the method's verify function.
+     *
+     * @example
+     * ```ts
+     * const receipt = await mppx.verifyCredential('eyJjaGFsbGVuZ2...')
+     * const receipt = await mppx.verifyCredential(credential)
+     * ```
+     */
+    verifyCredential(
+      credential: string | Credential.Credential,
+    ): Promise<Receipt.Receipt>
+  }
 
 /** Extracts the transport override from a method, if any. */
 type TransportOverrideOf<mi> = mi extends { transport?: infer transport }
@@ -136,6 +163,22 @@ type Handlers<
 } & UniqueIntentHandlers<methods, transport> &
   NestedHandlers<methods, transport>
 
+/** Nested challenge generators: `mppx.challenge.tempo.charge(...)`. */
+type ChallengeHandlers<methods extends readonly Method.AnyServer[]> = {
+  [name in methods[number]['name']]: {
+    [mi in Extract<methods[number], { name: name }> as mi['intent']]: ChallengeFn<
+      mi,
+      NonNullable<mi['defaults']>
+    >
+  }
+}
+
+/** A function that generates a Challenge object from intent options. */
+type ChallengeFn<
+  method extends Method.Method,
+  defaults extends Record<string, unknown>,
+> = (options: MethodFn.Options<method, defaults>) => Challenge.Challenge
+
 /**
  * Creates a server-side payment handler from methods.
  *
@@ -200,6 +243,59 @@ export function create<
     ;(handlers[mi.name] as Record<string, unknown>)[mi.intent] = fn
   }
 
+  // Build challenge generators: mppx.challenge.tempo.charge(...)
+  const challengeHandlers: Record<string, Record<string, unknown>> = {}
+  for (const mi of methods) {
+    if (!challengeHandlers[mi.name]) challengeHandlers[mi.name] = {}
+    challengeHandlers[mi.name]![mi.intent] = createChallengeFn({
+      defaults: mi.defaults,
+      method: mi,
+      realm,
+      request: mi.request as never,
+      secretKey,
+    })
+  }
+
+  // verifyCredential: single-call end-to-end verification
+  async function verifyCredentialFn(
+    input: string | Credential.Credential,
+  ): Promise<Receipt.Receipt> {
+    const credential =
+      typeof input === 'string' ? Credential.deserialize(input) : input
+
+    // HMAC provenance check (secretKey is guaranteed non-null by the guard at the top of create())
+    if (!Challenge.verify(credential.challenge, { secretKey: secretKey! }))
+      throw new Errors.InvalidChallengeError({
+        id: credential.challenge.id,
+        reason: 'challenge was not issued by this server',
+      })
+
+    // Expiry check
+    Expires.assert(credential.challenge.expires, credential.challenge.id)
+
+    // Find matching method by name + intent
+    const { method: credMethod, intent: credIntent } = credential.challenge
+    const mi = (methods as readonly Method.AnyServer[]).find(
+      (m) => m.name === credMethod && m.intent === credIntent,
+    )
+    if (!mi)
+      throw new Errors.InvalidChallengeError({
+        id: credential.challenge.id,
+        reason: `no registered method for ${credMethod}/${credIntent}`,
+      })
+
+    // Validate payload against method schema
+    mi.schema.credential.payload.parse(credential.payload)
+
+    // The challenge already contains the request params (HMAC-bound),
+    // so we use them directly — no need for the caller to re-supply.
+    const request = credential.challenge.request as z.input<
+      typeof mi.schema.request
+    >
+
+    return mi.verify({ credential, request } as never)
+  }
+
   function composeFn(
     ...entries: readonly [
       Method.AnyServer | AnyMethodFnWithMethod | string,
@@ -225,9 +321,11 @@ export function create<
 
   return {
     methods,
+    challenge: challengeHandlers,
     compose: composeFn,
     realm: realm as string | undefined,
     transport,
+    verifyCredential: verifyCredentialFn,
     ...handlers,
   } as never
 }
@@ -479,6 +577,53 @@ function createMethodFn(parameters: createMethodFn.Parameters): createMethodFn.R
         },
       },
     )
+  }
+}
+
+/**
+ * Creates a challenge generator for a single method+intent.
+ * Applies the same defaults and request transform as createMethodFn,
+ * but returns a Challenge object directly instead of a request handler.
+ */
+function createChallengeFn(parameters: {
+  defaults?: Record<string, unknown>
+  method: Method.Method
+  realm: string | undefined
+  request?: Method.RequestFn<Method.Method>
+  secretKey: string
+}): (options: Record<string, unknown>) => Challenge.Challenge {
+  const { defaults, method, realm, secretKey } = parameters
+
+  return (options) => {
+    const { description, meta, ...rest } = options as {
+      description?: string
+      expires?: string
+      meta?: Record<string, string>
+      [key: string]: unknown
+    }
+    const merged = { ...defaults, ...rest }
+    const expires =
+      'expires' in options ? (options.expires as string | undefined) : Expires.minutes(5)
+
+    // Transform request if method provides a `request` function.
+    const request = (
+      parameters.request
+        ? (parameters.request as (opts: { request: unknown }) => unknown)({
+            request: merged,
+          })
+        : merged
+    ) as never
+
+    const effectiveRealm = realm ?? defaultRealm
+
+    return Challenge.fromMethod(method, {
+      description,
+      expires,
+      meta,
+      realm: effectiveRealm,
+      request,
+      secretKey,
+    })
   }
 }
 

--- a/src/server/Mppx.ts
+++ b/src/server/Mppx.ts
@@ -78,7 +78,7 @@ export type Mppx<
      *
      * @example
      * ```ts
-     * const challenge = mppx.challenge.tempo.charge({ amount: '25.92' })
+     * const challenge = await mppx.challenge.tempo.charge({ amount: '25.92' })
      * ```
      */
     challenge: ChallengeHandlers<FlattenMethods<methods>>
@@ -94,9 +94,7 @@ export type Mppx<
      * const receipt = await mppx.verifyCredential(credential)
      * ```
      */
-    verifyCredential(
-      credential: string | Credential.Credential,
-    ): Promise<Receipt.Receipt>
+    verifyCredential(credential: string | Credential.Credential): Promise<Receipt.Receipt>
   }
 
 /** Extracts the transport override from a method, if any. */
@@ -174,10 +172,9 @@ type ChallengeHandlers<methods extends readonly Method.AnyServer[]> = {
 }
 
 /** A function that generates a Challenge object from intent options. */
-type ChallengeFn<
-  method extends Method.Method,
-  defaults extends Record<string, unknown>,
-> = (options: MethodFn.Options<method, defaults>) => Challenge.Challenge
+type ChallengeFn<method extends Method.Method, defaults extends Record<string, unknown>> = (
+  options: MethodFn.Options<method, defaults>,
+) => Promise<Challenge.Challenge>
 
 /**
  * Creates a server-side payment handler from methods.
@@ -260,8 +257,7 @@ export function create<
   async function verifyCredentialFn(
     input: string | Credential.Credential,
   ): Promise<Receipt.Receipt> {
-    const credential =
-      typeof input === 'string' ? Credential.deserialize(input) : input
+    const credential = typeof input === 'string' ? Credential.deserialize(input) : input
 
     // HMAC provenance check (secretKey is guaranteed non-null by the guard at the top of create())
     if (!Challenge.verify(credential.challenge, { secretKey: secretKey! }))
@@ -289,9 +285,7 @@ export function create<
 
     // The challenge already contains the request params (HMAC-bound),
     // so we use them directly — no need for the caller to re-supply.
-    const request = credential.challenge.request as z.input<
-      typeof mi.schema.request
-    >
+    const request = credential.challenge.request as z.input<typeof mi.schema.request>
 
     return mi.verify({ credential, request } as never)
   }
@@ -591,10 +585,10 @@ function createChallengeFn(parameters: {
   realm: string | undefined
   request?: Method.RequestFn<Method.Method>
   secretKey: string
-}): (options: Record<string, unknown>) => Challenge.Challenge {
+}): (options: Record<string, unknown>) => Promise<Challenge.Challenge> {
   const { defaults, method, realm, secretKey } = parameters
 
-  return (options) => {
+  return async (options) => {
     const { description, meta, ...rest } = options as {
       description?: string
       expires?: string
@@ -608,7 +602,7 @@ function createChallengeFn(parameters: {
     // Transform request if method provides a `request` function.
     const request = (
       parameters.request
-        ? (parameters.request as (opts: { request: unknown }) => unknown)({
+        ? await (parameters.request as (opts: { request: unknown }) => unknown)({
             request: merged,
           })
         : merged

--- a/src/stripe/server/Charge.ts
+++ b/src/stripe/server/Charge.ts
@@ -94,7 +94,13 @@ export function charge<const parameters extends charge.Parameters>(parameters: p
 
     async verify({ credential, request }) {
       const { challenge } = credential
-      const resolvedRequest = Methods.charge.schema.request.parse(request)
+      const resolvedRequest = (() => {
+        const parsed = Methods.charge.schema.request.safeParse(request)
+        if (parsed.success) return parsed.data
+        // verifyCredential() passes the HMAC-bound challenge request, which is
+        // already in canonical output form and should not be transformed again.
+        return request as unknown as z.output<typeof Methods.charge.schema.request>
+      })()
 
       Expires.assert(challenge.expires, challenge.id)
 

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -155,13 +155,24 @@ export function charge<const parameters extends charge.Parameters>(
 
     async verify({ credential, request }) {
       const { challenge } = credential
-      const resolvedRequest = Methods.charge.schema.request.parse(request)
+      const resolvedRequest = (() => {
+        const parsed = Methods.charge.schema.request.safeParse(request)
+        if (parsed.success) return parsed.data
+        // verifyCredential() passes the HMAC-bound challenge request, which is
+        // already in canonical output form and should not be transformed again.
+        return request as unknown as z.output<typeof Methods.charge.schema.request>
+      })()
       const chainId = resolvedRequest.methodDetails?.chainId ?? request.chainId
-      const feePayer = typeof request.feePayer === 'object' ? request.feePayer : undefined
 
       const client = await getClient({ chainId })
 
       const { amount, methodDetails } = resolvedRequest
+      const feePayerAccount =
+        typeof request.feePayer === 'object'
+          ? request.feePayer
+          : methodDetails?.feePayer === true
+            ? feePayer
+            : undefined
       const expires = challenge.expires
       const supportedModes = methodDetails?.supportedModes as
         | readonly Methods.ChargeMode[]
@@ -307,9 +318,9 @@ export function charge<const parameters extends charge.Parameters>(
             const resolvedFeeToken = transaction.feeToken ?? expectedFeeToken
 
             const serializedTransaction_final = await (async () => {
-              if (feePayer && methodDetails?.feePayer !== false) {
+              if (feePayerAccount && methodDetails?.feePayer !== false) {
                 const sponsored = FeePayer.prepareSponsoredTransaction({
-                  account: feePayer,
+                  account: feePayerAccount,
                   challengeExpires: expires,
                   chainId: chainId ?? client.chain!.id,
                   details: { amount, currency, recipient },

--- a/src/tempo/server/Session.ts
+++ b/src/tempo/server/Session.ts
@@ -35,6 +35,7 @@ import type { LooseOmit, NoExtraKeys } from '../../internal/types.js'
 import * as Method from '../../Method.js'
 import * as Store from '../../Store.js'
 import * as Client from '../../viem/Client.js'
+import type * as z from '../../zod.js'
 import * as Account from '../internal/account.js'
 import * as defaults from '../internal/defaults.js'
 import * as FeePayer from '../internal/fee-payer.js'
@@ -184,7 +185,13 @@ export function session<const parameters extends session.Parameters>(
     async verify({ credential, envelope, request }) {
       const { challenge, payload } = credential as Credential.Credential<SessionCredentialPayload>
 
-      const resolvedRequest = Methods.session.schema.request.parse(request)
+      const resolvedRequest = (() => {
+        const parsed = Methods.session.schema.request.safeParse(request)
+        if (parsed.success) return parsed.data
+        // verifyCredential() passes the HMAC-bound challenge request, which is
+        // already in canonical output form and should not be transformed again.
+        return request as unknown as z.output<typeof Methods.session.schema.request>
+      })()
       const methodDetails = resolvedRequest.methodDetails as SessionMethodDetails
       const client = await getClient({ chainId: methodDetails.chainId })
 


### PR DESCRIPTION
Two ergonomic changes to public `mppx` interface

**`mppx.challenge.{method}.{intent}(opts)`** — Generate a `Challenge` object using the same options, defaults, and schema transforms as the 402 handler. Eliminates manual base-unit conversion.

```ts
const challenge = mppx.challenge.tempo.charge({
  amount: '25.92',           // human-readable — SDK applies parseUnits
  description: 'Order #123',
})
```

**`mppx.verifyCredential(credential)`** — Single-call end-to-end verification (deserialize → HMAC → method match → schema validate → expiry → verify). Replaces 5 manual steps.

```ts
const receipt = await mppx.verifyCredential('eyJjaGFsbGVuZ2...')
const receipt = await mppx.verifyCredential(credential)
```

Both are extractions of existing `createMethodFn` internals — no new verification logic.