### PR TITLE
feat: support advertised tempo charge modes

### DIFF
--- a/.changeset/tempo-supported-modes.md
+++ b/.changeset/tempo-supported-modes.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Add Tempo charge `supportedModes` request support so clients and servers can explicitly negotiate `push` vs `pull` settlement.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,7 @@ overrides:
   elysia@<1.4.26: 1.4.26
   file-type: 21.3.2
   flatted@<=3.4.1: '>=3.4.2'
+  follow-redirects@<=1.15.11: 1.16.0
   undici@>=7.0.0 <7.24.0: 7.24.0
   socket.io-parser@>=4.0.0 <4.2.6: '>=4.2.6'
   yaml@<2.8.3: '>=2.8.3'
@@ -766,16 +767,6 @@ packages:
   '@metamask/utils@9.3.0':
     resolution: {integrity: sha512-w8CVbdkDrVXFJbfBSlDfafDR6BAkpDmv1bC1UJVCoVny5tW2RKAdn9i68Xf7asYT4TnUhl/hN4zfUiKQq9II4g==}
     engines: {node: '>=16.0.0'}
-
-  '@modelcontextprotocol/sdk@1.26.0':
-    resolution: {integrity: sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@cfworker/json-schema': ^4.1.1
-      zod: ^3.25 || ^4.0
-    peerDependenciesMeta:
-      '@cfworker/json-schema':
-        optional: true
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -2409,8 +2400,8 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -4315,31 +4306,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
-    dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.12)
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
-      content-type: 1.0.5
-      cors: 2.8.6
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.0.6
-      express: 5.2.1
-      express-rate-limit: 8.3.1(express@5.2.1)
-      hono: 4.12.12
-      jose: 6.2.1
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.1
-      raw-body: 3.0.2
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.1(zod@4.3.6)
-    optionalDependencies:
-      '@cfworker/json-schema': 4.1.1
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.13(hono@4.12.12)
@@ -5757,7 +5723,7 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   for-each@0.3.5:
     dependencies:
@@ -5886,7 +5852,7 @@ snapshots:
   http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,6 +37,7 @@ overrides:
   elysia@<1.4.26: '1.4.26'
   file-type: '21.3.2'
   flatted@<=3.4.1: '>=3.4.2'
+  follow-redirects@<=1.15.11: '1.16.0'
   undici@>=7.0.0 <7.24.0: '7.24.0'
   socket.io-parser@>=4.0.0 <4.2.6: '>=4.2.6'
   yaml@<2.8.3: '>=2.8.3'

--- a/src/tempo/Methods.test.ts
+++ b/src/tempo/Methods.test.ts
@@ -39,6 +39,20 @@ describe('charge', () => {
     expect(result.success).toBe(true)
   })
 
+  test('schema: validates request with supportedModes', () => {
+    const result = Methods.charge.schema.request.safeParse({
+      amount: '1',
+      currency: '0x20c0000000000000000000000000000000000001',
+      decimals: 6,
+      recipient: '0x1234567890abcdef1234567890abcdef12345678',
+      supportedModes: ['pull'],
+    })
+    expect(result.success).toBe(true)
+    if (!result.success) return
+
+    expect(result.data.methodDetails?.supportedModes).toEqual(['pull'])
+  })
+
   test('schema: validates request with memo', () => {
     const result = Methods.charge.schema.request.safeParse({
       amount: '1',

--- a/src/tempo/Methods.test.ts
+++ b/src/tempo/Methods.test.ts
@@ -53,6 +53,17 @@ describe('charge', () => {
     expect(result.data.methodDetails?.supportedModes).toEqual(['pull'])
   })
 
+  test('schema: rejects empty supportedModes', () => {
+    const result = Methods.charge.schema.request.safeParse({
+      amount: '1',
+      currency: '0x20c0000000000000000000000000000000000001',
+      decimals: 6,
+      recipient: '0x1234567890abcdef1234567890abcdef12345678',
+      supportedModes: [],
+    })
+    expect(result.success).toBe(false)
+  })
+
   test('schema: validates request with memo', () => {
     const result = Methods.charge.schema.request.safeParse({
       amount: '1',

--- a/src/tempo/Methods.ts
+++ b/src/tempo/Methods.ts
@@ -47,6 +47,7 @@ export const charge = Method.from({
           memo: z.optional(z.hash()),
           recipient: z.optional(z.string()),
           splits: z.optional(z.array(split).check(z.minLength(1), z.maxLength(10))),
+          supportedModes: z.optional(z.array(z.enum(['push', 'pull'])).check(z.minLength(1))),
         })
         .check(
           z.refine(({ amount, decimals, splits }) => {
@@ -64,13 +65,14 @@ export const charge = Method.from({
             )
           }, 'Invalid splits'),
         ),
-      z.transform(({ amount, chainId, decimals, feePayer, memo, splits, ...rest }) => ({
+      z.transform(({ amount, chainId, decimals, feePayer, memo, splits, supportedModes, ...rest }) => ({
         ...rest,
         amount: parseUnits(amount, decimals).toString(),
         ...(chainId !== undefined ||
         feePayer !== undefined ||
         memo !== undefined ||
-        splits !== undefined
+        splits !== undefined ||
+        supportedModes !== undefined
           ? {
               methodDetails: {
                 ...(chainId !== undefined && { chainId }),
@@ -82,6 +84,7 @@ export const charge = Method.from({
                     amount: parseUnits(split.amount, decimals).toString(),
                   })),
                 }),
+                ...(supportedModes !== undefined && { supportedModes }),
               },
             }
           : {}),

--- a/src/tempo/Methods.ts
+++ b/src/tempo/Methods.ts
@@ -4,6 +4,9 @@ import { parseUnits } from 'viem'
 import * as Method from '../Method.js'
 import * as z from '../zod.js'
 
+export const chargeModes = ['push', 'pull'] as const
+export type ChargeMode = (typeof chargeModes)[number]
+
 const split = z.object({
   amount: z.amount(),
   memo: z.optional(z.hash()),
@@ -47,7 +50,7 @@ export const charge = Method.from({
           memo: z.optional(z.hash()),
           recipient: z.optional(z.string()),
           splits: z.optional(z.array(split).check(z.minLength(1), z.maxLength(10))),
-          supportedModes: z.optional(z.array(z.enum(['push', 'pull'])).check(z.minLength(1))),
+          supportedModes: z.optional(z.array(z.enum(chargeModes)).check(z.minLength(1))),
         })
         .check(
           z.refine(({ amount, decimals, splits }) => {
@@ -65,30 +68,32 @@ export const charge = Method.from({
             )
           }, 'Invalid splits'),
         ),
-      z.transform(({ amount, chainId, decimals, feePayer, memo, splits, supportedModes, ...rest }) => ({
-        ...rest,
-        amount: parseUnits(amount, decimals).toString(),
-        ...(chainId !== undefined ||
-        feePayer !== undefined ||
-        memo !== undefined ||
-        splits !== undefined ||
-        supportedModes !== undefined
-          ? {
-              methodDetails: {
-                ...(chainId !== undefined && { chainId }),
-                ...(feePayer !== undefined && { feePayer }),
-                ...(memo !== undefined && { memo }),
-                ...(splits !== undefined && {
-                  splits: splits.map((split) => ({
-                    ...split,
-                    amount: parseUnits(split.amount, decimals).toString(),
-                  })),
-                }),
-                ...(supportedModes !== undefined && { supportedModes }),
-              },
-            }
-          : {}),
-      })),
+      z.transform(
+        ({ amount, chainId, decimals, feePayer, memo, splits, supportedModes, ...rest }) => ({
+          ...rest,
+          amount: parseUnits(amount, decimals).toString(),
+          ...(chainId !== undefined ||
+          feePayer !== undefined ||
+          memo !== undefined ||
+          splits !== undefined ||
+          supportedModes !== undefined
+            ? {
+                methodDetails: {
+                  ...(chainId !== undefined && { chainId }),
+                  ...(feePayer !== undefined && { feePayer }),
+                  ...(memo !== undefined && { memo }),
+                  ...(splits !== undefined && {
+                    splits: splits.map((split) => ({
+                      ...split,
+                      amount: parseUnits(split.amount, decimals).toString(),
+                    })),
+                  }),
+                  ...(supportedModes !== undefined && { supportedModes }),
+                },
+              }
+            : {}),
+        }),
+      ),
     ),
   },
 })

--- a/src/tempo/client/Charge.ts
+++ b/src/tempo/client/Charge.ts
@@ -74,11 +74,7 @@ export function charge(parameters: charge.Parameters = {}) {
         })
       }
 
-      const mode =
-        context?.mode ?? parameters.mode ?? (account.type === 'json-rpc' ? 'push' : 'pull')
-
       const currency = request.currency as Address
-
       if (parameters.expectedRecipients) {
         const allowed = new Set(parameters.expectedRecipients.map((a) => a.toLowerCase()))
         const splits = methodDetails?.splits as readonly { recipient: string }[] | undefined
@@ -89,6 +85,21 @@ export function charge(parameters: charge.Parameters = {}) {
           }
         }
       }
+      const supportedModes = (methodDetails?.supportedModes as
+        | readonly ('push' | 'pull')[]
+        | undefined) ?? ['pull', 'push']
+      const mode = (() => {
+        const explicitMode = context?.mode ?? parameters.mode
+        if (explicitMode) {
+          if (!supportedModes.includes(explicitMode))
+            throw new Error(`Challenge does not support ${explicitMode} mode.`)
+          return explicitMode
+        }
+
+        const preferredMode = account.type === 'json-rpc' ? 'push' : 'pull'
+        if (supportedModes.includes(preferredMode)) return preferredMode
+        return supportedModes[0]!
+      })()
 
       const memo = methodDetails?.memo
         ? (methodDetails.memo as Hex.Hex)
@@ -192,6 +203,9 @@ export declare namespace charge {
      *
      * - `'push'`: Client broadcasts the transaction and sends the tx hash to the server.
      * - `'pull'`: Client signs the transaction and sends the serialized tx to the server for broadcast.
+     *
+     * If the server advertises `supportedModes`, this setting must be one of
+     * the supported values for the challenge.
      *
      * @default `'push'` for JSON-RPC accounts, `'pull'` for local accounts.
      */

--- a/src/tempo/client/Charge.ts
+++ b/src/tempo/client/Charge.ts
@@ -47,7 +47,7 @@ export function charge(parameters: charge.Parameters = {}) {
     context: z.object({
       account: z.optional(z.custom<Account.getResolver.Parameters['account']>()),
       autoSwap: z.optional(z.custom<charge.AutoSwap>()),
-      mode: z.optional(z.enum(['push', 'pull'])),
+      mode: z.optional(z.enum(Methods.chargeModes)),
     }),
 
     async createCredential({ challenge, context }) {
@@ -86,7 +86,7 @@ export function charge(parameters: charge.Parameters = {}) {
         }
       }
       const supportedModes = (methodDetails?.supportedModes as
-        | readonly ('push' | 'pull')[]
+        | readonly Methods.ChargeMode[]
         | undefined) ?? ['pull', 'push']
       const mode = (() => {
         const explicitMode = context?.mode ?? parameters.mode
@@ -209,7 +209,7 @@ export declare namespace charge {
      *
      * @default `'push'` for JSON-RPC accounts, `'pull'` for local accounts.
      */
-    mode?: 'push' | 'pull' | undefined
+    mode?: Methods.ChargeMode | undefined
   } & Account.getResolver.Parameters &
     Client.getResolver.Parameters
 }

--- a/src/tempo/server/Charge.test.ts
+++ b/src/tempo/server/Charge.test.ts
@@ -124,6 +124,75 @@ describe('tempo', () => {
       httpServer.close()
     })
 
+    test('behavior: client rejects unsupported explicit push mode', async () => {
+      const mppx = Mppx_client.create({
+        polyfill: false,
+        methods: [
+          tempo_client({
+            account: accounts[1],
+            mode: 'push',
+            getClient: () => client,
+          }),
+        ],
+      })
+
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await Mppx_server.toNodeListener(
+          server.charge({ amount: '1', decimals: 6, supportedModes: ['pull'] }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
+      })
+
+      const response = await fetch(httpServer.url)
+      expect(response.status).toBe(402)
+
+      await expect(mppx.createCredential(response)).rejects.toThrow(
+        'Challenge does not support push mode.',
+      )
+
+      httpServer.close()
+    })
+
+    test('behavior: rejects hash credential when challenge supports only pull', async () => {
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await Mppx_server.toNodeListener(
+          server.charge({ amount: '1', decimals: 6, supportedModes: ['pull'] }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
+      })
+
+      const response = await fetch(httpServer.url)
+      expect(response.status).toBe(402)
+
+      const challenge = Challenge.fromResponse(response, {
+        methods: [tempo_client.charge()],
+      })
+
+      const { receipt } = await Actions.token.transferSync(client, {
+        account: accounts[1],
+        amount: BigInt(challenge.request.amount),
+        to: challenge.request.recipient as Hex.Hex,
+        token: challenge.request.currency as Hex.Hex,
+      })
+
+      const credential = Credential.from({
+        challenge,
+        payload: { hash: receipt.transactionHash, type: 'hash' as const },
+      })
+
+      const rejected = await fetch(httpServer.url, {
+        headers: { Authorization: Credential.serialize(credential) },
+      })
+      expect(rejected.status).toBe(402)
+
+      const body = (await rejected.json()) as { detail: string }
+      expect(body.detail).toContain('Hash credentials are not supported for this challenge.')
+
+      httpServer.close()
+    })
+
     test('behavior: rejects replayed transaction hash', async () => {
       const dedupServer = Mppx_server.create({
         methods: [
@@ -3115,6 +3184,31 @@ describe('tempo', () => {
         methods: [tempo_client.charge()],
       })
       expect(challenge.request.currency).toBe(asset)
+    })
+
+    test('challenge contains supportedModes when configured', async () => {
+      const handler = Mppx_server.create({
+        methods: [
+          tempo_server.charge({
+            getClient: () => client,
+            account: accounts[0].address,
+            currency: asset,
+          }),
+        ],
+        realm,
+        secretKey,
+      })
+
+      const result = await handler.charge({ amount: '1', supportedModes: ['pull'] })(
+        new Request('https://example.com'),
+      )
+      expect(result.status).toBe(402)
+      if (result.status !== 402) throw new Error()
+
+      const challenge = Challenge.fromResponse(result.challenge, {
+        methods: [tempo_client.charge()],
+      })
+      expect(challenge.request.methodDetails?.supportedModes).toEqual(['pull'])
     })
   })
 

--- a/src/tempo/server/Charge.test.ts
+++ b/src/tempo/server/Charge.test.ts
@@ -15,7 +15,7 @@ import { Abis, Account, Actions, Addresses, Secp256k1, Tick, Transaction } from 
 import { beforeAll, describe, expect, test } from 'vp/test'
 import * as Http from '~test/Http.js'
 import { closeChannelOnChain, deployEscrow, openChannel } from '~test/tempo/session.js'
-import { accounts, asset, chain, client, fundAccount } from '~test/tempo/viem.js'
+import { accounts, asset, chain, client, fundAccount, http } from '~test/tempo/viem.js'
 
 import * as Store from '../../Store.js'
 import * as Attribution from '../Attribution.js'
@@ -154,6 +154,46 @@ describe('tempo', () => {
       httpServer.close()
     })
 
+    test('behavior: falls back to pull when push is not advertised', async () => {
+      const jsonRpcClient = createClient({
+        account: accounts[1].address,
+        chain,
+        transport: http(),
+      })
+
+      const mppx = Mppx_client.create({
+        polyfill: false,
+        methods: [
+          tempo_client({
+            getClient: () => jsonRpcClient,
+          }),
+        ],
+      })
+
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await Mppx_server.toNodeListener(
+          server.charge({ amount: '1', decimals: 6, supportedModes: ['pull'] }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
+      })
+
+      const response = await fetch(httpServer.url)
+      expect(response.status).toBe(402)
+
+      const credential = Credential.deserialize<
+        { type: 'hash' | 'proof' | 'transaction' }
+      >(await mppx.createCredential(response))
+      expect(credential.payload.type).toBe('transaction')
+
+      const authResponse = await fetch(httpServer.url, {
+        headers: { Authorization: Credential.serialize(credential) },
+      })
+      expect(authResponse.status).toBe(200)
+
+      httpServer.close()
+    })
+
     test('behavior: rejects hash credential when challenge supports only pull', async () => {
       const httpServer = await Http.createServer(async (req, res) => {
         const result = await Mppx_server.toNodeListener(
@@ -189,6 +229,52 @@ describe('tempo', () => {
 
       const body = (await rejected.json()) as { detail: string }
       expect(body.detail).toContain('Hash credentials are not supported for this challenge.')
+
+      httpServer.close()
+    })
+
+    test('behavior: rejects transaction credential when challenge supports only push', async () => {
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await Mppx_server.toNodeListener(
+          server.charge({ amount: '1', decimals: 6, supportedModes: ['push'] }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
+      })
+
+      const response = await fetch(httpServer.url)
+      expect(response.status).toBe(402)
+
+      const challenge = Challenge.fromResponse(response, {
+        methods: [tempo_client.charge()],
+      })
+
+      const prepared = await prepareTransactionRequest(client, {
+        account: accounts[1]!,
+        calls: [
+          Actions.token.transfer.call({
+            amount: BigInt(challenge.request.amount),
+            to: challenge.request.recipient as Hex.Hex,
+            token: challenge.request.currency as Hex.Hex,
+          }),
+        ],
+        nonceKey: 'expiring',
+      } as never)
+      prepared.gas = prepared.gas! + 5_000n
+      const signature = await signTransaction(client, prepared as never)
+
+      const credential = Credential.from({
+        challenge,
+        payload: { signature, type: 'transaction' as const },
+      })
+
+      const rejected = await fetch(httpServer.url, {
+        headers: { Authorization: Credential.serialize(credential) },
+      })
+      expect(rejected.status).toBe(402)
+
+      const body = (await rejected.json()) as { detail: string }
+      expect(body.detail).toContain('Transaction credentials are not supported for this challenge.')
 
       httpServer.close()
     })

--- a/src/tempo/server/Charge.test.ts
+++ b/src/tempo/server/Charge.test.ts
@@ -156,7 +156,7 @@ describe('tempo', () => {
 
     test('behavior: falls back to pull when push is not advertised', async () => {
       const jsonRpcClient = createClient({
-        account: accounts[1].address,
+        account: accounts[0].address,
         chain,
         transport: http(),
       })
@@ -172,7 +172,12 @@ describe('tempo', () => {
 
       const httpServer = await Http.createServer(async (req, res) => {
         const result = await Mppx_server.toNodeListener(
-          server.charge({ amount: '1', decimals: 6, supportedModes: ['pull'] }),
+          server.charge({
+            amount: '1',
+            decimals: 6,
+            recipient: accounts[2].address,
+            supportedModes: ['pull'],
+          }),
         )(req, res)
         if (result.status === 402) return
         res.end('OK')
@@ -181,9 +186,9 @@ describe('tempo', () => {
       const response = await fetch(httpServer.url)
       expect(response.status).toBe(402)
 
-      const credential = Credential.deserialize<
-        { type: 'hash' | 'proof' | 'transaction' }
-      >(await mppx.createCredential(response))
+      const credential = Credential.deserialize<{ type: 'hash' | 'proof' | 'transaction' }>(
+        await mppx.createCredential(response),
+      )
       expect(credential.payload.type).toBe('transaction')
 
       const authResponse = await fetch(httpServer.url, {

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -162,6 +162,9 @@ export function charge<const parameters extends charge.Parameters>(
 
       const { amount, methodDetails } = resolvedRequest
       const expires = challenge.expires
+      const supportedModes = methodDetails?.supportedModes as
+        | readonly ('push' | 'pull')[]
+        | undefined
 
       const currency = resolvedRequest.currency as `0x${string}`
       const recipient = resolvedRequest.recipient as `0x${string}`
@@ -178,6 +181,9 @@ export function charge<const parameters extends charge.Parameters>(
 
       switch (payload.type) {
         case 'hash': {
+          if (supportedModes && !supportedModes.includes('push'))
+            throw new MismatchError('Hash credentials are not supported for this challenge.', {})
+
           const hash = payload.hash as `0x${string}`
           if (!(await markHashUsed(store, hash))) {
             throw new VerificationFailedError({ reason: 'Transaction hash has already been used' })
@@ -258,6 +264,12 @@ export function charge<const parameters extends charge.Parameters>(
         }
 
         case 'transaction': {
+          if (supportedModes && !supportedModes.includes('pull'))
+            throw new MismatchError(
+              'Transaction credentials are not supported for this challenge.',
+              {},
+            )
+
           const serializedTransaction = payload.signature as Transaction.TransactionSerializedTempo
 
           // Pre-broadcast dedup: catch exact byte-for-byte replays early.

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -163,7 +163,7 @@ export function charge<const parameters extends charge.Parameters>(
       const { amount, methodDetails } = resolvedRequest
       const expires = challenge.expires
       const supportedModes = methodDetails?.supportedModes as
-        | readonly ('push' | 'pull')[]
+        | readonly Methods.ChargeMode[]
         | undefined
 
       const currency = resolvedRequest.currency as `0x${string}`


### PR DESCRIPTION
## Summary
- add `supportedModes` to the Tempo charge request schema and serialize it into `methodDetails`
- negotiate client submission mode from the server-advertised modes while preserving the existing default preference order
- reject `hash` or `transaction` credentials on the server when the challenge did not advertise the corresponding mode

## Context
This matches the Tempo charge spec update in tempoxyz/mpp-specs#243, where:
- `pull` maps to `type="transaction"` credentials
- `push` maps to `type="hash"` credentials
- omitting `supportedModes` means both modes are supported for back-compat