### PR TITLE
Harden Tempo session billing

### DIFF
--- a/.changeset/empty-badgers-clean.md
+++ b/.changeset/empty-badgers-clean.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Hardened Tempo session billing against concurrent replay, bodyless POST bypasses, inflated receipts, and close races.

--- a/src/cli/plugins/tempo.ts
+++ b/src/cli/plugins/tempo.ts
@@ -247,6 +247,7 @@ export function tempo() {
       const channelId = parsed.payload.channelId
       const escrowContract = sessionMd?.escrowContract as Address | undefined
       const chainId = sessionMd?.chainId ?? 0
+      const tickCost = BigInt(challengeRequest.amount as string)
       let cumulativeAmount =
         'cumulativeAmount' in parsed.payload && parsed.payload.cumulativeAmount
           ? BigInt(parsed.payload.cumulativeAmount)
@@ -287,11 +288,11 @@ export function tempo() {
       if (receiptHeader) {
         try {
           const receiptJson = JSON.parse(Base64.toString(receiptHeader)) as Record<string, unknown>
+          assertReceiptWithinCliState(receiptJson, cumulativeAmount)
           if (
             typeof receiptJson.acceptedCumulative === 'string' &&
             receiptJson.acceptedCumulative
           ) {
-            cumulativeAmount = BigInt(receiptJson.acceptedCumulative)
             writeChannelCumulative(channelId, cumulativeAmount)
           }
           if (verbose >= 1)
@@ -315,6 +316,7 @@ export function tempo() {
           escrowContract,
           chainId,
           cumulativeAmount,
+          tickCost,
           fetchUrl,
           fetchInit,
           session: _session,
@@ -415,6 +417,24 @@ function printReceipt(
   if (opts.prefix) opts.info('\n')
 }
 
+function assertReceiptWithinCliState(
+  receiptJson: Record<string, unknown>,
+  cumulativeAmount: bigint,
+) {
+  if (typeof receiptJson.acceptedCumulative !== 'string') return
+  const acceptedCumulative = BigInt(receiptJson.acceptedCumulative)
+  const spent = typeof receiptJson.spent === 'string' ? BigInt(receiptJson.spent) : 0n
+  if (spent > acceptedCumulative) {
+    throw new Error('receipt spent exceeds accepted cumulative voucher amount')
+  }
+  if (acceptedCumulative > cumulativeAmount) {
+    throw new Error('receipt accepted cumulative exceeds locally signed voucher amount')
+  }
+  if (spent > cumulativeAmount) {
+    throw new Error('receipt spent exceeds locally signed voucher amount')
+  }
+}
+
 async function handleSseStream(
   response: Response,
   opts: {
@@ -423,6 +443,7 @@ async function handleSseStream(
     escrowContract: Address | undefined
     chainId: number
     cumulativeAmount: bigint
+    tickCost: bigint
     fetchUrl: string
     fetchInit: RequestInit
     session: {
@@ -500,7 +521,13 @@ async function handleSseStream(
             channelId: string
             requiredCumulative: string
           }
+          if (event.channelId !== opts.channelId) {
+            throw new Error('payment-need-voucher channelId does not match current session')
+          }
           const required = BigInt(event.requiredCumulative)
+          if (required > cumulativeAmount + opts.tickCost) {
+            throw new Error('payment-need-voucher exceeds next locally billable amount')
+          }
           cumulativeAmount = cumulativeAmount > required ? cumulativeAmount : required
 
           const voucherCred = await opts.session.signVoucher({

--- a/src/tempo/client/SessionManager.ts
+++ b/src/tempo/client/SessionManager.ts
@@ -138,8 +138,26 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
 
   function updateSpentFromReceipt(receipt: SessionReceipt | null | undefined) {
     if (!receipt || receipt.channelId !== channel?.channelId) return
+    assertReceiptWithinLocalState(receipt)
     const next = BigInt(receipt.spent)
     spent = spent > next ? spent : next
+  }
+
+  function assertReceiptWithinLocalState(receipt: SessionReceipt) {
+    if (!channel || receipt.channelId !== channel.channelId) return
+    const acceptedCumulative = BigInt(receipt.acceptedCumulative)
+    const receiptSpent = BigInt(receipt.spent)
+    if (receiptSpent > acceptedCumulative) {
+      throw new Error('receipt spent exceeds accepted cumulative voucher amount')
+    }
+    if (acceptedCumulative > channel.cumulativeAmount) {
+      throw new Error('receipt accepted cumulative exceeds local voucher state')
+    }
+    if (receiptSpent > channel.cumulativeAmount) {
+      throw new Error('receipt spent exceeds local voucher state')
+    }
+    assertVoucherWithinLocalLimit(acceptedCumulative)
+    assertVoucherWithinLocalLimit(receiptSpent)
   }
 
   function waitForReceipt(predicate: (receipt: SessionReceipt) => boolean = () => true) {
@@ -762,7 +780,14 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
         context: {
           action: 'close',
           channelId: closeChannelId,
-          cumulativeAmountRaw: getFallbackCloseAmount(closeChallenge, closeChannelId),
+          cumulativeAmountRaw: (() => {
+            const closeAmount = BigInt(getFallbackCloseAmount(closeChallenge, closeChannelId))
+            if (closeAmount > channel.cumulativeAmount) {
+              throw new Error('fallback close amount exceeds local voucher state')
+            }
+            assertVoucherWithinLocalLimit(closeAmount)
+            return closeAmount.toString()
+          })(),
         },
       })
 

--- a/src/tempo/server/Session.test.ts
+++ b/src/tempo/server/Session.test.ts
@@ -2083,6 +2083,10 @@ describe.runIf(isLocalnet)('session', () => {
       ).rejects.toThrow(
         `Cannot close channel ${channelId}: tx sender ${rawAccessKey.address} is not the channel payee ${recipientAccount.address}. If using an access key, pass a Tempo access-key account whose address is the payee wallet, not the raw delegated key address.`,
       )
+
+      const persisted = await store.getChannel(channelId)
+      expect(persisted?.closeRequestedAt).toBe(0n)
+      expect(persisted?.finalized).toBe(false)
     })
 
     test('sessionManager.close surfaces problem details from HTTP close failures', async () => {
@@ -2645,6 +2649,77 @@ describe.runIf(isLocalnet)('session', () => {
       const channel = await store.getChannel(channelId)
       expect(channel?.highestVoucherAmount).toBe(5000000n)
       expect(channel?.spent).toBe(0n)
+    })
+
+    test('close marks the channel pending before on-chain close so concurrent charges fail', async () => {
+      const baseStore = Store.memory()
+      let pendingChargeError: unknown
+      let probedPendingClose = false
+
+      const probingStore = Store.from<Store.AtomicStore>({
+        get: (key) => baseStore.get(key),
+        put: (key, value) => baseStore.put(key, value),
+        delete: (key) => baseStore.delete(key),
+        async update(key, fn) {
+          const result = await baseStore.update(key, fn)
+          const current = await baseStore.get(key)
+          if (
+            current &&
+            typeof current === 'object' &&
+            'closeRequestedAt' in current &&
+            (current as ChannelStore.State).closeRequestedAt !== 0n &&
+            !(current as ChannelStore.State).finalized &&
+            !probedPendingClose
+          ) {
+            probedPendingClose = true
+            try {
+              await charge(ChannelStore.fromStore(probingStore), channelId, 1000000n)
+            } catch (error) {
+              pendingChargeError = error
+            }
+          }
+          return result
+        },
+      })
+
+      const probedStore = ChannelStore.fromStore(baseStore)
+      const server = createServerWithStore(probingStore)
+      const { channelId, serializedTransaction } = await createSignedOpenTransaction(10000000n)
+
+      await server.verify({
+        credential: {
+          challenge: makeChallenge({ id: 'open-before-pending-close', channelId }),
+          payload: {
+            action: 'open' as const,
+            type: 'transaction' as const,
+            channelId,
+            transaction: serializedTransaction,
+            cumulativeAmount: '3000000',
+            signature: await signTestVoucher(channelId, 3000000n),
+          },
+        },
+        request: makeRequest(),
+      })
+
+      await charge(probedStore, channelId, 1000000n)
+
+      const receipt = await server.verify({
+        credential: {
+          challenge: makeChallenge({ id: 'pending-close', channelId }),
+          payload: {
+            action: 'close' as const,
+            channelId,
+            cumulativeAmount: '3000000',
+            signature: await signTestVoucher(channelId, 3000000n),
+          },
+        },
+        request: makeRequest(),
+      })
+
+      expect(receipt.status).toBe('success')
+      expect(probedPendingClose).toBe(true)
+      expect(pendingChargeError).toBeInstanceOf(ChannelClosedError)
+      expect((pendingChargeError as Error).message).toContain('pending close request')
     })
   })
 
@@ -3220,6 +3295,47 @@ describe.runIf(isLocalnet)('session', () => {
       expect(persisted?.finalized).toBe(true)
     })
 
+    test('sessionManager rejects receipts that exceed the locally signed voucher', async () => {
+      const handler = createHandler()
+      const route = handler.session({
+        amount: '1',
+        decimals: 6,
+        unitType: 'token',
+      })
+
+      const fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = new Request(input, init)
+        const result = await route(request)
+        if (result.status === 402) return result.challenge
+
+        const response = result.withReceipt(new Response('ok'))
+        const receipt = deserializeSessionReceipt(response.headers.get('Payment-Receipt')!)
+        return new Response(response.body, {
+          status: response.status,
+          statusText: response.statusText,
+          headers: {
+            'Payment-Receipt': serializeSessionReceipt({
+              ...receipt,
+              acceptedCumulative: '3000000',
+              spent: '3000000',
+            }),
+          },
+        })
+      }
+
+      const manager = sessionManager({
+        account: payer,
+        client,
+        escrowContract,
+        fetch,
+        maxDeposit: '3',
+      })
+
+      await expect(manager.fetch('https://api.example.com/resource')).rejects.toThrow(
+        'receipt accepted cumulative exceeds local voucher state',
+      )
+    })
+
     test('does not return Payment-Receipt on verification errors', async () => {
       const { channelId, serializedTransaction } = await createSignedOpenTransaction(10000000n)
       const handler = createHandler()
@@ -3467,6 +3583,79 @@ describe.runIf(isLocalnet)('session', () => {
       )
       expect(replay.status).toBe(402)
       expect(replay.headers.get('Payment-Receipt')).toBeNull()
+    })
+
+    test('default HTTP bodyless POST query flow charges instead of treating voucher as management', async () => {
+      const { channelId, serializedTransaction } = await createSignedOpenTransaction(10000000n)
+      const signature = await signTestVoucher(channelId, 1000000n)
+      const handler = createHandler()
+      const route = handler.session({
+        amount: '1',
+        decimals: 6,
+        unitType: 'token',
+      })
+
+      const first = await route(
+        new Request('https://api.example.com/search?q=paid', {
+          method: 'POST',
+        }),
+      )
+      expect(first.status).toBe(402)
+      if (first.status !== 402) throw new Error('expected challenge')
+
+      const open = await route(
+        new Request('https://api.example.com/search?q=paid', {
+          method: 'POST',
+          headers: {
+            Authorization: Credential.serialize({
+              challenge: Challenge.fromResponse(first.challenge),
+              payload: {
+                action: 'open',
+                type: 'transaction',
+                channelId,
+                transaction: serializedTransaction,
+                cumulativeAmount: '1000000',
+                signature,
+              },
+            }),
+          },
+        }),
+      )
+      expect(open.status).toBe(200)
+      if (open.status !== 200) throw new Error('expected paid response')
+      const paid = open.withReceipt(new Response('query-result'))
+      expect(await paid.text()).toBe('query-result')
+      const receipt = deserializeSessionReceipt(paid.headers.get('Payment-Receipt') as string)
+      expect(receipt.spent).toBe('1000000')
+      expect(receipt.units).toBe(1)
+
+      const replayChallenge = await route(
+        new Request('https://api.example.com/search?q=paid', {
+          method: 'POST',
+        }),
+      )
+      expect(replayChallenge.status).toBe(402)
+      if (replayChallenge.status !== 402) throw new Error('expected challenge')
+
+      const replay = await route(
+        new Request('https://api.example.com/search?q=paid', {
+          method: 'POST',
+          headers: {
+            Authorization: Credential.serialize({
+              challenge: Challenge.fromResponse(replayChallenge.challenge),
+              payload: {
+                action: 'voucher',
+                channelId,
+                cumulativeAmount: '1000000',
+                signature,
+              },
+            }),
+          },
+        }),
+      )
+      expect(replay.status).toBe(402)
+      if (replay.status !== 402) throw new Error('expected challenge')
+      expect(replay.challenge.headers.get('Payment-Receipt')).toBeNull()
     })
 
     test('converts amount/suggestedDeposit/minVoucherDelta with decimals=18', async () => {
@@ -4243,6 +4432,89 @@ describe.runIf(isLocalnet)('session', () => {
       expect(persisted?.spent).toBe(1000000n)
       expect(persisted?.units).toBe(1)
       expect(persisted?.finalized).toBe(true)
+    })
+
+    test('plain-response SSE fallback precharges before running concurrent paid handlers', async () => {
+      const backingStore = Store.memory()
+      const route = Mppx_server.create({
+        methods: [
+          tempo_server.session({
+            store: backingStore,
+            getClient: () => client,
+            account: recipientAccount,
+            currency,
+            escrowContract,
+            chainId: chain.id,
+            sse: true,
+          }),
+        ],
+        realm: 'api.example.com',
+        secretKey: 'secret',
+      }).session({ amount: '1', decimals: 6, unitType: 'token' })
+
+      const { channelId, serializedTransaction } = await createSignedOpenTransaction(10000000n)
+
+      const openChallenge = await route(new Request('https://api.example.com/fallback'))
+      expect(openChallenge.status).toBe(402)
+      if (openChallenge.status !== 402) throw new Error('expected challenge')
+
+      const openResult = await route(
+        new Request('https://api.example.com/fallback', {
+          method: 'POST',
+          headers: {
+            Authorization: Credential.serialize({
+              challenge: Challenge.fromResponse(openChallenge.challenge),
+              payload: {
+                action: 'open',
+                type: 'transaction',
+                channelId,
+                transaction: serializedTransaction,
+                cumulativeAmount: '1000000',
+                signature: await signTestVoucher(channelId, 1000000n),
+              },
+            }),
+          },
+        }),
+      )
+      expect(openResult.status).toBe(200)
+      if (openResult.status !== 200) throw new Error('expected open response')
+      expect(openResult.withReceipt().status).toBe(204)
+
+      const replayChallenge = await route(new Request('https://api.example.com/fallback'))
+      expect(replayChallenge.status).toBe(402)
+      if (replayChallenge.status !== 402) throw new Error('expected challenge')
+
+      const authorization = Credential.serialize({
+        challenge: Challenge.fromResponse(replayChallenge.challenge),
+        payload: {
+          action: 'voucher',
+          channelId,
+          cumulativeAmount: '1000000',
+          signature: await signTestVoucher(channelId, 1000000n),
+        },
+      })
+
+      let handlerRuns = 0
+      const serve = async () => {
+        const result = await route(
+          new Request('https://api.example.com/fallback', {
+            headers: { Authorization: authorization },
+          }),
+        )
+        if (result.status === 402) return result.challenge
+        handlerRuns++
+        return result.withReceipt(new Response('paid-fallback'))
+      }
+
+      const [first, second] = await Promise.all([serve(), serve()])
+      const statuses = [first.status, second.status].sort()
+
+      expect(statuses).toEqual([200, 402])
+      expect(handlerRuns).toBe(1)
+
+      const persisted = await ChannelStore.fromStore(backingStore).getChannel(channelId)
+      expect(persisted?.spent).toBe(1000000n)
+      expect(persisted?.units).toBe(1)
     })
 
     test('handles repeated exhaustion/resume cycles within one stream', async () => {

--- a/src/tempo/server/Session.ts
+++ b/src/tempo/server/Session.ts
@@ -268,7 +268,6 @@ export function session<const parameters extends session.Parameters>(
       // This keeps equal-voucher replays bounded by the voucher's remaining
       // balance instead of serving repeated responses for free.
       if (
-        !parameters.sse &&
         envelope &&
         isSessionContentRequest(envelope.capturedRequest) &&
         (payload.action === 'open' || payload.action === 'voucher')
@@ -283,6 +282,7 @@ export function session<const parameters extends session.Parameters>(
           spent: charged.spent.toString(),
           units: charged.units,
         }
+        if (parameters.sse) sessionReceipt = Transport.markPrepaidSessionTick(sessionReceipt)
       }
 
       return sessionReceipt
@@ -917,16 +917,45 @@ async function handleClose(
     throw new InvalidSignatureError({ reason: 'invalid voucher signature' })
   }
 
-  assertSettlementSender({
-    operation: 'close',
-    channelId: payload.channelId,
-    payee: onChain.payee,
-    sender: account?.address ?? client.account?.address,
+  const pendingCloseStartedAt = BigInt(Math.floor(Date.now() / 1000) || 1)
+  const previousCloseRequestedAt = channel.closeRequestedAt
+  let pendingCloseMarked = false
+  await store.updateChannel(channelId, (current) => {
+    if (!current) return null
+    if (current.finalized) throw new ChannelClosedError({ reason: 'channel is already finalized' })
+    if (current.closeRequestedAt !== 0n)
+      throw new ChannelClosedError({ reason: 'channel has a pending close request' })
+    if (voucher.cumulativeAmount < current.spent) {
+      throw new VerificationFailedError({
+        reason: `close voucher amount must be >= ${current.spent} (spent)`,
+      })
+    }
+    pendingCloseMarked = true
+    return { ...current, closeRequestedAt: pendingCloseStartedAt }
   })
 
-  const txHash = await closeOnChain(client, methodDetails.escrowContract, voucher, {
-    ...(feePayer && account ? { feePayer, account } : { account }),
-  })
+  let txHash: Hex | undefined
+  try {
+    assertSettlementSender({
+      operation: 'close',
+      channelId: payload.channelId,
+      payee: onChain.payee,
+      sender: account?.address ?? client.account?.address,
+    })
+
+    txHash = await closeOnChain(client, methodDetails.escrowContract, voucher, {
+      ...(feePayer && account ? { feePayer, account } : { account }),
+    })
+  } catch (error) {
+    if (pendingCloseMarked) {
+      await store.updateChannel(channelId, (current) =>
+        current && current.closeRequestedAt === pendingCloseStartedAt
+          ? { ...current, closeRequestedAt: previousCloseRequestedAt }
+          : current,
+      )
+    }
+    throw error
+  }
 
   const updated = await store.updateChannel(channelId, (current) => {
     if (!current) return null

--- a/src/tempo/server/internal/request-body.test.ts
+++ b/src/tempo/server/internal/request-body.test.ts
@@ -82,6 +82,17 @@ describe('request-body', () => {
         }),
       ).toBe(false)
     })
+
+    test('treats bodyless POST requests with query parameters as content requests', () => {
+      expect(
+        isSessionContentRequest({
+          hasBody: false,
+          headers: new Headers(),
+          method: 'POST',
+          url: new URL('https://api.example.com/search?q=paid'),
+        }),
+      ).toBe(true)
+    })
   })
 
   describe('shouldChargePlainResponse', () => {
@@ -121,6 +132,20 @@ describe('request-body', () => {
         ),
       ).toBe(false)
     })
+
+    test('charges bodyless POST query requests', () => {
+      expect(
+        shouldChargePlainResponse(
+          {
+            hasBody: false,
+            headers: new Headers(),
+            method: 'POST',
+            url: new URL('https://api.example.com/search?q=paid'),
+          },
+          { action: 'voucher' },
+        ),
+      ).toBe(true)
+    })
   })
 
   describe('captureRequestBodyProbe', () => {
@@ -136,6 +161,7 @@ describe('request-body', () => {
         headers: request.headers,
         hasBody: true,
         method: 'POST',
+        url: new URL('https://example.com/'),
       })
     })
   })

--- a/src/tempo/server/internal/request-body.ts
+++ b/src/tempo/server/internal/request-body.ts
@@ -1,13 +1,15 @@
 import type * as Method from '../../../Method.js'
 import type { SessionCredentialPayload } from '../../session/Types.js'
 
-export type RequestBodyProbe = Pick<Method.CapturedRequest, 'headers' | 'hasBody' | 'method'>
+export type RequestBodyProbe = Pick<Method.CapturedRequest, 'headers' | 'hasBody' | 'method'> &
+  Partial<Pick<Method.CapturedRequest, 'url'>>
 
 export function captureRequestBodyProbe(input: Request): RequestBodyProbe {
   return {
     headers: input.headers,
     hasBody: input.body !== null,
     method: input.method,
+    url: new URL(input.url),
   }
 }
 
@@ -25,6 +27,7 @@ export function hasCapturedRequestBody(
 export function isSessionContentRequest(input: RequestBodyProbe): boolean {
   if (input.method === 'HEAD') return false
   if (input.method !== 'POST') return true
+  if (input.url?.search) return true
   return hasCapturedRequestBody(input)
 }
 

--- a/src/tempo/server/internal/transport.test.ts
+++ b/src/tempo/server/internal/transport.test.ts
@@ -7,7 +7,8 @@ import { chainId, escrowContract as escrowContractDefaults } from '../../interna
 import * as ChannelStore from '../../session/ChannelStore.js'
 import { deserializeSessionReceipt } from '../../session/Receipt.js'
 import { parseEvent } from '../../session/Sse.js'
-import { sse } from './transport.js'
+import type { SessionReceipt } from '../../session/Types.js'
+import { markPrepaidSessionTick, sse } from './transport.js'
 
 const channelId = '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex
 const challengeId = 'challenge-1'
@@ -129,7 +130,7 @@ type ReceiptOverrides = Partial<{
   units: number
 }>
 
-function makeReceipt(overrides: ReceiptOverrides = {}) {
+function makeReceipt(overrides: ReceiptOverrides = {}): SessionReceipt {
   return {
     method: 'tempo',
     intent: 'session' as const,
@@ -664,6 +665,31 @@ describe('sse transport', () => {
     })
     expect(response).toBeInstanceOf(Response)
     expect(response.headers.get('Payment-Receipt')).toBeTruthy()
+  })
+
+  test('respondReceipt with prepaid plain Response does not deduct again', async () => {
+    const store = memoryStore()
+    await seedChannel(store, 10000000n)
+    const transport = sse({ store })
+
+    const response = transport.respondReceipt({
+      credential: makeCredential(),
+      input: makeAuthorizedRequest(),
+      receipt: markPrepaidSessionTick(makeReceipt({ spent: '1000000', units: 1 })),
+      response: new Response('ok', {
+        headers: { 'Content-Type': 'application/json' },
+      }),
+      challengeId,
+    })
+
+    expect(await response.text()).toBe('ok')
+    const receipt = deserializeSessionReceipt(response.headers.get('Payment-Receipt')!)
+    const channel = await store.getChannel(channelId)
+
+    expect(channel!.spent).toBe(0n)
+    expect(channel!.units).toBe(0)
+    expect(receipt.spent).toBe('1000000')
+    expect(receipt.units).toBe(1)
   })
 
   test('respondReceipt no longer depends on prior getCredential side effects', async () => {

--- a/src/tempo/server/internal/transport.ts
+++ b/src/tempo/server/internal/transport.ts
@@ -13,8 +13,27 @@ import * as Sse_core from '../../session/Sse.js'
 import type { SessionCredentialPayload, SessionReceipt } from '../../session/Types.js'
 import { captureRequestBodyProbe, shouldChargePlainResponse } from './request-body.js'
 
+const prepaidSessionTick = Symbol('mppx.prepaidSessionTick')
+
 /** SSE transport with Tempo session controller. */
 export type Sse = Transport.Sse<Sse_core.SessionController>
+
+export type PrepaidSessionReceipt = SessionReceipt & {
+  [prepaidSessionTick]?: true | undefined
+}
+
+export function markPrepaidSessionTick(receipt: SessionReceipt): SessionReceipt {
+  Object.defineProperty(receipt, prepaidSessionTick, {
+    configurable: false,
+    enumerable: false,
+    value: true,
+  })
+  return receipt
+}
+
+function hasPrepaidSessionTick(receipt: SessionReceipt): boolean {
+  return (receipt as PrepaidSessionReceipt)[prepaidSessionTick] === true
+}
 
 /**
  * Creates a Tempo-metered SSE transport.
@@ -93,6 +112,7 @@ export function sse(options: sse.Options & { store: ChannelStore.ChannelStore })
           tickCost,
           pollIntervalMs: pollingInterval,
           generate,
+          prepaidUnits: hasPrepaidSessionTick(receipt as SessionReceipt) ? 1 : 0,
           signal: input.signal,
         })
         return Sse_core.toResponse(stream)
@@ -113,6 +133,9 @@ export function sse(options: sse.Options & { store: ChannelStore.ChannelStore })
       }
 
       const currentReceipt = receipt as SessionReceipt
+      if (hasPrepaidSessionTick(currentReceipt)) {
+        return baseResponse
+      }
       const available = BigInt(currentReceipt.acceptedCumulative) - BigInt(currentReceipt.spent)
       if (available < tickCost) {
         const error = new Errors.InsufficientBalanceError({

--- a/src/tempo/session/Sse.test.ts
+++ b/src/tempo/session/Sse.test.ts
@@ -258,6 +258,31 @@ describe('serve', () => {
     expect(channel!.units).toBe(3)
   })
 
+  test('uses a prepaid unit for the first generated value', async () => {
+    const storage = memoryStore()
+    await seedChannel(storage, 3000000n)
+    await storage.updateChannel(channelId, (current) =>
+      current ? { ...current, spent: 1000000n, units: 1 } : current,
+    )
+
+    const stream = serve({
+      store: storage,
+      channelId,
+      challengeId,
+      tickCost: 1000000n,
+      generate: generate(['hello', 'world']),
+      prepaidUnits: 1,
+    })
+
+    const output = await readStream(stream)
+    expect(output).toContain('event: message\ndata: hello\n\n')
+    expect(output).toContain('event: message\ndata: world\n\n')
+
+    const channel = await storage.getChannel(channelId)
+    expect(channel!.spent).toBe(2000000n)
+    expect(channel!.units).toBe(2)
+  })
+
   test('emits multiline message values as a single SSE message event', async () => {
     const storage = memoryStore()
     await seedChannel(storage, 1000000n)

--- a/src/tempo/session/Sse.ts
+++ b/src/tempo/session/Sse.ts
@@ -141,11 +141,16 @@ export function serve(options: serve.Options): ReadableStream<Uint8Array> {
     async start(controller) {
       const aborted = () => signal?.aborted ?? false
       const emit = (event: string) => controller.enqueue(encoder.encode(event))
+      let prepaidUnits = options.prepaidUnits ?? 0
       let reservedAmount = 0n
       let reservedUnits = 0
 
-      const charge = () =>
-        reserveChargeOrWait({
+      const charge = () => {
+        if (prepaidUnits > 0) {
+          prepaidUnits -= 1
+          return Promise.resolve()
+        }
+        return reserveChargeOrWait({
           store,
           channelId,
           amount: tickCost,
@@ -157,6 +162,7 @@ export function serve(options: serve.Options): ReadableStream<Uint8Array> {
           reservedAmount += tickCost
           reservedUnits += 1
         })
+      }
 
       const iterable: AsyncIterable<string> =
         typeof generate === 'function' ? generate({ charge }) : generate
@@ -207,6 +213,7 @@ export declare namespace serve {
     tickCost: bigint
     generate: AsyncIterable<string> | ((stream: SessionController) => AsyncIterable<string>)
     pollIntervalMs?: number | undefined
+    prepaidUnits?: number | undefined
     signal?: AbortSignal | undefined
   }
 }


### PR DESCRIPTION
## Summary

- Precharge session content requests before SSE/plain-response fallback handlers run, so concurrent voucher replays cannot execute more paid work than the voucher covers.
- Treat bodyless POST requests with query parameters as billable content requests instead of management updates.
- Validate session receipts on the client and CLI before updating local cumulative spend or signing follow-up close/voucher credentials.
- Mark channels as pending close before the on-chain close transaction is submitted, blocking concurrent charges during finalization.
