### PR TITLE
fix: bind zero-amount proof signatures to challenge realm

### DIFF
--- a/.changeset/fair-eggs-love.md
+++ b/.changeset/fair-eggs-love.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed zero-amount Tempo proof credentials to bind signatures to the challenge realm.

--- a/src/tempo/client/Charge.ts
+++ b/src/tempo/client/Charge.ts
@@ -65,7 +65,7 @@ export function charge(parameters: charge.Parameters = {}) {
           domain: Proof.domain(chainId!),
           types: Proof.types,
           primaryType: 'Proof',
-          message: Proof.message(challenge.id),
+          message: Proof.message(challenge.id, challenge.realm),
         })
         return Credential.serialize({
           challenge,

--- a/src/tempo/internal/proof.test.ts
+++ b/src/tempo/internal/proof.test.ts
@@ -44,15 +44,18 @@ const parseProofSourceCases = [
 ] as const
 
 describe('Proof', () => {
-  test('types has Proof with challengeId field', () => {
+  test('types has Proof with challengeId and realm fields', () => {
     expect(Proof.types).toEqual({
-      Proof: [{ name: 'challengeId', type: 'string' }],
+      Proof: [
+        { name: 'challengeId', type: 'string' },
+        { name: 'realm', type: 'string' },
+      ],
     })
   })
 
   test('domain returns EIP-712 domain with name, version, chainId', () => {
     const d = Proof.domain(42431)
-    expect(d).toEqual({ name: 'MPP', version: '1', chainId: 42431 })
+    expect(d).toEqual({ name: 'MPP', version: '2', chainId: 42431 })
   })
 
   test('domain uses provided chainId', () => {
@@ -60,8 +63,11 @@ describe('Proof', () => {
     expect(Proof.domain(99999).chainId).toBe(99999)
   })
 
-  test('message wraps challengeId', () => {
-    expect(Proof.message('abc123')).toEqual({ challengeId: 'abc123' })
+  test('message wraps challengeId and realm', () => {
+    expect(Proof.message('abc123', 'api.example.com')).toEqual({
+      challengeId: 'abc123',
+      realm: 'api.example.com',
+    })
   })
 
   test('proofSource constructs did:pkh DID', () => {

--- a/src/tempo/internal/proof.ts
+++ b/src/tempo/internal/proof.ts
@@ -2,17 +2,20 @@ import { isAddress, type Address } from 'viem'
 
 /** EIP-712 typed data types for proof credentials. */
 export const types = {
-  Proof: [{ name: 'challengeId', type: 'string' }],
+  Proof: [
+    { name: 'challengeId', type: 'string' },
+    { name: 'realm', type: 'string' },
+  ],
 } as const
 
 /** Constructs the EIP-712 domain for a proof credential. */
 export function domain(chainId: number) {
-  return { name: 'MPP', version: '1', chainId } as const
+  return { name: 'MPP', version: '2', chainId } as const
 }
 
 /** Constructs the EIP-712 message for a proof credential. */
-export function message(challengeId: string) {
-  return { challengeId } as const
+export function message(challengeId: string, realm: string) {
+  return { challengeId, realm } as const
 }
 
 /** Constructs the expected `did:pkh` source DID for a proof credential. */

--- a/src/tempo/server/Charge.test.ts
+++ b/src/tempo/server/Charge.test.ts
@@ -2292,7 +2292,7 @@ describe('tempo', () => {
         domain: Proof.domain(chain.id),
         types: Proof.types,
         primaryType: 'Proof',
-        message: Proof.message(challenge.id),
+        message: Proof.message(challenge.id, challenge.realm),
       })
 
       const credential = Credential.from({
@@ -2330,7 +2330,7 @@ describe('tempo', () => {
         domain: Proof.domain(chain.id),
         types: Proof.types,
         primaryType: 'Proof',
-        message: Proof.message(challenge.id),
+        message: Proof.message(challenge.id, challenge.realm),
       })
 
       const credential = Credential.from({
@@ -2445,7 +2445,7 @@ describe('tempo', () => {
             domain: Proof.domain(chain.id),
             types: Proof.types,
             primaryType: 'Proof',
-            message: Proof.message(challenge.id),
+            message: Proof.message(challenge.id, challenge.realm),
           })
 
           const credential = Credential.from({
@@ -2507,7 +2507,7 @@ describe('tempo', () => {
         domain: Proof.domain(chain.id),
         types: Proof.types,
         primaryType: 'Proof',
-        message: Proof.message(challenge.id),
+        message: Proof.message(challenge.id, challenge.realm),
       })
 
       const credential = Credential.from({
@@ -2568,7 +2568,7 @@ describe('tempo', () => {
         domain: Proof.domain(chain.id),
         types: Proof.types,
         primaryType: 'Proof',
-        message: Proof.message(challenge.id),
+        message: Proof.message(challenge.id, challenge.realm),
       })
 
       const credential = Credential.serialize(
@@ -2642,7 +2642,7 @@ describe('tempo', () => {
         domain: Proof.domain(chain.id),
         types: Proof.types,
         primaryType: 'Proof',
-        message: Proof.message(challenge.id),
+        message: Proof.message(challenge.id, challenge.realm),
       })
 
       const credential = Credential.from({
@@ -2703,7 +2703,7 @@ describe('tempo', () => {
         domain: Proof.domain(chain.id),
         types: Proof.types,
         primaryType: 'Proof',
-        message: Proof.message(challenge1.id),
+        message: Proof.message(challenge1.id, challenge1.realm),
       })
 
       const credential1 = Credential.from({
@@ -2730,7 +2730,7 @@ describe('tempo', () => {
         domain: Proof.domain(chain.id),
         types: Proof.types,
         primaryType: 'Proof',
-        message: Proof.message(challenge2.id),
+        message: Proof.message(challenge2.id, challenge2.realm),
       })
 
       const credential2 = Credential.from({
@@ -2767,7 +2767,7 @@ describe('tempo', () => {
         domain: Proof.domain(chain.id),
         types: Proof.types,
         primaryType: 'Proof',
-        message: Proof.message(challenge.id),
+        message: Proof.message(challenge.id, challenge.realm),
       })
 
       const credential = Credential.from({
@@ -2803,7 +2803,7 @@ describe('tempo', () => {
         domain: Proof.domain(chain.id),
         types: Proof.types,
         primaryType: 'Proof',
-        message: Proof.message(challenge.id),
+        message: Proof.message(challenge.id, challenge.realm),
       })
 
       const credential = Credential.from({
@@ -2902,7 +2902,7 @@ describe('tempo', () => {
         domain: Proof.domain(chain.id),
         types: Proof.types,
         primaryType: 'Proof',
-        message: Proof.message(challenge.id),
+        message: Proof.message(challenge.id, challenge.realm),
       })
 
       const credential = Credential.from({
@@ -2940,7 +2940,7 @@ describe('tempo', () => {
         domain: Proof.domain(chain.id),
         types: Proof.types,
         primaryType: 'Proof',
-        message: Proof.message(challenge.id),
+        message: Proof.message(challenge.id, challenge.realm),
       })
 
       const credential = Credential.from({
@@ -2979,7 +2979,43 @@ describe('tempo', () => {
         domain: Proof.domain(99999),
         types: Proof.types,
         primaryType: 'Proof',
-        message: Proof.message(challenge.id),
+        message: Proof.message(challenge.id, challenge.realm),
+      })
+
+      const credential = Credential.from({
+        challenge,
+        payload: { signature, type: 'proof' as const },
+        source: `did:pkh:eip155:${chain.id}:${accounts[1].address}`,
+      })
+
+      const response2 = await fetch(httpServer.url, {
+        headers: { Authorization: Credential.serialize(credential) },
+      })
+      expect(response2.status).toBe(402)
+
+      httpServer.close()
+    })
+
+    test('behavior: rejects proof signed with wrong realm', async () => {
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await Mppx_server.toNodeListener(
+          server.charge({ amount: '0', decimals: 6 }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
+      })
+
+      const response1 = await fetch(httpServer.url)
+      const challenge = Challenge.fromResponse(response1, {
+        methods: [tempo_client.charge()],
+      })
+
+      const signature = await signTypedData(client, {
+        account: accounts[1],
+        domain: Proof.domain(chain.id),
+        types: Proof.types,
+        primaryType: 'Proof',
+        message: Proof.message(challenge.id, 'evil.example.com'),
       })
 
       const credential = Credential.from({
@@ -3015,7 +3051,7 @@ describe('tempo', () => {
         domain: Proof.domain(chain.id),
         types: Proof.types,
         primaryType: 'Proof',
-        message: Proof.message(challenge.id),
+        message: Proof.message(challenge.id, challenge.realm),
       })
 
       const credential = Credential.from({
@@ -3051,7 +3087,7 @@ describe('tempo', () => {
         domain: Proof.domain(chain.id),
         types: Proof.types,
         primaryType: 'Proof',
-        message: Proof.message(challenge.id),
+        message: Proof.message(challenge.id, challenge.realm),
       })
 
       const credential = Credential.from({

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -244,13 +244,14 @@ export function charge<const parameters extends charge.Parameters>(
             domain: Proof.domain(resolvedChainId),
             types: Proof.types,
             primaryType: 'Proof',
-            message: Proof.message(challenge.id),
+            message: Proof.message(challenge.id, challenge.realm),
             signature: payload.signature as `0x${string}`,
           })
           if (!valid) {
             const proofSigner = recoverAuthorizedProofSigner({
               chainId: resolvedChainId,
               challengeId: challenge.id,
+              realm: challenge.realm,
               signature: payload.signature as `0x${string}`,
               sourceAddress: source.address,
             })
@@ -712,10 +713,11 @@ async function markProofUsed(
 function recoverAuthorizedProofSigner(parameters: {
   chainId: number
   challengeId: string
+  realm: string
   signature: `0x${string}`
   sourceAddress: `0x${string}`
 }): `0x${string}` | null {
-  const { chainId, challengeId, signature, sourceAddress } = parameters
+  const { chainId, challengeId, realm, signature, sourceAddress } = parameters
 
   try {
     const envelope = SignatureEnvelope.from(signature)
@@ -723,7 +725,7 @@ function recoverAuthorizedProofSigner(parameters: {
       domain: Proof.domain(chainId),
       types: Proof.types,
       primaryType: 'Proof',
-      message: Proof.message(challengeId),
+      message: Proof.message(challengeId, realm),
     })
 
     if (envelope.type === 'keychain') {


### PR DESCRIPTION
## Summary
- bind zero-amount Tempo proof signatures to the challenge `realm`
- bump the proof typed-data domain version and keep client verification plus access-key recovery aligned
- add regression coverage for the new realm binding and ship a patch changeset
