### PR TITLE
chore: format subscription fee payer changeset

### DIFF
--- a/.changeset/subscription-fee-payer-support.md
+++ b/.changeset/subscription-fee-payer-support.md
@@ -1,5 +1,5 @@
 ---
-"mppx": patch
+'mppx': patch
 ---
 
 Added fee payer support and an optional `feePayerPolicy` parameter to `tempo.subscription` so activation and renewal payments can be sponsored without consuming the access key's spending limit.


### PR DESCRIPTION
Fixes the changeset for #447, which was reformatted by Biome (`"mppx"` → `'mppx'`) but the format-only commit was dropped from the squash merge — causing `pnpm check:ci` to fail on `main`.