### PR TITLE
fix: align tempo session billing classification

### DIFF
--- a/.changeset/fair-dancers-notice.md
+++ b/.changeset/fair-dancers-notice.md
@@ -1,0 +1,3 @@
+'mppx': patch
+
+Fix tempo session billing classification so MCP tool calls and HEAD requests cannot bypass the shared management-vs-content gate.

--- a/.changeset/fair-dancers-notice.md
+++ b/.changeset/fair-dancers-notice.md
@@ -1,3 +1,3 @@
 'mppx': patch
 
-Fix tempo session billing classification so MCP tool calls and HEAD requests cannot bypass the shared management-vs-content gate.
+Thread context through pinned requests so MCP tool calls and HEAD requests cannot bypass the shared management-vs-content gate.

--- a/src/Method.ts
+++ b/src/Method.ts
@@ -168,8 +168,10 @@ export type VerifyFn<method extends Method> = (
  * response or generator. If it returns `undefined`, the server handler
  * is expected to serve content via `withReceipt(response)`.
  *
- * **HTTP-only.** The `input` parameter is a `Request` object; MCP transports
- * do not invoke this hook.
+ * Use `parameters.envelope?.capturedRequest` for any transport-agnostic
+ * authorization, billing, or routing decisions. The raw `input` should only
+ * be used for transport-specific response shaping (for example, HTTP content
+ * negotiation).
  */
 export type RespondFn<method extends Method> = (
   parameters: RespondContext<method>,

--- a/src/mcp-sdk/server/Transport.test.ts
+++ b/src/mcp-sdk/server/Transport.test.ts
@@ -31,7 +31,7 @@ describe('mcpSdk', () => {
       const transport = mcpSdk()
 
       expect(await transport.captureRequest?.({})).toEqual({
-        hasBody: false,
+        hasBody: true,
         headers: new Headers(),
         method: 'POST',
         url: new URL('mcp://request/sdk'),

--- a/src/mcp-sdk/server/Transport.ts
+++ b/src/mcp-sdk/server/Transport.ts
@@ -53,7 +53,7 @@ export function mcpSdk(): McpSdk {
 
     captureRequest() {
       return {
-        hasBody: false,
+        hasBody: true,
         headers: new Headers(),
         method: 'POST',
         url: new URL('mcp://request/sdk'),

--- a/src/mcp-sdk/server/Transport.ts
+++ b/src/mcp-sdk/server/Transport.ts
@@ -53,6 +53,8 @@ export function mcpSdk(): McpSdk {
 
     captureRequest() {
       return {
+        // MCP tool invocations are application content requests even though
+        // they do not carry HTTP body headers on the transport boundary.
         hasBody: true,
         headers: new Headers(),
         method: 'POST',

--- a/src/server/Transport.test.ts
+++ b/src/server/Transport.test.ts
@@ -432,7 +432,7 @@ describe('mcp', () => {
       const transport = Transport.mcp()
 
       expect(await transport.captureRequest?.(mcpRequest)).toEqual({
-        hasBody: false,
+        hasBody: true,
         headers: new Headers(),
         method: 'POST',
         url: new URL('mcp://request/tools%2Fcall'),

--- a/src/server/Transport.ts
+++ b/src/server/Transport.ts
@@ -222,6 +222,8 @@ export function mcp() {
 
     captureRequest(request) {
       return {
+        // MCP tool invocations are application content requests even though
+        // they do not carry HTTP body headers on the transport boundary.
         hasBody: true,
         headers: new Headers(),
         method: 'POST',

--- a/src/server/Transport.ts
+++ b/src/server/Transport.ts
@@ -222,7 +222,7 @@ export function mcp() {
 
     captureRequest(request) {
       return {
-        hasBody: false,
+        hasBody: true,
         headers: new Headers(),
         method: 'POST',
         url: new URL(`mcp://request/${encodeURIComponent(request.method ?? 'unknown')}`),

--- a/src/tempo/server/Session.test.ts
+++ b/src/tempo/server/Session.test.ts
@@ -2,7 +2,11 @@ import * as node_http from 'node:http'
 
 import type { z } from 'mppx'
 import { Challenge, Credential } from 'mppx'
-import { Mppx as Mppx_server, tempo as tempo_server } from 'mppx/server'
+import {
+  Mppx as Mppx_server,
+  Transport as ServerTransport,
+  tempo as tempo_server,
+} from 'mppx/server'
 import { Base64 } from 'ox'
 import {
   type Address,
@@ -2641,7 +2645,7 @@ describe.runIf(isLocalnet)('session', () => {
   })
 
   describe('protocol compatibility', () => {
-    test('HEAD voucher management request falls through to content handler', () => {
+    test('HEAD voucher request is gated as a non-billable management request', () => {
       const server = createServer()
       const response = server.respond!({
         credential: {
@@ -2650,12 +2654,135 @@ describe.runIf(isLocalnet)('session', () => {
           }),
           payload: { action: 'voucher' },
         },
+        envelope: {
+          capturedRequest: {
+            hasBody: false,
+            headers: new Headers(),
+            method: 'HEAD',
+            url: new URL('https://api.example.com/resource'),
+          },
+        },
         input: new Request('https://api.example.com/resource', {
           method: 'HEAD',
         }),
       } as never)
 
+      expect(response).toBeInstanceOf(Response)
+      expect((response as Response).status).toBe(204)
+    })
+
+    test('captured request classification wins over the raw input method', () => {
+      const server = createServer()
+      const response = server.respond!({
+        credential: {
+          challenge: makeChallenge({
+            channelId: '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex,
+          }),
+          payload: { action: 'voucher' },
+        },
+        envelope: {
+          capturedRequest: {
+            hasBody: false,
+            headers: new Headers(),
+            method: 'POST',
+            url: new URL('mcp://request/tools%2Fcall'),
+          },
+        },
+        input: new Request('https://api.example.com/resource', {
+          method: 'GET',
+        }),
+      } as never)
+
+      expect(response).toBeInstanceOf(Response)
+      expect((response as Response).status).toBe(204)
+    })
+
+    test('captured request body metadata wins over a bodyless raw input', () => {
+      const server = createServer()
+      const response = server.respond!({
+        credential: {
+          challenge: makeChallenge({
+            channelId: '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex,
+          }),
+          payload: { action: 'voucher' },
+        },
+        envelope: {
+          capturedRequest: {
+            hasBody: true,
+            headers: new Headers(),
+            method: 'POST',
+            url: new URL('mcp://request/tools%2Fcall'),
+          },
+        },
+        input: new Request('https://api.example.com/resource', {
+          method: 'POST',
+        }),
+      } as never)
+
       expect(response).toBeUndefined()
+    })
+
+    test('bills repeated MCP voucher replays using the captured request snapshot', async () => {
+      const { channelId, serializedTransaction } = await createSignedOpenTransaction(5000000n)
+      const server = createServer()
+      const mcpCapturedRequest = await ServerTransport.mcp().captureRequest?.({
+        id: 1,
+        jsonrpc: '2.0',
+        method: 'tools/call',
+        params: {},
+      })
+      if (!mcpCapturedRequest) throw new Error('missing MCP captured request')
+
+      const openChallenge = makeChallenge({ id: 'mcp-open', channelId })
+      const openCredential = {
+        challenge: openChallenge,
+        payload: {
+          action: 'open' as const,
+          type: 'transaction' as const,
+          channelId,
+          transaction: serializedTransaction,
+          cumulativeAmount: '2000000',
+          signature: await signTestVoucher(channelId, 2000000n),
+        },
+      }
+      const openReceipt = (await server.verify({
+        credential: openCredential,
+        envelope: {
+          capturedRequest: mcpCapturedRequest,
+          challenge: openChallenge,
+          credential: openCredential,
+        },
+        request: makeRequest({ amount: '1' }),
+      } as never)) as SessionReceipt
+      expect(openReceipt.spent).toBe('1000000')
+      expect(openReceipt.units).toBe(1)
+
+      const replayChallenge = makeChallenge({ id: 'mcp-replay', channelId })
+      const replayCredential = {
+        challenge: replayChallenge,
+        payload: {
+          action: 'voucher' as const,
+          channelId,
+          cumulativeAmount: '2000000',
+          signature: await signTestVoucher(channelId, 2000000n),
+        },
+      }
+      const replayReceipt = (await server.verify({
+        credential: replayCredential,
+        envelope: {
+          capturedRequest: mcpCapturedRequest,
+          challenge: replayChallenge,
+          credential: replayCredential,
+        },
+        request: makeRequest({ amount: '1' }),
+      } as never)) as SessionReceipt
+
+      expect(replayReceipt.spent).toBe('2000000')
+      expect(replayReceipt.units).toBe(2)
+
+      const channel = await store.getChannel(channelId)
+      expect(channel?.spent).toBe(2000000n)
+      expect(channel?.units).toBe(2)
     })
 
     test('ignores unknown challenge and credential fields for forward compatibility', async () => {

--- a/src/tempo/server/Session.ts
+++ b/src/tempo/server/Session.ts
@@ -287,26 +287,24 @@ export function session<const parameters extends session.Parameters>(
     //
     // close and topUp are always gated (204) — they are pure management.
     //
-    // open and voucher are gated only for bodyless POSTs (management
-    // updates). POSTs with a body are content requests — the client's
-    // original request piggybacked on the credential — so they fall
-    // through to serve content. GETs always fall through so auto-mode
-    // clients (whose fetch wrapper bundles open+voucher into a single
-    // GET retry) receive content as expected.
-    respond({ credential, input }) {
+    // open and voucher share the same captured-request classifier used
+    // during verification. Non-billable requests are treated as management
+    // updates; billable requests fall through to the application handler.
+    respond({ credential, envelope, input }) {
       const { payload } = credential as Credential.Credential<SessionCredentialPayload>
 
       if (payload.action === 'close') return new Response(null, { status: 204 })
       if (payload.action === 'topUp') return new Response(null, { status: 204 })
 
-      // open and voucher: gate only bodyless POSTs (management updates).
-      // POSTs with a body are content requests — fall through so the
-      // upstream response is returned to the client.
-      if (input.method === 'POST') {
-        if (hasRequestBody(input)) return undefined
-        return new Response(null, { status: 204 })
+      const capturedRequest = envelope?.capturedRequest ?? {
+        hasBody: input.body !== null,
+        headers: input.headers,
+        method: input.method,
+        url: new URL(input.url),
       }
-      return undefined
+
+      if (isBillableContentRequest(capturedRequest)) return undefined
+      return new Response(null, { status: 204 })
     },
   })
 }
@@ -494,14 +492,6 @@ function hasCapturedRequestBody(input: {
 
   if (input.hasBody === true) return true
   return headerIndicatesBody
-}
-
-function hasRequestBody(input: Request): boolean {
-  return (
-    input.body !== null ||
-    input.headers.has('transfer-encoding') ||
-    (input.headers.get('content-length') !== null && input.headers.get('content-length') !== '0')
-  )
 }
 
 /**


### PR DESCRIPTION
## Summary
- classify session management vs billable content from the captured request snapshot in `tempo/session`
- mark MCP transports as body-bearing so tool calls are billed like other content requests
- add regressions for HEAD gating, captured-request precedence, and billed MCP voucher replays