### PR TITLE
feat: add `--network` option

### DIFF
--- a/.changeset/cli-network-chain.md
+++ b/.changeset/cli-network-chain.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added Tempo CLI network shortcuts and challenge chain mismatch checks.

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -108,6 +108,7 @@ const cli = Cli.create('mppx', {
       .array(z.string())
       .optional()
       .describe('Method-specific option (key=value, repeatable)'),
+    network: z.enum(['mainnet', 'testnet']).optional().describe('Tempo network'),
     rpcUrl: z
       .string()
       .optional()
@@ -274,7 +275,11 @@ const cli = Cli.create('mppx', {
       if (plugin) {
         pluginResult = await plugin.setup({
           challenge,
-          options: { account: c.options.account, rpcUrl: c.options.rpcUrl },
+          options: {
+            account: c.options.account,
+            network: c.options.network,
+            rpcUrl: c.options.rpcUrl,
+          },
           methodOpts: parseMethodOpts(c.options.methodOpt),
         })
         tokenSymbol = pluginResult.tokenSymbol
@@ -542,6 +547,7 @@ const account = Cli.create('account', {
     description: 'Create new account',
     options: z.object({
       account: z.string().optional().describe('Account name (env: MPPX_ACCOUNT)'),
+      network: z.enum(['mainnet', 'testnet']).optional().describe('Tempo network'),
       rpcUrl: z.string().optional().describe('RPC endpoint (env: MPPX_RPC_URL)'),
     }),
     output: z.object({ address: z.string(), name: z.string() }),
@@ -587,8 +593,8 @@ const account = Cli.create('account', {
       const addrDisplay = explorerUrl
         ? link(`${explorerUrl}/address/${acct.address}`, acct.address)
         : acct.address
-      const rpcUrl = resolveRpcUrl(c.options.rpcUrl)
-      resolveChain({ rpcUrl })
+      const rpcUrl = resolveRpcUrl(c.options.rpcUrl, { network: c.options.network })
+      resolveChain({ network: c.options.network, rpcUrl })
         .then((chain) => createClient({ chain, transport: http(rpcUrl) }))
         .then((client) =>
           import('viem/tempo').then(({ Actions }) =>
@@ -702,6 +708,7 @@ const account = Cli.create('account', {
     description: 'Fund account with testnet tokens',
     options: z.object({
       account: z.string().optional().describe('Account name (env: MPPX_ACCOUNT)'),
+      network: z.enum(['mainnet', 'testnet']).optional().describe('Tempo network'),
       rpcUrl: z.string().optional().describe('RPC endpoint (env: MPPX_RPC_URL)'),
     }),
     output: z.object({ account: z.string(), chain: z.string(), transactions: z.array(z.string()) }),
@@ -722,8 +729,8 @@ const account = Cli.create('account', {
           return c.error({ code: 'ACCOUNT_NOT_FOUND', message: 'No account found.', exitCode: 69 })
       }
       const acct = privateKeyToAccount(key as `0x${string}`)
-      const rpcUrl = resolveRpcUrl(c.options.rpcUrl)
-      const chain = await resolveChain({ rpcUrl })
+      const rpcUrl = resolveRpcUrl(c.options.rpcUrl, { network: c.options.network })
+      const chain = await resolveChain({ network: c.options.network, rpcUrl })
       const client = createClient({ chain, transport: http(rpcUrl) })
       if (!structured) console.log(`Funding "${accountName}" on ${chainName(chain)}`)
       try {
@@ -852,6 +859,7 @@ const account = Cli.create('account', {
     description: 'View account address',
     options: z.object({
       account: z.string().optional().describe('Account name (env: MPPX_ACCOUNT)'),
+      network: z.enum(['mainnet', 'testnet']).optional().describe('Tempo network'),
       rpcUrl: z.string().optional().describe('RPC endpoint (env: MPPX_RPC_URL)'),
     }),
     output: accountViewSchema,
@@ -869,8 +877,8 @@ const account = Cli.create('account', {
           })
         }
         const address = tempoEntry.wallet_address as Address
-        const rpcUrl = resolveRpcUrl(c.options.rpcUrl)
-        const chain = await resolveChain({ rpcUrl })
+        const rpcUrl = resolveRpcUrl(c.options.rpcUrl, { network: c.options.network })
+        const chain = await resolveChain({ network: c.options.network, rpcUrl })
         const explorerUrl = chain.blockExplorers?.default?.url
         const addrDisplay = explorerUrl
           ? link(`${explorerUrl}/address/${address}`, address)
@@ -913,8 +921,8 @@ const account = Cli.create('account', {
           return c.error({ code: 'ACCOUNT_NOT_FOUND', message: 'No account found.', exitCode: 69 })
       }
       const acct = privateKeyToAccount(key as `0x${string}`)
-      const rpcUrl = resolveRpcUrl(c.options.rpcUrl)
-      const chain = await resolveChain({ rpcUrl })
+      const rpcUrl = resolveRpcUrl(c.options.rpcUrl, { network: c.options.network })
+      const chain = await resolveChain({ network: c.options.network, rpcUrl })
       const explorerUrl = chain.blockExplorers?.default?.url
       const addrDisplay = explorerUrl
         ? link(`${explorerUrl}/address/${acct.address}`, acct.address)
@@ -952,6 +960,7 @@ const sign = Cli.create('sign', {
       .array(z.string())
       .optional()
       .describe('Method-specific option (key=value, repeatable)'),
+    network: z.enum(['mainnet', 'testnet']).optional().describe('Tempo network'),
     rpcUrl: z
       .string()
       .optional()
@@ -1029,7 +1038,11 @@ const sign = Cli.create('sign', {
     if (plugin) {
       const result = await plugin.setup({
         challenge,
-        options: { account: c.options.account, rpcUrl: c.options.rpcUrl },
+        options: {
+          account: c.options.account,
+          network: c.options.network,
+          rpcUrl: c.options.rpcUrl,
+        },
         methodOpts,
       })
       if (result.createCredential) {

--- a/src/cli/plugins/plugin.ts
+++ b/src/cli/plugins/plugin.ts
@@ -1,5 +1,6 @@
 import type * as Challenge from '../../Challenge.js'
 import type * as Method from '../../Method.js'
+import type { Network } from '../utils.js'
 
 export function createPlugin(plugin: Plugin): Plugin {
   return plugin
@@ -18,7 +19,11 @@ export interface Plugin {
    */
   setup(ctx: {
     challenge: Challenge.Challenge
-    options: { account?: string | undefined; rpcUrl?: string | undefined }
+    options: {
+      account?: string | undefined
+      network?: Network | undefined
+      rpcUrl?: string | undefined
+    }
     methodOpts: Record<string, string>
   }): Promise<{
     /** Token symbol for display (e.g., 'PathUSD', 'USD') */

--- a/src/cli/plugins/tempo.ts
+++ b/src/cli/plugins/tempo.ts
@@ -71,11 +71,12 @@ export function tempo() {
         useTempoCliSign = true
         const tempoEntry = resolveTempoAccount(accountName)
         if (tempoEntry) {
-          const rpcUrl = resolveRpcUrl(options.rpcUrl)
+          const rpcUrl = resolveRpcUrl(options.rpcUrl, { network: options.network })
           client = createClient({
-            chain: await resolveChain({ rpcUrl }),
+            chain: await resolveChain({ network: options.network, rpcUrl }),
             transport: http(rpcUrl),
           })
+          assertChallengeChain({ challenge, clientChainId: client.chain?.id })
           explorerUrl = client.chain?.blockExplorers?.default?.url
           const tokenInfo = currency
             ? await fetchTokenInfo(
@@ -111,11 +112,12 @@ export function tempo() {
       } else account = privateKeyToAccount(privateKey as `0x${string}`)
 
       if (!useTempoCliSign && account) {
-        const rpcUrl = resolveRpcUrl(options.rpcUrl)
+        const rpcUrl = resolveRpcUrl(options.rpcUrl, { network: options.network })
         client = createClient({
-          chain: await resolveChain({ rpcUrl }),
+          chain: await resolveChain({ network: options.network, rpcUrl }),
           transport: http(rpcUrl),
         })
+        assertChallengeChain({ challenge, clientChainId: client.chain?.id })
         explorerUrl = client.chain?.blockExplorers?.default?.url
         const tokenInfo = currency
           ? await fetchTokenInfo(client, currency as Address, account.address).catch(
@@ -728,6 +730,28 @@ function parseOptions<const schema extends z.ZodType>(
     })
     .join(', ')
   throw new Error(`Invalid CLI options (${summary})`)
+}
+
+function assertChallengeChain(opts: {
+  challenge: { request: Record<string, unknown> }
+  clientChainId?: number | undefined
+}) {
+  const methodDetails = opts.challenge.request.methodDetails as
+    | { chainId?: number | undefined }
+    | undefined
+  const requiredChainId = methodDetails?.chainId
+  if (!requiredChainId || !opts.clientChainId || requiredChainId === opts.clientChainId) return
+  const hint =
+    requiredChainId === 4217
+      ? ' Use --network mainnet or --rpc-url https://rpc.tempo.xyz.'
+      : requiredChainId === 42431
+        ? ' Use --network testnet or --rpc-url https://rpc.moderato.tempo.xyz.'
+        : ''
+  throw new Errors.IncurError({
+    code: 'CHAIN_MISMATCH',
+    message: `Challenge requires chainId ${requiredChainId}, but RPC is chainId ${opts.clientChainId}.${hint}`,
+    exitCode: 2,
+  })
 }
 
 function channelStateDir() {

--- a/src/cli/utils.test.ts
+++ b/src/cli/utils.test.ts
@@ -1,7 +1,7 @@
 import { tempo as tempoMainnet, tempoModerato } from 'viem/chains'
 import { afterEach, describe, expect, test } from 'vp/test'
 
-import { resolveChain, resolveRpcUrl } from './utils.js'
+import { networkRpcUrls, resolveChain, resolveRpcUrl } from './utils.js'
 
 describe('resolveRpcUrl', () => {
   afterEach(() => {
@@ -12,6 +12,17 @@ describe('resolveRpcUrl', () => {
   test('returns explicit value when provided', () => {
     process.env.MPPX_RPC_URL = 'https://env.example.com'
     expect(resolveRpcUrl('https://explicit.example.com')).toBe('https://explicit.example.com')
+  })
+
+  test('uses network default before env vars', () => {
+    process.env.MPPX_RPC_URL = 'https://env.example.com'
+    expect(resolveRpcUrl(undefined, { network: 'testnet' })).toBe(networkRpcUrls.testnet)
+  })
+
+  test('prefers explicit rpc url over network default', () => {
+    expect(resolveRpcUrl('https://explicit.example.com', { network: 'mainnet' })).toBe(
+      'https://explicit.example.com',
+    )
   })
 
   test('falls back to MPPX_RPC_URL env var', () => {

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -4,6 +4,8 @@ import type { Chain } from 'viem'
 import { type Address, createClient, http } from 'viem'
 import { tempo as tempoMainnet, tempoModerato } from 'viem/chains'
 
+import * as defaults from '../tempo/internal/defaults.js'
+
 // Inlined from https://github.com/alexeyraspopov/picocolors (ISC License)
 export const pc = (() => {
   const p = process || ({} as NodeJS.Process)
@@ -221,13 +223,29 @@ export function fmtBalance(
   return `${dec ? `${formatted}.${dec}` : formatted} ${sym}`
 }
 
-/** Resolve RPC URL from explicit option, then MPPX_RPC_URL, then RPC_URL env vars. */
-export function resolveRpcUrl(explicit?: string | undefined): string | undefined {
-  return explicit ?? (process.env.MPPX_RPC_URL?.trim() || process.env.RPC_URL?.trim() || undefined)
+export type Network = 'mainnet' | 'testnet'
+
+export const networkRpcUrls = {
+  mainnet: defaults.rpcUrl[defaults.chainId.mainnet],
+  testnet: defaults.rpcUrl[defaults.chainId.testnet],
+} as const satisfies Record<Network, string>
+
+/** Resolve RPC URL from explicit option, network option, then MPPX_RPC_URL/RPC_URL env vars. */
+export function resolveRpcUrl(
+  explicit?: string | undefined,
+  options: { network?: Network | undefined } = {},
+): string | undefined {
+  return (
+    explicit ??
+    (options.network ? networkRpcUrls[options.network] : undefined) ??
+    (process.env.MPPX_RPC_URL?.trim() || process.env.RPC_URL?.trim() || undefined)
+  )
 }
 
-export async function resolveChain(opts: { rpcUrl?: string | undefined } = {}): Promise<Chain> {
-  const rpcUrl = resolveRpcUrl(opts.rpcUrl)
+export async function resolveChain(
+  opts: { network?: Network | undefined; rpcUrl?: string | undefined } = {},
+): Promise<Chain> {
+  const rpcUrl = resolveRpcUrl(opts.rpcUrl, { network: opts.network })
   if (!rpcUrl) return tempoMainnet
   const { getChainId } = await import('viem/actions')
   const chainId = await getChainId(createClient({ transport: http(rpcUrl) }))


### PR DESCRIPTION
Adds `--network mainnet|testnet` and checks the challenge chain against the connected RPC before signing.

This came up while dogfooding `mppx` with Hermes Agent. The agent hit a testnet MPP ping challenge but was configured with the mainnet RPC, and later hit a mainnet `fal` challenge while trying the testnet RPC. In both cases the CLI could still sign/broadcast on the wrong chain, which turned into confusing errors like token initialization failures, payment rejected, or verification failed.

Now the CLI fails before signing if the challenge says one chain and the RPC is connected to another.
