### PR TITLE
fix: preserve raw opaque challenge values

### DIFF
--- a/.changeset/raw-opaque-challenges.md
+++ b/.changeset/raw-opaque-challenges.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Preserved raw challenge opaque values when parsing and echoing credentials.

--- a/src/Challenge.test.ts
+++ b/src/Challenge.test.ts
@@ -693,7 +693,8 @@ describe('opaque', () => {
       meta: { pi: 'pi_3abc123XYZ' },
     })
 
-    expect(challenge.opaque).toEqual({ pi: 'pi_3abc123XYZ' })
+    expect(challenge.meta).toEqual({ pi: 'pi_3abc123XYZ' })
+    expect(challenge.opaque).toBe('eyJwaSI6InBpXzNhYmMxMjNYWVoifQ')
     expect((challenge.request as Record<string, unknown>).opaque).toBeUndefined()
   })
 
@@ -710,10 +711,11 @@ describe('opaque', () => {
       meta: { payment_intent: 'pi_3abc123XYZ' },
     })
 
-    expect(challenge.opaque).toEqual({ payment_intent: 'pi_3abc123XYZ' })
+    expect(challenge.meta).toEqual({ payment_intent: 'pi_3abc123XYZ' })
+    expect(challenge.opaque).toBe('eyJwYXltZW50X2ludGVudCI6InBpXzNhYmMxMjNYWVoifQ')
   })
 
-  test('behavior: challenge.opaque is undefined when no meta', () => {
+  test('behavior: challenge opaque and meta are undefined when no meta', () => {
     const challenge = Challenge.from({
       id: 'abc123',
       realm: 'api.example.com',
@@ -723,9 +725,10 @@ describe('opaque', () => {
     })
 
     expect(challenge.opaque).toBeUndefined()
+    expect(challenge.meta).toBeUndefined()
   })
 
-  test('behavior: opaque roundtrips through serialize/deserialize', () => {
+  test('behavior: opaque roundtrips through serialize/deserialize as a raw string', () => {
     const original = Challenge.from({
       id: 'abc123',
       realm: 'api.example.com',
@@ -738,10 +741,21 @@ describe('opaque', () => {
     const header = Challenge.serialize(original)
     const deserialized = Challenge.deserialize(header)
 
-    expect(deserialized.opaque).toEqual({ pi: 'pi_3abc123XYZ', deposit: 'dep_456' })
+    expect(deserialized.opaque).toBe('eyJkZXBvc2l0IjoiZGVwXzQ1NiIsInBpIjoicGlfM2FiYzEyM1hZWiJ9')
+    expect(deserialized.meta).toBeUndefined()
   })
 
-  test('behavior: meta with empty object produces opaque: {}', () => {
+  test('behavior: deserialize does not parse non-json opaque', () => {
+    const header =
+      'Payment id="abc123", realm="api.example.com", method="tempo", intent="charge", request="eyJhbW91bnQiOiIxMDAwMDAwIn0", opaque="eXkgd3Jvbmc"'
+
+    const challenge = Challenge.deserialize(header)
+
+    expect(challenge.opaque).toBe('eXkgd3Jvbmc')
+    expect(challenge.meta).toBeUndefined()
+  })
+
+  test('behavior: meta with empty object produces opaque string and meta: {}', () => {
     const challenge = Challenge.from({
       id: 'abc123',
       realm: 'api.example.com',
@@ -751,7 +765,8 @@ describe('opaque', () => {
       meta: {},
     })
 
-    expect(challenge.opaque).toEqual({})
+    expect(challenge.meta).toEqual({})
+    expect(challenge.opaque).toBe('e30')
   })
 
   test('hmac: opaque affects challenge ID', () => {
@@ -844,7 +859,8 @@ describe('opaque', () => {
 
     const tampered = {
       ...challenge,
-      opaque: { pi: 'pi_TAMPERED' },
+      meta: { pi: 'pi_TAMPERED' },
+      opaque: 'eyJwaSI6InBpX1RBTVBFUkVEIn0',
     }
     expect(Challenge.verify(tampered, { secretKey: 'my-secret' })).toBe(false)
   })
@@ -863,7 +879,7 @@ describe('opaque', () => {
       },
     })
 
-    expect(challenge.opaque).toEqual({
+    expect(challenge.meta).toEqual({
       payment_intent: 'pi_3abc123XYZ',
       customer: 'cus_xyz',
       session_id: 'sess_abc',

--- a/src/Challenge.ts
+++ b/src/Challenge.ts
@@ -29,8 +29,10 @@ export const Schema = z.object({
   intent: z.string(),
   /** Payment method (e.g., "tempo", "stripe"). */
   method: z.string(),
-  /** Optional server-defined correlation data. Flat string-to-string map; clients MUST NOT modify. */
-  opaque: z.optional(z.record(z.string(), z.string())),
+  /** Optional parsed server-defined correlation data. */
+  meta: z.optional(z.record(z.string(), z.string())),
+  /** Optional server-defined correlation data. Raw base64url string; clients MUST NOT modify. */
+  opaque: z.optional(z.string()),
   /** Server realm (e.g., hostname). */
   realm: z.string(),
   /** Method-specific request data. */
@@ -128,8 +130,13 @@ export function from<
   } = parameters
 
   const expires = parameters.expires as string
+  const opaque =
+    parameters.opaque ?? (meta !== undefined ? PaymentRequest.serialize(meta) : undefined)
   const id = secretKey
-    ? computeId({ ...parameters, expires, ...(meta && { opaque: meta }) }, { secretKey })
+    ? computeId(
+        { ...parameters, expires, ...(meta !== undefined && { meta }), opaque },
+        { secretKey },
+      )
     : (parameters as { id: string }).id
 
   return Schema.parse({
@@ -141,7 +148,8 @@ export function from<
     ...(description && { description }),
     ...(digest && { digest }),
     ...(expires && { expires }),
-    ...(meta && { opaque: meta }),
+    ...(meta !== undefined && { meta }),
+    ...(opaque !== undefined && { opaque }),
   }) as from.ReturnType<parameters, methods>
 }
 
@@ -170,6 +178,8 @@ export declare namespace from {
     intent: string
     /** Optional server-defined correlation data (serialized as `opaque` on the challenge). Flat string-to-string map; clients MUST NOT modify. */
     meta?: Record<string, string> | undefined
+    /** Optional raw base64url-encoded server-defined correlation data. Clients MUST NOT modify. */
+    opaque?: string | undefined
     /** Payment method (e.g., "tempo", "stripe"). */
     method: string
     /** Server realm (e.g., hostname). */
@@ -294,8 +304,9 @@ export function serialize(challenge: Challenge): string {
   if (challenge.description !== undefined) parts.push(`description="${challenge.description}"`)
   if (challenge.digest !== undefined) parts.push(`digest="${challenge.digest}"`)
   if (challenge.expires !== undefined) parts.push(`expires="${challenge.expires}"`)
-  if (challenge.opaque !== undefined)
-    parts.push(`opaque="${PaymentRequest.serialize(challenge.opaque)}"`)
+  if (challenge.opaque !== undefined) parts.push(`opaque="${challenge.opaque}"`)
+  else if (challenge.meta !== undefined)
+    parts.push(`opaque="${PaymentRequest.serialize(challenge.meta)}"`)
 
   return `Payment ${parts.join(', ')}`
 }
@@ -335,7 +346,7 @@ export function deserialize<const methods extends readonly Method.Method[] | und
     {
       ...rest,
       request: PaymentRequest.deserialize(request),
-      ...(opaque && { meta: PaymentRequest.deserialize(opaque) as Record<string, string> }),
+      ...(opaque && { opaque }),
     } as from.Parameters,
     options,
   )
@@ -604,9 +615,9 @@ export declare namespace verify {
   }
 }
 
-/** Alias for `challenge.opaque`. Extracts server-defined correlation data from a challenge. */
+/** Extracts parsed server-defined correlation data from a challenge when available. */
 export function meta(challenge: Challenge): Record<string, string> | undefined {
-  return challenge.opaque
+  return challenge.meta
 }
 
 /**
@@ -631,7 +642,7 @@ function idBindingInput(challenge: Omit<Challenge, 'id'>): string {
     PaymentRequest.serialize(challenge.request),
     challenge.expires ?? '',
     challenge.digest ?? '',
-    challenge.opaque ? PaymentRequest.serialize(challenge.opaque) : '',
+    challenge.opaque ?? (challenge.meta ? PaymentRequest.serialize(challenge.meta) : ''),
   ].join('|')
 }
 

--- a/src/Credential.test.ts
+++ b/src/Credential.test.ts
@@ -111,6 +111,24 @@ describe('serialize', () => {
 
     expect(parsed.challenge.opaque).toBe('eyJwaSI6InBpXzNhYmMxMjNYWVoifQ')
   })
+
+  test('behavior: echoes raw opaque unchanged', () => {
+    const rawChallenge = Challenge.deserialize(
+      'Payment id="opaque123", realm="api.example.com", method="tempo", intent="charge", request="eyJhbW91bnQiOiIxMDAwIn0", opaque="eXkgd3Jvbmc"',
+    )
+    const credential = Credential.from({
+      challenge: rawChallenge,
+      payload: { signature: '0x1234' },
+    })
+
+    const header = Credential.serialize(credential)
+    const encoded = header.replace(/^Payment\s+/i, '')
+    const parsed = JSON.parse(Base64.toString(encoded)) as {
+      challenge: { opaque?: unknown }
+    }
+
+    expect(parsed.challenge.opaque).toBe('eXkgd3Jvbmc')
+  })
 })
 
 describe('deserialize', () => {
@@ -175,7 +193,31 @@ describe('deserialize', () => {
 
     const credential = Credential.deserialize(`Payment ${encoded}`)
 
-    expect(credential.challenge.opaque).toEqual({ pi: 'pi_3abc123XYZ' })
+    expect(credential.challenge.opaque).toBe('eyJwaSI6InBpXzNhYmMxMjNYWVoifQ')
+    expect(credential.challenge.meta).toBeUndefined()
+    expect(credential.challenge.request).toEqual({ amount: '1000' })
+  })
+
+  test('behavior: preserves non-json opaque string credentials', () => {
+    const encoded = Base64.fromString(
+      JSON.stringify({
+        challenge: {
+          id: 'opaque123',
+          intent: 'charge',
+          method: 'tempo',
+          opaque: 'eXkgd3Jvbmc',
+          realm: 'api.example.com',
+          request: 'eyJhbW91bnQiOiIxMDAwIn0',
+        },
+        payload: { signature: '0x1234' },
+      }),
+      { pad: false, url: true },
+    )
+
+    const credential = Credential.deserialize(`Payment ${encoded}`)
+
+    expect(credential.challenge.opaque).toBe('eXkgd3Jvbmc')
+    expect(credential.challenge.meta).toBeUndefined()
     expect(credential.challenge.request).toEqual({ amount: '1000' })
   })
 
@@ -197,7 +239,27 @@ describe('deserialize', () => {
 
     const credential = Credential.deserialize(`Payment ${encoded}`)
 
-    expect(credential.challenge.opaque).toEqual({ pi: 'pi_3abc123XYZ' })
+    expect(credential.challenge.opaque).toBe('eyJwaSI6InBpXzNhYmMxMjNYWVoifQ')
+    expect(credential.challenge.meta).toEqual({ pi: 'pi_3abc123XYZ' })
+  })
+
+  test('error: rejects legacy object-shaped opaque with non-string values', () => {
+    const encoded = Base64.fromString(
+      JSON.stringify({
+        challenge: {
+          id: 'opaque123',
+          intent: 'charge',
+          method: 'tempo',
+          opaque: { pi: 123 },
+          realm: 'api.example.com',
+          request: 'eyJhbW91bnQiOiIxMDAwIn0',
+        },
+        payload: { signature: '0x1234' },
+      }),
+      { pad: false, url: true },
+    )
+
+    expect(() => Credential.deserialize(`Payment ${encoded}`)).toThrow('Invalid base64url or JSON.')
   })
 
   test('error: throws for missing Payment scheme', () => {

--- a/src/Credential.ts
+++ b/src/Credential.ts
@@ -63,27 +63,20 @@ export function deserialize<payload = unknown>(value: string): Credential<payloa
   try {
     const json = Base64.toString(prefixMatch[1])
     const parsed = JSON.parse(json) as {
-      challenge: Omit<Challenge.Challenge, 'opaque' | 'request'> & {
-        opaque?: Record<string, string> | string
+      challenge: Omit<Challenge.Challenge, 'meta' | 'opaque' | 'request'> & {
+        opaque?: unknown
         request: string
       }
       payload: payload
       source?: string
     }
+    const { opaque: challengeOpaque, request, ...challengeFields } = parsed.challenge
+    const { meta, opaque } = normalizeCredentialOpaque(challengeOpaque)
     const challenge = Challenge.Schema.parse({
-      ...parsed.challenge,
-      ...(parsed.challenge.opaque !== undefined && {
-        // TODO: Drop the legacy object-shaped `opaque` fallback after old mppx
-        // clients are no longer in circulation. Older mppx versions echoed
-        // `opaque` as an expanded JSON object in credentials, but the Payment
-        // auth spec requires clients to return the original base64url string
-        // unchanged in the credential challenge object.
-        opaque:
-          typeof parsed.challenge.opaque === 'string'
-            ? (PaymentRequest.deserialize(parsed.challenge.opaque) as Record<string, string>)
-            : parsed.challenge.opaque,
-      }),
-      request: PaymentRequest.deserialize(parsed.challenge.request),
+      ...challengeFields,
+      ...(meta !== undefined && { meta }),
+      ...(opaque !== undefined && { opaque }),
+      request: PaymentRequest.deserialize(request),
     })
     return {
       challenge,
@@ -93,6 +86,28 @@ export function deserialize<payload = unknown>(value: string): Credential<payloa
   } catch {
     throw new InvalidCredentialEncodingError()
   }
+}
+
+function normalizeCredentialOpaque(value: unknown): {
+  meta?: Record<string, string> | undefined
+  opaque?: string | undefined
+} {
+  if (value === undefined) return {}
+  if (typeof value === 'string') return { opaque: value }
+  if (!isStringRecord(value)) throw new Error('Invalid opaque.')
+
+  // Older mppx clients emitted credential challenge `opaque` as an expanded
+  // object. Keep accepting that legacy shape, but normalize it back to the
+  // spec-required base64url string.
+  return {
+    meta: value,
+    opaque: PaymentRequest.serialize(value),
+  }
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
+  return Object.values(value).every((entry) => typeof entry === 'string')
 }
 
 /**
@@ -156,8 +171,8 @@ export function fromRequest<payload = unknown>(request: Request): Credential<pay
 
 /**
  * Serializes a credential to the Authorization header format.
- * When present, `challenge.opaque` is encoded as the base64url string required
- * by the Payment auth credential format.
+ * When present, `challenge.opaque` is emitted unchanged as the base64url string
+ * required by the Payment auth credential format.
  *
  * @param credential - The credential to serialize.
  * @returns A string suitable for the Authorization header value.
@@ -171,11 +186,12 @@ export function fromRequest<payload = unknown>(request: Request): Credential<pay
  * ```
  */
 export function serialize(credential: Credential): string {
-  const { opaque, request, ...challenge } = credential.challenge
+  const { meta, opaque, request, ...challenge } = credential.challenge
+  const wireOpaque = opaque ?? (meta !== undefined ? PaymentRequest.serialize(meta) : undefined)
   const wire = {
     challenge: {
       ...challenge,
-      ...(opaque !== undefined && { opaque: PaymentRequest.serialize(opaque) }),
+      ...(wireOpaque !== undefined && { opaque: wireOpaque }),
       request: PaymentRequest.serialize(request),
     },
     payload: credential.payload,

--- a/src/middlewares/hono.test.ts
+++ b/src/middlewares/hono.test.ts
@@ -180,7 +180,7 @@ describe('scope binding', () => {
     expect(challengeResponse.status).toBe(402)
 
     const challenge = Challenge.fromResponse(challengeResponse)
-    expect(challenge.opaque).toEqual({ _mppx_scope: 'GET /alpha/:id' })
+    expect(challenge.opaque).toBe('eyJfbXBweF9zY29wZSI6IkdFVCAvYWxwaGEvOmlkIn0')
 
     const credential = Credential.from({ challenge, payload: { token: 'valid' } })
     const replay = await fetch(`${server.url}/beta/1`, {
@@ -207,7 +207,7 @@ describe('scope binding', () => {
     expect(challengeResponse.status).toBe(402)
 
     const challenge = Challenge.fromResponse(challengeResponse)
-    expect(challenge.opaque).toEqual({ _mppx_scope: 'shared-scope' })
+    expect(challenge.opaque).toBe('eyJfbXBweF9zY29wZSI6InNoYXJlZC1zY29wZSJ9')
 
     const credential = Credential.from({ challenge, payload: { token: 'valid' } })
     const replay = await fetch(`${server.url}/beta/2`, {

--- a/src/proxy/Proxy.test.ts
+++ b/src/proxy/Proxy.test.ts
@@ -771,7 +771,7 @@ describe('create', () => {
     expect(challengeResponse.status).toBe(402)
 
     const challenge = Challenge.fromResponse(challengeResponse)
-    expect(challenge.opaque).toEqual({ _mppx_scope: 'GET /api/v1/alpha' })
+    expect(challenge.opaque).toBe('eyJfbXBweF9zY29wZSI6IkdFVCAvYXBpL3YxL2FscGhhIn0')
 
     const credential = Credential.from({ challenge, payload: { token: 'valid' } })
     const replay = await fetch(`${proxyServer.url}/api/v1/beta`, {
@@ -813,7 +813,7 @@ describe('create', () => {
     expect(challengeResponse.status).toBe(402)
 
     const challenge = Challenge.fromResponse(challengeResponse)
-    expect(challenge.opaque).toEqual({ _mppx_scope: 'shared-scope' })
+    expect(challenge.opaque).toBe('eyJfbXBweF9zY29wZSI6InNoYXJlZC1zY29wZSJ9')
 
     const credential = Credential.from({ challenge, payload: { token: 'valid' } })
     const replay = await fetch(`${proxyServer.url}/api/v1/beta`, {

--- a/src/server/Mppx.test.ts
+++ b/src/server/Mppx.test.ts
@@ -588,7 +588,7 @@ describe('request handler', () => {
       method: rest.method,
       intent: rest.intent,
       request: rest.request,
-      ...(rest.opaque && { meta: rest.opaque }),
+      ...(rest.meta && { meta: rest.meta }),
     })
 
     const credential = Credential.from({
@@ -1413,8 +1413,8 @@ describe('compose', () => {
 
     const challenges = Challenge.fromResponseList(firstResult.challenge)
     expect(challenges).toHaveLength(2)
-    expect(challenges[0]?.opaque).toEqual({ route: 'a' })
-    expect(challenges[1]?.opaque).toEqual({ route: 'b' })
+    expect(challenges[0]?.opaque).toBe('eyJyb3V0ZSI6ImEifQ')
+    expect(challenges[1]?.opaque).toBe('eyJyb3V0ZSI6ImIifQ')
 
     const secondChallenge = challenges[1]!
     const credential = Credential.from({
@@ -2052,8 +2052,8 @@ describe('cross-route credential replay via scope binding flaw', () => {
     const routeAChallenge = Challenge.fromResponse(routeAChallengeResult.challenge)
     const routeBChallenge = Challenge.fromResponse(routeBChallengeResult.challenge)
 
-    expect(routeAChallenge.opaque).toEqual({ route: 'a' })
-    expect(routeBChallenge.opaque).toEqual({ route: 'b' })
+    expect(routeAChallenge.opaque).toBe('eyJyb3V0ZSI6ImEifQ')
+    expect(routeBChallenge.opaque).toBe('eyJyb3V0ZSI6ImIifQ')
 
     const credential = Credential.from({
       challenge: routeAChallenge,
@@ -2133,7 +2133,7 @@ describe('cross-route credential replay via scope binding flaw', () => {
     if (routeAChallengeResult.status !== 402) throw new Error()
 
     const routeAChallenge = Challenge.fromResponse(routeAChallengeResult.challenge)
-    expect(routeAChallenge.opaque).toEqual({ _mppx_scope: 'GET /a' })
+    expect(routeAChallenge.opaque).toBe('eyJfbXBweF9zY29wZSI6IkdFVCAvYSJ9')
 
     const credential = Credential.from({
       challenge: routeAChallenge,
@@ -3129,7 +3129,7 @@ describe('challenge', () => {
     })
 
     expect(challenge.description).toBe('Order #123')
-    expect(challenge.opaque).toEqual({ checkout_id: 'chk_abc' })
+    expect(challenge.meta).toEqual({ checkout_id: 'chk_abc' })
   })
 
   test('challenge binds scope via reserved opaque metadata', async () => {
@@ -3144,7 +3144,7 @@ describe('challenge', () => {
       scope: 'GET /premium',
     })
 
-    expect(challenge.opaque).toEqual({ _mppx_scope: 'GET /premium' })
+    expect(challenge.meta).toEqual({ _mppx_scope: 'GET /premium' })
   })
 
   test('scope throws when it conflicts with reserved meta scope', async () => {
@@ -3413,6 +3413,26 @@ describe('verifyCredential', () => {
       scope: 'GET /premium',
     })
     const credential = Credential.from({ challenge, payload: { token: 'valid' } })
+
+    const receipt = await mppx.verifyCredential(credential, { scope: 'GET /premium' })
+
+    expect(receipt.status).toBe('success')
+    expect(receipt.method).toBe('alpha')
+  })
+
+  test('verifies a parsed raw-opaque credential object when the expected scope matches', async () => {
+    const mppx = Mppx.create({
+      methods: [alphaChargeServer],
+      realm,
+      secretKey,
+    })
+
+    const challenge = await mppx.challenge.alpha.charge({
+      ...challengeOpts,
+      scope: 'GET /premium',
+    })
+    const rawChallenge = Challenge.deserialize(Challenge.serialize(challenge))
+    const credential = Credential.from({ challenge: rawChallenge, payload: { token: 'valid' } })
 
     const receipt = await mppx.verifyCredential(credential, { scope: 'GET /premium' })
 

--- a/src/server/Mppx.ts
+++ b/src/server/Mppx.ts
@@ -279,7 +279,9 @@ export function create<
     input: string | Credential.Credential,
     options?: VerifyCredentialOptions,
   ): Promise<Receipt.Receipt> {
-    const credential = typeof input === 'string' ? Credential.deserialize(input) : input
+    const credential = hydrateCredentialMeta(
+      typeof input === 'string' ? Credential.deserialize(input) : input,
+    )
 
     // HMAC provenance check (secretKey is guaranteed non-null by the guard at the top of create())
     if (!Challenge.verify(credential.challenge, { secretKey: secretKey! }))
@@ -307,7 +309,7 @@ export function create<
 
     const expectedMeta = Scope.merge({ meta: options?.meta, scope: options?.scope })
 
-    if (options?.scope !== undefined && Scope.read(credential.challenge.opaque) !== options.scope) {
+    if (options?.scope !== undefined && Scope.read(credential.challenge.meta) !== options.scope) {
       throw new Errors.InvalidChallengeError({
         id: credential.challenge.id,
         reason: "credential scope does not match this route's requirements",
@@ -438,10 +440,8 @@ function createMethodFn(parameters: createMethodFn.Parameters): createMethodFn.R
         // Extract credential once — getCredential may have side effects (e.g. SSE transports).
         const [credential, credentialError] = (() => {
           try {
-            return [
-              transport.getCredential(input) as Credential.Credential | null,
-              undefined,
-            ] as const
+            const credential = transport.getCredential(input) as Credential.Credential | null
+            return [credential ? hydrateCredentialMeta(credential) : null, undefined] as const
           } catch (e) {
             return [null, e as Error] as const
           }
@@ -851,7 +851,7 @@ function getPinnedChallengeMismatch(
     if (actualChallenge[field] !== expectedChallenge[field]) return field
   }
 
-  if (!opaqueValuesMatch(expectedChallenge.opaque, actualChallenge.opaque)) return 'opaque'
+  if (!opaqueValuesMatch(expectedChallenge.meta, actualChallenge.meta)) return 'opaque'
 
   return getPinnedRequestBindingMismatch(
     expectedChallenge.request as Record<string, unknown>,
@@ -942,6 +942,20 @@ function opaqueValuesMatch(
   actual: Record<string, string> | undefined,
 ): boolean {
   return isDeepStrictEqual(expected, actual)
+}
+
+function hydrateCredentialMeta<payload>(
+  credential: Credential.Credential<payload>,
+): Credential.Credential<payload> {
+  const { challenge } = credential
+  if (challenge.meta !== undefined || challenge.opaque === undefined) return credential
+  return {
+    ...credential,
+    challenge: {
+      ...challenge,
+      meta: PaymentRequest.deserialize(challenge.opaque) as Record<string, string>,
+    },
+  }
 }
 
 type CoreBinding = {
@@ -1112,7 +1126,7 @@ export function compose(
       // Parse the credential to find method+intent for dispatch.
       let credential: Credential.Credential | undefined
       try {
-        credential = Credential.deserialize(paymentHeader)
+        credential = hydrateCredentialMeta(Credential.deserialize(paymentHeader))
       } catch {}
 
       if (credential) {
@@ -1132,7 +1146,7 @@ export function compose(
           if (!canonical) return true
           return (
             !getPinnedRequestBindingMismatch(canonical, credReq) &&
-            opaqueValuesMatch(internal.meta, credential.challenge.opaque)
+            opaqueValuesMatch(internal.meta, credential.challenge.meta)
           )
         })
 


### PR DESCRIPTION
## Summary

Preserved raw challenge opaque values when parsing challenges and serializing credentials.
