### PR TITLE
feat(cli): add account private-key command

### DIFF
--- a/.changeset/account-private-key-command.md
+++ b/.changeset/account-private-key-command.md
@@ -2,4 +2,4 @@
 'mppx': patch
 ---
 
-Add an `mppx account private-key` command for exporting the private key of local keychain-backed accounts.
+Added `mppx account private-key` command for exporting the private key of local keychain-backed accounts.

--- a/.changeset/account-private-key-command.md
+++ b/.changeset/account-private-key-command.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Add an `mppx account private-key` command for exporting the private key of local keychain-backed accounts.

--- a/.changeset/account-private-key-command.md
+++ b/.changeset/account-private-key-command.md
@@ -2,4 +2,4 @@
 'mppx': patch
 ---
 
-Added `mppx account private-key` command for exporting the private key of local keychain-backed accounts.
+Added `mppx account export` command for exporting the private key of local keychain-backed accounts.

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -1118,12 +1118,12 @@ describe.skipIf(!!process.env.CI)('account', () => {
     expect(result.stdout).toContain('not found')
   })
 
-  // --- account private-key ---
+  // --- account export ---
 
-  test('private-key: prints private key for existing account', () => {
-    const name = `${prefix}_private_key`
+  test('export: prints private key for existing account', () => {
+    const name = `${prefix}_export`
     createAccount(name)
-    const result = accountRun(['account', 'private-key', '--account', name])
+    const result = accountRun(['account', 'export', '--account', name])
     expect(result.status).toBe(0)
 
     const privateKey = result.stdout.match(/0x[0-9a-fA-F]{64}/)?.[0]
@@ -1133,8 +1133,8 @@ describe.skipIf(!!process.env.CI)('account', () => {
     expect(view.stdout).toContain(privateKeyToAccount(privateKey as `0x${string}`).address)
   })
 
-  test('private-key: missing account exits non-zero', () => {
-    const result = accountRun(['account', 'private-key', '--account', `${prefix}_missing_private`])
+  test('export: missing account exits non-zero', () => {
+    const result = accountRun(['account', 'export', '--account', `${prefix}_missing_export`])
     expect(result.status).not.toBe(0)
     expect(result.stdout).toContain('not found')
   })

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -1118,6 +1118,27 @@ describe.skipIf(!!process.env.CI)('account', () => {
     expect(result.stdout).toContain('not found')
   })
 
+  // --- account private-key ---
+
+  test('private-key: prints private key for existing account', () => {
+    const name = `${prefix}_private_key`
+    createAccount(name)
+    const result = accountRun(['account', 'private-key', '--account', name])
+    expect(result.status).toBe(0)
+
+    const privateKey = result.stdout.match(/0x[0-9a-fA-F]{64}/)?.[0]
+    expect(privateKey).toBeDefined()
+
+    const view = accountRun(['account', 'view', '--account', name])
+    expect(view.stdout).toContain(privateKeyToAccount(privateKey as `0x${string}`).address)
+  })
+
+  test('private-key: missing account exits non-zero', () => {
+    const result = accountRun(['account', 'private-key', '--account', `${prefix}_missing_private`])
+    expect(result.status).not.toBe(0)
+    expect(result.stdout).toContain('not found')
+  })
+
   // --- account list ---
 
   test('list: includes created accounts', () => {

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -497,7 +497,7 @@ const cli = Cli.create('mppx', {
 })
 
 const account = Cli.create('account', {
-  description: 'Manage accounts (create, default, delete, fund, list, view)',
+  description: 'Manage accounts (create, default, delete, fund, list, private-key, view)',
 })
   .command('create', {
     description: 'Create new account',
@@ -711,6 +711,38 @@ const account = Cli.create('account', {
           `${label}${' '.repeat(maxWidth - width + 2)}${pc.dim(addrDisplay)}${sourceLabel}`,
         )
       }
+    },
+  })
+  .command('private-key', {
+    description: 'Print the private key for a local account',
+    options: z.object({
+      account: z.string().optional().describe('Account name (env: MPPX_ACCOUNT)'),
+    }),
+    alias: { account: 'a' },
+    async run(c) {
+      const accountName = resolveAccountName(c.options.account)
+
+      if (isTempoAccount(accountName)) {
+        return c.error({
+          code: 'UNSUPPORTED_ACCOUNT',
+          message: `Account "${accountName}" is managed by Tempo wallet and does not expose a private key via mppx.`,
+          exitCode: 2,
+        })
+      }
+
+      const key = await createKeychain(accountName).get()
+      if (!key) {
+        if (c.options.account)
+          return c.error({
+            code: 'ACCOUNT_NOT_FOUND',
+            message: `Account "${accountName}" not found.`,
+            exitCode: 69,
+          })
+        else
+          return c.error({ code: 'ACCOUNT_NOT_FOUND', message: 'No account found.', exitCode: 69 })
+      }
+
+      console.log(key)
     },
   })
   .command('view', {

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -497,7 +497,7 @@ const cli = Cli.create('mppx', {
 })
 
 const account = Cli.create('account', {
-  description: 'Manage accounts (create, default, delete, fund, list, private-key, view)',
+  description: 'Manage accounts (create, default, delete, export, fund, list, view)',
 })
   .command('create', {
     description: 'Create new account',
@@ -713,8 +713,8 @@ const account = Cli.create('account', {
       }
     },
   })
-  .command('private-key', {
-    description: 'Print the private key for a local account',
+  .command('export', {
+    description: 'Export the private key for a local account',
     options: z.object({
       account: z.string().optional().describe('Account name (env: MPPX_ACCOUNT)'),
     }),


### PR DESCRIPTION
## Summary
- add `mppx account private-key` for exporting local keychain-backed account keys
- return a clear error for Tempo wallet pseudo-accounts, which are not stored in the local mppx keychain
- add CLI coverage for success and missing-account cases
