### PR TITLE
fix: short-circuit express management responses

### DIFF
--- a/.changeset/fresh-blue-keys.md
+++ b/.changeset/fresh-blue-keys.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed Express middleware to short-circuit Tempo session management responses before route handlers run.

--- a/src/middlewares/express.test.ts
+++ b/src/middlewares/express.test.ts
@@ -253,6 +253,33 @@ describe('session', () => {
 })
 
 describe('payment', () => {
+  test('short-circuits management responses', async () => {
+    let handlerRan = false
+    const managementResponse = new Response(null, {
+      status: 204,
+      headers: { 'Payment-Receipt': 'management-receipt' },
+    })
+    const intent = () => async () => ({
+      status: 200 as const,
+      withReceipt: () => managementResponse,
+    })
+
+    const app = express()
+    app.get('/', payment(intent as any, {} as any), (_req, res) => {
+      handlerRan = true
+      res.json({ data: 'content' })
+    })
+
+    const server = await createServer(app)
+    const response = await globalThis.fetch(server.url)
+    expect(response.status).toBe(204)
+    expect(response.headers.get('Payment-Receipt')).toBe('management-receipt')
+    expect(await response.text()).toBe('')
+    expect(handlerRan).toBe(false)
+
+    server.close()
+  })
+
   test('returns 402 when no credential', async () => {
     const { mppx } = createCoreChargeHarness(false)
 

--- a/src/middlewares/express.ts
+++ b/src/middlewares/express.ts
@@ -76,6 +76,30 @@ export function payment<const intent extends Mppx_internal.AnyMethodFn>(
       return
     }
 
+    const managementResponse = (() => {
+      try {
+        return (result.withReceipt as () => Response)()
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          error.message === 'withReceipt() requires a response argument'
+        )
+          return null
+        throw error
+      }
+    })()
+
+    if (managementResponse) {
+      res.status(managementResponse.status)
+      for (const [key, value] of managementResponse.headers) res.setHeader(key, value)
+      if (managementResponse.body === null) {
+        res.end()
+        return
+      }
+      res.send(Buffer.from(await managementResponse.arrayBuffer()))
+      return
+    }
+
     const originalJson = res.json.bind(res)
     res.json = (body: any) => {
       const wrapped = result.withReceipt(Response.json(body))


### PR DESCRIPTION
## Summary

Fix Express middleware to short-circuit session management responses returned by `withReceipt()` and send their status, headers, and body directly before route handlers run.

Add a regression test covering a management `204` response with `Payment-Receipt`.

Add a patch changeset for the Express middleware fix.

Fixes #404.
