### PR TITLE
fix: harden session settle and close access-key flows

### DIFF
--- a/.changeset/settle-access-key-payee-check.md
+++ b/.changeset/settle-access-key-payee-check.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Validate session settle/close senders against the channel payee so raw delegated access-key accounts fail fast with a clear error, and use the raw Tempo transaction path for access-key-compatible settlement and close flows.

--- a/src/tempo/client/SessionManager.ts
+++ b/src/tempo/client/SessionManager.ts
@@ -778,9 +778,21 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
       })
       if (!response.ok) {
         const body = await response.text().catch(() => '')
+        const detail = (() => {
+          if (!body) return ''
+          if (!response.headers.get('Content-Type')?.includes('application/problem+json')) {
+            return body
+          }
+          try {
+            const problem = JSON.parse(body) as { detail?: string }
+            return problem.detail ?? body
+          } catch {
+            return body
+          }
+        })()
         const wwwAuth = response.headers.get('WWW-Authenticate') ?? ''
         throw new Error(
-          `Close request failed with status ${response.status}${body ? `: ${body}` : ''}${wwwAuth ? ` [WWW-Authenticate: ${wwwAuth}]` : ''}`,
+          `Close request failed with status ${response.status}${detail ? `: ${detail}` : ''}${wwwAuth ? ` [WWW-Authenticate: ${wwwAuth}]` : ''}`,
         )
       }
       const receiptHeader = response.headers.get('Payment-Receipt')

--- a/src/tempo/server/Session.test.ts
+++ b/src/tempo/server/Session.test.ts
@@ -2088,8 +2088,7 @@ describe.runIf(isLocalnet)('session', () => {
     test('sessionManager.close surfaces problem details from HTTP close failures', async () => {
       const challenge = makeChallenge({
         id: 'close-http-failure',
-        channelId:
-          '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex,
+        channelId: '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex,
       })
       let requests = 0
 
@@ -2135,7 +2134,9 @@ describe.runIf(isLocalnet)('session', () => {
           )
         }
 
-        throw new Error(`unexpected payment action ${(credential.payload as { action: string }).action}`)
+        throw new Error(
+          `unexpected payment action ${(credential.payload as { action: string }).action}`,
+        )
       }
 
       const manager = sessionManager({

--- a/src/tempo/server/Session.test.ts
+++ b/src/tempo/server/Session.test.ts
@@ -7,7 +7,7 @@ import {
   Transport as ServerTransport,
   tempo as tempo_server,
 } from 'mppx/server'
-import { Base64 } from 'ox'
+import { Base64, Secp256k1 } from 'ox'
 import {
   type Address,
   createClient,
@@ -17,7 +17,7 @@ import {
   signatureToCompactSignature,
 } from 'viem'
 import { waitForTransactionReceipt } from 'viem/actions'
-import { Addresses } from 'viem/tempo'
+import { Account as TempoAccount, Actions, Addresses } from 'viem/tempo'
 import { beforeAll, beforeEach, describe, expect, expectTypeOf, test } from 'vp/test'
 import { WebSocketServer } from 'ws'
 import { nodeEnv } from '~test/config.js'
@@ -50,7 +50,8 @@ import {
 import type * as Methods from '../Methods.js'
 import * as ChannelStore from '../session/ChannelStore.js'
 import { deserializeSessionReceipt } from '../session/Receipt.js'
-import type { SessionReceipt } from '../session/Types.js'
+import { serializeSessionReceipt } from '../session/Receipt.js'
+import type { SessionCredentialPayload, SessionReceipt } from '../session/Types.js'
 import { signVoucher } from '../session/Voucher.js'
 import * as TempoWs from '../session/Ws.js'
 import { charge, session, settle } from './Session.js'
@@ -1886,12 +1887,272 @@ describe.runIf(isLocalnet)('session', () => {
       expect(ch!.settledOnChain).toBe(5000000n)
     })
 
+    test('accepts a Tempo access-key account for settlement', async () => {
+      const { channelId, serializedTransaction } = await createSignedOpenTransaction(10000000n)
+      const server = createServer()
+
+      await server.verify({
+        credential: {
+          challenge: makeChallenge({ id: 'settle-access-key-open', channelId }),
+          payload: {
+            action: 'open' as const,
+            type: 'transaction' as const,
+            channelId,
+            transaction: serializedTransaction,
+            cumulativeAmount: '5000000',
+            signature: await signTestVoucher(channelId, 5000000n),
+          },
+        },
+        request: makeRequest(),
+      })
+
+      const privateKey = Secp256k1.randomPrivateKey()
+      const accessKey = TempoAccount.fromSecp256k1(privateKey, {
+        access: recipientAccount,
+      })
+
+      await Actions.accessKey.authorizeSync(client, {
+        account: recipientAccount,
+        accessKey,
+        feeToken: currency,
+      })
+
+      const settleTxHash = await settle(store, client, channelId, {
+        escrowContract,
+        account: accessKey,
+      })
+      expect(settleTxHash).toMatch(/^0x/)
+
+      const ch = await store.getChannel(channelId)
+      expect(ch!.settledOnChain).toBe(5000000n)
+    })
+
+    test('rejects a raw delegated key account with a helpful error', async () => {
+      const { channelId, serializedTransaction } = await createSignedOpenTransaction(10000000n)
+      const server = createServer()
+
+      await server.verify({
+        credential: {
+          challenge: makeChallenge({ id: 'settle-raw-access-key-open', channelId }),
+          payload: {
+            action: 'open' as const,
+            type: 'transaction' as const,
+            channelId,
+            transaction: serializedTransaction,
+            cumulativeAmount: '5000000',
+            signature: await signTestVoucher(channelId, 5000000n),
+          },
+        },
+        request: makeRequest(),
+      })
+
+      const rawAccessKey = TempoAccount.fromSecp256k1(Secp256k1.randomPrivateKey())
+
+      await expect(
+        settle(store, client, channelId, {
+          escrowContract,
+          account: rawAccessKey,
+        }),
+      ).rejects.toThrow(
+        `Cannot settle channel ${channelId}: tx sender ${rawAccessKey.address} is not the channel payee ${recipientAccount.address}. If using an access key, pass a Tempo access-key account whose address is the payee wallet, not the raw delegated key address.`,
+      )
+    })
+
     test('settle rejects when no channel found', async () => {
       const fakeChannelId =
         '0x0000000000000000000000000000000000000000000000000000000000000000' as Hex
       await expect(settle(store, client, fakeChannelId, { escrowContract })).rejects.toThrow(
         ChannelNotFoundError,
       )
+    })
+  })
+
+  describe('close account shapes', () => {
+    test('root payee account closes successfully', async () => {
+      const { channelId, serializedTransaction } = await createSignedOpenTransaction(10000000n)
+      const server = createServer()
+      await server.verify({
+        credential: {
+          challenge: makeChallenge({ id: 'close-root-payee-open', channelId }),
+          payload: {
+            action: 'open' as const,
+            type: 'transaction' as const,
+            channelId,
+            transaction: serializedTransaction,
+            cumulativeAmount: '1000000',
+            signature: await signTestVoucher(channelId, 1000000n),
+          },
+        },
+        request: makeRequest(),
+      })
+
+      const closeReceipt = await server.verify({
+        credential: {
+          challenge: makeChallenge({ id: 'close-root-payee', channelId }),
+          payload: {
+            action: 'close' as const,
+            channelId,
+            cumulativeAmount: '1000000',
+            signature: await signTestVoucher(channelId, 1000000n),
+          },
+        },
+        request: makeRequest(),
+      })
+
+      expect(closeReceipt.status).toBe('success')
+      expect((await store.getChannel(channelId))?.finalized).toBe(true)
+    })
+
+    test('payee access-key account closes successfully', async () => {
+      const accessKey = TempoAccount.fromSecp256k1(Secp256k1.randomPrivateKey(), {
+        access: recipientAccount,
+      })
+
+      await Actions.accessKey.authorizeSync(client, {
+        account: recipientAccount,
+        accessKey,
+        feeToken: currency,
+      })
+
+      const { channelId, serializedTransaction } = await createSignedOpenTransaction(10000000n)
+      const server = createServer({ account: accessKey })
+      await server.verify({
+        credential: {
+          challenge: makeChallenge({ id: 'close-access-key-open', channelId }),
+          payload: {
+            action: 'open' as const,
+            type: 'transaction' as const,
+            channelId,
+            transaction: serializedTransaction,
+            cumulativeAmount: '1000000',
+            signature: await signTestVoucher(channelId, 1000000n),
+          },
+        },
+        request: makeRequest(),
+      })
+
+      const closeReceipt = await server.verify({
+        credential: {
+          challenge: makeChallenge({ id: 'close-access-key', channelId }),
+          payload: {
+            action: 'close' as const,
+            channelId,
+            cumulativeAmount: '1000000',
+            signature: await signTestVoucher(channelId, 1000000n),
+          },
+        },
+        request: makeRequest(),
+      })
+
+      expect(closeReceipt.status).toBe('success')
+      expect((await store.getChannel(channelId))?.finalized).toBe(true)
+    })
+
+    test('raw delegated server key fails clearly during close', async () => {
+      const rawAccessKey = TempoAccount.fromSecp256k1(Secp256k1.randomPrivateKey())
+      const { channelId, serializedTransaction } = await createSignedOpenTransaction(10000000n)
+      const server = createServer({ account: rawAccessKey, recipient })
+      await server.verify({
+        credential: {
+          challenge: makeChallenge({ id: 'close-raw-access-key-open', channelId }),
+          payload: {
+            action: 'open' as const,
+            type: 'transaction' as const,
+            channelId,
+            transaction: serializedTransaction,
+            cumulativeAmount: '1000000',
+            signature: await signTestVoucher(channelId, 1000000n),
+          },
+        },
+        request: makeRequest(),
+      })
+
+      await expect(
+        server.verify({
+          credential: {
+            challenge: makeChallenge({ id: 'close-raw-access-key', channelId }),
+            payload: {
+              action: 'close' as const,
+              channelId,
+              cumulativeAmount: '1000000',
+              signature: await signTestVoucher(channelId, 1000000n),
+            },
+          },
+          request: makeRequest(),
+        }),
+      ).rejects.toThrow(
+        `Cannot close channel ${channelId}: tx sender ${rawAccessKey.address} is not the channel payee ${recipientAccount.address}. If using an access key, pass a Tempo access-key account whose address is the payee wallet, not the raw delegated key address.`,
+      )
+    })
+
+    test('sessionManager.close surfaces problem details from HTTP close failures', async () => {
+      const challenge = makeChallenge({
+        id: 'close-http-failure',
+        channelId:
+          '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex,
+      })
+      let requests = 0
+
+      const fetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
+        requests++
+
+        const authorization = new Headers(init?.headers).get('Authorization')
+        if (!authorization) {
+          return new Response(null, {
+            status: 402,
+            headers: { 'WWW-Authenticate': Challenge.serialize(challenge) },
+          })
+        }
+
+        const credential = Credential.deserialize<SessionCredentialPayload>(authorization)
+        if (credential.payload.action === 'open') {
+          return new Response('ok', {
+            status: 200,
+            headers: {
+              'Payment-Receipt': serializeSessionReceipt({
+                method: 'tempo',
+                intent: 'session',
+                status: 'success',
+                timestamp: new Date().toISOString(),
+                reference: credential.payload.channelId,
+                challengeId: credential.challenge.id,
+                channelId: credential.payload.channelId,
+                acceptedCumulative: credential.payload.cumulativeAmount,
+                spent: credential.payload.cumulativeAmount,
+                units: 1,
+              }),
+            },
+          })
+        }
+
+        if (credential.payload.action === 'close') {
+          return new Response(
+            JSON.stringify({ detail: 'raw delegated key is not the payee wallet' }),
+            {
+              status: 400,
+              headers: { 'Content-Type': 'application/problem+json' },
+            },
+          )
+        }
+
+        throw new Error(`unexpected payment action ${(credential.payload as { action: string }).action}`)
+      }
+
+      const manager = sessionManager({
+        account: payer,
+        client,
+        escrowContract,
+        fetch,
+        maxDeposit: '1',
+      })
+
+      const response = await manager.fetch('https://api.example.com/resource')
+      expect(response.status).toBe(200)
+
+      await expect(manager.close()).rejects.toThrow(
+        'Close request failed with status 400: raw delegated key is not the payee wallet',
+      )
+      expect(requests).toBe(3)
     })
   })
 

--- a/src/tempo/server/Session.ts
+++ b/src/tempo/server/Session.ts
@@ -369,6 +369,22 @@ export declare namespace session {
   }
 }
 
+function assertSettlementSender(parameters: {
+  operation: 'close' | 'settle'
+  channelId: Hex
+  payee: Address
+  sender: Address | undefined
+}) {
+  const { operation, channelId, payee, sender } = parameters
+  if (!sender) return
+  if (sender.toLowerCase() === payee.toLowerCase()) return
+  throw new BadRequestError({
+    reason:
+      `Cannot ${operation} channel ${channelId}: tx sender ${sender} is not the channel payee ${payee}. ` +
+      'If using an access key, pass a Tempo access-key account whose address is the payee wallet, not the raw delegated key address.',
+  })
+}
+
 /**
  * One-shot settle: reads highest voucher from store and submits on-chain.
  */
@@ -392,6 +408,13 @@ export async function settle(
     options?.escrowContract ??
     defaults.escrowContract[chainId as keyof typeof defaults.escrowContract]
   if (!resolvedEscrow) throw new Error(`No escrow contract for chainId ${chainId}.`)
+
+  assertSettlementSender({
+    operation: 'settle',
+    channelId,
+    payee: channel.payee,
+    sender: options?.account?.address ?? client.account?.address,
+  })
 
   const settledAmount = channel.highestVoucher.cumulativeAmount
   const txHash = await settleOnChain(client, resolvedEscrow, channel.highestVoucher, {
@@ -890,6 +913,13 @@ async function handleClose(
   if (!isValid) {
     throw new InvalidSignatureError({ reason: 'invalid voucher signature' })
   }
+
+  assertSettlementSender({
+    operation: 'close',
+    channelId: payload.channelId,
+    payee: onChain.payee,
+    sender: account?.address ?? client.account?.address,
+  })
 
   const txHash = await closeOnChain(client, methodDetails.escrowContract, voucher, {
     ...(feePayer && account ? { feePayer, account } : { account }),

--- a/src/tempo/session/Chain.ts
+++ b/src/tempo/session/Chain.ts
@@ -94,7 +94,9 @@ function assertUint128(amount: bigint): void {
   }
 }
 
-function isTempoAccessKeyAccount(account: Account): account is Account & { accessKeyAddress: Address } {
+function isTempoAccessKeyAccount(
+  account: Account,
+): account is Account & { accessKeyAddress: Address } {
   return 'accessKeyAddress' in account && typeof account.accessKeyAddress === 'string'
 }
 

--- a/src/tempo/session/Chain.ts
+++ b/src/tempo/session/Chain.ts
@@ -17,7 +17,6 @@ import {
   sendRawTransaction,
   sendRawTransactionSync,
   signTransaction,
-  writeContract,
 } from 'viem/actions'
 import { Transaction } from 'viem/tempo'
 
@@ -119,14 +118,13 @@ export async function settleOnChain(
     const data = encodeFunctionData({ abi: escrowAbi, functionName: 'settle', args })
     return sendFeePayerTx(client, resolved, options.feePayer, escrowContract, data, 'settle')
   }
-  return writeContract(client, {
-    account: resolved,
-    chain: client.chain,
-    address: escrowContract,
-    abi: escrowAbi,
-    functionName: 'settle',
-    args,
-  })
+  return sendAccountTx(
+    client,
+    resolved,
+    escrowContract,
+    encodeFunctionData({ abi: escrowAbi, functionName: 'settle', args }),
+    'settle',
+  )
 }
 
 /** Options for {@link closeOnChain}. */
@@ -154,14 +152,43 @@ export async function closeOnChain(
     const data = encodeFunctionData({ abi: escrowAbi, functionName: 'close', args })
     return sendFeePayerTx(client, resolved, options.feePayer, escrowContract, data, 'close')
   }
-  return writeContract(client, {
-    account: resolved,
-    chain: client.chain,
-    address: escrowContract,
-    abi: escrowAbi,
-    functionName: 'close',
-    args,
+  return sendAccountTx(
+    client,
+    resolved,
+    escrowContract,
+    encodeFunctionData({ abi: escrowAbi, functionName: 'close', args }),
+    'close',
+  )
+}
+
+async function sendAccountTx(
+  client: Client,
+  account: Account,
+  to: Address,
+  data: Hex,
+  label: string,
+): Promise<Hex> {
+  const prepared = await prepareTransactionRequest(client, {
+    account,
+    calls: [{ to, data }],
+  } as never)
+
+  const serialized = (await signTransaction(client, {
+    ...prepared,
+    account,
+  } as never)) as Hex
+
+  const receipt = await sendRawTransactionSync(client, {
+    serializedTransaction: serialized as Transaction.TransactionSerializedTempo,
   })
+
+  if (receipt.status !== 'success') {
+    throw new VerificationFailedError({
+      reason: `${label} transaction reverted: ${receipt.transactionHash}`,
+    })
+  }
+
+  return receipt.transactionHash
 }
 
 /**

--- a/src/tempo/session/Chain.ts
+++ b/src/tempo/session/Chain.ts
@@ -17,6 +17,7 @@ import {
   sendRawTransaction,
   sendRawTransactionSync,
   signTransaction,
+  writeContract,
 } from 'viem/actions'
 import { Transaction } from 'viem/tempo'
 
@@ -93,6 +94,10 @@ function assertUint128(amount: bigint): void {
   }
 }
 
+function isTempoAccessKeyAccount(account: Account): account is Account & { accessKeyAddress: Address } {
+  return 'accessKeyAddress' in account && typeof account.accessKeyAddress === 'string'
+}
+
 /** Options for {@link settleOnChain}. */
 export type SettleOptions =
   | { feePayer: Account; account: Account }
@@ -118,13 +123,23 @@ export async function settleOnChain(
     const data = encodeFunctionData({ abi: escrowAbi, functionName: 'settle', args })
     return sendFeePayerTx(client, resolved, options.feePayer, escrowContract, data, 'settle')
   }
-  return sendAccountTx(
-    client,
-    resolved,
-    escrowContract,
-    encodeFunctionData({ abi: escrowAbi, functionName: 'settle', args }),
-    'settle',
-  )
+  if (isTempoAccessKeyAccount(resolved)) {
+    return sendAccountTx(
+      client,
+      resolved,
+      escrowContract,
+      encodeFunctionData({ abi: escrowAbi, functionName: 'settle', args }),
+      'settle',
+    )
+  }
+  return writeContract(client, {
+    account: resolved,
+    chain: client.chain,
+    address: escrowContract,
+    abi: escrowAbi,
+    functionName: 'settle',
+    args,
+  })
 }
 
 /** Options for {@link closeOnChain}. */
@@ -152,13 +167,23 @@ export async function closeOnChain(
     const data = encodeFunctionData({ abi: escrowAbi, functionName: 'close', args })
     return sendFeePayerTx(client, resolved, options.feePayer, escrowContract, data, 'close')
   }
-  return sendAccountTx(
-    client,
-    resolved,
-    escrowContract,
-    encodeFunctionData({ abi: escrowAbi, functionName: 'close', args }),
-    'close',
-  )
+  if (isTempoAccessKeyAccount(resolved)) {
+    return sendAccountTx(
+      client,
+      resolved,
+      escrowContract,
+      encodeFunctionData({ abi: escrowAbi, functionName: 'close', args }),
+      'close',
+    )
+  }
+  return writeContract(client, {
+    account: resolved,
+    chain: client.chain,
+    address: escrowContract,
+    abi: escrowAbi,
+    functionName: 'close',
+    args,
+  })
 }
 
 async function sendAccountTx(
@@ -172,6 +197,7 @@ async function sendAccountTx(
     account,
     calls: [{ to, data }],
   } as never)
+  prepared.gas = prepared.gas! + 5_000n
 
   const serialized = (await signTransaction(client, {
     ...prepared,


### PR DESCRIPTION
## Summary
- validate session settle/close senders against the channel payee with operation-specific errors
- use the raw Tempo transaction path for non-fee-payer settle/close and wait for confirmed success before mutating local state
- add access-key settle/close regressions plus a sessionManager.close HTTP failure test