### PR TITLE
docs: add jsdoc guidance for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,7 +173,7 @@ The changelog is auto-generated from changesets during `changeset version`.
 
 ## Code Documentation
 
-Add JSDoc to exported functions and to any complicated functions.
+ You MUST add JSDoc to exported functions and to any complicated functions. 
 
 ## Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,7 +173,7 @@ The changelog is auto-generated from changesets during `changeset version`.
 
 ## Code Documentation
 
- You MUST add JSDoc to exported functions and to any complicated functions. 
+You MUST add JSDoc to exported functions and to any complicated functions.
 
 ## Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,10 @@ Changeset descriptions **must use past tense** (e.g. "Added support for …", "F
 
 The changelog is auto-generated from changesets during `changeset version`.
 
+## Code Documentation
+
+Add JSDoc to exported functions and to any complicated functions.
+
 ## Commands
 
 ```bash


### PR DESCRIPTION
## Summary

Added AGENTS.md guidance that exported functions and complicated functions should include JSDoc.