### PR TITLE
fix: `compose()` JSDoc example

### DIFF
--- a/.changeset/fix-compose-jsdoc-example.md
+++ b/.changeset/fix-compose-jsdoc-example.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed `mppx.compose()` JSDoc example to use the `[method, options]` tuple form that the implementation actually accepts.

--- a/.changeset/fix-compose-jsdoc-example.md
+++ b/.changeset/fix-compose-jsdoc-example.md
@@ -1,5 +1,0 @@
----
-'mppx': patch
----
-
-Fixed `mppx.compose()` JSDoc example to use the `[method, options]` tuple form that the implementation actually accepts.

--- a/src/server/Mppx.ts
+++ b/src/server/Mppx.ts
@@ -61,15 +61,21 @@ export type Mppx<
        * const mppx = Mppx.create({
        *   methods: [
        *     tempo.charge({ currency: USDC, recipient: '0x...' }),
-       *     stripe.charge({ currency: 'usd' }),
+       *     stripe.charge({
+       *       client: stripeClient,
+       *       networkId: 'internal',
+       *       currency: 'usd',
+       *       decimals: 2,
+       *       paymentMethodTypes: ['card'],
+       *     }),
        *   ],
        *   secretKey,
        * })
        *
        * app.get('/api/resource', async (req) => {
        *   const result = await mppx.compose(
-       *     mppx.tempo.charge({ amount: '100' }),
-       *     mppx.stripe.charge({ amount: '100' }),
+       *     ['tempo/charge', { amount: '100' }],
+       *     ['stripe/charge', { amount: '100' }],
        *   )(req)
        *   if (result.status === 402) return result.challenge
        *   return result.withReceipt(new Response('OK'))


### PR DESCRIPTION
The example called `mppx.tempo.charge({...})` but the impl destructures `[methodOrKey, options]` tuples. Updated the docs to match impl