### PR TITLE
chore: consolidate dependabot updates to weekly grouped PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,24 @@ updates:
     directory: /
     schedule:
       interval: weekly
+      day: monday
     cooldown:
       default-days: 7
     open-pull-requests-limit: 10
+    groups:
+      npm-production:
+        dependency-type: production
+      npm-development:
+        dependency-type: development
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+      day: monday
     cooldown:
       default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
Groups dependabot PRs by type instead of one PR per dependency:

- **npm-production** — production dependency updates
- **npm-development** — dev dependency updates  
- **github-actions** — all GitHub Actions updates

All groups run once a week on Mondays.