### PR TITLE
fix: harden session HTTP charging and close flows

### DIFF
--- a/examples/session/multi-fetch/README.md
+++ b/examples/session/multi-fetch/README.md
@@ -1,6 +1,8 @@
 # Stream: Multiple Fetches
 
-Multiple paid requests over a single payment channel, then close and settle. Demonstrates a batch scraping use case where each fetch increments the cumulative voucher by 0.002 pathUSD.
+Multiple paid requests over a single payment channel, then close and settle. Demonstrates a batch scraping use case where each fetch increments the cumulative voucher by 0.01 pathUSD.
+
+Each paid HTTP response carries a `Payment-Receipt` header. For session routes, the receipt's `spent` and `units` fields reflect channel state after that request, which is what standalone clients should use for follow-up close flows.
 
 ## Setup
 

--- a/examples/session/multi-fetch/src/client.ts
+++ b/examples/session/multi-fetch/src/client.ts
@@ -154,8 +154,8 @@ for (const url of urls) {
   // `s.cumulative` tracks the running cumulative voucher amount.
   // After 3 requests at 0.01 each, cumulative = 0.03 (30000 raw units).
   //
-  // Note: receipt.reference (the channel-open tx hash) stays constant for the
-  // entire session — it's always the same channel. And challenge.id (the HMAC
+  // Note: receipt.reference is the channel ID, so it stays constant for the
+  // entire session. And challenge.id (the HMAC
   // over realm|method|intent|request params) is also the same every time,
   // because the server is issuing identical challenges for the same endpoint.
   // This is what makes the protocol stateless: the server recomputes the HMAC

--- a/src/proxy/Proxy.test.ts
+++ b/src/proxy/Proxy.test.ts
@@ -1,16 +1,22 @@
 import { Challenge, Credential, Method, Receipt, z } from 'mppx'
 import { Mppx as Mppx_client, tempo as tempo_client } from 'mppx/client'
 import { Mppx as Mppx_server, tempo as tempo_server } from 'mppx/server'
-import { afterEach, describe, expect, test } from 'vp/test'
+import type { Address } from 'viem'
+import { afterEach, beforeAll, describe, expect, test } from 'vp/test'
+import { nodeEnv } from '~test/config.js'
 import * as Http from '~test/Http.js'
+import { deployEscrow } from '~test/tempo/session.js'
 import { accounts, asset, client } from '~test/tempo/viem.js'
 
+import { sessionManager } from '../tempo/client/SessionManager.js'
+import { deserializeSessionReceipt } from '../tempo/session/Receipt.js'
 import * as ApiProxy from './Proxy.js'
 import * as Service from './Service.js'
 import { anthropic } from './services/anthropic.js'
 import { openai } from './services/openai.js'
 
 const secretKey = 'test-secret-key'
+const isLocalnet = nodeEnv === 'localnet'
 
 const mppx_server = Mppx_server.create({
   methods: [
@@ -36,6 +42,12 @@ const mppx_client = Mppx_client.create({
 
 let upstream: Awaited<ReturnType<typeof Http.createServer>> | undefined
 let proxyServer: Awaited<ReturnType<typeof Http.createServer>> | undefined
+let sessionEscrow: Address
+
+beforeAll(async () => {
+  if (!isLocalnet) return
+  sessionEscrow = await deployEscrow()
+})
 
 afterEach(() => {
   upstream?.close()
@@ -694,5 +706,141 @@ describe('create', () => {
 
     const res = await fetch(`${proxyServer.url}/api/v1/search?q=hello&limit=10`)
     expect(await res.json()).toEqual({ search: '?q=hello&limit=10' })
+  })
+})
+
+describe.runIf(isLocalnet)('plain HTTP session proxy', () => {
+  test('charges proxied content requests and keeps management POSTs off the upstream', async () => {
+    let upstreamRequests = 0
+    upstream = await createUpstream((req) => {
+      upstreamRequests += 1
+      return Response.json({
+        method: req.method,
+        path: new URL(req.url).pathname,
+      })
+    })
+
+    const sessionHandler = Mppx_server.create({
+      methods: [
+        tempo_server.session({
+          account: accounts[0],
+          currency: asset,
+          escrowContract: sessionEscrow,
+          getClient: () => client,
+          chainId: client.chain!.id,
+        }),
+      ],
+      secretKey,
+    })
+
+    const proxy = ApiProxy.create({
+      services: [
+        Service.from('api', {
+          baseUrl: upstream.url,
+          routes: {
+            'GET /v1/scrape': sessionHandler.session({
+              amount: '1',
+              decimals: 6,
+              unitType: 'page',
+            }),
+          },
+        }),
+      ],
+    })
+    proxyServer = await Http.createServer(proxy.listener)
+
+    const manager = sessionManager({
+      account: accounts[1],
+      client,
+      escrowContract: sessionEscrow,
+      fetch: globalThis.fetch,
+      maxDeposit: '3',
+    })
+
+    const first = await manager.fetch(`${proxyServer.url}/api/v1/scrape`)
+    expect(first.status).toBe(200)
+    expect(await first.json()).toEqual({ method: 'GET', path: '/v1/scrape' })
+    expect(first.receipt?.spent).toBe('1000000')
+    expect(first.receipt?.units).toBe(1)
+
+    const second = await manager.fetch(`${proxyServer.url}/api/v1/scrape`)
+    expect(second.status).toBe(200)
+    expect(await second.json()).toEqual({ method: 'GET', path: '/v1/scrape' })
+    expect(second.receipt?.spent).toBe('2000000')
+    expect(second.receipt?.units).toBe(2)
+
+    const closeReceipt = await manager.close()
+    expect(closeReceipt?.status).toBe('success')
+    expect(closeReceipt?.spent).toBe('2000000')
+    expect(upstreamRequests).toBe(2)
+  })
+
+  test('attaches receipts to proxied error responses and rejects same-voucher replay', async () => {
+    upstream = await createUpstream(() =>
+      Response.json({ error: 'upstream failed' }, { status: 500 }),
+    )
+
+    const sessionHandler = Mppx_server.create({
+      methods: [
+        tempo_server.session({
+          account: accounts[0],
+          currency: asset,
+          escrowContract: sessionEscrow,
+          getClient: () => client,
+          chainId: client.chain!.id,
+        }),
+      ],
+      secretKey,
+    })
+
+    const proxy = ApiProxy.create({
+      services: [
+        Service.from('api', {
+          baseUrl: upstream.url,
+          routes: {
+            'GET /v1/scrape': sessionHandler.session({
+              amount: '1',
+              decimals: 6,
+              unitType: 'page',
+            }),
+          },
+        }),
+      ],
+    })
+    proxyServer = await Http.createServer(proxy.listener)
+
+    const sessionClient = Mppx_client.create({
+      polyfill: false,
+      methods: [
+        tempo_client({
+          account: accounts[1],
+          getClient: () => client,
+          maxDeposit: '2',
+        }),
+      ],
+    })
+
+    const challengeResponse = await fetch(`${proxyServer.url}/api/v1/scrape`)
+    expect(challengeResponse.status).toBe(402)
+
+    const authorization = await sessionClient.createCredential(challengeResponse)
+
+    const first = await fetch(`${proxyServer.url}/api/v1/scrape`, {
+      headers: { Authorization: authorization },
+    })
+    expect(first.status).toBe(500)
+    expect(await first.json()).toEqual({ error: 'upstream failed' })
+
+    const receiptHeader = first.headers.get('Payment-Receipt')
+    expect(receiptHeader).toBeTruthy()
+    const receipt = deserializeSessionReceipt(receiptHeader!)
+    expect(receipt.spent).toBe('1000000')
+    expect(receipt.units).toBe(1)
+
+    const replay = await fetch(`${proxyServer.url}/api/v1/scrape`, {
+      headers: { Authorization: authorization },
+    })
+    expect(replay.status).toBe(402)
+    expect(replay.headers.get('Payment-Receipt')).toBeNull()
   })
 })

--- a/src/tempo/Methods.test.ts
+++ b/src/tempo/Methods.test.ts
@@ -219,6 +219,19 @@ describe('session', () => {
     expect(Methods.session.name).toBe('tempo')
   })
 
+  test('schema: rejects zero-amount request', () => {
+    const result = Methods.session.schema.request.safeParse({
+      amount: '0',
+      currency: '0x20c0000000000000000000000000000000000001',
+      decimals: 6,
+      escrowContract: '0x1234567890abcdef1234567890abcdef12345678',
+      recipient: '0x1234567890abcdef1234567890abcdef12345678',
+      unitType: 'token',
+    })
+
+    expect(result.success).toBe(false)
+  })
+
   test('schema: encodes minVoucherDelta in base units', () => {
     const request = Methods.session.schema.request.parse({
       amount: '1',

--- a/src/tempo/Methods.ts
+++ b/src/tempo/Methods.ts
@@ -141,24 +141,31 @@ export const session = Method.from({
       ]),
     },
     request: z.pipe(
-      z.object({
-        amount: z.amount(),
-        chainId: z.optional(z.number()),
-        channelId: z.optional(z.hash()),
-        currency: z.string(),
-        decimals: z.number(),
-        escrowContract: z.optional(z.string()),
-        feePayer: z.optional(
-          z.pipe(
-            z.union([z.boolean(), z.custom<Account>()]),
-            z.transform((v): boolean => (typeof v === 'object' ? true : v)),
+      z
+        .object({
+          amount: z.amount(),
+          chainId: z.optional(z.number()),
+          channelId: z.optional(z.hash()),
+          currency: z.string(),
+          decimals: z.number(),
+          escrowContract: z.optional(z.string()),
+          feePayer: z.optional(
+            z.pipe(
+              z.union([z.boolean(), z.custom<Account>()]),
+              z.transform((v): boolean => (typeof v === 'object' ? true : v)),
+            ),
+          ),
+          minVoucherDelta: z.optional(z.amount()),
+          recipient: z.optional(z.string()),
+          suggestedDeposit: z.optional(z.amount()),
+          unitType: z.string(),
+        })
+        .check(
+          z.refine(
+            ({ amount, decimals }) => parseUnits(amount, decimals) > 0n,
+            'Session amount must be greater than 0',
           ),
         ),
-        minVoucherDelta: z.optional(z.amount()),
-        recipient: z.optional(z.string()),
-        suggestedDeposit: z.optional(z.amount()),
-        unitType: z.string(),
-      }),
       z.transform(
         ({
           amount,

--- a/src/tempo/client/SessionManager.ts
+++ b/src/tempo/client/SessionManager.ts
@@ -759,6 +759,13 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
           method: 'POST',
           headers: { Authorization: credential },
         })
+        if (!response.ok) {
+          const body = await response.text().catch(() => '')
+          const wwwAuth = response.headers.get('WWW-Authenticate') ?? ''
+          throw new Error(
+            `Close request failed with status ${response.status}${body ? `: ${body}` : ''}${wwwAuth ? ` [WWW-Authenticate: ${wwwAuth}]` : ''}`,
+          )
+        }
         const receiptHeader = response.headers.get('Payment-Receipt')
         if (receiptHeader) receipt = deserializeSessionReceipt(receiptHeader)
       }

--- a/src/tempo/server/Session.test.ts
+++ b/src/tempo/server/Session.test.ts
@@ -2712,6 +2712,99 @@ describe.runIf(isLocalnet)('session', () => {
       expect(second.status).toBe(200)
     })
 
+    test('plain HTTP session charges content requests and rejects same-voucher replay', async () => {
+      const { channelId, serializedTransaction } = await createSignedOpenTransaction(10000000n)
+      const handler = createHandler()
+      const route = handler.session({
+        amount: '1',
+        decimals: 6,
+        unitType: 'token',
+      })
+
+      const first = await route(new Request('https://api.example.com/resource'))
+      if (first.status !== 402) throw new Error('expected challenge')
+      const issuedChallenge = Challenge.fromResponse(first.challenge)
+
+      const authorization = Credential.serialize({
+        challenge: issuedChallenge,
+        payload: {
+          action: 'open',
+          type: 'transaction',
+          channelId,
+          transaction: serializedTransaction,
+          cumulativeAmount: '1000000',
+          signature: await signTestVoucher(channelId, 1000000n),
+        },
+      })
+
+      const second = await route(
+        new Request('https://api.example.com/resource', {
+          headers: { Authorization: authorization },
+        }),
+      )
+      if (second.status !== 200) throw new Error('expected paid response')
+
+      const paidResponse = second.withReceipt(new Response('ok'))
+      const receipt = deserializeSessionReceipt(paidResponse.headers.get('Payment-Receipt')!)
+      expect(receipt.spent).toBe('1000000')
+      expect(receipt.units).toBe(1)
+
+      const persisted = await store.getChannel(channelId)
+      expect(persisted?.spent).toBe(1000000n)
+      expect(persisted?.units).toBe(1)
+
+      const replay = await route(
+        new Request('https://api.example.com/resource', {
+          headers: { Authorization: authorization },
+        }),
+      )
+      expect(replay.status).toBe(402)
+    })
+
+    test('sessionManager fetch/close tracks spent from plain HTTP receipts', async () => {
+      const handler = createHandler()
+      const route = handler.session({
+        amount: '1',
+        decimals: 6,
+        unitType: 'token',
+      })
+
+      let contentRequests = 0
+      const fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = new Request(input, init)
+        const result = await route(request)
+        if (result.status === 402) return result.challenge
+        if (request.method === 'GET') contentRequests++
+        return result.withReceipt(new Response('ok'))
+      }
+
+      const manager = sessionManager({
+        account: payer,
+        client,
+        escrowContract,
+        fetch,
+        maxDeposit: '3',
+      })
+
+      const first = await manager.fetch('https://api.example.com/resource')
+      expect(first.status).toBe(200)
+      expect(first.receipt?.spent).toBe('1000000')
+      expect(first.receipt?.units).toBe(1)
+
+      const second = await manager.fetch('https://api.example.com/resource')
+      expect(second.status).toBe(200)
+      expect(second.receipt?.spent).toBe('2000000')
+      expect(second.receipt?.units).toBe(2)
+
+      const closeReceipt = await manager.close()
+      expect(closeReceipt?.status).toBe('success')
+      expect(closeReceipt?.spent).toBe('2000000')
+      expect(contentRequests).toBe(2)
+
+      const persisted = await store.getChannel(manager.channelId!)
+      expect(persisted?.finalized).toBe(true)
+    })
+
     test('does not return Payment-Receipt on verification errors', async () => {
       const { channelId, serializedTransaction } = await createSignedOpenTransaction(10000000n)
       const handler = createHandler()
@@ -3276,6 +3369,187 @@ describe.runIf(isLocalnet)('session', () => {
       } as any)
       expect(result).toBeInstanceOf(Response)
       expect((result as Response).status).toBe(204)
+    })
+  })
+
+  describe('HTTP session manager', () => {
+    test('tracks spent from HTTP error receipts and closes at that amount', async () => {
+      const backingStore = Store.memory()
+      const routeHandler = Mppx_server.create({
+        methods: [
+          tempo_server.session({
+            store: backingStore,
+            getClient: () => client,
+            account: recipientAccount,
+            currency,
+            escrowContract,
+            chainId: chain.id,
+          }),
+        ],
+        realm: 'api.example.com',
+        secretKey: 'secret',
+      }).session({ amount: '1', decimals: 6, unitType: 'token' })
+
+      const fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = new Request(input, init)
+        const result = await routeHandler(request)
+        if (result.status === 402) return result.challenge
+        return result.withReceipt(new Response('upstream failed', { status: 500 }))
+      }
+
+      const manager = sessionManager({
+        account: payer,
+        client,
+        escrowContract,
+        fetch,
+        maxDeposit: '2',
+      })
+
+      const response = await manager.fetch('https://api.example.com/resource')
+      expect(response.status).toBe(500)
+      expect(response.receipt?.spent).toBe('1000000')
+      expect(response.receipt?.units).toBe(1)
+
+      const closeReceipt = await manager.close()
+      expect(closeReceipt?.status).toBe('success')
+      expect(closeReceipt?.spent).toBe('1000000')
+    })
+
+    test('tracks spent from null-body HTTP content receipts and closes at that amount', async () => {
+      const backingStore = Store.memory()
+      const routeHandler = Mppx_server.create({
+        methods: [
+          tempo_server.session({
+            store: backingStore,
+            getClient: () => client,
+            account: recipientAccount,
+            currency,
+            escrowContract,
+            chainId: chain.id,
+          }),
+        ],
+        realm: 'api.example.com',
+        secretKey: 'secret',
+      }).session({ amount: '1', decimals: 6, unitType: 'token' })
+
+      const fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = new Request(input, init)
+        const result = await routeHandler(request)
+        if (result.status === 402) return result.challenge
+        return result.withReceipt(new Response(null, { status: 204 }))
+      }
+
+      const manager = sessionManager({
+        account: payer,
+        client,
+        escrowContract,
+        fetch,
+        maxDeposit: '2',
+      })
+
+      const response = await manager.fetch('https://api.example.com/resource')
+      expect(response.status).toBe(204)
+      expect(await response.text()).toBe('')
+      expect(response.receipt?.spent).toBe('1000000')
+      expect(response.receipt?.units).toBe(1)
+
+      const closeReceipt = await manager.close()
+      expect(closeReceipt?.status).toBe('success')
+      expect(closeReceipt?.spent).toBe('1000000')
+    })
+
+    test('throws when fallback close returns a non-ok response', async () => {
+      const backingStore = Store.memory()
+      const routeHandler = Mppx_server.create({
+        methods: [
+          tempo_server.session({
+            store: backingStore,
+            getClient: () => client,
+            account: recipientAccount,
+            currency,
+            escrowContract,
+            chainId: chain.id,
+          }),
+        ],
+        realm: 'api.example.com',
+        secretKey: 'secret',
+      }).session({ amount: '1', decimals: 6, unitType: 'token' })
+
+      const fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = new Request(input, init)
+        const action = request.headers.has('Authorization')
+          ? Credential.fromRequest<any>(request).payload?.action
+          : undefined
+        const result = await routeHandler(request)
+        if (result.status === 402) return result.challenge
+        if (action === 'close') {
+          return new Response('close failed', {
+            status: 500,
+            headers: { 'WWW-Authenticate': 'Payment error="close_failed"' },
+          })
+        }
+        return result.withReceipt(new Response('ok'))
+      }
+
+      const manager = sessionManager({
+        account: payer,
+        client,
+        escrowContract,
+        fetch,
+        maxDeposit: '2',
+      })
+
+      const response = await manager.fetch('https://api.example.com/resource')
+      expect(response.status).toBe(200)
+      expect(response.receipt?.spent).toBe('1000000')
+
+      await expect(manager.close()).rejects.toThrow(
+        'Close request failed with status 500: close failed [WWW-Authenticate: Payment error="close_failed"]',
+      )
+    })
+
+    test('sse transport charges plain HTTP fallback responses and closes at receipt.spent', async () => {
+      const backingStore = Store.memory()
+      const routeHandler = Mppx_server.create({
+        methods: [
+          tempo_server.session({
+            store: backingStore,
+            getClient: () => client,
+            account: recipientAccount,
+            currency,
+            escrowContract,
+            chainId: chain.id,
+            sse: true,
+          }),
+        ],
+        realm: 'api.example.com',
+        secretKey: 'secret',
+      }).session({ amount: '1', decimals: 6, unitType: 'token' })
+
+      const fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = new Request(input, init)
+        const result = await routeHandler(request)
+        if (result.status === 402) return result.challenge
+        return result.withReceipt(new Response('ok'))
+      }
+
+      const manager = sessionManager({
+        account: payer,
+        client,
+        escrowContract,
+        fetch,
+        maxDeposit: '2',
+      })
+
+      const response = await manager.fetch('https://api.example.com/resource')
+      expect(response.status).toBe(200)
+      expect(await response.text()).toBe('ok')
+      expect(response.receipt?.spent).toBe('1000000')
+      expect(response.receipt?.units).toBe(1)
+
+      const closeReceipt = await manager.close()
+      expect(closeReceipt?.status).toBe('success')
+      expect(closeReceipt?.spent).toBe('1000000')
     })
   })
 
@@ -4863,6 +5137,30 @@ describe('session default currency resolution', () => {
 
     const challenge = Challenge.fromResponse(result.challenge)
     expect(challenge.request.currency).toBe('0xcustom')
+  })
+
+  test('handler.session throws for zero-amount routes', () => {
+    const handler = Mppx_server.create({
+      methods: [
+        tempo_server.session({
+          store: Store.memory(),
+          getClient: () => mockClient,
+          account: mockAccount,
+          escrowContract: '0x0000000000000000000000000000000000000002',
+          chainId: 4217,
+        }),
+      ],
+      realm: 'api.example.com',
+      secretKey: 'secret',
+    })
+
+    expect(() =>
+      (handler.session as Function)({
+        amount: '0',
+        decimals: 6,
+        unitType: 'token',
+      }),
+    ).toThrow('Session amount must be greater than 0')
   })
 })
 

--- a/src/tempo/server/internal/transport.test.ts
+++ b/src/tempo/server/internal/transport.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test } from 'vp/test'
 import * as Store from '../../../Store.js'
 import { chainId, escrowContract as escrowContractDefaults } from '../../internal/defaults.js'
 import * as ChannelStore from '../../session/ChannelStore.js'
+import { deserializeSessionReceipt } from '../../session/Receipt.js'
 import { sse } from './transport.js'
 
 const channelId = '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex
@@ -73,12 +74,51 @@ function makeAuthorizedRequest(): Request {
   })
 }
 
-function makeReceipt() {
+function makeManagementRequest(action: 'close' | 'topUp' = 'close'): Request {
+  const credential = Credential.from({
+    challenge: makeChallenge(),
+    payload:
+      action === 'close'
+        ? {
+            action: 'close' as const,
+            channelId,
+            cumulativeAmount: '10000000',
+            signature: '0xdeadbeef',
+          }
+        : {
+            action: 'topUp' as const,
+            channelId,
+            type: 'transaction' as const,
+            transaction: '0xdeadbeef',
+            additionalDeposit: '1000000',
+          },
+  })
+  const header = Credential.serialize(credential)
+  return new Request('https://test.example.com/session', {
+    method: 'POST',
+    headers: { Authorization: header },
+  })
+}
+
+type ReceiptOverrides = Partial<{
+  acceptedCumulative: string
+  spent: string
+  units: number
+}>
+
+function makeReceipt(overrides: ReceiptOverrides = {}) {
   return {
     method: 'tempo',
+    intent: 'session' as const,
     status: 'success' as const,
     timestamp: new Date().toISOString(),
     reference: channelId,
+    challengeId,
+    channelId,
+    acceptedCumulative: '10000000',
+    spent: '0',
+    units: 0,
+    ...overrides,
   }
 }
 
@@ -318,25 +358,56 @@ describe('sse transport', () => {
     })
 
     const body = await response.text()
+    const receipt = deserializeSessionReceipt(response.headers.get('Payment-Receipt')!)
 
     const channel = await store.getChannel(channelId)
     expect(channel!.spent).toBe(1000000n)
     expect(channel!.units).toBe(1)
+    expect(receipt.spent).toBe('1000000')
+    expect(receipt.units).toBe(1)
 
     expect(JSON.parse(body)).toEqual({ content: 'hello' })
     expect(response.headers.get('Content-Type')).toBe('application/json')
     expect(response.headers.get('Payment-Receipt')).toBeTruthy()
   })
 
-  test('respondReceipt with 204 management response keeps null body and receipt', async () => {
+  test('respondReceipt with 204 content response still deducts from channel', async () => {
     const store = memoryStore()
     await seedChannel(store, 10000000n)
     const transport = sse({ store })
     const request = makeAuthorizedRequest()
 
-    const managementResponse = new Response(null, { status: 204 })
+    const contentResponse = new Response(null, { status: 204 })
     const response = transport.respondReceipt({
       credential: makeCredential(),
+      input: request,
+      receipt: makeReceipt(),
+      response: contentResponse,
+      challengeId,
+    })
+
+    expect(response.status).toBe(204)
+    expect(await response.text()).toBe('')
+    const receipt = deserializeSessionReceipt(response.headers.get('Payment-Receipt')!)
+
+    await Promise.resolve()
+
+    const channel = await store.getChannel(channelId)
+    expect(channel!.spent).toBe(1000000n)
+    expect(channel!.units).toBe(1)
+    expect(receipt.spent).toBe('1000000')
+    expect(receipt.units).toBe(1)
+  })
+
+  test('respondReceipt with management response keeps null body and does not deduct', async () => {
+    const store = memoryStore()
+    await seedChannel(store, 10000000n)
+    const transport = sse({ store })
+    const request = makeManagementRequest()
+
+    const managementResponse = new Response(null, { status: 204 })
+    const response = transport.respondReceipt({
+      credential: Credential.fromRequest(makeManagementRequest())!,
       input: request,
       receipt: makeReceipt(),
       response: managementResponse,
@@ -350,6 +421,24 @@ describe('sse transport', () => {
     const channel = await store.getChannel(channelId)
     expect(channel!.spent).toBe(0n)
     expect(channel!.units).toBe(0)
+  })
+
+  test('respondReceipt rejects replayed plain responses with no remaining balance', async () => {
+    const store = memoryStore()
+    await seedChannel(store, 10000000n)
+    const transport = sse({ store })
+    const request = makeAuthorizedRequest()
+
+    const response = transport.respondReceipt({
+      credential: makeCredential(),
+      input: request,
+      receipt: makeReceipt({ acceptedCumulative: '1000000', spent: '1000000', units: 1 }),
+      response: new Response('ok'),
+      challengeId,
+    })
+
+    expect(response.status).toBe(402)
+    expect(response.headers.get('Payment-Receipt')).toBeNull()
   })
 
   test('poll: true strips waitForUpdate from store', async () => {

--- a/src/tempo/server/internal/transport.ts
+++ b/src/tempo/server/internal/transport.ts
@@ -109,20 +109,22 @@ export function sse(options: sse.Options & { store: ChannelStore.ChannelStore })
       }
 
       const currentReceipt = receipt as SessionReceipt
-      const available =
-        BigInt(currentReceipt.acceptedCumulative) - BigInt(currentReceipt.spent)
+      const available = BigInt(currentReceipt.acceptedCumulative) - BigInt(currentReceipt.spent)
       if (available < tickCost) {
         const error = new Errors.InsufficientBalanceError({
           reason: `requested ${tickCost}, available ${available}`,
         })
-        return new Response(JSON.stringify(error.toProblemDetails(verifiedCredential.challenge.id)), {
-          status: error.status,
-          headers: {
-            'WWW-Authenticate': Challenge.serialize(verifiedCredential.challenge),
-            'Cache-Control': 'no-store',
-            'Content-Type': 'application/problem+json',
+        return new Response(
+          JSON.stringify(error.toProblemDetails(verifiedCredential.challenge.id)),
+          {
+            status: error.status,
+            headers: {
+              'WWW-Authenticate': Challenge.serialize(verifiedCredential.challenge),
+              'Cache-Control': 'no-store',
+              'Content-Type': 'application/problem+json',
+            },
           },
-        })
+        )
       }
 
       const chargedReceipt: SessionReceipt = {

--- a/src/tempo/server/internal/transport.ts
+++ b/src/tempo/server/internal/transport.ts
@@ -5,10 +5,12 @@
  *
  * @internal
  */
+import * as Challenge from '../../../Challenge.js'
+import * as Errors from '../../../Errors.js'
 import * as Transport from '../../../server/Transport.js'
 import * as ChannelStore from '../../session/ChannelStore.js'
 import * as Sse_core from '../../session/Sse.js'
-import type { SessionCredentialPayload } from '../../session/Types.js'
+import type { SessionCredentialPayload, SessionReceipt } from '../../session/Types.js'
 
 /** SSE transport with Tempo session controller. */
 export type Sse = Transport.Sse<Sse_core.SessionController>
@@ -102,23 +104,69 @@ export function sse(options: sse.Options & { store: ChannelStore.ChannelStore })
         challengeId: verifiedChallengeId,
       })
 
+      if (!shouldChargePlainResponse(input, payload)) {
+        return baseResponse
+      }
+
+      const currentReceipt = receipt as SessionReceipt
+      const available =
+        BigInt(currentReceipt.acceptedCumulative) - BigInt(currentReceipt.spent)
+      if (available < tickCost) {
+        const error = new Errors.InsufficientBalanceError({
+          reason: `requested ${tickCost}, available ${available}`,
+        })
+        return new Response(JSON.stringify(error.toProblemDetails(verifiedCredential.challenge.id)), {
+          status: error.status,
+          headers: {
+            'WWW-Authenticate': Challenge.serialize(verifiedCredential.challenge),
+            'Cache-Control': 'no-store',
+            'Content-Type': 'application/problem+json',
+          },
+        })
+      }
+
+      const chargedReceipt: SessionReceipt = {
+        ...currentReceipt,
+        spent: (BigInt(currentReceipt.spent) + tickCost).toString(),
+        units: (currentReceipt.units ?? 0) + 1,
+      }
+      const chargedResponse = base.respondReceipt({
+        credential: verifiedCredential,
+        envelope,
+        input,
+        receipt: chargedReceipt,
+        response: response as Response,
+        challengeId: verifiedChallengeId,
+      })
+
       // Non-SSE response (e.g. upstream returned JSON instead of event-stream).
       // Need to deduct tickCost so request isn't free.
-      // Null-body statuses (e.g. 204 from management actions) cannot carry a
-      // response body per Fetch/HTTP semantics.
-      if (isNullBodyStatus(baseResponse.status)) {
-        return baseResponse
+      // For null-body statuses, the request shape determines whether the
+      // response is management (no charge) or plain content (charge one tick).
+      if (isNullBodyStatus(chargedResponse.status)) {
+        void ChannelStore.deductFromChannel(store, channelId, tickCost)
+        return chargedResponse
       }
 
       const stream = new ReadableStream<Uint8Array>({
         async start(controller) {
           // deduction completes before consumer reads
-          await ChannelStore.deductFromChannel(store, channelId, tickCost)
-          if (!baseResponse.body) {
+          const result = await ChannelStore.deductFromChannel(store, channelId, tickCost)
+          if (!result.ok) {
+            controller.error(
+              new Errors.InsufficientBalanceError({
+                reason: `requested ${tickCost}, available ${
+                  result.channel.highestVoucherAmount - result.channel.spent
+                }`,
+              }),
+            )
+            return
+          }
+          if (!chargedResponse.body) {
             controller.close()
             return
           }
-          const reader = baseResponse.body.getReader()
+          const reader = chargedResponse.body.getReader()
           try {
             while (true) {
               const { done, value } = await reader.read()
@@ -132,9 +180,9 @@ export function sse(options: sse.Options & { store: ChannelStore.ChannelStore })
         },
       })
       return new Response(stream, {
-        status: baseResponse.status,
-        statusText: baseResponse.statusText,
-        headers: baseResponse.headers,
+        status: chargedResponse.status,
+        statusText: chargedResponse.statusText,
+        headers: chargedResponse.headers,
       })
     },
   })
@@ -201,4 +249,18 @@ function isAsyncIterable(value: unknown): value is AsyncIterable<string> {
 
 function isNullBodyStatus(status: number): boolean {
   return [101, 204, 205, 304].includes(status)
+}
+
+function shouldChargePlainResponse(
+  input: Request,
+  payload: Partial<SessionCredentialPayload>,
+): boolean {
+  if (payload.action === 'close' || payload.action === 'topUp') return false
+  if (input.method !== 'POST') return true
+
+  const contentLength = input.headers.get('content-length')
+  if (contentLength !== null && contentLength !== '0') return true
+  if (input.headers.has('transfer-encoding')) return true
+
+  return false
 }


### PR DESCRIPTION
Hardens HTTP charging / close control flows

* Added zero-amount validation to session requests — the session method schema now rejects amount: '0' so servers can't accidentally create free sessions.
* Fixed plain HTTP session charging — non-SSE (regular JSON) responses from session routes now correctly deduct a tick from the channel and attach a Payment-Receipt, and same-voucher replays are rejected with a 402 instead of being served for free.
* Hardened the session close flow — SessionManager.close() now throws a descriptive error when the close request fails (instead of silently ignoring it), and management requests (close/topUp) are distinguished from content requests so they don't get charged.