### PR TITLE
fix: make Tempo fee-payer policy chain-aware

### DIFF
--- a/.changeset/fee-payer-policy-config.md
+++ b/.changeset/fee-payer-policy-config.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Make Tempo charge fee-sponsorship policy resolve per chain and allow overriding it with `feePayerPolicy`.

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -119,7 +119,7 @@ jobs:
   test-html:
     name: Test HTML
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - name: Clone repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -44,7 +44,9 @@ jobs:
           fi
 
       - name: Audit dependencies
-        run: pnpm audit
+        # npm's legacy audit endpoint is returning 410 Gone. Keep the audit
+        # check enabled, but don't fail CI on registry-level audit outages.
+        run: pnpm audit --ignore-registry-errors
 
       - name: Lint & format
         run: pnpm check:ci

--- a/src/tempo/internal/fee-payer.test.ts
+++ b/src/tempo/internal/fee-payer.test.ts
@@ -285,6 +285,42 @@ describe('prepareSponsoredTransaction', () => {
     ).not.toThrow()
   })
 
+  test('accepts higher Moderato priority fees by default', () => {
+    expect(() =>
+      prepareSponsoredTransaction({
+        account: sponsor,
+        chainId: 42431,
+        details,
+        expectedFeeToken: bogus,
+        transaction: {
+          ...baseTransaction,
+          gas: 626_497n,
+          maxFeePerGas: 24_000_000_000n,
+          maxPriorityFeePerGas: 24_000_000_000n,
+        } as any,
+      }),
+    ).not.toThrow()
+  })
+
+  test('accepts fee-payer policy overrides', () => {
+    expect(() =>
+      prepareSponsoredTransaction({
+        account: sponsor,
+        chainId: 4217,
+        details,
+        expectedFeeToken: bogus,
+        policy: { maxPriorityFeePerGas: 50_000_000_000n },
+        transaction: {
+          ...baseTransaction,
+          chainId: 4217,
+          gas: 626_497n,
+          maxFeePerGas: 24_000_000_000n,
+          maxPriorityFeePerGas: 24_000_000_000n,
+        } as any,
+      }),
+    ).not.toThrow()
+  })
+
   test('drops unknown top-level fields from the sponsored transaction', () => {
     const sponsored = prepareSponsoredTransaction({
       account: sponsor,

--- a/src/tempo/internal/fee-payer.test.ts
+++ b/src/tempo/internal/fee-payer.test.ts
@@ -321,6 +321,44 @@ describe('prepareSponsoredTransaction', () => {
     ).not.toThrow()
   })
 
+  test('error: rejects excessive priority fee under a custom policy override', () => {
+    expect(() =>
+      prepareSponsoredTransaction({
+        account: sponsor,
+        chainId: 4217,
+        details,
+        expectedFeeToken: bogus,
+        policy: { maxPriorityFeePerGas: 20_000_000_000n },
+        transaction: {
+          ...baseTransaction,
+          chainId: 4217,
+          gas: 626_497n,
+          maxFeePerGas: 24_000_000_000n,
+          maxPriorityFeePerGas: 24_000_000_000n,
+        } as any,
+      }),
+    ).toThrow('maxPriorityFeePerGas exceeds sponsor policy')
+  })
+
+  test('ignores undefined policy override values', () => {
+    expect(() =>
+      prepareSponsoredTransaction({
+        account: sponsor,
+        chainId: 4217,
+        details,
+        expectedFeeToken: bogus,
+        policy: { maxPriorityFeePerGas: undefined } as any,
+        transaction: {
+          ...baseTransaction,
+          chainId: 4217,
+          gas: 626_497n,
+          maxFeePerGas: 24_000_000_000n,
+          maxPriorityFeePerGas: 24_000_000_000n,
+        } as any,
+      }),
+    ).toThrow('maxPriorityFeePerGas exceeds sponsor policy')
+  })
+
   test('drops unknown top-level fields from the sponsored transaction', () => {
     const sponsored = prepareSponsoredTransaction({
       account: sponsor,

--- a/src/tempo/internal/fee-payer.ts
+++ b/src/tempo/internal/fee-payer.ts
@@ -5,6 +5,7 @@ import { decodeFunctionData } from 'viem'
 import { Abis, Addresses, Transaction } from 'viem/tempo'
 
 import * as TempoAddress_internal from './address.js'
+import * as defaults from './defaults.js'
 import * as Selectors from './selectors.js'
 
 /** Returns true if the serialized transaction has a Tempo envelope prefix. */
@@ -26,17 +27,41 @@ export const callScopes = [
   [Selectors.approve, Selectors.swapExactAmountOut, Selectors.transferWithMemo],
 ]
 
+export type Policy = {
+  maxGas: bigint
+  maxFeePerGas: bigint
+  maxPriorityFeePerGas: bigint
+  maxTotalFee: bigint
+  maxValidityWindowSeconds: number
+}
+
 /**
  * maxTotalFee must be high enough to cover `transferWithMemo` and
  * swap transactions at peak gas prices. Bumped from 0.01 ETH in #327.
  */
-const policy = {
+const defaultPolicy: Policy = {
   maxGas: 2_000_000n,
   maxFeePerGas: 100_000_000_000n,
   maxPriorityFeePerGas: 10_000_000_000n,
   maxTotalFee: 50_000_000_000_000_000n,
   maxValidityWindowSeconds: 15 * 60,
-} as const
+}
+
+const policyByChainId = {
+  [defaults.chainId.mainnet]: defaultPolicy,
+  // Moderato regularly needs a higher priority fee than mainnet.
+  [defaults.chainId.testnet]: {
+    ...defaultPolicy,
+    maxPriorityFeePerGas: 50_000_000_000n,
+  },
+} as const satisfies Record<defaults.ChainId, Policy>
+
+function getPolicy(chainId: number, overrides: Partial<Policy> | undefined): Policy {
+  return {
+    ...(policyByChainId[chainId as defaults.ChainId] ?? defaultPolicy),
+    ...overrides,
+  }
+}
 
 /** Validates that a set of transaction calls matches an allowed fee-payer pattern. */
 export function validateCalls(
@@ -89,6 +114,7 @@ export function prepareSponsoredTransaction(parameters: {
   details: Record<string, string>
   expectedFeeToken?: TempoAddress.Address | undefined
   now?: Date | undefined
+  policy?: Partial<Policy> | undefined
   transaction: ReturnType<(typeof Transaction)['deserialize']>
 }) {
   const {
@@ -98,8 +124,10 @@ export function prepareSponsoredTransaction(parameters: {
     details,
     expectedFeeToken,
     now = new Date(),
+    policy: policyOverrides,
     transaction,
   } = parameters
+  const policy = getPolicy(chainId, policyOverrides)
 
   const {
     accessList,

--- a/src/tempo/internal/fee-payer.ts
+++ b/src/tempo/internal/fee-payer.ts
@@ -57,9 +57,15 @@ const policyByChainId = {
 } as const satisfies Record<defaults.ChainId, Policy>
 
 function getPolicy(chainId: number, overrides: Partial<Policy> | undefined): Policy {
+  const base = policyByChainId[chainId as defaults.ChainId] ?? defaultPolicy
+  if (!overrides) return base
+
   return {
-    ...(policyByChainId[chainId as defaults.ChainId] ?? defaultPolicy),
-    ...overrides,
+    maxGas: overrides.maxGas ?? base.maxGas,
+    maxFeePerGas: overrides.maxFeePerGas ?? base.maxFeePerGas,
+    maxPriorityFeePerGas: overrides.maxPriorityFeePerGas ?? base.maxPriorityFeePerGas,
+    maxTotalFee: overrides.maxTotalFee ?? base.maxTotalFee,
+    maxValidityWindowSeconds: overrides.maxValidityWindowSeconds ?? base.maxValidityWindowSeconds,
   }
 }
 

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -403,6 +403,9 @@ export declare namespace charge {
      * Override the fee-sponsor policy used when co-signing Tempo charge
      * transactions. Defaults resolve per chain, including a higher
      * priority-fee ceiling on Moderato.
+     *
+     * If you increase `maxGas` or `maxFeePerGas`, you may also need to raise
+     * `maxTotalFee` so the combined fee budget remains valid.
      */
     feePayerPolicy?: FeePayerPolicy | undefined
     /** Testnet mode. */
@@ -445,13 +448,7 @@ export declare namespace charge {
     decimals: number
   }
 
-  type FeePayerPolicy = {
-    maxGas?: bigint
-    maxFeePerGas?: bigint
-    maxPriorityFeePerGas?: bigint
-    maxTotalFee?: bigint
-    maxValidityWindowSeconds?: number
-  }
+  type FeePayerPolicy = Partial<FeePayer.Policy>
 }
 
 type ExpectedTransfer = {

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -60,6 +60,7 @@ export function charge<const parameters extends charge.Parameters>(
     decimals = defaults.decimals,
     description,
     externalId,
+    feePayerPolicy,
     html,
     memo,
     waitForConfirmation = true,
@@ -313,6 +314,7 @@ export function charge<const parameters extends charge.Parameters>(
                   chainId: chainId ?? client.chain!.id,
                   details: { amount, currency, recipient },
                   expectedFeeToken,
+                  policy: feePayerPolicy,
                   transaction: {
                     ...transaction,
                     ...(resolvedFeeToken ? { feeToken: resolvedFeeToken } : {}),
@@ -397,6 +399,12 @@ export declare namespace charge {
   type Parameters = {
     /** Render payment page when Accept header is text/html (e.g. in browsers) */
     html?: boolean | Html.Config | undefined
+    /**
+     * Override the fee-sponsor policy used when co-signing Tempo charge
+     * transactions. Defaults resolve per chain, including a higher
+     * priority-fee ceiling on Moderato.
+     */
+    feePayerPolicy?: FeePayerPolicy | undefined
     /** Testnet mode. */
     testnet?: boolean | undefined
     /**
@@ -435,6 +443,14 @@ export declare namespace charge {
     Defaults
   > & {
     decimals: number
+  }
+
+  type FeePayerPolicy = {
+    maxGas?: bigint
+    maxFeePerGas?: bigint
+    maxPriorityFeePerGas?: bigint
+    maxTotalFee?: bigint
+    maxValidityWindowSeconds?: number
   }
 }
 


### PR DESCRIPTION
## Summary
- resolve the Tempo fee-sponsor policy by chain instead of a single hardcoded constant
- raise the default Moderato/testnet `maxPriorityFeePerGas` ceiling to `50 gwei` while keeping mainnet at `10 gwei`
- add an optional `feePayerPolicy` override on `tempo.charge()` so servers can tune sponsorship limits without patching `mppx`
