### PR TITLE
fix: charge request-unit SSE streams once

### DIFF
--- a/.changeset/rare-kiwis-travel.md
+++ b/.changeset/rare-kiwis-travel.md
@@ -1,0 +1,3 @@
+'mppx': patch
+
+Charge `tempo/session` SSE streams with `unitType: "request"` once per streamed response instead of once per emitted SSE data event.

--- a/src/tempo/server/Session.test.ts
+++ b/src/tempo/server/Session.test.ts
@@ -3429,6 +3429,91 @@ describe.runIf(isLocalnet)('session', () => {
       expect(persisted?.finalized).toBe(true)
     })
 
+    test('unitType=request auto-metered SSE responses charge once across the stream', async () => {
+      const backingStore = Store.memory()
+      const routeHandler = Mppx_server.create({
+        methods: [
+          tempo_server.session({
+            store: backingStore,
+            getClient: () => client,
+            account: recipientAccount,
+            currency,
+            escrowContract,
+            chainId: chain.id,
+            sse: true,
+          }),
+        ],
+        realm: 'api.example.com',
+        secretKey: 'secret',
+      }).session({ amount: '1', decimals: 6, unitType: 'request' })
+
+      let voucherPosts = 0
+      const fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = new Request(input, init)
+        let action: 'open' | 'topUp' | 'voucher' | 'close' | undefined
+
+        if (request.method === 'POST' && request.headers.has('Authorization')) {
+          try {
+            const credential = Credential.fromRequest<any>(request)
+            action = credential.payload?.action
+            if (action === 'voucher') voucherPosts++
+          } catch {}
+        }
+
+        const result = await routeHandler(request)
+        if (result.status === 402) return result.challenge
+
+        if (action === 'voucher') {
+          return new Response(null, { status: 200 })
+        }
+
+        if (request.headers.get('Accept')?.includes('text/event-stream')) {
+          const encoder = new TextEncoder()
+          const upstream = new Response(
+            new ReadableStream({
+              start(controller) {
+                controller.enqueue(encoder.encode('event: message\ndata: chunk-1\n\n'))
+                controller.enqueue(encoder.encode('event: message\ndata: chunk-2\n\n'))
+                controller.enqueue(encoder.encode('event: message\ndata: chunk-3\n\n'))
+                controller.close()
+              },
+            }),
+            { headers: { 'Content-Type': 'text/event-stream; charset=utf-8' } },
+          )
+          return result.withReceipt(upstream)
+        }
+
+        return result.withReceipt(new Response('ok'))
+      }
+
+      const manager = sessionManager({
+        account: payer,
+        client,
+        escrowContract,
+        fetch,
+        maxDeposit: '1',
+      })
+
+      const chunks: string[] = []
+      const stream = await manager.sse('https://api.example.com/stream')
+      for await (const chunk of stream) chunks.push(chunk)
+
+      expect(chunks).toEqual(['chunk-1', 'chunk-2', 'chunk-3'])
+      expect(voucherPosts).toBe(0)
+
+      const closeReceipt = await manager.close()
+      expect(closeReceipt?.status).toBe('success')
+      expect(closeReceipt?.spent).toBe('1000000')
+
+      const channelId = manager.channelId
+      expect(channelId).toBeTruthy()
+
+      const persisted = await ChannelStore.fromStore(backingStore).getChannel(channelId!)
+      expect(persisted?.spent).toBe(1000000n)
+      expect(persisted?.units).toBe(1)
+      expect(persisted?.finalized).toBe(true)
+    })
+
     test('handles repeated exhaustion/resume cycles within one stream', async () => {
       const backingStore = Store.memory()
       const routeHandler = Mppx_server.create({

--- a/src/tempo/server/internal/transport.test.ts
+++ b/src/tempo/server/internal/transport.test.ts
@@ -38,7 +38,14 @@ function seedChannel(
   }))
 }
 
-function makeChallenge() {
+function makeChallenge(
+  request: Partial<{
+    amount: string
+    currency: string
+    recipient: string
+    unitType: string
+  }> = {},
+) {
   return Challenge.from({
     id: challengeId,
     realm: 'test.example.com',
@@ -48,12 +55,20 @@ function makeChallenge() {
       amount: '1000000',
       currency: '0x20c0000000000000000000000000000000000001',
       recipient: '0x0000000000000000000000000000000000000002',
+      ...request,
     },
   })
 }
 
-function makeCredential() {
-  const challenge = makeChallenge()
+function makeCredential(
+  request: Partial<{
+    amount: string
+    currency: string
+    recipient: string
+    unitType: string
+  }> = {},
+) {
+  const challenge = makeChallenge(request)
   return Credential.from({
     challenge,
     payload: {
@@ -65,8 +80,15 @@ function makeCredential() {
   })
 }
 
-function makeAuthorizedRequest(): Request {
-  const credential = makeCredential()
+function makeAuthorizedRequest(
+  request: Partial<{
+    amount: string
+    currency: string
+    recipient: string
+    unitType: string
+  }> = {},
+): Request {
+  const credential = makeCredential(request)
   const header = Credential.serialize(credential)
   return new Request('https://test.example.com/session', {
     headers: { Authorization: header },
@@ -93,6 +115,17 @@ async function readResponseText(response: Response): Promise<string> {
     result += decoder.decode(value, { stream: true })
   }
   return result
+}
+
+function readTerminalReceipt(output: string) {
+  const receiptRaw = output.split('event: payment-receipt\ndata: ')[1]?.split('\n\n')[0]
+  if (!receiptRaw) throw new Error('expected terminal receipt')
+  return JSON.parse(receiptRaw) as {
+    challengeId: string
+    channelId: string
+    spent: string
+    units?: number
+  }
 }
 
 describe('sse transport', () => {
@@ -169,8 +202,7 @@ describe('sse transport', () => {
     expect(response.headers.get('Content-Type')).toContain('text/event-stream')
 
     const body = await readResponseText(response)
-    const receiptRaw = body.split('event: payment-receipt\ndata: ')[1]?.split('\n\n')[0]
-    const terminalReceipt = JSON.parse(receiptRaw!)
+    const terminalReceipt = readTerminalReceipt(body)
 
     expect(response.headers.get('Payment-Receipt')).toBeNull()
     expect(body).toContain('event: message\ndata: hello\n\n')
@@ -180,6 +212,62 @@ describe('sse transport', () => {
     expect(terminalReceipt.channelId).toBe(channelId)
     expect(terminalReceipt.units).toBe(2)
     expect(terminalReceipt.spent).toBe('2000000')
+  })
+
+  test('respondReceipt with AsyncIterable and unitType=request charges once', async () => {
+    const store = memoryStore()
+    await seedChannel(store, 10000000n)
+    const transport = sse({ store })
+    const request = makeAuthorizedRequest({ unitType: 'request' })
+
+    async function* gen() {
+      yield 'hello'
+      yield 'world'
+      yield 'again'
+    }
+
+    const response = transport.respondReceipt({
+      credential: makeCredential({ unitType: 'request' }),
+      input: request,
+      receipt: makeReceipt(),
+      response: gen(),
+      challengeId,
+    })
+
+    const body = await readResponseText(response)
+    const terminalReceipt = readTerminalReceipt(body)
+    const channel = await store.getChannel(channelId)
+
+    expect(channel!.spent).toBe(1000000n)
+    expect(channel!.units).toBe(1)
+    expect(terminalReceipt.spent).toBe('1000000')
+    expect(terminalReceipt.units).toBe(1)
+  })
+
+  test('respondReceipt with unitType=request does not charge an empty AsyncIterable', async () => {
+    const store = memoryStore()
+    await seedChannel(store, 10000000n)
+    const transport = sse({ store })
+    const request = makeAuthorizedRequest({ unitType: 'request' })
+
+    async function* gen() {}
+
+    const response = transport.respondReceipt({
+      credential: makeCredential({ unitType: 'request' }),
+      input: request,
+      receipt: makeReceipt(),
+      response: gen(),
+      challengeId,
+    })
+
+    const body = await readResponseText(response)
+    const terminalReceipt = readTerminalReceipt(body)
+    const channel = await store.getChannel(channelId)
+
+    expect(channel!.spent).toBe(0n)
+    expect(channel!.units).toBe(0)
+    expect(terminalReceipt.spent).toBe('0')
+    expect(terminalReceipt.units).toBe(0)
   })
 
   test('respondReceipt with AsyncGeneratorFunction passes stream controller', async () => {
@@ -233,6 +321,46 @@ describe('sse transport', () => {
     expect(body).toContain('event: message\ndata: chunk1\n\n')
     expect(body).toContain('event: message\ndata: chunk2\n\n')
     expect(body).toContain('event: payment-receipt\n')
+  })
+
+  test('respondReceipt with upstream SSE Response and unitType=request charges once', async () => {
+    const store = memoryStore()
+    await seedChannel(store, 10000000n)
+    const transport = sse({ store })
+    const request = makeAuthorizedRequest({ unitType: 'request' })
+
+    const encoder = new TextEncoder()
+    const upstream = new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode('event: message\ndata: chunk1\n\n'))
+          controller.enqueue(encoder.encode('event: message\ndata: chunk2\n\n'))
+          controller.enqueue(encoder.encode('event: message\ndata: chunk3\n\n'))
+          controller.close()
+        },
+      }),
+      { headers: { 'Content-Type': 'text/event-stream; charset=utf-8' } },
+    )
+
+    const response = transport.respondReceipt({
+      credential: makeCredential({ unitType: 'request' }),
+      input: request,
+      receipt: makeReceipt(),
+      response: upstream,
+      challengeId,
+    })
+
+    const body = await readResponseText(response)
+    const terminalReceipt = readTerminalReceipt(body)
+    const channel = await store.getChannel(channelId)
+
+    expect(channel!.spent).toBe(1000000n)
+    expect(channel!.units).toBe(1)
+    expect(body).toContain('event: message\ndata: chunk1\n\n')
+    expect(body).toContain('event: message\ndata: chunk2\n\n')
+    expect(body).toContain('event: message\ndata: chunk3\n\n')
+    expect(terminalReceipt.spent).toBe('1000000')
+    expect(terminalReceipt.units).toBe(1)
   })
 
   test('respondReceipt with plain Response delegates to base http transport', () => {

--- a/src/tempo/server/internal/transport.test.ts
+++ b/src/tempo/server/internal/transport.test.ts
@@ -244,6 +244,36 @@ describe('sse transport', () => {
     expect(terminalReceipt.units).toBe(1)
   })
 
+  test('respondReceipt with AsyncIterable and non-request unitType still charges per chunk', async () => {
+    const store = memoryStore()
+    await seedChannel(store, 10000000n)
+    const transport = sse({ store })
+    const request = makeAuthorizedRequest({ unitType: 'token' })
+
+    async function* gen() {
+      yield 'hello'
+      yield 'world'
+      yield 'again'
+    }
+
+    const response = transport.respondReceipt({
+      credential: makeCredential({ unitType: 'token' }),
+      input: request,
+      receipt: makeReceipt(),
+      response: gen(),
+      challengeId,
+    })
+
+    const body = await readResponseText(response)
+    const terminalReceipt = readTerminalReceipt(body)
+    const channel = await store.getChannel(channelId)
+
+    expect(channel!.spent).toBe(3000000n)
+    expect(channel!.units).toBe(3)
+    expect(terminalReceipt.spent).toBe('3000000')
+    expect(terminalReceipt.units).toBe(3)
+  })
+
   test('respondReceipt with unitType=request does not charge an empty AsyncIterable', async () => {
     const store = memoryStore()
     await seedChannel(store, 10000000n)
@@ -287,6 +317,35 @@ describe('sse transport', () => {
       challengeId,
     })
     expect(response.headers.get('Content-Type')).toContain('text/event-stream')
+  })
+
+  test('respondReceipt with AsyncGeneratorFunction and unitType=request preserves manual charge calls', async () => {
+    const store = memoryStore()
+    await seedChannel(store, 10000000n)
+    const transport = sse({ store })
+    const request = makeAuthorizedRequest({ unitType: 'request' })
+
+    const response = transport.respondReceipt({
+      credential: makeCredential({ unitType: 'request' }),
+      input: request,
+      receipt: makeReceipt(),
+      response: async function* (stream) {
+        await stream.charge()
+        yield 'hello'
+        await stream.charge()
+        yield 'world'
+      },
+      challengeId,
+    })
+
+    const body = await readResponseText(response)
+    const terminalReceipt = readTerminalReceipt(body)
+    const channel = await store.getChannel(channelId)
+
+    expect(channel!.spent).toBe(2000000n)
+    expect(channel!.units).toBe(2)
+    expect(terminalReceipt.spent).toBe('2000000')
+    expect(terminalReceipt.units).toBe(2)
   })
 
   test('respondReceipt with upstream SSE Response auto-detects and iterates', async () => {
@@ -361,6 +420,41 @@ describe('sse transport', () => {
     expect(body).toContain('event: message\ndata: chunk3\n\n')
     expect(terminalReceipt.spent).toBe('1000000')
     expect(terminalReceipt.units).toBe(1)
+  })
+
+  test('respondReceipt with empty upstream SSE Response and unitType=request does not charge', async () => {
+    const store = memoryStore()
+    await seedChannel(store, 10000000n)
+    const transport = sse({ store })
+    const request = makeAuthorizedRequest({ unitType: 'request' })
+
+    const encoder = new TextEncoder()
+    const upstream = new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode('event: message\ndata: [DONE]\n\n'))
+          controller.close()
+        },
+      }),
+      { headers: { 'Content-Type': 'text/event-stream; charset=utf-8' } },
+    )
+
+    const response = transport.respondReceipt({
+      credential: makeCredential({ unitType: 'request' }),
+      input: request,
+      receipt: makeReceipt(),
+      response: upstream,
+      challengeId,
+    })
+
+    const body = await readResponseText(response)
+    const terminalReceipt = readTerminalReceipt(body)
+    const channel = await store.getChannel(channelId)
+
+    expect(channel!.spent).toBe(0n)
+    expect(channel!.units).toBe(0)
+    expect(terminalReceipt.spent).toBe('0')
+    expect(terminalReceipt.units).toBe(0)
   })
 
   test('respondReceipt with plain Response delegates to base http transport', () => {

--- a/src/tempo/server/internal/transport.ts
+++ b/src/tempo/server/internal/transport.ts
@@ -64,6 +64,10 @@ export function sse(options: sse.Options & { store: ChannelStore.ChannelStore })
       if (!payload.channelId) throw new Error('No SSE context available')
       const channelId = payload.channelId
       const tickCost = BigInt(verifiedCredential.challenge.request.amount as string)
+      const unitType =
+        typeof verifiedCredential.challenge.request.unitType === 'string'
+          ? verifiedCredential.challenge.request.unitType
+          : undefined
 
       // Auto-detect upstream SSE responses and parse them into an
       // AsyncIterable so they flow through the metered pipeline.
@@ -78,9 +82,7 @@ export function sse(options: sse.Options & { store: ChannelStore.ChannelStore })
         // Pass async generator functions directly so Sse.serve gives them
         // a SessionController for manual charge(). Pass raw AsyncIterables
         // as-is so Sse.serve auto-charges per yielded value.
-        const generate: Sse_core.serve.Options['generate'] = isAsyncGeneratorFunction(resolved)
-          ? (resolved as Sse_core.serve.Options['generate'])
-          : (resolved as AsyncIterable<string>)
+        const generate = resolveMeteredGenerate(resolved, unitType)
         const stream = Sse_core.serve({
           store,
           channelId,
@@ -197,6 +199,26 @@ function isAsyncGeneratorFunction(
 
 function isAsyncIterable(value: unknown): value is AsyncIterable<string> {
   return value !== null && typeof value === 'object' && Symbol.asyncIterator in (value as object)
+}
+
+function resolveMeteredGenerate(
+  value: AsyncIterable<string> | ((...args: unknown[]) => AsyncIterable<string>),
+  unitType: string | undefined,
+): Sse_core.serve.Options['generate'] {
+  if (isAsyncGeneratorFunction(value)) return value as Sse_core.serve.Options['generate']
+  if (unitType !== 'request') return value as AsyncIterable<string>
+
+  const iterable = value as AsyncIterable<string>
+  return async function* chargeOnce(stream) {
+    let charged = false
+    for await (const chunk of iterable) {
+      if (!charged) {
+        await stream.charge()
+        charged = true
+      }
+      yield chunk
+    }
+  }
 }
 
 function isNullBodyStatus(status: number): boolean {


### PR DESCRIPTION
## Summary
- charge auto-metered `tempo/session` streams with `unitType: "request"` once on first delivered chunk instead of once per emitted SSE data event
- keep existing per-chunk metering for non-request unit types and leave manual `stream.charge()` generators unchanged
- add transport and end-to-end session tests for direct async iterables, upstream SSE responses, empty streams, and the proxy-style `withReceipt(upstreamResponse)` flow

## Root cause
`mppx` treated all auto-metered async iterables as per-unit streams. For proxy-style SSE responses, that meant a request-level estimated `amount` was charged once per upstream SSE frame. This could result in overcharging in some cases, depending on how the lower level frames were buffered. 