### PR TITLE
feat: migrate discovery payment info to offers

### DIFF
--- a/.changeset/tiny-dingos-type.md
+++ b/.changeset/tiny-dingos-type.md
@@ -1,3 +1,5 @@
+---
 'mppx': patch
+---
 
 Added canonical discovery output using `x-payment-info.offers[]` while continuing to accept the legacy flat shorthand during validation and parsing.

--- a/.changeset/tiny-dingos-type.md
+++ b/.changeset/tiny-dingos-type.md
@@ -1,0 +1,3 @@
+'mppx': patch
+
+Added canonical discovery output using `x-payment-info.offers[]` while continuing to accept the legacy flat shorthand during validation and parsing.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,7 @@ overrides:
   brace-expansion@<5.0.5: '>=5.0.5'
   lodash@<=4.17.23: '>=4.18.0'
   protobufjs@<7.5.5: 7.5.5
+  uuid@<14.0.0: 14.0.0
 
 importers:
 
@@ -3664,16 +3665,8 @@ packages:
   util@0.12.5:
     resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
 
-  uuid@10.0.0:
-    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
-    hasBin: true
-
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    hasBin: true
-
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   vary@1.1.2:
@@ -4374,7 +4367,7 @@ snapshots:
       readable-stream: 3.6.2
       socket.io-client: 4.8.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       utf-8-validate: 5.0.10
-      uuid: 8.3.2
+      uuid: 14.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -4403,7 +4396,7 @@ snapshots:
       socket.io-client: 4.8.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       tslib: 2.8.1
       util: 0.12.5
-      uuid: 8.3.2
+      uuid: 14.0.0
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -4422,7 +4415,7 @@ snapshots:
       debug: 4.4.3
       pony-cause: 2.1.11
       semver: 7.7.4
-      uuid: 9.0.1
+      uuid: 14.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -4436,7 +4429,7 @@ snapshots:
       debug: 4.4.3
       pony-cause: 2.1.11
       semver: 7.7.4
-      uuid: 9.0.1
+      uuid: 14.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -5529,7 +5522,7 @@ snapshots:
       docker-modem: 5.0.7
       protobufjs: 7.5.5
       tar-fs: 2.1.4
-      uuid: 10.0.0
+      uuid: 14.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -7094,11 +7087,7 @@ snapshots:
       is-typed-array: 1.1.15
       which-typed-array: 1.1.20
 
-  uuid@10.0.0: {}
-
-  uuid@8.3.2: {}
-
-  uuid@9.0.1: {}
+  uuid@14.0.0: {}
 
   vary@1.1.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -44,5 +44,6 @@ overrides:
   brace-expansion@<5.0.5: '>=5.0.5'
   lodash@<=4.17.23: '>=4.18.0'
   protobufjs@<7.5.5: '7.5.5'
+  uuid@<14.0.0: '14.0.0'
 
 nodeOptions: '--disable-warning=ExperimentalWarning --disable-warning=DeprecationWarning'

--- a/src/discovery/Discovery.test.ts
+++ b/src/discovery/Discovery.test.ts
@@ -1,14 +1,26 @@
 import { DiscoveryDocument, PaymentInfo, ServiceInfo } from './Discovery.js'
 
 describe('PaymentInfo', () => {
-  test('parses a valid charge payment info', () => {
+  test('normalizes legacy shorthand to offers', () => {
     const result = PaymentInfo.safeParse({
       amount: '1000',
       intent: 'charge',
       method: 'tempo',
     })
     expect(result.success).toBe(true)
-    expect(result.data).toEqual({ amount: '1000', intent: 'charge', method: 'tempo' })
+    expect(result.data).toEqual({
+      offers: [{ amount: '1000', intent: 'charge', method: 'tempo' }],
+    })
+  })
+
+  test('parses offers format without modification', () => {
+    const result = PaymentInfo.safeParse({
+      offers: [{ amount: '1000', intent: 'charge', method: 'tempo' }],
+    })
+    expect(result.success).toBe(true)
+    expect(result.data).toEqual({
+      offers: [{ amount: '1000', intent: 'charge', method: 'tempo' }],
+    })
   })
 
   test('parses a session with null amount', () => {
@@ -18,7 +30,7 @@ describe('PaymentInfo', () => {
       method: 'tempo',
     })
     expect(result.success).toBe(true)
-    expect(result.data?.amount).toBeNull()
+    expect(result.data?.offers[0]?.amount).toBeNull()
   })
 
   test('accepts custom intents', () => {
@@ -28,7 +40,7 @@ describe('PaymentInfo', () => {
       method: 'tempo',
     })
     expect(result.success).toBe(true)
-    expect(result.data?.intent).toBe('subscribe')
+    expect(result.data?.offers[0]?.intent).toBe('subscribe')
   })
 
   test('rejects invalid amount pattern', () => {
@@ -40,6 +52,26 @@ describe('PaymentInfo', () => {
     expect(result.success).toBe(false)
   })
 
+  test('rejects mixed shorthand and offers shapes', () => {
+    const result = PaymentInfo.safeParse({
+      amount: '100',
+      offers: [{ amount: '100', intent: 'charge', method: 'tempo' }],
+    })
+    expect(result.success).toBe(false)
+  })
+
+  test('rejects empty offers arrays', () => {
+    const result = PaymentInfo.safeParse({ offers: [] })
+    expect(result.success).toBe(false)
+  })
+
+  test('rejects malformed offers', () => {
+    const result = PaymentInfo.safeParse({
+      offers: [{ amount: '01', intent: 'charge', method: 'tempo' }],
+    })
+    expect(result.success).toBe(false)
+  })
+
   test('accepts x402 format with unknown fields', () => {
     const result = PaymentInfo.safeParse({
       price: '0.54',
@@ -47,6 +79,9 @@ describe('PaymentInfo', () => {
       protocols: ['x402', 'mpp'],
     })
     expect(result.success).toBe(true)
+    expect(result.data).toEqual({
+      offers: [{ price: '0.54', pricingMode: 'fixed', protocols: ['x402', 'mpp'] }],
+    })
   })
 })
 
@@ -118,6 +153,33 @@ describe('DiscoveryDocument', () => {
       },
     })
     expect(result.success).toBe(true)
+    expect(result.data?.paths?.['/search']?.post?.['x-payment-info']).toEqual({
+      offers: [{ amount: '100', intent: 'charge', method: 'tempo' }],
+    })
+  })
+
+  test('normalizes offers-based discovery documents', () => {
+    const result = DiscoveryDocument.safeParse({
+      info: { title: 'Test', version: '1.0.0' },
+      openapi: '3.1.0',
+      paths: {
+        '/search': {
+          post: {
+            'x-payment-info': {
+              offers: [{ amount: '100', intent: 'charge', method: 'tempo' }],
+            },
+            responses: {
+              '200': { description: 'OK' },
+              '402': { description: 'Payment Required' },
+            },
+          },
+        },
+      },
+    })
+    expect(result.success).toBe(true)
+    expect(result.data?.paths?.['/search']?.post?.['x-payment-info']).toEqual({
+      offers: [{ amount: '100', intent: 'charge', method: 'tempo' }],
+    })
   })
 
   test('accepts path items with summary, parameters, and extensions', () => {

--- a/src/discovery/Discovery.ts
+++ b/src/discovery/Discovery.ts
@@ -1,18 +1,13 @@
 import * as z from '../zod.js'
 
 const uriOrPathPattern = /^([a-zA-Z][a-zA-Z\d+.-]*:\/\/\S+|\/\S*)$/
+const paymentInfoFieldNames = new Set(['amount', 'currency', 'description', 'intent', 'method'])
 
 function uriOrPath() {
   return z.string().check(z.regex(uriOrPathPattern, 'Invalid URI or path'))
 }
 
-/**
- * Schema for the `x-payment-info` OpenAPI extension on an operation.
- *
- * Only validates spec-defined fields when present; unknown fields are ignored.
- * Discovery is advisory only. Runtime 402 challenges remain authoritative.
- */
-export const PaymentInfo = z.looseObject({
+const PaymentOffer = z.looseObject({
   amount: z.optional(
     z.union([z.null(), z.string().check(z.regex(/^(0|[1-9][0-9]*)$/, 'Invalid amount'))]),
   ),
@@ -21,6 +16,44 @@ export const PaymentInfo = z.looseObject({
   intent: z.optional(z.string()),
   method: z.optional(z.string()),
 })
+
+/**
+ * Schema for the `x-payment-info` OpenAPI extension on an operation.
+ *
+ * Only validates spec-defined fields when present; unknown fields are ignored.
+ * Discovery is advisory only. Runtime 402 challenges remain authoritative.
+ */
+export const PaymentInfo = z.pipe(
+  z
+    .looseObject({
+      amount: z.optional(
+        z.union([z.null(), z.string().check(z.regex(/^(0|[1-9][0-9]*)$/, 'Invalid amount'))]),
+      ),
+      currency: z.optional(z.string()),
+      description: z.optional(z.string()),
+      intent: z.optional(z.string()),
+      method: z.optional(z.string()),
+      offers: z.optional(z.array(PaymentOffer).check(z.minLength(1))),
+    })
+    .check(
+      z.refine(
+        (value) =>
+          value.offers === undefined || Object.keys(value).every((key) => key === 'offers'),
+        'Cannot mix offers with flat payment info fields',
+      ),
+    ),
+  z.transform((value) => {
+    if (value.offers) return { offers: value.offers }
+
+    const offer: Record<string, unknown> = {}
+    for (const [key, field] of Object.entries(value)) {
+      if (key === 'offers') continue
+      if (paymentInfoFieldNames.has(key) || field !== undefined) offer[key] = field
+    }
+
+    return { offers: [offer] }
+  }),
+)
 export type PaymentInfo = z.infer<typeof PaymentInfo>
 
 const ServiceDocs = z.looseObject({

--- a/src/discovery/OpenApi.test.ts
+++ b/src/discovery/OpenApi.test.ts
@@ -110,11 +110,15 @@ describe('generate', () => {
                 },
               },
               "x-payment-info": {
-                "amount": "100",
-                "currency": "0xUSDC",
-                "intent": "charge",
-                "method": "tempo",
-                "recipient": "0x123",
+                "offers": [
+                  {
+                    "amount": "100",
+                    "currency": "0xUSDC",
+                    "intent": "charge",
+                    "method": "tempo",
+                    "recipient": "0x123",
+                  },
+                ],
               },
             },
           },
@@ -161,11 +165,15 @@ describe('generate', () => {
                 },
               },
               "x-payment-info": {
-                "amount": "50",
-                "currency": "usd",
-                "intent": "charge",
-                "method": "tempo",
-                "recipient": "0x1",
+                "offers": [
+                  {
+                    "amount": "50",
+                    "currency": "usd",
+                    "intent": "charge",
+                    "method": "tempo",
+                    "recipient": "0x1",
+                  },
+                ],
               },
             },
           },
@@ -206,10 +214,14 @@ describe('generate', () => {
                 },
               },
               "x-payment-info": {
-                "amount": null,
-                "intent": "session",
-                "method": "tempo",
-                "recipient": "0x123",
+                "offers": [
+                  {
+                    "amount": null,
+                    "intent": "session",
+                    "method": "tempo",
+                    "recipient": "0x123",
+                  },
+                ],
               },
             },
           },
@@ -305,11 +317,15 @@ describe('generate', () => {
                 },
               },
               "x-payment-info": {
-                "amount": "100",
-                "currency": "0xUSDC",
-                "intent": "charge",
-                "method": "tempo",
-                "recipient": "0xABC",
+                "offers": [
+                  {
+                    "amount": "100",
+                    "currency": "0xUSDC",
+                    "intent": "charge",
+                    "method": "tempo",
+                    "recipient": "0xABC",
+                  },
+                ],
               },
             },
           },
@@ -334,11 +350,15 @@ describe('generate', () => {
               },
               "summary": "Search the index",
               "x-payment-info": {
-                "amount": "500",
-                "currency": "0xUSDC",
-                "intent": "charge",
-                "method": "tempo",
-                "recipient": "0xABC",
+                "offers": [
+                  {
+                    "amount": "500",
+                    "currency": "0xUSDC",
+                    "intent": "charge",
+                    "method": "tempo",
+                    "recipient": "0xABC",
+                  },
+                ],
               },
             },
           },
@@ -353,10 +373,14 @@ describe('generate', () => {
                 },
               },
               "x-payment-info": {
-                "amount": null,
-                "intent": "session",
-                "method": "tempo",
-                "recipient": "0xABC",
+                "offers": [
+                  {
+                    "amount": null,
+                    "intent": "session",
+                    "method": "tempo",
+                    "recipient": "0xABC",
+                  },
+                ],
               },
             },
           },
@@ -410,11 +434,15 @@ describe('generate', () => {
               },
               "summary": "Monthly subscription",
               "x-payment-info": {
-                "amount": "100",
-                "intent": "subscribe",
-                "interval": "monthly",
-                "method": "tempo",
-                "recipient": "0xABC",
+                "offers": [
+                  {
+                    "amount": "100",
+                    "intent": "subscribe",
+                    "interval": "monthly",
+                    "method": "tempo",
+                    "recipient": "0xABC",
+                  },
+                ],
               },
             },
           },

--- a/src/discovery/OpenApi.ts
+++ b/src/discovery/OpenApi.ts
@@ -1,5 +1,5 @@
 import type * as Method from '../Method.js'
-import type { ServiceInfo } from './Discovery.js'
+import { PaymentInfo, type ServiceInfo } from './Discovery.js'
 
 export type DiscoveryHandler = ((...args: any[]) => unknown) & {
   _internal?: {
@@ -121,7 +121,7 @@ function createDocument(config: {
       },
     }
 
-    if (route.payment) operation['x-payment-info'] = route.payment
+    if (route.payment) operation['x-payment-info'] = PaymentInfo.parse(route.payment)
     if (route.summary) operation.summary = route.summary
     if (route.requestBody) operation.requestBody = route.requestBody
 

--- a/src/discovery/Validate.test.ts
+++ b/src/discovery/Validate.test.ts
@@ -32,6 +32,31 @@ describe('validate', () => {
     expect(errors.filter((error) => error.severity === 'error')).toHaveLength(0)
   })
 
+  test('accepts offers-based x-payment-info', () => {
+    const errors = validate(
+      makeDoc({
+        paths: {
+          '/search': {
+            post: {
+              'x-payment-info': {
+                offers: [{ amount: '100', intent: 'charge', method: 'tempo' }],
+              },
+              requestBody: {
+                content: { 'application/json': { schema: { type: 'object' } } },
+              },
+              responses: {
+                '200': { description: 'OK' },
+                '402': { description: 'Payment Required' },
+              },
+            },
+          },
+        },
+      }),
+    )
+
+    expect(errors.filter((error) => error.severity === 'error')).toHaveLength(0)
+  })
+
   test('returns error for missing 402 response', () => {
     const errors = validate(
       makeDoc({
@@ -110,6 +135,98 @@ describe('validate', () => {
     )
 
     expect(errors.some((error) => error.severity === 'error')).toBe(true)
+  })
+
+  test('returns errors for mixed shorthand and offers shapes', () => {
+    const errors = validate(
+      makeDoc({
+        paths: {
+          '/search': {
+            post: {
+              'x-payment-info': {
+                amount: '100',
+                offers: [{ amount: '100', intent: 'charge', method: 'tempo' }],
+              },
+              requestBody: {
+                content: { 'application/json': { schema: { type: 'object' } } },
+              },
+              responses: {
+                '200': { description: 'OK' },
+                '402': { description: 'Payment Required' },
+              },
+            },
+          },
+        },
+      }),
+    )
+
+    expect(errors).toContainEqual(
+      expect.objectContaining({
+        message: 'Cannot mix offers with flat payment info fields',
+        path: 'paths./search.post.x-payment-info',
+        severity: 'error',
+      }),
+    )
+  })
+
+  test('returns errors for empty offers arrays', () => {
+    const errors = validate(
+      makeDoc({
+        paths: {
+          '/search': {
+            post: {
+              'x-payment-info': {
+                offers: [],
+              },
+              requestBody: {
+                content: { 'application/json': { schema: { type: 'object' } } },
+              },
+              responses: {
+                '200': { description: 'OK' },
+                '402': { description: 'Payment Required' },
+              },
+            },
+          },
+        },
+      }),
+    )
+
+    expect(errors).toContainEqual(
+      expect.objectContaining({
+        path: 'paths./search.post.x-payment-info.offers',
+        severity: 'error',
+      }),
+    )
+  })
+
+  test('returns errors for malformed offers', () => {
+    const errors = validate(
+      makeDoc({
+        paths: {
+          '/search': {
+            post: {
+              'x-payment-info': {
+                offers: [{ amount: '01', intent: 'charge', method: 'tempo' }],
+              },
+              requestBody: {
+                content: { 'application/json': { schema: { type: 'object' } } },
+              },
+              responses: {
+                '200': { description: 'OK' },
+                '402': { description: 'Payment Required' },
+              },
+            },
+          },
+        },
+      }),
+    )
+
+    expect(errors).toContainEqual(
+      expect.objectContaining({
+        path: 'paths./search.post.x-payment-info.offers.0.amount',
+        severity: 'error',
+      }),
+    )
   })
 
   test('ignores path-item-level fields like summary and parameters', () => {

--- a/src/discovery/Validate.ts
+++ b/src/discovery/Validate.ts
@@ -40,9 +40,10 @@ export function validate(doc: unknown): ValidationError[] {
       const paymentResult = PaymentInfo.safeParse(rawPaymentInfo)
       if (!paymentResult.success) {
         for (const issue of paymentResult.error.issues) {
+          const issuePath = issue.path.length > 0 ? `.${issue.path.map(String).join('.')}` : ''
           errors.push({
             message: issue.message,
-            path: `${opPath}.x-payment-info.${issue.path.map(String).join('.')}`,
+            path: `${opPath}.x-payment-info${issuePath}`,
             severity: 'error',
           })
         }

--- a/src/middlewares/elysia.test.ts
+++ b/src/middlewares/elysia.test.ts
@@ -130,7 +130,7 @@ describe('charge', () => {
 
     const body = (await response.json()) as Record<string, any>
     expect(body.info).toEqual({ title: 'Elysia API', version: '1.0.0' })
-    expect(body.paths['/'].get['x-payment-info']).toMatchObject({
+    expect(body.paths['/'].get['x-payment-info'].offers[0]).toMatchObject({
       amount: '1000000',
       currency: asset,
       intent: 'charge',

--- a/src/middlewares/express.test.ts
+++ b/src/middlewares/express.test.ts
@@ -151,7 +151,7 @@ describe('charge', () => {
 
     const body = (await response.json()) as Record<string, any>
     expect(body.info).toEqual({ title: 'Express API', version: '1.2.3' })
-    expect(body.paths['/'].get['x-payment-info']).toMatchObject({
+    expect(body.paths['/'].get['x-payment-info'].offers[0]).toMatchObject({
       amount: '1000000',
       currency: asset,
       intent: 'charge',

--- a/src/middlewares/hono.test.ts
+++ b/src/middlewares/hono.test.ts
@@ -149,7 +149,7 @@ describe('charge', () => {
 
     const body = (await response.json()) as Record<string, any>
     expect(body.info).toEqual({ title: 'Auto API', version: '2.0.0' })
-    expect(body.paths['/'].get['x-payment-info']).toMatchObject({
+    expect(body.paths['/'].get['x-payment-info'].offers[0]).toMatchObject({
       amount: '1000000',
       currency: asset,
       intent: 'charge',

--- a/src/middlewares/nextjs.test.ts
+++ b/src/middlewares/nextjs.test.ts
@@ -213,7 +213,7 @@ describe('charge', () => {
 
     const body = (await response.json()) as Record<string, any>
     expect(body.info).toEqual({ title: 'Next API', version: '3.0.0' })
-    expect(body.paths['/'].get['x-payment-info']).toMatchObject({
+    expect(body.paths['/'].get['x-payment-info'].offers[0]).toMatchObject({
       amount: '1000000',
       currency: asset,
       intent: 'charge',

--- a/src/proxy/Proxy.test.ts
+++ b/src/proxy/Proxy.test.ts
@@ -155,14 +155,14 @@ describe('create', () => {
     expect(body.paths['/api/v1/models'].get.responses['200']).toEqual({
       description: 'Successful response',
     })
-    expect(body.paths['/api/v1/generate'].post['x-payment-info']).toMatchObject({
+    expect(body.paths['/api/v1/generate'].post['x-payment-info'].offers[0]).toMatchObject({
       amount: '1000000',
       currency: asset,
       description: 'Generate text',
       intent: 'charge',
       method: 'tempo',
     })
-    expect(body.paths['/api/v1/stream'].post['x-payment-info']).toMatchObject({
+    expect(body.paths['/api/v1/stream'].post['x-payment-info'].offers[0]).toMatchObject({
       amount: '1000000',
       currency: asset,
       description: 'Stream text',
@@ -241,7 +241,7 @@ describe('create', () => {
     const res = await fetch(`${proxyServer.url}/proxy/openapi.json`)
     expect(res.status).toBe(200)
     const body = (await res.json()) as Record<string, any>
-    expect(body.paths['/proxy/api/v1/generate'].post['x-payment-info']).toMatchObject({
+    expect(body.paths['/proxy/api/v1/generate'].post['x-payment-info'].offers[0]).toMatchObject({
       amount: '1000000',
       currency: asset,
       description: 'Generate text',


### PR DESCRIPTION
## Summary

This migrates discovery's `x-payment-info` model to the PR #249 multi-offer shape while keeping the migration small and compatibility-minded.

- accept both legacy flat `x-payment-info` objects and canonical `x-payment-info.offers[]`
- normalize both accepted shapes to an internal offers-based representation
- emit `offers[]` by default from `discovery()` and OpenAPI generation
- reject ambiguous mixed shapes, empty `offers` arrays, and malformed offers
- keep existing validation behavior like requiring a `402` response for paid operations