### PR TITLE
fix: reject expired client challenges

### DIFF
--- a/.changeset/client-expiration-validation.md
+++ b/.changeset/client-expiration-validation.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Rejected expired challenges before client-side credential creation.

--- a/src/client/Mppx.test.ts
+++ b/src/client/Mppx.test.ts
@@ -1,8 +1,8 @@
-import { Challenge, Credential, Mcp, Method, Receipt } from 'mppx'
+import { Challenge, Credential, Errors, Mcp, Method, Receipt } from 'mppx'
 import { Mppx, Transport, tempo } from 'mppx/client'
 import { Mppx as Mppx_server, tempo as tempo_server } from 'mppx/server'
 import { Methods } from 'mppx/tempo'
-import { afterEach, describe, expect, test } from 'vp/test'
+import { afterEach, describe, expect, test, vi } from 'vp/test'
 import * as Http from '~test/Http.js'
 import { accounts, asset, client } from '~test/tempo/viem.js'
 
@@ -134,6 +134,42 @@ describe('createCredential', () => {
     )
   })
 
+  test('behavior: rejects expired challenges before creating credential', async () => {
+    const createCredential = vi.fn(async ({ challenge }) =>
+      Credential.serialize({
+        challenge,
+        payload: { signature: '0xsignature', type: 'transaction' },
+      }),
+    )
+    const method = Method.toClient(Methods.charge, { createCredential })
+    const mppx = Mppx.create({
+      polyfill: false,
+      methods: [method],
+    })
+
+    const challenge = Challenge.fromMethod(Methods.charge, {
+      realm,
+      secretKey,
+      expires: new Date(Date.now() - 60_000).toISOString(),
+      request: {
+        amount: '1000',
+        currency: '0x1234567890123456789012345678901234567890',
+        decimals: 6,
+        recipient: '0x1234567890123456789012345678901234567890',
+      },
+    })
+
+    const response = new Response(null, {
+      status: 402,
+      headers: {
+        'WWW-Authenticate': Challenge.serialize(challenge),
+      },
+    })
+
+    await expect(mppx.createCredential(response)).rejects.toThrow(Errors.PaymentExpiredError)
+    expect(createCredential).not.toHaveBeenCalled()
+  })
+
   test('behavior: routes to correct method with multiple methods', async () => {
     const stripeCharge = Method.from({
       name: 'stripe',
@@ -165,7 +201,6 @@ describe('createCredential', () => {
       realm,
       method: 'stripe',
       intent: 'charge',
-      expires: new Date(Date.now() + 60_000).toISOString(),
       request: {
         amount: '2000',
         currency: '0xabcd',
@@ -294,6 +329,7 @@ describe('createCredential', () => {
       realm,
       method: 'stripe',
       intent: 'charge',
+      expires: new Date(Date.now() + 60_000).toISOString(),
       request: {
         amount: '2000',
         currency: '0xabcd',

--- a/src/client/Mppx.ts
+++ b/src/client/Mppx.ts
@@ -1,4 +1,5 @@
 import type * as Challenge from '../Challenge.js'
+import * as Expires from '../Expires.js'
 import * as AcceptPayment from '../internal/AcceptPayment.js'
 import type * as Method from '../Method.js'
 import type * as z from '../zod.js'
@@ -106,6 +107,7 @@ export function create<
         )
 
       const { challenge, method: mi } = selected
+      if (challenge.expires) Expires.assert(challenge.expires, challenge.id)
 
       const parsedContext =
         mi.context && context !== undefined ? mi.context.parse(context) : undefined

--- a/src/client/internal/Fetch.test.ts
+++ b/src/client/internal/Fetch.test.ts
@@ -1,4 +1,4 @@
-import { Receipt } from 'mppx'
+import { Errors, Receipt } from 'mppx'
 import { tempo } from 'mppx/client'
 import { Mppx as Mppx_server, tempo as tempo_server } from 'mppx/server'
 import { createClient, defineChain } from 'viem'
@@ -335,14 +335,15 @@ const noopMethod = {
 } as any
 
 /** Builds a valid 402 response with a WWW-Authenticate header. */
-function make402(overrides?: { method?: string; intent?: string }) {
+function make402(overrides?: { expires?: string; intent?: string; method?: string }) {
   const method = overrides?.method ?? 'test'
   const intent = overrides?.intent ?? 'test'
+  const expires = overrides?.expires ? `, expires="${overrides.expires}"` : ''
   const request = btoa(JSON.stringify({ amount: '1' }))
     .replace(/\+/g, '-')
     .replace(/\//g, '_')
     .replace(/=+$/, '')
-  const header = `Payment id="abc", realm="test", method="${method}", intent="${intent}", request="${request}"`
+  const header = `Payment id="abc", realm="test", method="${method}", intent="${intent}", request="${request}"${expires}`
   return new Response(null, {
     status: 402,
     headers: { 'WWW-Authenticate': header },
@@ -603,6 +604,24 @@ describe('Fetch.from: init passthrough (non-402)', () => {
 })
 
 describe('Fetch.from: 402 retry path', () => {
+  test('rejects expired challenges before hooks or credential creation', async () => {
+    const createCredential = vi.fn(async () => 'credential')
+    const onChallenge = vi.fn(async () => undefined)
+    const mockFetch = vi.fn(async () =>
+      make402({ expires: new Date(Date.now() - 60_000).toISOString() }),
+    )
+    const fetch = Fetch.from({
+      fetch: mockFetch as typeof globalThis.fetch,
+      methods: [{ ...noopMethod, createCredential }],
+      onChallenge,
+    })
+
+    await expect(fetch('https://example.com/api')).rejects.toThrow(Errors.PaymentExpiredError)
+    expect(onChallenge).not.toHaveBeenCalled()
+    expect(createCredential).not.toHaveBeenCalled()
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
   test('strips context from init on retry', async () => {
     const calls: { init: RequestInit | undefined }[] = []
     let callCount = 0

--- a/src/client/internal/Fetch.ts
+++ b/src/client/internal/Fetch.ts
@@ -1,4 +1,5 @@
 import * as Challenge from '../../Challenge.js'
+import * as Expires from '../../Expires.js'
 import * as AcceptPayment from '../../internal/AcceptPayment.js'
 import type * as Method from '../../Method.js'
 import type * as z from '../../zod.js'
@@ -80,6 +81,7 @@ export function from<const methods extends readonly Method.AnyClient[]>(
       )
 
     const { challenge, method: mi } = selected
+    if (challenge.expires) Expires.assert(challenge.expires, challenge.id)
 
     const onChallengeCredential = onChallenge
       ? await onChallenge(challenge, {

--- a/src/mcp-sdk/client/McpClient.test.ts
+++ b/src/mcp-sdk/client/McpClient.test.ts
@@ -2,11 +2,12 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { McpError } from '@modelcontextprotocol/sdk/types.js'
-import { Challenge, Mcp as core_Mcp } from 'mppx'
+import { Challenge, Credential, Errors, Mcp as core_Mcp, Method } from 'mppx'
 import { tempo as tempo_client } from 'mppx/client'
 import { Mppx as Mppx_server, tempo as tempo_server } from 'mppx/server'
+import { Methods } from 'mppx/tempo'
 import { createClient } from 'viem'
-import { afterEach, beforeEach, describe, expect, test } from 'vp/test'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vp/test'
 import { accounts, asset, chain, http, client as testClient } from '~test/tempo/viem.js'
 
 import * as McpServer_transport from '../server/Transport.js'
@@ -186,6 +187,42 @@ describe('McpClient.wrap', () => {
     await expect(mcp.callTool({ name: 'tool_unknown_method', arguments: {} })).rejects.toThrow(
       'No compatible payment method. Server offers: unknown_method.charge. Client has: tempo.charge',
     )
+  })
+
+  test('behavior: rejects expired challenges before creating credential', async () => {
+    const challenge = Challenge.fromMethod(Methods.charge, {
+      realm,
+      secretKey,
+      expires: new Date(Date.now() - 60_000).toISOString(),
+      request: {
+        amount: '1',
+        currency: asset,
+        decimals: 6,
+        recipient: accounts[0].address,
+      },
+    })
+
+    server.registerTool('expired_tool', { description: 'Tool' }, async () => {
+      throw new McpError(core_Mcp.paymentRequiredCode, 'Payment Required', {
+        httpStatus: 402,
+        challenges: [challenge],
+      })
+    })
+
+    const createCredential = vi.fn(async ({ challenge }) =>
+      Credential.serialize({
+        challenge,
+        payload: { signature: '0xsignature', type: 'transaction' },
+      }),
+    )
+    const mcp = McpClient.wrap(client, {
+      methods: [Method.toClient(Methods.charge, { createCredential })],
+    })
+
+    await expect(mcp.callTool({ name: 'expired_tool', arguments: {} })).rejects.toThrow(
+      Errors.PaymentExpiredError,
+    )
+    expect(createCredential).not.toHaveBeenCalled()
   })
 })
 

--- a/src/mcp-sdk/client/McpClient.ts
+++ b/src/mcp-sdk/client/McpClient.ts
@@ -3,6 +3,7 @@ import type { McpError } from '@modelcontextprotocol/sdk/types.js'
 
 import type * as Challenge from '../../Challenge.js'
 import * as Credential from '../../Credential.js'
+import * as Expires from '../../Expires.js'
 import * as AcceptPayment from '../../internal/AcceptPayment.js'
 import * as core_Mcp from '../../Mcp.js'
 import type * as Method from '../../Method.js'
@@ -185,6 +186,8 @@ async function createCredential<methods extends readonly Method.AnyClient[]>(
     throw new Error(
       `No method found for "${challenge.method}.${challenge.intent}". Available: ${methods.map((m) => `${m.name}.${m.intent}`).join(', ')}`,
     )
+
+  if (challenge.expires) Expires.assert(challenge.expires, challenge.id)
 
   const parsedContext = mi.context && context !== undefined ? mi.context.parse(context) : undefined
   return mi.createCredential(


### PR DESCRIPTION
## Summary

Reject expired challenges before client-side credential creation in manual HTTP, automatic fetch, and MCP client flows.

Fixes #198.