### PR TITLE
fix: resolve dependency audit failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint-plugin-compat": "^7.0.1",
     "express": "^5.2.1",
     "fast-check": "^4.7.0",
-    "file-type": "^22.0.1",
+    "file-type": "21.3.2",
     "hono": "4.12.16",
     "isows": "^1.0.7",
     "playwright": "^1.59.1",
@@ -50,7 +50,7 @@
     "tempo.ts": "^0.14.2",
     "testcontainers": "^11.14.0",
     "tsx": "^4.21.0",
-    "typescript": "~6.0.3",
+    "typescript": "~5.9.3",
     "viem": "^2.47.6",
     "vite": "^8.0.10",
     "vp": "npm:vite-plus@~0.1.17",
@@ -184,7 +184,7 @@
   },
   "dependencies": {
     "incur": "^0.4.5",
-    "ox": "0.14.20",
+    "ox": "0.14.18",
     "zod": "^4.3.6"
   },
   "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,7 @@ overrides:
   file-type: 21.3.2
   flatted@<=3.4.1: '>=3.4.2'
   follow-redirects@<=1.15.11: 1.16.0
+  fast-uri@<=3.1.0: 3.1.1
   undici@>=7.0.0 <7.24.0: 7.24.0
   socket.io-parser@>=4.0.0 <4.2.6: '>=4.2.6'
   yaml@<2.8.3: '>=2.8.3'
@@ -2482,8 +2483,8 @@ packages:
   fast-string-width@1.1.0:
     resolution: {integrity: sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.1:
+    resolution: {integrity: sha512-h2r7rcm6Ee/J8o0LD5djLuFVcfbZxhvho4vvsbeV0aMvXjUgqv4YpxpkEx0d68l6+IleVfLAdVEfhR7QNMkGHQ==}
 
   fast-wrap-ansi@0.1.6:
     resolution: {integrity: sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==}
@@ -5235,7 +5236,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.1
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -5888,7 +5889,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 1.2.1
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.1: {}
 
   fast-wrap-ansi@0.1.6:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -39,6 +39,7 @@ overrides:
   file-type: '21.3.2'
   flatted@<=3.4.1: '>=3.4.2'
   follow-redirects@<=1.15.11: '1.16.0'
+  fast-uri@<=3.1.0: '3.1.1'
   undici@>=7.0.0 <7.24.0: '7.24.0'
   socket.io-parser@>=4.0.0 <4.2.6: '>=4.2.6'
   yaml@<2.8.3: '>=2.8.3'


### PR DESCRIPTION
## Summary

Aligned root dependency declarations with the workspace-pinned versions and added a fast-uri override to resolve the dependency audit failure.