### PR TITLE
feat: add tempo autoswap cli options

### DIFF
--- a/.changeset/cli-autoswap-options.md
+++ b/.changeset/cli-autoswap-options.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added Tempo CLI auto-swap and payment source token options.

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -1646,6 +1646,17 @@ export default defineConfig({
     expect(output.trim()).toMatch(/^Payment\s+\S+/)
   })
 
+  test('rejects unsupported tempo method options', async () => {
+    const { output, exitCode } = await serve(
+      ['sign', '--challenge', validChallenge, '--rpc-url', rpcUrl, '-M', 'feeToken=0xabc'],
+      { env: { MPPX_PRIVATE_KEY: testPrivateKey } },
+    )
+
+    expect(exitCode).toBeDefined()
+    expect(output).toContain('Unsupported CLI method option')
+    expect(output).toContain('feeToken')
+  })
+
   test('happy path: --json outputs authorization', { timeout: 120_000 }, async () => {
     const { output, stderr, exitCode } = await serve(
       ['sign', '--challenge', validChallenge, '--rpc-url', rpcUrl, '--json'],

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -193,6 +193,7 @@ const cli = Cli.create('mppx', {
   }),
   options: z.object({
     account: z.string().optional().describe('Account name (env: MPPX_ACCOUNT)'),
+    autoSwap: z.boolean().optional().describe('Auto-swap source tokens into payment currency'),
     config: z.string().optional().describe('Path to config file'),
     confirm: z.boolean().optional().default(false).describe('Show confirmation prompts'),
     data: z.string().optional().describe('Send request body (implies POST unless -X is set)'),
@@ -214,11 +215,13 @@ const cli = Cli.create('mppx', {
       .optional()
       .describe('Method-specific option (key=value, repeatable)'),
     network: z.enum(['mainnet', 'testnet']).optional().describe('Tempo network'),
+    payWith: z.string().optional().describe('Source token for Tempo auto-swap'),
     rpcUrl: z
       .string()
       .optional()
       .describe('RPC endpoint, defaults to public RPC for chain (env: MPPX_RPC_URL)'),
     silent: z.boolean().default(false).describe('Silent mode (suppress progress and info)'),
+    slippage: z.number().optional().describe('Tempo auto-swap max slippage percentage'),
     userAgent: z
       .string()
       .optional()
@@ -382,8 +385,11 @@ const cli = Cli.create('mppx', {
           challenge,
           options: {
             account: c.options.account,
+            autoSwap: c.options.autoSwap,
             network: c.options.network,
+            payWith: c.options.payWith,
             rpcUrl: c.options.rpcUrl,
+            slippage: c.options.slippage,
           },
           methodOpts: parseMethodOpts(c.options.methodOpt),
         })
@@ -1061,15 +1067,18 @@ const sign = Cli.create('sign', {
     challenge: z.string().optional().describe('WWW-Authenticate challenge value'),
     config: z.string().optional().describe('Path to config file'),
     dryRun: z.boolean().optional().describe('Validate and parse the challenge without signing'),
+    autoSwap: z.boolean().optional().describe('Auto-swap source tokens into payment currency'),
     methodOpt: z
       .array(z.string())
       .optional()
       .describe('Method-specific option (key=value, repeatable)'),
     network: z.enum(['mainnet', 'testnet']).optional().describe('Tempo network'),
+    payWith: z.string().optional().describe('Source token for Tempo auto-swap'),
     rpcUrl: z
       .string()
       .optional()
       .describe('RPC endpoint, defaults to public RPC for chain (env: MPPX_RPC_URL)'),
+    slippage: z.number().optional().describe('Tempo auto-swap max slippage percentage'),
   }),
   output: z.object({ authorization: z.string() }),
   alias: {
@@ -1145,8 +1154,11 @@ const sign = Cli.create('sign', {
         challenge,
         options: {
           account: c.options.account,
+          autoSwap: c.options.autoSwap,
           network: c.options.network,
+          payWith: c.options.payWith,
           rpcUrl: c.options.rpcUrl,
+          slippage: c.options.slippage,
         },
         methodOpts,
       })

--- a/src/cli/plugins/plugin.ts
+++ b/src/cli/plugins/plugin.ts
@@ -21,8 +21,11 @@ export interface Plugin {
     challenge: Challenge.Challenge
     options: {
       account?: string | undefined
+      autoSwap?: boolean | undefined
       network?: Network | undefined
+      payWith?: string | undefined
       rpcUrl?: string | undefined
+      slippage?: number | undefined
     }
     methodOpts: Record<string, string>
   }): Promise<{

--- a/src/cli/plugins/stripe.ts
+++ b/src/cli/plugins/stripe.ts
@@ -20,6 +20,7 @@ export function stripe() {
           paymentMethod: z.string(),
         }),
         methodOpts,
+        ['paymentMethod'],
       )
 
       const stripeSecretKey = process.env.MPPX_STRIPE_SECRET_KEY
@@ -134,7 +135,13 @@ export function stripe() {
 function parseOptions<const schema extends z.ZodType>(
   schema: schema,
   rawOptions: unknown,
+  allowedKeys: readonly string[],
 ): z.output<schema> {
+  if (rawOptions && typeof rawOptions === 'object' && !Array.isArray(rawOptions)) {
+    const unknownKeys = Object.keys(rawOptions).filter((key) => !allowedKeys.includes(key))
+    if (unknownKeys.length)
+      throw new Error(`Unsupported CLI method option(s): ${unknownKeys.join(', ')}`)
+  }
   const result = schema.safeParse(rawOptions ?? {})
   if (result.success) return result.data
   const summary = result.error.issues

--- a/src/cli/plugins/tempo.ts
+++ b/src/cli/plugins/tempo.ts
@@ -54,6 +54,29 @@ export function tempo() {
       const accountName = resolveAccountName(options.account)
       const challengeRequest = challenge.request as Record<string, unknown>
       const currency = challengeRequest.currency as string | undefined
+      const booleanOption = z.union([
+        z.boolean(),
+        z.literal('true').transform(() => true),
+        z.literal('false').transform(() => false),
+      ])
+      const tempoOpts = parseOptions(
+        z.object({
+          autoSwap: z.optional(booleanOption),
+          channel: z.optional(z.coerce.string()),
+          deposit: z.optional(z.union([z.string(), z.number()])),
+          payWith: z.optional(z.string()),
+          slippage: z.optional(z.coerce.number()),
+          tokenIn: z.optional(z.string()),
+        }),
+        methodOpts,
+        ['autoSwap', 'channel', 'deposit', 'payWith', 'slippage', 'tokenIn'],
+      )
+      const autoSwap = resolveAutoSwap({
+        autoSwap: tempoOpts.autoSwap ?? options.autoSwap,
+        payWith: tempoOpts.payWith ?? options.payWith,
+        slippage: tempoOpts.slippage ?? options.slippage,
+        tokenIn: tempoOpts.tokenIn,
+      })
 
       let tokenSymbol = currency ?? ''
       let tokenDecimals = (challengeRequest.decimals as number | undefined) ?? 6
@@ -149,17 +172,10 @@ export function tempo() {
           exitCode: 69,
         })
 
-      const tempoOpts = parseOptions(
-        z.object({
-          channel: z.optional(z.coerce.string()),
-          deposit: z.optional(z.union([z.string(), z.number()])),
-        }),
-        methodOpts,
-      )
-
       const methods = tempoMethods({
         account,
         getClient: () => client!,
+        ...(autoSwap !== undefined ? { autoSwap } : {}),
         deposit: (() => {
           if (challenge.intent !== 'session') return undefined
           const suggestedDeposit = (challenge.request as Record<string, unknown>)
@@ -720,7 +736,13 @@ function detectTerminalBg(
 function parseOptions<const schema extends z.ZodType>(
   schema: schema,
   rawOptions: unknown,
+  allowedKeys: readonly string[],
 ): z.output<schema> {
+  if (rawOptions && typeof rawOptions === 'object' && !Array.isArray(rawOptions)) {
+    const unknownKeys = Object.keys(rawOptions).filter((key) => !allowedKeys.includes(key))
+    if (unknownKeys.length)
+      throw new Error(`Unsupported CLI method option(s): ${unknownKeys.join(', ')}`)
+  }
   const result = schema.safeParse(rawOptions ?? {})
   if (result.success) return result.data
   const summary = result.error.issues
@@ -752,6 +774,31 @@ function assertChallengeChain(opts: {
     message: `Challenge requires chainId ${requiredChainId}, but RPC is chainId ${opts.clientChainId}.${hint}`,
     exitCode: 2,
   })
+}
+
+function parseTokenList(value: string | undefined): Address[] | undefined {
+  if (!value) return undefined
+  return value
+    .split(',')
+    .map((token) => token.trim())
+    .filter(Boolean) as Address[]
+}
+
+function resolveAutoSwap(opts: {
+  autoSwap?: boolean | undefined
+  payWith?: string | undefined
+  slippage?: number | undefined
+  tokenIn?: string | undefined
+}) {
+  const tokenIn = parseTokenList(opts.tokenIn) ?? parseTokenList(opts.payWith)
+  if (!opts.autoSwap && !tokenIn && opts.slippage === undefined) return undefined
+  if (opts.autoSwap === false && !tokenIn && opts.slippage === undefined) return false
+  if (opts.slippage !== undefined && (!Number.isFinite(opts.slippage) || opts.slippage < 0))
+    throw new Error('Invalid CLI options (slippage: expected a non-negative number)')
+  return {
+    ...(tokenIn ? { tokenIn } : {}),
+    ...(opts.slippage !== undefined ? { slippage: opts.slippage } : {}),
+  }
 }
 
 function channelStateDir() {


### PR DESCRIPTION
Wires autoswap through the CLI.

This came up while dogfooding `mppx` with Hermes Agent against `fal`. The `fal` endpoint requested `USDC.e` on Tempo mainnet, but the funded account had `PathUSD`. Autoswap already existed in the client, but there was no CLI path to turn it on or choose the source token.

Adds `--auto-swap`, `--pay-with`, `--slippage`, plus the matching `-M` opts. Also rejects unknown method opts now, so things like `-M feeToken=...` don't look like they worked when they were actually ignored.
