### PR TITLE
fix(tempo): send spec-compliant `scopes` and hex-encoded `limit` in subscription wallet_authorizeAccessKey

### DIFF
--- a/.changeset/fix-subscription-rpc-params.md
+++ b/.changeset/fix-subscription-rpc-params.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed Tempo subscription `wallet_authorizeAccessKey` RPC payload to send `scopes` (the spec-compliant field) instead of `allowedCalls`, and to hex-encode `limits[].limit` so the parameters match the encoded variant of the `wallet_authorizeAccessKey` schema.

--- a/src/tempo/client/Subscription.test.ts
+++ b/src/tempo/client/Subscription.test.ts
@@ -104,6 +104,57 @@ describe('tempo.subscription client', () => {
     )
   })
 
+  test('passes hex-encoded `scopes` and `limits` to wallet_authorizeAccessKey', async () => {
+    const challenge = createChallenge()
+    const keyAuthorization = await signSubscriptionKeyAuthorization({
+      accessKey,
+      account: selectedAccount,
+      chainId,
+      request: challenge.request,
+    })
+    if (!keyAuthorization) throw new Error('expected key authorization')
+
+    let capturedParams: Record<string, unknown> | undefined
+    const method = subscription({
+      account: selectedAccount.address,
+      getClient: async () =>
+        ({
+          request: async ({ params }: { params: readonly Record<string, unknown>[] }) => {
+            capturedParams = params[0]
+            return { keyAuthorization: KeyAuthorization.toRpc(keyAuthorization) }
+          },
+        }) as never,
+    })
+
+    await method.createCredential({ challenge, context: {} })
+
+    expect(capturedParams).toMatchObject({
+      address: accessKey.accessKeyAddress.toLowerCase(),
+      keyType: accessKey.keyType,
+      expiry: expect.any(Number),
+      limits: [
+        {
+          token: expect.stringMatching(/^0x[0-9a-fA-F]{40}$/),
+          limit: '0xf4240',
+          period: expect.any(Number),
+        },
+      ],
+      scopes: [
+        {
+          address: expect.stringMatching(/^0x[0-9a-fA-F]{40}$/),
+          selector: expect.stringMatching(/^0x/),
+          recipients: expect.any(Array),
+        },
+        {
+          address: expect.stringMatching(/^0x[0-9a-fA-F]{40}$/),
+          selector: expect.stringMatching(/^0x/),
+          recipients: expect.any(Array),
+        },
+      ],
+    })
+    expect(capturedParams).not.toHaveProperty('allowedCalls')
+  })
+
   test('rejects key authorizations signed by a different account', async () => {
     const challenge = createChallenge()
     const keyAuthorization = await signSubscriptionKeyAuthorization({

--- a/src/tempo/client/Subscription.ts
+++ b/src/tempo/client/Subscription.ts
@@ -1,3 +1,4 @@
+import { Hex } from 'ox'
 import { KeyAuthorization } from 'ox/tempo'
 import { isAddressEqual, type Address } from 'viem'
 import { tempo as tempo_chain } from 'viem/chains'
@@ -11,7 +12,7 @@ import * as z from '../../zod.js'
 import * as defaults from '../internal/defaults.js'
 import * as Methods from '../Methods.js'
 import {
-  getSubscriptionRpcAllowedCalls,
+  getSubscriptionScopes,
   signSubscriptionKeyAuthorization,
   toSubscriptionExpiryDate,
   toSubscriptionExpirySeconds,
@@ -117,16 +118,16 @@ async function authorizeAccessKey(
     params: [
       {
         address: accessKey.accessKeyAddress,
-        allowedCalls: getSubscriptionRpcAllowedCalls(request),
         expiry: toSubscriptionExpirySeconds(toSubscriptionExpiryDate(request.subscriptionExpires)),
         keyType: accessKey.keyType,
         limits: [
           {
             token: request.currency as Address,
-            limit: BigInt(request.amount),
+            limit: Hex.fromNumber(BigInt(request.amount)),
             period: toSubscriptionPeriodSeconds(request),
           },
         ],
+        scopes: getSubscriptionScopes(request),
       },
     ],
   } as never)) as {


### PR DESCRIPTION
The Tempo subscription client was sending an mppx-specific `allowedCalls` field in the `wallet_authorizeAccessKey` RPC payload, and a raw bigint for `limits[].limit`. Wallets that follow the encoded spec (e.g. [tempoxyz/accounts](https://github.com/tempoxyz/accounts)) reject the payload because they expect `scopes` (not `allowedCalls`) and a hex-encoded `limit`.

### Changes

- Replace `allowedCalls` with `scopes` (using the existing `getSubscriptionScopes` helper).
- Hex-encode `limits[].limit` via `Hex.fromNumber` so it matches `u.bigint()` on the wallet side.
- Add a client test that captures the RPC params and locks in the encoded shape, asserting `scopes` is present, `allowedCalls` is absent, and `limit` is a hex string.

### Verification

- `pnpm test src/tempo/client/Subscription src/tempo/Subscription.integration src/tempo/server/Subscription src/tempo/subscription` → 57/57 passing.