### PR TITLE
fix: preserve key authorization in sponsored charges

### DIFF
--- a/.changeset/fair-schools-tie.md
+++ b/.changeset/fair-schools-tie.md
@@ -1,0 +1,3 @@
+'mppx': patch
+
+Preserve `keyAuthorization` in fee-sponsored Tempo charge transactions and reject unsupported transaction fields instead of silently dropping them.

--- a/src/tempo/internal/fee-payer.test.ts
+++ b/src/tempo/internal/fee-payer.test.ts
@@ -395,16 +395,52 @@ describe('prepareSponsoredTransaction', () => {
     ).toThrow('maxPriorityFeePerGas exceeds sponsor policy')
   })
 
-  test('drops unknown top-level fields from the sponsored transaction', () => {
+  test('preserves keyAuthorization', () => {
+    const keyAuthorization = {
+      address: bogus,
+      chainId: 42431,
+      nonce: 1n,
+      r: 1n,
+      s: 2n,
+      yParity: 0,
+    }
+
     const sponsored = prepareSponsoredTransaction({
       account: sponsor,
       chainId: 42431,
       details,
       expectedFeeToken: bogus,
-      transaction: { ...baseTransaction, unexpectedField: 'ignored' } as any,
-    }) as Record<string, unknown>
+      transaction: { ...baseTransaction, keyAuthorization } as any,
+    }) as { keyAuthorization?: unknown }
 
-    expect(sponsored.unexpectedField).toBeUndefined()
+    expect(sponsored.keyAuthorization).toEqual(keyAuthorization)
+  })
+
+  test('error: rejects unknown top-level fields from the sponsored transaction', () => {
+    expect(() =>
+      prepareSponsoredTransaction({
+        account: sponsor,
+        chainId: 42431,
+        details,
+        expectedFeeToken: bogus,
+        transaction: { ...baseTransaction, unexpectedField: 'ignored' } as any,
+      }),
+    ).toThrow('contains unsupported fields')
+  })
+
+  test('error: rejects feePayerSignature on client-submitted transactions', () => {
+    expect(() =>
+      prepareSponsoredTransaction({
+        account: sponsor,
+        chainId: 42431,
+        details,
+        expectedFeeToken: bogus,
+        transaction: {
+          ...baseTransaction,
+          feePayerSignature: { r: 2n, s: 3n, yParity: 1 },
+        } as any,
+      }),
+    ).toThrow('contains rejected fields')
   })
 
   test('error: rejects excessive maxFeePerGas', () => {

--- a/src/tempo/internal/fee-payer.ts
+++ b/src/tempo/internal/fee-payer.ts
@@ -35,6 +35,11 @@ export type Policy = {
   maxValidityWindowSeconds: number
 }
 
+// Reuse the exact object shape returned by `Transaction.deserialize()`.
+// `typeof Transaction` gets the module value type, `['deserialize']` picks the
+// deserialize function off that module, and `ReturnType<...>` asks TypeScript
+// for that function's return type so this helper stays aligned with upstream
+// Tempo transaction fields.
 type SponsoredTransaction = ReturnType<(typeof Transaction)['deserialize']>
 
 const preservedTransactionKeys = [

--- a/src/tempo/internal/fee-payer.ts
+++ b/src/tempo/internal/fee-payer.ts
@@ -35,6 +35,50 @@ export type Policy = {
   maxValidityWindowSeconds: number
 }
 
+type SponsoredTransaction = ReturnType<(typeof Transaction)['deserialize']>
+
+const preservedTransactionKeys = [
+  'accessList',
+  'calls',
+  'chainId',
+  'feeToken',
+  'from',
+  'gas',
+  'keyAuthorization',
+  'maxFeePerGas',
+  'maxPriorityFeePerGas',
+  'nonce',
+  'nonceKey',
+  'signature',
+  'validAfter',
+  'validBefore',
+] as const satisfies readonly (keyof SponsoredTransaction)[]
+
+const rejectedTransactionKeys = [
+  'blobVersionedHashes',
+  'blobs',
+  'data',
+  'feePayerSignature',
+  'gasPrice',
+  'kzg',
+  'maxFeePerBlobGas',
+  'r',
+  's',
+  'sidecars',
+  'to',
+  'v',
+  'value',
+  'yParity',
+] as const
+
+const rewrittenTransactionKeys = ['type'] as const
+
+const supportedTransactionKeys = new Set<string>([
+  ...preservedTransactionKeys,
+  ...rejectedTransactionKeys,
+  ...rewrittenTransactionKeys,
+])
+
 /**
  * maxTotalFee must be high enough to cover `transferWithMemo` and
  * swap transactions at peak gas prices. Bumped from 0.01 ETH in #327.
@@ -132,7 +176,7 @@ export function prepareSponsoredTransaction(parameters: {
   expectedFeeToken?: TempoAddress.Address | undefined
   now?: Date | undefined
   policy?: Partial<Policy> | undefined
-  transaction: ReturnType<(typeof Transaction)['deserialize']>
+  transaction: SponsoredTransaction
 }) {
   const {
     account,
@@ -145,6 +189,7 @@ export function prepareSponsoredTransaction(parameters: {
     transaction,
   } = parameters
   const policy = getPolicy(chainId, policyOverrides)
+  const transactionRecord = transaction as Record<string, unknown>
 
   const {
     accessList,
@@ -153,6 +198,7 @@ export function prepareSponsoredTransaction(parameters: {
     feeToken,
     from,
     gas,
+    keyAuthorization,
     maxFeePerGas,
     maxPriorityFeePerGas,
     nonce,
@@ -166,35 +212,61 @@ export function prepareSponsoredTransaction(parameters: {
     throw new FeePayerValidationError(reason, { ...details, ...extra })
   }
 
+  const unsupportedKeys = Object.entries(transaction).flatMap(([key, value]) => {
+    if (value === undefined) return []
+    if (supportedTransactionKeys.has(key)) return []
+    return [key]
+  })
+  if (unsupportedKeys.length > 0)
+    fail('fee-sponsored transaction contains unsupported fields', {
+      unsupportedFields: unsupportedKeys.join(', '),
+    })
+
+  const rejectedKeys = rejectedTransactionKeys.filter((key) => {
+    const value = transactionRecord[key]
+    return value !== undefined && value !== null
+  })
+  if (rejectedKeys.length > 0)
+    fail('fee-sponsored transaction contains rejected fields', {
+      rejectedFields: rejectedKeys.join(', '),
+    })
+
+  if (transaction.type !== undefined && transaction.type !== 'tempo')
+    fail('fee-sponsored transaction type is invalid', {
+      type: String(transaction.type),
+    })
+
   if (transactionChainId !== chainId)
     fail('fee-sponsored transaction chainId does not match challenge', {
       chainId: String(transactionChainId),
     })
 
   if (gas === undefined || gas <= 0n) fail('fee-sponsored transaction must declare gas')
-  if (gas > policy.maxGas)
+  const gasLimit = gas
+  if (gasLimit > policy.maxGas)
     fail('fee-sponsored transaction gas exceeds sponsor policy', {
-      gas: gas.toString(),
+      gas: gasLimit.toString(),
     })
 
   if (maxFeePerGas === undefined || maxFeePerGas <= 0n)
     fail('fee-sponsored transaction must declare maxFeePerGas')
-  if (maxFeePerGas > policy.maxFeePerGas)
+  const maxFeePerGasValue = maxFeePerGas
+  if (maxFeePerGasValue > policy.maxFeePerGas)
     fail('fee-sponsored transaction maxFeePerGas exceeds sponsor policy', {
-      maxFeePerGas: maxFeePerGas.toString(),
+      maxFeePerGas: maxFeePerGasValue.toString(),
     })
 
-  const maxTotalFee = gas * maxFeePerGas
+  const maxTotalFee = gasLimit * maxFeePerGasValue
   if (maxTotalFee > policy.maxTotalFee)
     fail('fee-sponsored transaction total fee budget exceeds sponsor policy', {
-      gas: gas.toString(),
-      maxFeePerGas: maxFeePerGas.toString(),
+      gas: gasLimit.toString(),
+      maxFeePerGas: maxFeePerGasValue.toString(),
       totalFee: maxTotalFee.toString(),
     })
 
-  if (maxPriorityFeePerGas !== undefined && maxPriorityFeePerGas > maxFeePerGas)
+  if (maxPriorityFeePerGas !== undefined && maxPriorityFeePerGas > maxFeePerGasValue)
     fail('fee-sponsored transaction maxPriorityFeePerGas exceeds maxFeePerGas', {
-      maxFeePerGas: maxFeePerGas.toString(),
+      maxFeePerGas: maxFeePerGasValue.toString(),
       maxPriorityFeePerGas: maxPriorityFeePerGas.toString(),
     })
   if (maxPriorityFeePerGas !== undefined && maxPriorityFeePerGas > policy.maxPriorityFeePerGas)
@@ -205,11 +277,12 @@ export function prepareSponsoredTransaction(parameters: {
   if (nonceKey === undefined) fail('fee-sponsored transaction must use an expiring nonce')
   if (validBefore === undefined)
     fail('fee-sponsored transaction must declare validBefore for the expiring nonce')
+  const validBeforeValue = validBefore
 
   const nowSeconds = Math.floor(now.getTime() / 1_000)
-  if (validBefore <= nowSeconds)
+  if (validBeforeValue <= nowSeconds)
     fail('fee-sponsored transaction has already expired', {
-      validBefore: String(validBefore),
+      validBefore: String(validBeforeValue),
     })
 
   const challengeExpirySeconds = challengeExpires
@@ -219,16 +292,21 @@ export function prepareSponsoredTransaction(parameters: {
     nowSeconds + policy.maxValidityWindowSeconds,
     challengeExpirySeconds ? challengeExpirySeconds + 60 : Number.MAX_SAFE_INTEGER,
   )
-  if (validBefore > maxValidBefore)
+  if (validBeforeValue > maxValidBefore)
     fail('fee-sponsored transaction validity window exceeds sponsor policy', {
-      validBefore: String(validBefore),
+      validBefore: String(validBeforeValue),
     })
 
-  if (feeToken !== undefined) {
+  const normalizedFeeToken = (() => {
+    if (feeToken === undefined) return undefined
     if (typeof feeToken !== 'string') fail('fee-sponsored transaction feeToken is invalid')
-    if (expectedFeeToken && !TempoAddress_internal.isEqual(feeToken, expectedFeeToken))
+    return feeToken
+  })()
+
+  if (normalizedFeeToken !== undefined) {
+    if (expectedFeeToken && !TempoAddress_internal.isEqual(normalizedFeeToken, expectedFeeToken))
       fail('fee-sponsored transaction feeToken is not allowed', {
-        feeToken,
+        feeToken: normalizedFeeToken,
       })
   }
 
@@ -238,17 +316,18 @@ export function prepareSponsoredTransaction(parameters: {
     calls,
     chainId: transactionChainId,
     feePayer: account,
-    ...(feeToken ? { feeToken } : {}),
+    ...(normalizedFeeToken ? { feeToken: normalizedFeeToken } : {}),
     ...(from ? { from } : {}),
-    gas,
+    gas: gasLimit,
+    ...(keyAuthorization !== undefined ? { keyAuthorization } : {}),
     ...(nonce !== undefined ? { nonce } : {}),
-    maxFeePerGas,
+    maxFeePerGas: maxFeePerGasValue,
     ...(maxPriorityFeePerGas !== undefined ? { maxPriorityFeePerGas } : {}),
     nonceKey,
     ...(signature ? { signature } : {}),
     type: 'tempo' as const,
     ...(validAfter !== undefined ? { validAfter } : {}),
-    validBefore,
+    validBefore: validBeforeValue,
   } satisfies ReturnType<(typeof Transaction)['deserialize']> & {
     account: Account
     feePayer: Account

--- a/src/viem/Client.test.ts
+++ b/src/viem/Client.test.ts
@@ -2,7 +2,7 @@ import { createClient, custom, defineChain, type Hex } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { signTransaction } from 'viem/actions'
 import { tempoLocalnet } from 'viem/chains'
-import { Transaction } from 'viem/tempo'
+import { Account as TempoAccount, Transaction } from 'viem/tempo'
 import { describe, expect, test } from 'vp/test'
 
 import * as Client from './Client.js'
@@ -167,6 +167,57 @@ describe('feePayer transaction serialization', () => {
       feeToken: '0x20c0000000000000000000000000000000000001' as const,
     } as never)
     expect(serverSigned).toMatch(/^0x7[68]/)
+  })
+
+  test('behavior: deserialized + re-signed tx preserves keyAuthorization', async () => {
+    const rootAccount = TempoAccount.fromSecp256k1(
+      '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+    )
+    const accessKey = TempoAccount.fromSecp256k1(
+      '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d',
+      { access: rootAccount },
+    )
+    const feePayerAccount = privateKeyToAccount(
+      '0x5de4111afa1a4b94908f83103f52c5de640f0e4f465f975fa6d6640d3c5e3b48',
+    )
+    const accessKeyClient = createClient({
+      account: accessKey,
+      chain: tempoLocalnet,
+      transport: mockTransport,
+    })
+
+    const keyAuthorization = await rootAccount.signKeyAuthorization(
+      {
+        accessKeyAddress: accessKey.accessKeyAddress,
+        keyType: accessKey.keyType,
+      },
+      {
+        chainId: BigInt(tempoLocalnet.id),
+      },
+    )
+
+    const clientSigned = await signTransaction(accessKeyClient, {
+      account: accessKey,
+      ...feePayer_prepared,
+      keyAuthorization,
+    } as never)
+    const deserialized = Transaction.deserialize(
+      clientSigned as Transaction.TransactionSerializedTempo,
+    )
+
+    expect(deserialized.keyAuthorization).toEqual(keyAuthorization)
+
+    const serverSigned = await signTransaction(tempoClient, {
+      ...deserialized,
+      account: feePayerAccount,
+      feePayer: feePayerAccount,
+      feeToken: '0x20c0000000000000000000000000000000000001' as const,
+    } as never)
+    const serverDeserialized = Transaction.deserialize(
+      serverSigned as Transaction.TransactionSerializedTempo,
+    )
+
+    expect(serverDeserialized.keyAuthorization).toEqual(keyAuthorization)
   })
 })
 


### PR DESCRIPTION
## Summary
- preserve `keyAuthorization` when rebuilding sponsored Tempo charge transactions
- fail closed on unsupported or explicitly rejected top-level transaction fields instead of silently dropping them
- add regression coverage for `prepareSponsoredTransaction` and server-style re-signing with `keyAuthorization`