### PR TITLE
fix: verify charge hashes by credential source

### DIFF
--- a/.changeset/soft-camels-charge.md
+++ b/.changeset/soft-camels-charge.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed Tempo charge push verification for smart-account transaction hashes.

--- a/src/tempo/Proof.test-d.ts
+++ b/src/tempo/Proof.test-d.ts
@@ -7,6 +7,10 @@ test('Proof exports public proof source helpers', () => {
     (parameters: { address: string; chainId: number }) => string
   >()
 
+  expectTypeOf(Proof.parsePkhSource).toEqualTypeOf<
+    (source: string) => { address: `0x${string}`; chainId: number } | null
+  >()
+
   expectTypeOf(Proof.parseProofSource).toEqualTypeOf<
     (source: string) => { address: `0x${string}`; chainId: number } | null
   >()

--- a/src/tempo/Proof.test.ts
+++ b/src/tempo/Proof.test.ts
@@ -23,6 +23,15 @@ describe('tempo.Proof', () => {
     })
   })
 
+  test('parsePkhSource parses a valid did:pkh:eip155 source', () => {
+    expect(
+      tempo.Proof.parsePkhSource('did:pkh:eip155:42431:0xa5cc3c03994db5b0d9ba5e4f6d2efbd9f213b141'),
+    ).toEqual({
+      address: '0xa5cc3c03994db5b0d9ba5e4f6d2efbd9f213b141',
+      chainId: 42431,
+    })
+  })
+
   test('parseProofSource rejects invalid source values', () => {
     expect(
       tempo.Proof.parseProofSource('did:pkh:eip155:01:0xa5cc3c03994db5b0d9ba5e4f6d2efbd9f213b141'),

--- a/src/tempo/Proof.ts
+++ b/src/tempo/Proof.ts
@@ -7,7 +7,12 @@ export function proofSource(parameters: { address: string; chainId: number }): s
   return Proof_internal.proofSource(parameters)
 }
 
+/** Parses a Tempo `did:pkh:eip155` source DID into its chain ID and wallet address. */
+export function parsePkhSource(source: string): { address: Address; chainId: number } | null {
+  return Proof_internal.parsePkhSource(source)
+}
+
 /** Parses a Tempo proof credential source DID into its chain ID and wallet address. */
 export function parseProofSource(source: string): { address: Address; chainId: number } | null {
-  return Proof_internal.parseProofSource(source)
+  return Proof_internal.parsePkhSource(source)
 }

--- a/src/tempo/internal/proof.test.ts
+++ b/src/tempo/internal/proof.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'vp/test'
 
 import * as Proof from './proof.js'
 
-const parseProofSourceCases = [
+const parsePkhSourceCases = [
   {
     expected: {
       address: '0xa5cc3c03994db5b0d9ba5e4f6d2efbd9f213b141',
@@ -81,9 +81,9 @@ describe('Proof', () => {
     expect(Proof.proofSource({ address, chainId: 1 })).toBe(`did:pkh:eip155:1:${address}`)
   })
 
-  for (const { expected, name, source } of parseProofSourceCases) {
-    test(`parseProofSource ${name}`, () => {
-      expect(Proof.parseProofSource(source)).toEqual(expected)
+  for (const { expected, name, source } of parsePkhSourceCases) {
+    test(`parsePkhSource ${name}`, () => {
+      expect(Proof.parsePkhSource(source)).toEqual(expected)
     })
   }
 })

--- a/src/tempo/internal/proof.ts
+++ b/src/tempo/internal/proof.ts
@@ -23,8 +23,8 @@ export function proofSource(parameters: { address: string; chainId: number }): s
   return `did:pkh:eip155:${parameters.chainId}:${parameters.address}`
 }
 
-/** Parses a proof credential `did:pkh:eip155` source DID. */
-export function parseProofSource(source: string): { address: Address; chainId: number } | null {
+/** Parses a `did:pkh:eip155` source DID. */
+export function parsePkhSource(source: string): { address: Address; chainId: number } | null {
   const match = /^did:pkh:eip155:(0|[1-9]\d*):([^:]+)$/.exec(source)
   if (!match) return null
 

--- a/src/tempo/server/Charge.test.ts
+++ b/src/tempo/server/Charge.test.ts
@@ -3687,6 +3687,133 @@ describe('tempo', () => {
       httpServer.close()
     })
 
+    test('server verifies hash transfers from credential source', async () => {
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await Mppx_server.toNodeListener(
+          server.charge({ amount: '1', decimals: 6 }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
+      })
+
+      const response = await fetch(httpServer.url)
+      expect(response.status).toBe(402)
+
+      const challenge = Challenge.fromResponse(response, {
+        methods: [tempo_client.charge()],
+      })
+      const memo = Attribution.encode({ challengeId: challenge.id, serverId: challenge.realm })
+
+      const { receipt } = await Actions.token.transferSync(client, {
+        account: accounts[1],
+        amount: BigInt(challenge.request.amount),
+        memo: memo as Hex.Hex,
+        to: challenge.request.recipient as Hex.Hex,
+        token: challenge.request.currency as Hex.Hex,
+      })
+
+      const credential = Credential.from({
+        challenge,
+        payload: { hash: receipt.transactionHash, type: 'hash' as const },
+        source: `did:pkh:eip155:${chain.id}:${accounts[1].address}`,
+      })
+
+      {
+        const response = await fetch(httpServer.url, {
+          headers: { Authorization: Credential.serialize(credential) },
+        })
+        expect(response.status).toBe(200)
+      }
+
+      httpServer.close()
+    })
+
+    test('server rejects hash transfers from a different source', async () => {
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await Mppx_server.toNodeListener(
+          server.charge({ amount: '1', decimals: 6 }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
+      })
+
+      const response = await fetch(httpServer.url)
+      expect(response.status).toBe(402)
+
+      const challenge = Challenge.fromResponse(response, {
+        methods: [tempo_client.charge()],
+      })
+      const memo = Attribution.encode({ challengeId: challenge.id, serverId: challenge.realm })
+
+      const { receipt } = await Actions.token.transferSync(client, {
+        account: accounts[1],
+        amount: BigInt(challenge.request.amount),
+        memo: memo as Hex.Hex,
+        to: challenge.request.recipient as Hex.Hex,
+        token: challenge.request.currency as Hex.Hex,
+      })
+
+      const credential = Credential.from({
+        challenge,
+        payload: { hash: receipt.transactionHash, type: 'hash' as const },
+        source: `did:pkh:eip155:${chain.id}:${accounts[2].address}`,
+      })
+
+      {
+        const response = await fetch(httpServer.url, {
+          headers: { Authorization: Credential.serialize(credential) },
+        })
+        expect(response.status).toBe(402)
+        const body = (await response.json()) as { detail: string }
+        expect(body.detail).toContain('no matching transfer found')
+      }
+
+      httpServer.close()
+    })
+
+    test('server rejects hash credentials with source from a different chain', async () => {
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await Mppx_server.toNodeListener(
+          server.charge({ amount: '1', decimals: 6 }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
+      })
+
+      const response = await fetch(httpServer.url)
+      expect(response.status).toBe(402)
+
+      const challenge = Challenge.fromResponse(response, {
+        methods: [tempo_client.charge()],
+      })
+      const memo = Attribution.encode({ challengeId: challenge.id, serverId: challenge.realm })
+
+      const { receipt } = await Actions.token.transferSync(client, {
+        account: accounts[1],
+        amount: BigInt(challenge.request.amount),
+        memo: memo as Hex.Hex,
+        to: challenge.request.recipient as Hex.Hex,
+        token: challenge.request.currency as Hex.Hex,
+      })
+
+      const credential = Credential.from({
+        challenge,
+        payload: { hash: receipt.transactionHash, type: 'hash' as const },
+        source: `did:pkh:eip155:1:${accounts[1].address}`,
+      })
+
+      {
+        const response = await fetch(httpServer.url, {
+          headers: { Authorization: Credential.serialize(credential) },
+        })
+        expect(response.status).toBe(402)
+        const body = (await response.json()) as { detail: string }
+        expect(body.detail).toContain('Hash credential source is invalid')
+      }
+
+      httpServer.close()
+    })
+
     test('anonymous client (no clientId) generates valid attribution memo', async () => {
       const httpServer = await Http.createServer(async (req, res) => {
         const result = await Mppx_server.toNodeListener(

--- a/src/tempo/server/Charge.test.ts
+++ b/src/tempo/server/Charge.test.ts
@@ -8,6 +8,7 @@ import { createClient, custom, encodeFunctionData, parseUnits } from 'viem'
 import {
   getTransactionReceipt,
   prepareTransactionRequest,
+  sendRawTransactionSync,
   signTypedData,
   signTransaction,
 } from 'viem/actions'
@@ -3728,6 +3729,115 @@ describe('tempo', () => {
       httpServer.close()
     })
 
+    test('server verifies hash transfers from receipt sender when source is omitted', async () => {
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await Mppx_server.toNodeListener(
+          server.charge({ amount: '1', decimals: 6 }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
+      })
+
+      const response = await fetch(httpServer.url)
+      expect(response.status).toBe(402)
+
+      const challenge = Challenge.fromResponse(response, {
+        methods: [tempo_client.charge()],
+      })
+      const memo = Attribution.encode({ challengeId: challenge.id, serverId: challenge.realm })
+
+      const { receipt } = await Actions.token.transferSync(client, {
+        account: accounts[1],
+        amount: BigInt(challenge.request.amount),
+        memo: memo as Hex.Hex,
+        to: challenge.request.recipient as Hex.Hex,
+        token: challenge.request.currency as Hex.Hex,
+      })
+
+      const credential = Credential.from({
+        challenge,
+        payload: { hash: receipt.transactionHash, type: 'hash' as const },
+      })
+
+      {
+        const response = await fetch(httpServer.url, {
+          headers: { Authorization: Credential.serialize(credential) },
+        })
+        expect(response.status).toBe(200)
+      }
+
+      httpServer.close()
+    })
+
+    test('server verifies hash transfers from source when receipt sender differs', async () => {
+      let useRelayerReceiptFrom = false
+      const smartAccountClient = createClient({
+        chain: client.chain,
+        transport: custom({
+          async request(args: any) {
+            const result = await client.transport.request(args)
+            if (useRelayerReceiptFrom && args?.method === 'eth_getTransactionReceipt') {
+              return { ...(result as any), from: accounts[2].address }
+            }
+            return result
+          },
+        }),
+      })
+      const smartAccountServer = Mppx_server.create({
+        methods: [
+          tempo_server.charge({
+            getClient() {
+              return smartAccountClient
+            },
+            currency: asset,
+            account: accounts[0],
+          }),
+        ],
+        realm,
+        secretKey,
+      })
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await Mppx_server.toNodeListener(
+          smartAccountServer.charge({ amount: '1', decimals: 6 }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
+      })
+
+      const response = await fetch(httpServer.url)
+      expect(response.status).toBe(402)
+
+      const challenge = Challenge.fromResponse(response, {
+        methods: [tempo_client.charge()],
+      })
+      const memo = Attribution.encode({ challengeId: challenge.id, serverId: challenge.realm })
+
+      const { receipt } = await Actions.token.transferSync(client, {
+        account: accounts[1],
+        amount: BigInt(challenge.request.amount),
+        memo: memo as Hex.Hex,
+        to: challenge.request.recipient as Hex.Hex,
+        token: challenge.request.currency as Hex.Hex,
+      })
+
+      useRelayerReceiptFrom = true
+
+      const credential = Credential.from({
+        challenge,
+        payload: { hash: receipt.transactionHash, type: 'hash' as const },
+        source: `did:pkh:eip155:${chain.id}:${accounts[1].address}`,
+      })
+
+      {
+        const response = await fetch(httpServer.url, {
+          headers: { Authorization: Credential.serialize(credential) },
+        })
+        expect(response.status).toBe(200)
+      }
+
+      httpServer.close()
+    })
+
     test('server rejects hash transfers from a different source', async () => {
       const httpServer = await Http.createServer(async (req, res) => {
         const result = await Mppx_server.toNodeListener(
@@ -3766,6 +3876,103 @@ describe('tempo', () => {
         expect(response.status).toBe(402)
         const body = (await response.json()) as { detail: string }
         expect(body.detail).toContain('no matching transfer found')
+      }
+
+      httpServer.close()
+    })
+
+    test('server rejects hash credentials with malformed source', async () => {
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await Mppx_server.toNodeListener(
+          server.charge({ amount: '1', decimals: 6 }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
+      })
+
+      const response = await fetch(httpServer.url)
+      expect(response.status).toBe(402)
+
+      const challenge = Challenge.fromResponse(response, {
+        methods: [tempo_client.charge()],
+      })
+      const memo = Attribution.encode({ challengeId: challenge.id, serverId: challenge.realm })
+
+      const { receipt } = await Actions.token.transferSync(client, {
+        account: accounts[1],
+        amount: BigInt(challenge.request.amount),
+        memo: memo as Hex.Hex,
+        to: challenge.request.recipient as Hex.Hex,
+        token: challenge.request.currency as Hex.Hex,
+      })
+
+      const credential = Credential.from({
+        challenge,
+        payload: { hash: receipt.transactionHash, type: 'hash' as const },
+        source: 'not-a-valid-did',
+      })
+
+      {
+        const response = await fetch(httpServer.url, {
+          headers: { Authorization: Credential.serialize(credential) },
+        })
+        expect(response.status).toBe(402)
+        const body = (await response.json()) as { detail: string }
+        expect(body.detail).toContain('Hash credential source is invalid')
+      }
+
+      httpServer.close()
+    })
+
+    test('server does not consume a hash when credential source is malformed', async () => {
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await Mppx_server.toNodeListener(
+          server.charge({ amount: '1', decimals: 6 }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
+      })
+
+      const response = await fetch(httpServer.url)
+      expect(response.status).toBe(402)
+
+      const challenge = Challenge.fromResponse(response, {
+        methods: [tempo_client.charge()],
+      })
+      const memo = Attribution.encode({ challengeId: challenge.id, serverId: challenge.realm })
+
+      const { receipt } = await Actions.token.transferSync(client, {
+        account: accounts[1],
+        amount: BigInt(challenge.request.amount),
+        memo: memo as Hex.Hex,
+        to: challenge.request.recipient as Hex.Hex,
+        token: challenge.request.currency as Hex.Hex,
+      })
+
+      {
+        const credential = Credential.from({
+          challenge,
+          payload: { hash: receipt.transactionHash, type: 'hash' as const },
+          source: 'not-a-valid-did',
+        })
+        const response = await fetch(httpServer.url, {
+          headers: { Authorization: Credential.serialize(credential) },
+        })
+        expect(response.status).toBe(402)
+        const body = (await response.json()) as { detail: string }
+        expect(body.detail).toContain('Hash credential source is invalid')
+      }
+
+      {
+        const credential = Credential.from({
+          challenge,
+          payload: { hash: receipt.transactionHash, type: 'hash' as const },
+          source: `did:pkh:eip155:${chain.id}:${accounts[1].address}`,
+        })
+        const response = await fetch(httpServer.url, {
+          headers: { Authorization: Credential.serialize(credential) },
+        })
+        expect(response.status).toBe(200)
       }
 
       httpServer.close()
@@ -3810,6 +4017,148 @@ describe('tempo', () => {
         const body = (await response.json()) as { detail: string }
         expect(body.detail).toContain('Hash credential source is invalid')
       }
+
+      httpServer.close()
+    })
+
+    test('server verifies split hash transfers from credential source', async () => {
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await Mppx_server.toNodeListener(
+          server.charge({
+            amount: '1',
+            currency: asset,
+            recipient: accounts[0].address,
+            splits: [
+              { amount: '0.2', recipient: accounts[2].address },
+              { amount: '0.1', recipient: accounts[3].address },
+            ],
+          }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
+      })
+
+      const response = await fetch(httpServer.url)
+      expect(response.status).toBe(402)
+
+      const challenge = Challenge.fromResponse(response, {
+        methods: [tempo_client.charge()],
+      })
+      const splits = challenge.request.methodDetails?.splits ?? []
+      const primaryAmount =
+        BigInt(challenge.request.amount) - BigInt(splits[0]!.amount) - BigInt(splits[1]!.amount)
+      const memo = Attribution.encode({ challengeId: challenge.id, serverId: challenge.realm })
+
+      const prepared = await prepareTransactionRequest(client, {
+        account: accounts[1]!,
+        calls: [
+          Actions.token.transfer.call({
+            amount: BigInt(splits[0]!.amount),
+            to: splits[0]!.recipient as Hex.Hex,
+            token: challenge.request.currency as Hex.Hex,
+          }),
+          Actions.token.transfer.call({
+            amount: primaryAmount,
+            memo: memo as Hex.Hex,
+            to: challenge.request.recipient as Hex.Hex,
+            token: challenge.request.currency as Hex.Hex,
+          }),
+          Actions.token.transfer.call({
+            amount: BigInt(splits[1]!.amount),
+            to: splits[1]!.recipient as Hex.Hex,
+            token: challenge.request.currency as Hex.Hex,
+          }),
+        ],
+        nonceKey: 'expiring',
+      } as never)
+      prepared.gas = prepared.gas! + 5_000n
+      const signature = await signTransaction(client, prepared as never)
+      const { transactionHash } = await sendRawTransactionSync(client, {
+        serializedTransaction: signature,
+      })
+
+      const credential = Credential.from({
+        challenge,
+        payload: { hash: transactionHash, type: 'hash' as const },
+        source: `did:pkh:eip155:${chain.id}:${accounts[1].address}`,
+      })
+
+      const authResponse = await fetch(httpServer.url, {
+        headers: { Authorization: Credential.serialize(credential) },
+      })
+      expect(authResponse.status).toBe(200)
+
+      httpServer.close()
+    })
+
+    test('server rejects split hash transfers from a different source', async () => {
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await Mppx_server.toNodeListener(
+          server.charge({
+            amount: '1',
+            currency: asset,
+            recipient: accounts[0].address,
+            splits: [
+              { amount: '0.2', recipient: accounts[2].address },
+              { amount: '0.1', recipient: accounts[3].address },
+            ],
+          }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
+      })
+
+      const response = await fetch(httpServer.url)
+      expect(response.status).toBe(402)
+
+      const challenge = Challenge.fromResponse(response, {
+        methods: [tempo_client.charge()],
+      })
+      const splits = challenge.request.methodDetails?.splits ?? []
+      const primaryAmount =
+        BigInt(challenge.request.amount) - BigInt(splits[0]!.amount) - BigInt(splits[1]!.amount)
+      const memo = Attribution.encode({ challengeId: challenge.id, serverId: challenge.realm })
+
+      const prepared = await prepareTransactionRequest(client, {
+        account: accounts[1]!,
+        calls: [
+          Actions.token.transfer.call({
+            amount: BigInt(splits[0]!.amount),
+            to: splits[0]!.recipient as Hex.Hex,
+            token: challenge.request.currency as Hex.Hex,
+          }),
+          Actions.token.transfer.call({
+            amount: primaryAmount,
+            memo: memo as Hex.Hex,
+            to: challenge.request.recipient as Hex.Hex,
+            token: challenge.request.currency as Hex.Hex,
+          }),
+          Actions.token.transfer.call({
+            amount: BigInt(splits[1]!.amount),
+            to: splits[1]!.recipient as Hex.Hex,
+            token: challenge.request.currency as Hex.Hex,
+          }),
+        ],
+        nonceKey: 'expiring',
+      } as never)
+      prepared.gas = prepared.gas! + 5_000n
+      const signature = await signTransaction(client, prepared as never)
+      const { transactionHash } = await sendRawTransactionSync(client, {
+        serializedTransaction: signature,
+      })
+
+      const credential = Credential.from({
+        challenge,
+        payload: { hash: transactionHash, type: 'hash' as const },
+        source: `did:pkh:eip155:${chain.id}:${accounts[4].address}`,
+      })
+
+      const authResponse = await fetch(httpServer.url, {
+        headers: { Authorization: Credential.serialize(credential) },
+      })
+      expect(authResponse.status).toBe(402)
+      const body = (await authResponse.json()) as { detail: string }
+      expect(body.detail).toContain('no matching transfer found')
 
       httpServer.close()
     })

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -203,14 +203,22 @@ export function charge<const parameters extends charge.Parameters>(
             throw new MismatchError('Hash credentials are not supported for this challenge.', {})
 
           const hash = payload.hash as `0x${string}`
+          // Validate client-supplied identity before reserving the hash so a
+          // malformed source cannot burn an otherwise valid payment attempt.
           const source = parseHashCredentialSource({
             chainId: chainId ?? client.chain?.id,
             source: credential.source,
           })
+          // Reserve the hash while we verify it. This blocks concurrent
+          // requests from racing to reuse the same on-chain payment.
           if (!(await markHashUsed(store, hash))) {
             throw new VerificationFailedError({ reason: 'Transaction hash has already been used' })
           }
 
+          // If verification fails after reservation, release it so transient
+          // RPC/log-validation errors do not force the payer to pay again.
+          // Once we have proven the receipt is a successful matching payment,
+          // keep the marker to enforce single-use semantics.
           let releaseReservation = true
 
           try {
@@ -238,6 +246,8 @@ export function charge<const parameters extends charge.Parameters>(
               })
 
             const paymentReceipt = toReceipt(receipt)
+            // `toReceipt` can throw for reverted transactions. Only keep the
+            // reservation after it confirms the referenced transaction settled.
             releaseReservation = false
             return paymentReceipt
           } catch (error) {

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -209,9 +209,14 @@ export function charge<const parameters extends charge.Parameters>(
 
           const expectedTransfers = getExpectedTransfers({ amount, memo, methodDetails, recipient })
           const receipt = await getTransactionReceipt(client, { hash })
+          const sender = getHashCredentialSender({
+            chainId: chainId ?? client.chain?.id,
+            receiptFrom: receipt.from,
+            source: credential.source,
+          })
           const matchedLogs = assertTransferLogs(receipt, {
             currency,
-            sender: receipt.from,
+            sender,
             transfers: expectedTransfers,
           })
           // Only verify challenge binding when using auto-generated attribution memos.
@@ -755,6 +760,22 @@ async function releaseHashUse(
   hash: `0x${string}`,
 ): Promise<void> {
   await store.delete(getHashStoreKey(hash))
+}
+
+function getHashCredentialSender(parameters: {
+  chainId: number | undefined
+  receiptFrom: `0x${string}`
+  source: string | undefined
+}): `0x${string}` {
+  const { chainId, receiptFrom, source } = parameters
+  if (!source) return receiptFrom
+
+  const parsed = Proof.parseProofSource(source)
+  if (!parsed || (chainId !== undefined && parsed.chainId !== chainId)) {
+    throw new MismatchError('Hash credential source is invalid.', {})
+  }
+
+  return parsed.address
 }
 
 /** @internal */

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -203,33 +203,47 @@ export function charge<const parameters extends charge.Parameters>(
             throw new MismatchError('Hash credentials are not supported for this challenge.', {})
 
           const hash = payload.hash as `0x${string}`
+          const source = parseHashCredentialSource({
+            chainId: chainId ?? client.chain?.id,
+            source: credential.source,
+          })
           if (!(await markHashUsed(store, hash))) {
             throw new VerificationFailedError({ reason: 'Transaction hash has already been used' })
           }
 
-          const expectedTransfers = getExpectedTransfers({ amount, memo, methodDetails, recipient })
-          const receipt = await getTransactionReceipt(client, { hash })
-          const sender = getHashCredentialSender({
-            chainId: chainId ?? client.chain?.id,
-            receiptFrom: receipt.from,
-            source: credential.source,
-          })
-          const matchedLogs = assertTransferLogs(receipt, {
-            currency,
-            sender,
-            transfers: expectedTransfers,
-          })
-          // Only verify challenge binding when using auto-generated attribution memos.
-          // Explicit memos (set by the server) are strictly matched by assertTransferLogs
-          // but are NOT challenge-bound — callers that set explicit memos are responsible
-          // for ensuring memo uniqueness per challenge to prevent cross-challenge hash reuse.
-          if (!memo)
-            assertChallengeBoundMemo(matchedLogs, {
-              challengeId: challenge.id,
-              realm: challenge.realm,
-            })
+          let releaseReservation = true
 
-          return toReceipt(receipt)
+          try {
+            const expectedTransfers = getExpectedTransfers({
+              amount,
+              memo,
+              methodDetails,
+              recipient,
+            })
+            const receipt = await getTransactionReceipt(client, { hash })
+            const sender = source?.address ?? receipt.from
+            const matchedLogs = assertTransferLogs(receipt, {
+              currency,
+              sender,
+              transfers: expectedTransfers,
+            })
+            // Only verify challenge binding when using auto-generated attribution memos.
+            // Explicit memos (set by the server) are strictly matched by assertTransferLogs
+            // but are NOT challenge-bound — callers that set explicit memos are responsible
+            // for ensuring memo uniqueness per challenge to prevent cross-challenge hash reuse.
+            if (!memo)
+              assertChallengeBoundMemo(matchedLogs, {
+                challengeId: challenge.id,
+                realm: challenge.realm,
+              })
+
+            const paymentReceipt = toReceipt(receipt)
+            releaseReservation = false
+            return paymentReceipt
+          } catch (error) {
+            if (releaseReservation) await releaseHashUse(store, hash)
+            throw error
+          }
         }
 
         case 'proof': {
@@ -244,7 +258,7 @@ export function charge<const parameters extends charge.Parameters>(
             throw new MismatchError('Proof credential must include a source.', {})
 
           const resolvedChainId = challenge.request.methodDetails?.chainId ?? chainId!
-          const source = Proof.parseProofSource(expectedSource)
+          const source = Proof.parsePkhSource(expectedSource)
 
           if (!source || source.chainId !== resolvedChainId) {
             throw new MismatchError('Proof credential source is invalid.', {})
@@ -762,20 +776,19 @@ async function releaseHashUse(
   await store.delete(getHashStoreKey(hash))
 }
 
-function getHashCredentialSender(parameters: {
+function parseHashCredentialSource(parameters: {
   chainId: number | undefined
-  receiptFrom: `0x${string}`
   source: string | undefined
-}): `0x${string}` {
-  const { chainId, receiptFrom, source } = parameters
-  if (!source) return receiptFrom
+}): { address: `0x${string}`; chainId: number } | undefined {
+  const { chainId, source } = parameters
+  if (!source) return undefined
 
-  const parsed = Proof.parseProofSource(source)
+  const parsed = Proof.parsePkhSource(source)
   if (!parsed || (chainId !== undefined && parsed.chainId !== chainId)) {
     throw new MismatchError('Hash credential source is invalid.', {})
   }
 
-  return parsed.address
+  return parsed
 }
 
 /** @internal */


### PR DESCRIPTION
## Summary

Charge-only fix for smart-account push payments (for example, Crossmint/ERC-4337):

- uses `Credential.source` as the expected `Transfer` sender for Tempo charge hash credentials
- keeps the existing `receipt.from` fallback for clients that do not send `source`
- rejects malformed or wrong-chain hash credential sources instead of silently falling back
- preserves existing challenge-bound MPP attribution memo verification for push hashes

This lets a smart wallet broadcast a `transferWithMemo` itself and submit a hash credential whose `source` is the smart wallet DID, even when the transaction's top-level sender is a bundler or EntryPoint path rather than the smart wallet.