### PR TITLE
fix: format changeset test file

### DIFF
--- a/src/internal/changeset.test.ts
+++ b/src/internal/changeset.test.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
+
 import { describe, expect, test } from 'vp/test'
 
 const changesetDir = path.resolve(import.meta.dirname, '../../.changeset')


### PR DESCRIPTION
Fixes CI — `src/internal/changeset.test.ts` was missing a blank line between import groups, causing the `vp fmt --check` step to fail.