### PR TITLE
feat: add `acceptPaymentPolicy` to control Accept-Payment header injection

### DIFF
--- a/.changeset/accept-payment-breaking.md
+++ b/.changeset/accept-payment-breaking.md
@@ -1,0 +1,5 @@
+---
+'mppx': minor
+---
+
+**Breaking:** Removed default `Accept-Payment` headers on every outgoing request for polyfilled fetch. Now defaults to same-origin requests. Use `acceptPaymentPolicy.origins` to control supported payment origins.

--- a/.changeset/accept-payment-breaking.md
+++ b/.changeset/accept-payment-breaking.md
@@ -2,4 +2,4 @@
 'mppx': minor
 ---
 
-**Breaking:** Removed default `Accept-Payment` headers on every outgoing request for polyfilled fetch. Now defaults to same-origin requests. Use `acceptPaymentPolicy.origins` to control supported payment origins.
+**Breaking:** Removed default `Accept-Payment` headers on every outgoing request for polyfilled fetch in browsers. Now defaults to same-origin requests in browser environments. Non-browser environments are unaffected. Use `acceptPaymentPolicy` to control supported payment origins.

--- a/.changeset/accept-payment-policy.md
+++ b/.changeset/accept-payment-policy.md
@@ -4,5 +4,7 @@
 
 Added `acceptPaymentPolicy` option to control when the `Accept-Payment` header is injected on outgoing requests, mitigating CORS preflight failures on non-payment-aware servers.
 
-- `Fetch.polyfill` and `Mppx.create` (with `polyfill: true`) default to `'same-origin'`, preventing cross-origin CORS issues.
-- `Mppx.create` with `polyfill: false` defaults to `'always'`.
+- In browsers, `Fetch.polyfill` and `Mppx.create` (with `polyfill: true`) default to `'same-origin'`, preventing cross-origin CORS issues.
+- Non-browser environments and `Mppx.create` with `polyfill: false` default to `'always'`.
+- Supported values: `'always'`, `'same-origin'`, `'never'`, `{ origins: string[] }` (with `*.` wildcard support).
+- Exported `Fetch` namespace from `mppx/client`.

--- a/.changeset/accept-payment-policy.md
+++ b/.changeset/accept-payment-policy.md
@@ -1,0 +1,8 @@
+---
+'mppx': patch
+---
+
+Added `acceptPaymentPolicy` option to control when the `Accept-Payment` header is injected on outgoing requests, mitigating CORS preflight failures on non-payment-aware servers.
+
+- `Fetch.polyfill` and `Mppx.create` (with `polyfill: true`) default to `'same-origin'`, preventing cross-origin CORS issues.
+- `Mppx.create` with `polyfill: false` defaults to `'always'`.

--- a/src/client/Mppx.ts
+++ b/src/client/Mppx.ts
@@ -58,10 +58,14 @@ export function create<
     Response
   >,
 >(config: create.Config<methods, transport>): Mppx<methods, transport> {
-  const { onChallenge, polyfill = true, transport = Transport.http() as transport } = config
+  const {
+    onChallenge,
+    polyfill = true,
+    acceptPaymentPolicy = polyfill ? 'same-origin' : 'always',
+    transport = Transport.http() as transport,
+  } = config
 
   const rawFetch = config.fetch ?? globalThis.fetch
-
   const methods = config.methods.flat() as unknown as FlattenMethods<methods>
   const acceptPayment = AcceptPayment.resolve(methods, config.paymentPreferences)
 
@@ -70,6 +74,7 @@ export function create<
   >['onChallenge']
   const config_fetch = {
     acceptPayment,
+    acceptPaymentPolicy,
     ...(config.fetch && { fetch: config.fetch }),
     ...(resolvedOnChallenge && { onChallenge: resolvedOnChallenge }),
     methods,
@@ -142,6 +147,8 @@ export declare namespace create {
     methods extends Methods = Methods,
     transport extends Transport.Transport = Transport.Transport,
   > = {
+    /** Controls when `Accept-Payment` is injected. */
+    acceptPaymentPolicy?: Fetch.from.Config['acceptPaymentPolicy'] | undefined
     /** Custom fetch function to wrap. Defaults to `globalThis.fetch`. */
     fetch?: typeof globalThis.fetch
     /** Called when a 402 challenge is received, before credential creation. */

--- a/src/client/Mppx.ts
+++ b/src/client/Mppx.ts
@@ -61,7 +61,9 @@ export function create<
   const {
     onChallenge,
     polyfill = true,
-    acceptPaymentPolicy = polyfill ? 'same-origin' : 'always',
+    acceptPaymentPolicy = polyfill && typeof globalThis.location !== 'undefined'
+      ? 'same-origin'
+      : 'always',
     transport = Transport.http() as transport,
   } = config
 

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,4 +1,5 @@
 export * as Expires from '../Expires.js'
+export * as Fetch from './internal/Fetch.js'
 export { session, stripe, tempo } from './Methods.js'
 export * as Mppx from './Mppx.js'
 export * as Transport from './Transport.js'

--- a/src/client/internal/Fetch.browser.test.ts
+++ b/src/client/internal/Fetch.browser.test.ts
@@ -94,6 +94,64 @@ describe('Fetch.from: browser header normalization', () => {
   })
 })
 
+describe('Fetch.from: acceptPaymentPolicy (browser)', () => {
+  test('policy: "same-origin" injects for same-origin requests', async () => {
+    const receivedInits: (RequestInit | undefined)[] = []
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      receivedInits.push(init)
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [noopMethod],
+      acceptPaymentPolicy: 'same-origin',
+    })
+
+    await fetch(`${globalThis.location.origin}/api`)
+    expect(toHeaders(receivedInits[0]?.headers).get('Accept-Payment')).toBe('test/test')
+  })
+
+  test('policy: "same-origin" skips for cross-origin requests', async () => {
+    const receivedInits: (RequestInit | undefined)[] = []
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      receivedInits.push(init)
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [noopMethod],
+      acceptPaymentPolicy: 'same-origin',
+    })
+
+    await fetch('https://cross-origin.example.com/api')
+    expect(toHeaders(receivedInits[0]?.headers).get('Accept-Payment')).toBeNull()
+  })
+
+  test('policy: "same-origin" still handles 402 on cross-origin', async () => {
+    let callCount = 0
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      callCount++
+      if (callCount === 1) {
+        expect(toHeaders(init?.headers).get('Accept-Payment')).toBeNull()
+        return make402()
+      }
+      expect(toHeaders(init?.headers).get('Authorization')).toBe('credential')
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [noopMethod],
+      acceptPaymentPolicy: 'same-origin',
+    })
+
+    const response = await fetch('https://cross-origin.example.com/api')
+    expect(response.status).toBe(200)
+  })
+})
+
 describe('Fetch.polyfill / restore: browser', () => {
   test('restore is a no-op when polyfill was never called', () => {
     const before = globalThis.fetch

--- a/src/client/internal/Fetch.test.ts
+++ b/src/client/internal/Fetch.test.ts
@@ -907,6 +907,179 @@ describe('Fetch.from: 402 retry path', () => {
   })
 })
 
+describe('Fetch.from: acceptPaymentPolicy', () => {
+  test('policy: "always" injects Accept-Payment on all requests', async () => {
+    const receivedInits: (RequestInit | undefined)[] = []
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      receivedInits.push(init)
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [noopMethod],
+      acceptPaymentPolicy: 'always',
+    })
+
+    await fetch('https://cross-origin.com/api')
+    expect(new Headers(receivedInits[0]?.headers).get('Accept-Payment')).toBe('test/test')
+  })
+
+  test('policy: "never" skips Accept-Payment on all requests', async () => {
+    const receivedInits: (RequestInit | undefined)[] = []
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      receivedInits.push(init)
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [noopMethod],
+      acceptPaymentPolicy: 'never',
+    })
+
+    await fetch('https://example.com/api')
+    expect(new Headers(receivedInits[0]?.headers).get('Accept-Payment')).toBeNull()
+  })
+
+  test('policy: "same-origin" injects when no globalThis.location (server-side)', async () => {
+    const receivedInits: (RequestInit | undefined)[] = []
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      receivedInits.push(init)
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [noopMethod],
+      acceptPaymentPolicy: 'same-origin',
+    })
+
+    await fetch('https://example.com/api')
+    expect(new Headers(receivedInits[0]?.headers).get('Accept-Payment')).toBe('test/test')
+  })
+
+  test('policy: { origins } injects only for matching origins', async () => {
+    const receivedInits: (RequestInit | undefined)[] = []
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      receivedInits.push(init)
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [noopMethod],
+      acceptPaymentPolicy: { origins: ['https://pay.example.com'] },
+    })
+
+    await fetch('https://pay.example.com/resource')
+    expect(new Headers(receivedInits[0]?.headers).get('Accept-Payment')).toBe('test/test')
+
+    await fetch('https://other.example.com/resource')
+    expect(new Headers(receivedInits[1]?.headers).get('Accept-Payment')).toBeNull()
+  })
+
+  test('policy: { origins } matches origin regardless of path', async () => {
+    const receivedInits: (RequestInit | undefined)[] = []
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      receivedInits.push(init)
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [noopMethod],
+      acceptPaymentPolicy: { origins: ['https://pay.example.com/some/path'] },
+    })
+
+    await fetch('https://pay.example.com/different/path')
+    expect(new Headers(receivedInits[0]?.headers).get('Accept-Payment')).toBe('test/test')
+  })
+
+  test('policy: { origins } supports wildcard subdomains', async () => {
+    const receivedInits: (RequestInit | undefined)[] = []
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      receivedInits.push(init)
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [noopMethod],
+      acceptPaymentPolicy: { origins: ['*.example.com'] },
+    })
+
+    await fetch('https://pay.example.com/resource')
+    expect(new Headers(receivedInits[0]?.headers).get('Accept-Payment')).toBe('test/test')
+
+    await fetch('https://api.pay.example.com/resource')
+    expect(new Headers(receivedInits[1]?.headers).get('Accept-Payment')).toBe('test/test')
+
+    await fetch('https://example.com/resource')
+    expect(new Headers(receivedInits[2]?.headers).get('Accept-Payment')).toBe('test/test')
+
+    await fetch('https://notexample.com/resource')
+    expect(new Headers(receivedInits[3]?.headers).get('Accept-Payment')).toBeNull()
+  })
+
+  test('policy: "never" still handles 402 responses', async () => {
+    let callCount = 0
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      callCount++
+      if (callCount === 1) {
+        expect(new Headers(init?.headers).get('Accept-Payment')).toBeNull()
+        return make402()
+      }
+      expect(new Headers(init?.headers).get('Authorization')).toBe('credential')
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [noopMethod],
+      acceptPaymentPolicy: 'never',
+    })
+
+    const response = await fetch('https://example.com/api')
+    expect(response.status).toBe(200)
+  })
+
+  test('policy: explicit Accept-Payment header always takes precedence over "never"', async () => {
+    const receivedInits: (RequestInit | undefined)[] = []
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      receivedInits.push(init)
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [noopMethod],
+      acceptPaymentPolicy: 'never',
+    })
+
+    await fetch('https://example.com/api', {
+      headers: { 'Accept-Payment': 'custom/charge' },
+    })
+    expect(new Headers(receivedInits[0]?.headers).get('Accept-Payment')).toBe('custom/charge')
+  })
+
+  test('defaults to "always" for Fetch.from', async () => {
+    const receivedInits: (RequestInit | undefined)[] = []
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      receivedInits.push(init)
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [noopMethod],
+    })
+
+    await fetch('https://cross-origin.com/api')
+    expect(new Headers(receivedInits[0]?.headers).get('Accept-Payment')).toBe('test/test')
+  })
+})
+
 describe('Fetch.from: input passthrough', () => {
   test('passes URL input through on both initial and retry calls', async () => {
     let callCount = 0

--- a/src/client/internal/Fetch.ts
+++ b/src/client/internal/Fetch.ts
@@ -38,7 +38,13 @@ let originalFetch: typeof globalThis.fetch | undefined
 export function from<const methods extends readonly Method.AnyClient[]>(
   config: from.Config<methods>,
 ): from.Fetch<methods> {
-  const { acceptPayment, fetch = globalThis.fetch, methods, onChallenge } = config
+  const {
+    acceptPayment,
+    acceptPaymentPolicy = 'always',
+    fetch = globalThis.fetch,
+    methods,
+    onChallenge,
+  } = config
   const resolvedAcceptPayment = acceptPayment ?? AcceptPayment.resolve(methods)
   // Always operate on the true underlying fetch to avoid wrapper-on-wrapper stacking,
   // which can duplicate retries and make restore semantics fragile.
@@ -54,6 +60,7 @@ export function from<const methods extends readonly Method.AnyClient[]>(
       callerHeaders,
       paymentPreferences.header,
       hasExplicitAcceptPayment,
+      acceptPaymentPolicy,
     )
     const response = await baseFetch(initialRequest.input, initialRequest.init)
 
@@ -108,6 +115,13 @@ export declare namespace from {
   type Config<methods extends readonly Method.AnyClient[] = readonly Method.AnyClient[]> = {
     /** Resolved `Accept-Payment` header and selection preferences. */
     acceptPayment?: AcceptPayment.Resolved<methods> | undefined
+    /** Controls when `Accept-Payment` is injected. @default 'always' */
+    acceptPaymentPolicy?:
+      | 'always'
+      | 'same-origin'
+      | 'never'
+      | { origins: readonly string[] }
+      | undefined
     /** Custom fetch function to wrap. Defaults to `globalThis.fetch`. */
     fetch?: typeof globalThis.fetch
     /** Array of methods to use. */
@@ -165,7 +179,11 @@ export function polyfill<const methods extends readonly Method.AnyClient[]>(
   }
 
   if (!originalFetch) originalFetch = globalThis.fetch
-  globalThis.fetch = from({ ...config, fetch: globalThis.fetch }) as typeof globalThis.fetch
+  globalThis.fetch = from({
+    ...config,
+    acceptPaymentPolicy: config.acceptPaymentPolicy ?? 'same-origin',
+    fetch: globalThis.fetch,
+  }) as typeof globalThis.fetch
 }
 
 export declare namespace polyfill {
@@ -229,8 +247,10 @@ function prepareInitialRequest<methods extends readonly Method.AnyClient[]>(
   callerHeaders: Headers,
   header: string,
   hasExplicitAcceptPayment: boolean,
+  policy: NonNullable<from.Config['acceptPaymentPolicy']>,
 ): { headers: Headers; init: from.RequestInit<methods> | undefined; input: RequestInfo | URL } {
-  const shouldInjectAcceptPayment = Boolean(header) && !hasExplicitAcceptPayment
+  const shouldInjectAcceptPayment =
+    Boolean(header) && !hasExplicitAcceptPayment && shouldInjectForPolicy(input, policy)
   if (!shouldInjectAcceptPayment) return { headers: callerHeaders, init, input }
 
   const headers = new Headers(input instanceof Request ? input.headers : undefined)
@@ -316,4 +336,41 @@ function resolvePaymentPreferences<methods extends readonly Method.AnyClient[]>(
     // defaults instead of throwing from the wrapper.
     return acceptPayment
   }
+}
+
+/** @internal */
+function shouldInjectForPolicy(
+  input: RequestInfo | URL,
+  policy: NonNullable<from.Config['acceptPaymentPolicy']>,
+): boolean {
+  if (policy === 'always') return true
+  if (policy === 'never') return false
+
+  const url = resolveRequestUrl(input)
+
+  if (policy === 'same-origin') {
+    if (typeof globalThis.location === 'undefined') return true
+    return url.origin === globalThis.location.origin
+  }
+
+  return policy.origins.some((origin) => matchesOrigin(url, origin))
+}
+
+/** @internal Matches an origin pattern, supporting `*.` prefix for subdomain wildcards. */
+function matchesOrigin(url: URL, pattern: string): boolean {
+  if (pattern.startsWith('*.')) {
+    const suffix = pattern.slice(1) // e.g. ".example.com"
+    return url.hostname.endsWith(suffix) || url.hostname === pattern.slice(2)
+  }
+  return url.origin === new URL(pattern).origin
+}
+
+/** @internal */
+function resolveRequestUrl(input: RequestInfo | URL): URL {
+  if (input instanceof URL) return input
+  if (input instanceof Request) return new URL(input.url)
+  return new URL(
+    input,
+    typeof globalThis.location !== 'undefined' ? globalThis.location.href : undefined,
+  )
 }

--- a/src/client/internal/Fetch.ts
+++ b/src/client/internal/Fetch.ts
@@ -181,7 +181,7 @@ export function polyfill<const methods extends readonly Method.AnyClient[]>(
   if (!originalFetch) originalFetch = globalThis.fetch
   globalThis.fetch = from({
     ...config,
-    acceptPaymentPolicy: config.acceptPaymentPolicy ?? 'same-origin',
+    acceptPaymentPolicy: config.acceptPaymentPolicy ?? (isBrowser() ? 'same-origin' : 'always'),
     fetch: globalThis.fetch,
   }) as typeof globalThis.fetch
 }
@@ -349,7 +349,7 @@ function shouldInjectForPolicy(
   const url = resolveRequestUrl(input)
 
   if (policy === 'same-origin') {
-    if (typeof globalThis.location === 'undefined') return true
+    if (!isBrowser()) return true
     return url.origin === globalThis.location.origin
   }
 
@@ -366,11 +366,13 @@ function matchesOrigin(url: URL, pattern: string): boolean {
 }
 
 /** @internal */
+function isBrowser(): boolean {
+  return typeof globalThis.location !== 'undefined'
+}
+
+/** @internal */
 function resolveRequestUrl(input: RequestInfo | URL): URL {
   if (input instanceof URL) return input
   if (input instanceof Request) return new URL(input.url)
-  return new URL(
-    input,
-    typeof globalThis.location !== 'undefined' ? globalThis.location.href : undefined,
-  )
+  return new URL(input, isBrowser() ? globalThis.location.href : undefined)
 }


### PR DESCRIPTION
## Summary

Adds `acceptPaymentPolicy` option to control when the `Accept-Payment` header is injected on outgoing requests, mitigating CORS preflight failures on non-payment-aware servers.

## Breaking Change

In **browser environments**, polyfilled fetch (`Fetch.polyfill` / `Mppx.create` with `polyfill: true`) now defaults to `'same-origin'` instead of injecting `Accept-Payment` on every request. This prevents CORS preflights from being triggered on cross-origin servers that don't know about `Accept-Payment`.

**Non-browser environments are unaffected** — they continue to default to `'always'` since CORS is not a concern.

## API

```ts
// Mppx.create (browser: defaults to 'same-origin', non-browser: defaults to 'always')
Mppx.create({
  methods: [tempo({ account })],
  acceptPaymentPolicy: 'same-origin',
})
```

### Supported values

- `'always'` — inject on every request (default for `Fetch.from`, and polyfill in non-browser environments)
- `'same-origin'` — inject only for same-origin requests (default for polyfill in browsers)
- `'never'` — never auto-inject
- `{ origins: ['https://pay.example.com', '*.example.com'] }` — inject only for listed origins (supports wildcard subdomains)