### PR TITLE
fix: strip `feeToken` and `feePayerSignature` from pre-broadcast simulation

### DIFF
--- a/.changeset/charge-strip-fee-token-simulation.md
+++ b/.changeset/charge-strip-fee-token-simulation.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed pre-broadcast simulation in `tempo.charge` and `tempo.session` by stripping `feeToken` and `feePayerSignature` from the simulation request, so the node does not try to recover `feePayerSignature` against a sender signature that viem's `call` action never includes.

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -409,8 +409,8 @@ export function charge<const parameters extends charge.Parameters>(
               await viem_call(client, {
                 ...transaction,
                 account: transaction.from,
-                feeToken: resolvedFeeToken,
                 calls: transaction.calls,
+                feePayerSignature: undefined,
               } as never)
               const receipt = await sendRawTransactionSync(client, {
                 serializedTransaction: serializedTransaction_final,
@@ -447,8 +447,8 @@ export function charge<const parameters extends charge.Parameters>(
             await viem_call(client, {
               ...transaction,
               account: transaction.from,
-              feeToken: resolvedFeeToken,
               calls: transaction.calls,
+              feePayerSignature: undefined,
             } as never)
             const reference = await sendRawTransaction(client, {
               serializedTransaction: serializedTransaction_final,

--- a/src/tempo/session/Chain.ts
+++ b/src/tempo/session/Chain.ts
@@ -606,8 +606,8 @@ export async function broadcastOpenTransaction(parameters: {
     await call(client, {
       ...transaction,
       account: transaction.from,
-      feeToken: resolvedFeeToken,
       calls,
+      feePayerSignature: undefined,
     } as never)
     const txHash = await sendRawTransaction(client, {
       serializedTransaction: serializedTransaction_final as Transaction.TransactionSerializedTempo,
@@ -625,8 +625,8 @@ export async function broadcastOpenTransaction(parameters: {
       await call(client, {
         ...transaction,
         account: transaction.from,
-        feeToken: resolvedFeeToken,
         calls,
+        feePayerSignature: undefined,
       } as never)
 
     const receipt = await sendRawTransactionSync(client, {
@@ -762,10 +762,8 @@ export async function broadcastTopUpTransaction(parameters: {
     await call(client, {
       ...transaction,
       account: transaction.from,
-      feeToken:
-        transaction.feeToken ??
-        defaults.currency[client.chain?.id as keyof typeof defaults.currency],
       calls,
+      feePayerSignature: undefined,
     } as never)
 
   const receipt = await sendRawTransactionSync(client, {


### PR DESCRIPTION
The `viem_call` simulation in `tempo.charge` and `tempo.session` spreads the deserialized transaction (including `feePayerSignature`) into the `eth_call` request and explicitly sets `feeToken`. The Tempo node treats those fields as a sponsored-tx hint and tries to recover both signatures, but `call` strips the sender signature, so recovery fails with `fee payer signature recovery failed` on every sponsored 0x76 charge.

Strip `feeToken` and `feePayerSignature` from the simulation so the node executes the calls as a regular `eth_call`. The VERIA-145 revert guard is preserved -- a malicious `approve.to` (or any other revert) is still caught before broadcast; the simulation just runs without the sponsorship-routing fields the node was choking on.
