### PR TITLE
Harden fee-payer sponsorship

### DIFF
--- a/.changeset/quiet-silver-clouds.md
+++ b/.changeset/quiet-silver-clouds.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Hardened fee-payer gas sponsorship validation.

--- a/src/tempo/internal/fee-payer.test.ts
+++ b/src/tempo/internal/fee-payer.test.ts
@@ -123,6 +123,145 @@ describe('validateCalls', () => {
     ).not.toThrow()
   })
 
+  test('accepts approve + buy + exact expected split transfers', () => {
+    expect(() =>
+      validateCalls(
+        [
+          {
+            to: swapTokenIn,
+            data: encodeFunctionData({
+              abi: Abis.tip20,
+              functionName: 'approve',
+              args: [Addresses.stablecoinDex, 100n],
+            }),
+          },
+          {
+            to: Addresses.stablecoinDex,
+            data: swapData,
+          },
+          {
+            to: swapTokenOut,
+            data: encodeFunctionData({
+              abi: Abis.tip20,
+              functionName: 'transfer',
+              args: [bogus, 90n],
+            }),
+          },
+          {
+            to: swapTokenOut,
+            data: encodeFunctionData({
+              abi: Abis.tip20,
+              functionName: 'transferWithMemo',
+              args: [
+                '0x0000000000000000000000000000000000000002',
+                10n,
+                '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+              ],
+            }),
+          },
+        ],
+        details,
+        {
+          currency: swapTokenOut,
+          expectedTransfers: [
+            { amount: '90', recipient: bogus },
+            {
+              amount: '10',
+              memo: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+              recipient: '0x0000000000000000000000000000000000000002',
+            },
+          ],
+        },
+      ),
+    ).not.toThrow()
+  })
+
+  test('error: rejects extra transfers when expected payments are supplied', () => {
+    expect(() =>
+      validateCalls(
+        [
+          {
+            to: swapTokenOut,
+            data: encodeFunctionData({
+              abi: Abis.tip20,
+              functionName: 'transfer',
+              args: [bogus, 100n],
+            }),
+          },
+          {
+            to: swapTokenOut,
+            data: encodeFunctionData({
+              abi: Abis.tip20,
+              functionName: 'transfer',
+              args: ['0x0000000000000000000000000000000000000002', 1n],
+            }),
+          },
+        ],
+        details,
+        {
+          currency: swapTokenOut,
+          expectedTransfers: [{ amount: '100', recipient: bogus }],
+        },
+      ),
+    ).toThrow('disallowed call pattern')
+  })
+
+  test('error: rejects expected transfers to the wrong token', () => {
+    expect(() =>
+      validateCalls(
+        [
+          {
+            to: swapTokenIn,
+            data: encodeFunctionData({
+              abi: Abis.tip20,
+              functionName: 'transfer',
+              args: [bogus, 100n],
+            }),
+          },
+        ],
+        details,
+        {
+          currency: swapTokenOut,
+          expectedTransfers: [{ amount: '100', recipient: bogus }],
+        },
+      ),
+    ).toThrow('payment transfer does not match challenge')
+  })
+
+  test('error: rejects swaps whose output token does not fund the payment', () => {
+    expect(() =>
+      validateCalls(
+        [
+          {
+            to: swapTokenIn,
+            data: encodeFunctionData({
+              abi: Abis.tip20,
+              functionName: 'approve',
+              args: [Addresses.stablecoinDex, 100n],
+            }),
+          },
+          {
+            to: Addresses.stablecoinDex,
+            data: swapData,
+          },
+          {
+            to: bogus,
+            data: encodeFunctionData({
+              abi: Abis.tip20,
+              functionName: 'transfer',
+              args: [bogus, 100n],
+            }),
+          },
+        ],
+        details,
+        {
+          currency: bogus,
+          expectedTransfers: [{ amount: '100', recipient: bogus }],
+        },
+      ),
+    ).toThrow('swap tokenOut does not match payment currency')
+  })
+
   test('error: rejects empty calls', () => {
     expect(() => validateCalls([], details)).toThrow(FeePayerValidationError)
   })

--- a/src/tempo/internal/fee-payer.ts
+++ b/src/tempo/internal/fee-payer.ts
@@ -1,5 +1,6 @@
 import type { TempoAddress } from 'ox/tempo'
 import { TxEnvelopeTempo } from 'ox/tempo'
+import type { Hex } from 'viem'
 import type { Account } from 'viem'
 import { decodeFunctionData } from 'viem'
 import { Abis, Addresses, Transaction } from 'viem/tempo'
@@ -41,6 +42,13 @@ export type Policy = {
 // for that function's return type so this helper stays aligned with upstream
 // Tempo transaction fields.
 type SponsoredTransaction = ReturnType<(typeof Transaction)['deserialize']>
+
+type ExpectedTransfer = {
+  amount: string
+  allowAnyMemo?: boolean | undefined
+  memo?: Hex | undefined
+  recipient: TempoAddress.Address
+}
 
 const preservedTransactionKeys = [
   'accessList',
@@ -122,6 +130,10 @@ function getPolicy(chainId: number, overrides: Partial<Policy> | undefined): Pol
 export function validateCalls(
   calls: readonly { data?: `0x${string}` | undefined; to?: TempoAddress.Address | undefined }[],
   details: Record<string, string>,
+  options?: {
+    currency?: TempoAddress.Address | undefined
+    expectedTransfers?: readonly ExpectedTransfer[] | undefined
+  },
 ) {
   if (calls.length === 0)
     throw new FeePayerValidationError('disallowed call pattern in fee-payer transaction', details)
@@ -137,15 +149,19 @@ export function validateCalls(
   }
 
   const transferSelectors = callSelectors.slice(hasSwapPrefix ? 2 : 0)
+  if (transferSelectors.length === 0)
+    throw new FeePayerValidationError('disallowed call pattern in fee-payer transaction', details)
+
+  const expectedTransfers = options?.expectedTransfers
+  const transferLimit = expectedTransfers?.length ?? 11
   if (
-    transferSelectors.length === 0 ||
-    transferSelectors.length > 11 ||
+    transferSelectors.length > transferLimit ||
     transferSelectors.some(
       (selector) => selector !== Selectors.transfer && selector !== Selectors.transferWithMemo,
-    )
-  ) {
+    ) ||
+    (expectedTransfers && transferSelectors.length !== expectedTransfers.length)
+  )
     throw new FeePayerValidationError('disallowed call pattern in fee-payer transaction', details)
-  }
 
   // Bind the swap approval to the token the DEX call will actually spend.
   const buyCall = calls.find((c) => c.data?.slice(0, 10) === Selectors.swapExactAmountOut)
@@ -161,16 +177,79 @@ export function validateCalls(
   const approveCall = calls.find((c) => c.data?.slice(0, 10) === Selectors.approve)
   if (approveCall) {
     const { args } = decodeFunctionData({ abi: Abis.tip20, data: approveCall.data! })
+    const [spender, amount] = args as [`0x${string}`, bigint]
     if (!approveCall.to || (buyArgs && !TempoAddress_internal.isEqual(approveCall.to, buyArgs[0])))
       throw new FeePayerValidationError('approve target does not match swap tokenIn', details)
-    if (!TempoAddress_internal.isEqual((args as [`0x${string}`])[0]!, Addresses.stablecoinDex))
+    if (!TempoAddress_internal.isEqual(spender, Addresses.stablecoinDex))
       throw new FeePayerValidationError('approve spender is not the DEX', details)
+    if (buyArgs && amount !== buyArgs[3])
+      throw new FeePayerValidationError('approve amount does not match swap max input', details)
   }
   if (
     buyCall &&
     (!buyCall.to || !TempoAddress_internal.isEqual(buyCall.to, Addresses.stablecoinDex))
   )
     throw new FeePayerValidationError('buy target is not the DEX', details)
+
+  if (!expectedTransfers) return
+
+  const currency = options?.currency ?? (details.currency as TempoAddress.Address | undefined)
+  if (!currency) throw new FeePayerValidationError('missing payment currency', details)
+
+  if (buyArgs) {
+    const [, tokenOut, amountOut] = buyArgs
+    const expectedAmountOut = expectedTransfers.reduce(
+      (sum, transfer) => sum + BigInt(transfer.amount),
+      0n,
+    )
+    if (!TempoAddress_internal.isEqual(tokenOut, currency))
+      throw new FeePayerValidationError('swap tokenOut does not match payment currency', details)
+    if (amountOut !== expectedAmountOut)
+      throw new FeePayerValidationError('swap output does not match payment amount', details)
+  }
+
+  const transferCalls = calls.slice(hasSwapPrefix ? 2 : 0)
+  const sorted = [...expectedTransfers].sort((a, b) => {
+    if (a.memo && !b.memo) return -1
+    if (!a.memo && b.memo) return 1
+    return 0
+  })
+
+  const used = new Set<number>()
+  for (const expected of sorted) {
+    const matchIndex = transferCalls.findIndex((call, index) => {
+      if (used.has(index)) return false
+      if (!call.to || !TempoAddress_internal.isEqual(call.to, currency) || !call.data) return false
+
+      try {
+        const selector = call.data.slice(0, 10)
+        const { args } = decodeFunctionData({ abi: Abis.tip20, data: call.data })
+        if (selector === Selectors.transfer) {
+          const [recipient, amount] = args as [`0x${string}`, bigint]
+          if (!TempoAddress_internal.isEqual(recipient, expected.recipient)) return false
+          if (amount.toString() !== expected.amount) return false
+          return expected.memo === undefined
+        }
+
+        if (selector === Selectors.transferWithMemo) {
+          const [recipient, amount, memo] = args as [`0x${string}`, bigint, Hex]
+          if (!TempoAddress_internal.isEqual(recipient, expected.recipient)) return false
+          if (amount.toString() !== expected.amount) return false
+          if (expected.memo) return memo.toLowerCase() === expected.memo.toLowerCase()
+          return expected.allowAnyMemo === true
+        }
+      } catch {
+        return false
+      }
+
+      return false
+    })
+
+    if (matchIndex === -1)
+      throw new FeePayerValidationError('payment transfer does not match challenge', details)
+
+    used.add(matchIndex)
+  }
 }
 
 export function prepareSponsoredTransaction(parameters: {

--- a/src/tempo/server/Charge.test.ts
+++ b/src/tempo/server/Charge.test.ts
@@ -1579,6 +1579,104 @@ describe('tempo', () => {
       httpServer.close()
     })
 
+    test('behavior: fee payer rejects concurrent in-flight transactions from one sender', async () => {
+      let releaseSimulation!: () => void
+      let resolveSimulationStarted!: () => void
+      const simulationStarted = new Promise<void>((resolve) => {
+        resolveSimulationStarted = resolve
+      })
+      const releaseSimulationPromise = new Promise<void>((resolve) => {
+        releaseSimulation = resolve
+      })
+      let heldFirstSimulation = false
+
+      const interceptingClient = createClient({
+        account: accounts[0],
+        chain: client.chain,
+        transport: custom({
+          async request(args: any) {
+            if (args.method === 'eth_call' && !heldFirstSimulation) {
+              heldFirstSimulation = true
+              resolveSimulationStarted()
+              await releaseSimulationPromise
+            }
+            return client.transport.request(args)
+          },
+        }),
+      })
+
+      const sponsoredStore = Store.memory()
+      const serverWithSlowSimulation = Mppx_server.create({
+        methods: [
+          tempo_server.charge({
+            getClient() {
+              return interceptingClient
+            },
+            currency: asset,
+            account: accounts[0],
+            store: sponsoredStore,
+          }),
+        ],
+        realm,
+        secretKey,
+      })
+
+      const mppx = Mppx_client.create({
+        polyfill: false,
+        methods: [
+          tempo_client({
+            account: accounts[1],
+            getClient() {
+              return client
+            },
+          }),
+        ],
+      })
+
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await Mppx_server.toNodeListener(
+          serverWithSlowSimulation.charge({
+            feePayer: accounts[0],
+            amount: '1',
+            currency: asset,
+            recipient: accounts[0].address,
+          }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
+      })
+
+      const [challengeResponse1, challengeResponse2] = await Promise.all([
+        fetch(httpServer.url),
+        fetch(httpServer.url),
+      ])
+      expect(challengeResponse1.status).toBe(402)
+      expect(challengeResponse2.status).toBe(402)
+
+      const [credential1, credential2] = await Promise.all([
+        mppx.createCredential(challengeResponse1),
+        mppx.createCredential(challengeResponse2),
+      ])
+
+      const first = fetch(httpServer.url, { headers: { Authorization: credential1 } })
+      await simulationStarted
+      const second = fetch(httpServer.url, { headers: { Authorization: credential2 } })
+
+      try {
+        const secondResponse = await second
+        expect(secondResponse.status).toBe(402)
+        const body = (await secondResponse.json()) as { detail: string }
+        expect(body.detail).toContain('Sponsored transaction from this sender is already in flight')
+      } finally {
+        releaseSimulation()
+      }
+
+      const firstResponse = await first
+      expect(firstResponse.status).toBe(200)
+
+      httpServer.close()
+    })
+
     test('behavior: fee payer with splits', async () => {
       const mppx = Mppx_client.create({
         polyfill: false,
@@ -3337,6 +3435,27 @@ describe('tempo', () => {
         account: accounts[0].address,
       })
       expect(method.defaults?.recipient).toBe(accounts[0].address)
+    })
+
+    test('request keeps explicit feePayer false disabled during verification', async () => {
+      const method = tempo_server.charge({
+        getClient: () => client,
+        account: accounts[0],
+        currency: asset,
+        feePayer: accounts[0],
+      })
+
+      const normalized = await method.request!({
+        credential: { challenge: {}, payload: {} } as never,
+        request: {
+          amount: '1',
+          currency: asset,
+          decimals: 6,
+          feePayer: false,
+        },
+      } as never)
+
+      expect(normalized.feePayer).toBe(false)
     })
   })
 

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -138,9 +138,10 @@ export function charge<const parameters extends charge.Parameters>(
         throw new Error(`Client not configured with chainId ${chainId}.`)
 
       const resolvedFeePayer = (() => {
+        if (request.feePayer === false) return credential ? false : undefined
         const account = typeof request.feePayer === 'object' ? request.feePayer : feePayer
-        const requested = request.feePayer !== false && (account ?? feePayer ?? feePayerUrl)
-        if (credential) return account
+        const requested = account ?? feePayer ?? feePayerUrl
+        if (credential) return account ?? (feePayerUrl ? true : undefined)
         if (requested) return true
         return undefined
       })()
@@ -167,12 +168,17 @@ export function charge<const parameters extends charge.Parameters>(
       const client = await getClient({ chainId })
 
       const { amount, methodDetails } = resolvedRequest
+      const requestAllowsFeePayer =
+        request.feePayer !== false &&
+        (request.feePayer === undefined ||
+          request.feePayer === true ||
+          typeof request.feePayer === 'object')
       const feePayerAccount =
-        typeof request.feePayer === 'object'
-          ? request.feePayer
-          : methodDetails?.feePayer === true
-            ? feePayer
-            : undefined
+        methodDetails?.feePayer === true && requestAllowsFeePayer
+          ? typeof request.feePayer === 'object'
+            ? request.feePayer
+            : feePayer
+          : undefined
       const expires = challenge.expires
       const supportedModes = methodDetails?.supportedModes as
         | readonly Methods.ChargeMode[]
@@ -292,6 +298,7 @@ export function charge<const parameters extends charge.Parameters>(
           }
 
           let releaseReservation = true
+          let sponsoredSenderReservation: { chainId: number; sender: `0x${string}` } | undefined
 
           try {
             if (!FeePayer.isTempoTransaction(serializedTransaction))
@@ -309,7 +316,10 @@ export function charge<const parameters extends charge.Parameters>(
               to?: `0x${string}` | undefined
             }[]
             const transfers = getExpectedTransfers({ amount, memo, methodDetails, recipient })
-            const isFeePayerTx = !!(feePayer || feePayerUrl) && methodDetails?.feePayer !== false
+            const isFeePayerTx =
+              methodDetails?.feePayer === true &&
+              requestAllowsFeePayer &&
+              !!(feePayerAccount || feePayerUrl)
             const matchedCalls = assertTransferCalls(calls, {
               currency,
               exactCount: isFeePayerTx,
@@ -321,8 +331,28 @@ export function charge<const parameters extends charge.Parameters>(
                 realm: challenge.realm,
               })
 
-            if (isFeePayerTx)
-              FeePayer.validateCalls(transaction.calls, { amount, currency, recipient })
+            if (isFeePayerTx) {
+              const reservationChainId = chainId ?? client.chain!.id
+              if (
+                !(await markSponsoredSenderInFlight(store, {
+                  chainId: reservationChainId,
+                  sender: transaction.from as `0x${string}`,
+                }))
+              ) {
+                throw new VerificationFailedError({
+                  reason: 'Sponsored transaction from this sender is already in flight',
+                })
+              }
+              sponsoredSenderReservation = {
+                chainId: reservationChainId,
+                sender: transaction.from as `0x${string}`,
+              }
+              FeePayer.validateCalls(
+                transaction.calls,
+                { amount, currency, recipient },
+                { currency, expectedTransfers: transfers },
+              )
+            }
 
             const expectedFeeToken = defaults.currency[chainId as keyof typeof defaults.currency]
             const resolvedFeeToken = transaction.feeToken ?? expectedFeeToken
@@ -413,6 +443,9 @@ export function charge<const parameters extends charge.Parameters>(
           } catch (error) {
             if (releaseReservation) await releaseHashUse(store, hash)
             throw error
+          } finally {
+            if (sponsoredSenderReservation)
+              await releaseSponsoredSenderInFlight(store, sponsoredSenderReservation)
           }
         }
 
@@ -698,6 +731,14 @@ function getProofStoreKey(challengeId: string): `mppx:charge:${string}` {
   return `mppx:charge:proof:${challengeId}`
 }
 
+/** @internal */
+function getSponsoredSenderStoreKey(parameters: {
+  chainId: number
+  sender: `0x${string}`
+}): `mppx:charge:${string}` {
+  return `mppx:charge:sponsor:${parameters.chainId}:${parameters.sender.toLowerCase()}`
+}
+
 async function markHashUsed(
   store: Store.AtomicStore<charge.StoreItemMap>,
   hash: `0x${string}`,
@@ -714,6 +755,25 @@ async function releaseHashUse(
   hash: `0x${string}`,
 ): Promise<void> {
   await store.delete(getHashStoreKey(hash))
+}
+
+/** @internal */
+async function markSponsoredSenderInFlight(
+  store: Store.AtomicStore<charge.StoreItemMap>,
+  parameters: { chainId: number; sender: `0x${string}` },
+): Promise<boolean> {
+  return store.update(getSponsoredSenderStoreKey(parameters), (current) => {
+    if (current !== null) return { op: 'noop', result: false }
+    return { op: 'set', value: Date.now(), result: true }
+  })
+}
+
+/** @internal */
+async function releaseSponsoredSenderInFlight(
+  store: Store.AtomicStore<charge.StoreItemMap>,
+  parameters: { chainId: number; sender: `0x${string}` },
+): Promise<void> {
+  await store.delete(getSponsoredSenderStoreKey(parameters))
 }
 
 /** @internal */

--- a/src/tempo/server/Session.test.ts
+++ b/src/tempo/server/Session.test.ts
@@ -11,6 +11,7 @@ import { Base64, Secp256k1 } from 'ox'
 import {
   type Address,
   createClient,
+  custom,
   type Hex,
   parseSignature,
   serializeCompactSignature,
@@ -256,6 +257,54 @@ describe.runIf(isLocalnet)('session', () => {
           request: makeRequest(),
         }),
       ).rejects.toThrow('invalid voucher signature')
+    })
+
+    test('rejects sponsored open with invalid voucher before broadcasting', async () => {
+      const rpcMethods: string[] = []
+      const interceptingClient = createClient({
+        account: recipientAccount,
+        chain,
+        transport: custom({
+          async request(args: any) {
+            rpcMethods.push(args.method)
+            return client.transport.request(args)
+          },
+        }),
+      })
+
+      const salt = nextSalt()
+      const { channelId, serializedTransaction } = await signOpenChannel({
+        escrow: escrowContract,
+        payer,
+        payee: recipient,
+        token: currency,
+        deposit: 10000000n,
+        salt,
+        feePayer: true,
+      })
+      const server = createServer({
+        feePayer: recipientAccount,
+        getClient: () => interceptingClient,
+      })
+
+      await expect(
+        server.verify({
+          credential: {
+            challenge: makeChallenge({ channelId }),
+            payload: {
+              action: 'open' as const,
+              type: 'transaction' as const,
+              channelId,
+              transaction: serializedTransaction,
+              cumulativeAmount: '1000000',
+              signature: `0x${'ab'.repeat(65)}` as Hex,
+            },
+          },
+          request: makeRequest({ feePayer: true }),
+        }),
+      ).rejects.toThrow('invalid voucher signature')
+
+      expect(rpcMethods).not.toContain('eth_sendRawTransactionSync')
     })
 
     test('reopen existing channel with higher voucher updates state', async () => {
@@ -5709,6 +5758,12 @@ describe('session request and verify guardrails', () => {
       request: makeRequest({ feePayer: false }),
     } as never)
     expect(normalized.feePayer).toBeUndefined()
+
+    const verificationRequest = await server.request!({
+      credential: { challenge: {}, payload: {} } as never,
+      request: makeRequest({ feePayer: false }),
+    } as never)
+    expect(verificationRequest.feePayer).toBe(false)
   })
 
   test('request leaves escrowContract undefined when chain has no configured default', async () => {

--- a/src/tempo/server/Session.ts
+++ b/src/tempo/server/Session.ts
@@ -168,9 +168,10 @@ export function session<const parameters extends session.Parameters>(
 
       // Extract feePayer.
       const resolvedFeePayer = (() => {
+        if (request.feePayer === false) return credential ? false : undefined
         const account = typeof request.feePayer === 'object' ? request.feePayer : feePayer
-        const requested = request.feePayer !== false && (account ?? feePayer ?? feePayerUrl)
-        if (credential) return account
+        const requested = account ?? feePayer ?? feePayerUrl
+        if (credential) return account ?? (feePayerUrl ? true : undefined)
         if (requested) return true
         return undefined
       })()
@@ -196,7 +197,17 @@ export function session<const parameters extends session.Parameters>(
       const methodDetails = resolvedRequest.methodDetails as SessionMethodDetails
       const client = await getClient({ chainId: methodDetails.chainId })
 
-      const resolvedFeePayer = methodDetails.feePayer === true ? feePayer : undefined
+      const requestAllowsFeePayer =
+        request.feePayer !== false &&
+        (request.feePayer === undefined ||
+          request.feePayer === true ||
+          typeof request.feePayer === 'object')
+      const resolvedFeePayer =
+        methodDetails.feePayer === true && requestAllowsFeePayer
+          ? typeof request.feePayer === 'object'
+            ? request.feePayer
+            : feePayer
+          : undefined
       const minVoucherDelta = parseUnits(parameters.minVoucherDelta ?? '0', decimals)
       const effectiveMinVoucherDelta = methodDetails.minVoucherDelta
         ? BigInt(methodDetails.minVoucherDelta)
@@ -625,6 +636,38 @@ async function handleOpen(
   const currency = challenge.request.currency as Address
   const amount = challenge.request.amount ? BigInt(challenge.request.amount as string) : undefined
 
+  const validateOpenVoucher = async (onChain: OnChainChannel) => {
+    validateOnChainChannel(onChain, recipient, currency, amount)
+
+    const authorizedSigner =
+      onChain.authorizedSigner === '0x0000000000000000000000000000000000000000'
+        ? onChain.payer
+        : onChain.authorizedSigner
+
+    if (voucher.cumulativeAmount > onChain.deposit) {
+      throw new AmountExceedsDepositError({ reason: 'voucher amount exceeds on-chain deposit' })
+    }
+
+    if (voucher.cumulativeAmount <= onChain.settled) {
+      throw new VerificationFailedError({
+        reason: 'voucher cumulativeAmount is below on-chain settled amount',
+      })
+    }
+
+    const isValid = await verifyVoucher(
+      methodDetails.escrowContract,
+      methodDetails.chainId,
+      voucher,
+      authorizedSigner,
+    )
+
+    if (!isValid) {
+      throw new InvalidSignatureError({ reason: 'invalid voucher signature' })
+    }
+
+    return authorizedSigner
+  }
+
   const { onChain, txHash } = await broadcastOpenTransaction({
     client,
     serializedTransaction: payload.transaction,
@@ -635,36 +678,13 @@ async function handleOpen(
     challengeExpires: challenge.expires,
     feePayerPolicy,
     feePayer,
+    beforeBroadcast: async (pendingOnChain) => {
+      await validateOpenVoucher(pendingOnChain)
+    },
     waitForConfirmation,
   })
 
-  validateOnChainChannel(onChain, recipient, currency, amount)
-
-  const authorizedSigner =
-    onChain.authorizedSigner === '0x0000000000000000000000000000000000000000'
-      ? onChain.payer
-      : onChain.authorizedSigner
-
-  if (voucher.cumulativeAmount > onChain.deposit) {
-    throw new AmountExceedsDepositError({ reason: 'voucher amount exceeds on-chain deposit' })
-  }
-
-  if (voucher.cumulativeAmount <= onChain.settled) {
-    throw new VerificationFailedError({
-      reason: 'voucher cumulativeAmount is below on-chain settled amount',
-    })
-  }
-
-  const isValid = await verifyVoucher(
-    methodDetails.escrowContract,
-    methodDetails.chainId,
-    voucher,
-    authorizedSigner,
-  )
-
-  if (!isValid) {
-    throw new InvalidSignatureError({ reason: 'invalid voucher signature' })
-  }
+  const authorizedSigner = await validateOpenVoucher(onChain)
 
   const updated = await store.updateChannel(channelId, (existing) => {
     if (existing) {

--- a/src/tempo/session/Chain.test.ts
+++ b/src/tempo/session/Chain.test.ts
@@ -1,4 +1,12 @@
-import { type Address, encodeFunctionData, erc20Abi, type Hex, zeroAddress } from 'viem'
+import {
+  type Address,
+  createClient,
+  custom,
+  encodeFunctionData,
+  erc20Abi,
+  type Hex,
+  zeroAddress,
+} from 'viem'
 import { prepareTransactionRequest, signTransaction, waitForTransactionReceipt } from 'viem/actions'
 import { Addresses, Transaction } from 'viem/tempo'
 import { beforeAll, describe, expect, test } from 'vp/test'
@@ -450,6 +458,70 @@ describe.runIf(isLocalnet)('on-chain', () => {
       ).rejects.toThrow('gas exceeds sponsor policy')
     })
 
+    test('fee-payer: simulates open before broadcasting', async () => {
+      const rpcMethods: string[] = []
+      const interceptingClient = createClient({
+        account: accounts[0],
+        chain: client.chain,
+        transport: custom({
+          async request(args: any) {
+            rpcMethods.push(args.method)
+            return client.transport.request(args)
+          },
+        }),
+      })
+
+      const salt = nextSalt()
+      const deposit = 5_000_000n
+      const approveData = encodeFunctionData({
+        abi: erc20Abi,
+        functionName: 'approve',
+        args: [escrowContract, deposit],
+      })
+      const openData = encodeFunctionData({
+        abi: escrowAbi,
+        functionName: 'open',
+        args: [recipient, currency, deposit, salt, zeroAddress],
+      })
+      const channelId = Channel.computeId({
+        authorizedSigner: zeroAddress,
+        chainId: chain.id,
+        escrowContract,
+        payee: recipient,
+        payer: payer.address,
+        salt,
+        token: currency,
+      }) as Hex
+      const prepared = await prepareTransactionRequest(client, {
+        account: payer,
+        calls: [
+          { to: currency, data: approveData },
+          { to: escrowContract, data: openData },
+        ],
+        feePayer: true,
+        feeToken: currency,
+      } as never)
+      prepared.gas = prepared.gas! + 5_000n
+      const serializedTransaction = await signTransaction(client, prepared as never)
+
+      await broadcastOpenTransaction({
+        client: interceptingClient,
+        serializedTransaction,
+        escrowContract,
+        channelId,
+        recipient,
+        currency,
+        feePayer: accounts[0],
+      })
+
+      const broadcastIndex = rpcMethods.indexOf('eth_sendRawTransactionSync')
+      const simulationIndex = rpcMethods.indexOf('eth_call')
+
+      expect(broadcastIndex).toBeGreaterThan(-1)
+      expect(simulationIndex).toBeGreaterThan(-1)
+      expect(simulationIndex).toBeLessThan(broadcastIndex)
+    })
+
     test('fee-payer: rejects smuggled second open call', async () => {
       const deposit = 5_000_000n
       const smuggledDeposit = 7_000_000n
@@ -890,6 +962,73 @@ describe.runIf(isLocalnet)('on-chain', () => {
           feePayer: accounts[0],
         }),
       ).rejects.toThrow('gas exceeds sponsor policy')
+    })
+
+    test('fee-payer: simulates topUp before broadcasting', async () => {
+      const rpcMethods: string[] = []
+      const interceptingClient = createClient({
+        account: accounts[0],
+        chain: client.chain,
+        transport: custom({
+          async request(args: any) {
+            rpcMethods.push(args.method)
+            return client.transport.request(args)
+          },
+        }),
+      })
+
+      const salt = nextSalt()
+      const deposit = 5_000_000n
+      const topUpAmount = 3_000_000n
+
+      const { channelId } = await openChannel({
+        escrow: escrowContract,
+        payer,
+        payee: recipient,
+        token: currency,
+        deposit,
+        salt,
+      })
+
+      const approveData = encodeFunctionData({
+        abi: erc20Abi,
+        functionName: 'approve',
+        args: [escrowContract, topUpAmount],
+      })
+      const topUpData = encodeFunctionData({
+        abi: escrowAbi,
+        functionName: 'topUp',
+        args: [channelId, topUpAmount],
+      })
+      const prepared = await prepareTransactionRequest(client, {
+        account: payer,
+        calls: [
+          { to: currency, data: approveData },
+          { to: escrowContract, data: topUpData },
+        ],
+        feePayer: true,
+        feeToken: currency,
+      } as never)
+      prepared.gas = prepared.gas! + 5_000n
+      const serializedTransaction = await signTransaction(client, prepared as never)
+
+      await broadcastTopUpTransaction({
+        client: interceptingClient,
+        serializedTransaction,
+        escrowContract,
+        channelId,
+        currency: asset,
+        declaredDeposit: topUpAmount,
+        previousDeposit: deposit,
+        feePayer: accounts[0],
+      })
+
+      const broadcastIndex = rpcMethods.indexOf('eth_sendRawTransactionSync')
+      const simulationIndex = rpcMethods.indexOf('eth_call')
+
+      expect(broadcastIndex).toBeGreaterThan(-1)
+      expect(simulationIndex).toBeGreaterThan(-1)
+      expect(simulationIndex).toBeLessThan(broadcastIndex)
     })
 
     test('fee-payer: rejects smuggled second topUp call', async () => {

--- a/src/tempo/session/Chain.ts
+++ b/src/tempo/session/Chain.ts
@@ -449,6 +449,7 @@ export async function broadcastOpenTransaction(parameters: {
   challengeExpires?: string | undefined
   feePayerPolicy?: Partial<FeePayer.Policy> | undefined
   feePayer?: Account | undefined
+  beforeBroadcast?: ((onChain: OnChainChannel) => Promise<void> | void) | undefined
   /** When false, simulates instead of waiting for confirmation and returns derived on-chain state. @default true */
   waitForConfirmation?: boolean | undefined
 }): Promise<BroadcastResult> {
@@ -462,6 +463,7 @@ export async function broadcastOpenTransaction(parameters: {
     challengeExpires,
     feePayerPolicy,
     feePayer,
+    beforeBroadcast,
     waitForConfirmation = true,
   } = parameters
 
@@ -551,6 +553,19 @@ export async function broadcastOpenTransaction(parameters: {
   const resolvedFeeToken =
     transaction.feeToken ?? defaults.currency[client.chain?.id as keyof typeof defaults.currency]
 
+  const pendingOnChain = {
+    finalized: false,
+    closeRequestedAt: 0n,
+    payer: transaction.from,
+    payee,
+    token,
+    authorizedSigner,
+    deposit,
+    settled: 0n,
+  } as OnChainChannel
+
+  await beforeBroadcast?.(pendingOnChain)
+
   const serializedTransaction_final = await (async () => {
     if (feePayer) {
       if (!sponsoredOpenCall)
@@ -588,21 +603,20 @@ export async function broadcastOpenTransaction(parameters: {
 
     return {
       txHash,
-      onChain: {
-        finalized: false,
-        closeRequestedAt: 0n,
-        payer: transaction.from,
-        payee,
-        token,
-        authorizedSigner,
-        deposit,
-        settled: 0n,
-      } as OnChainChannel,
+      onChain: pendingOnChain,
     }
   }
 
   let txHash: Hex | undefined
   try {
+    if (feePayer)
+      await call(client, {
+        ...transaction,
+        account: transaction.from,
+        feeToken: resolvedFeeToken,
+        calls,
+      } as never)
+
     const receipt = await sendRawTransactionSync(client, {
       serializedTransaction: serializedTransaction_final as Transaction.TransactionSerializedTempo,
     })
@@ -731,6 +745,16 @@ export async function broadcastTopUpTransaction(parameters: {
     }
     return serializedTransaction
   })()
+
+  if (feePayer)
+    await call(client, {
+      ...transaction,
+      account: transaction.from,
+      feeToken:
+        transaction.feeToken ??
+        defaults.currency[client.chain?.id as keyof typeof defaults.currency],
+      calls,
+    } as never)
 
   const receipt = await sendRawTransactionSync(client, {
     serializedTransaction: serializedTransaction_final as Transaction.TransactionSerializedTempo,


### PR DESCRIPTION
## Summary

- Bound sponsored DEX swaps and payment transfers to the expected charge details.
- Enforced route-level fee-payer opt-in during charge and session verification.
- Validated and simulated sponsored session open and top-up transactions before broadcast.
- Serialized sponsored charge submissions per sender to block concurrent gas drains.