### PR TITLE
fix: reject forged credential metadata

### DIFF
--- a/.changeset/quiet-rings-fix.md
+++ b/.changeset/quiet-rings-fix.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed credential metadata hydration to reject forged route scope metadata.

--- a/.changeset/quiet-rings-fix.md
+++ b/.changeset/quiet-rings-fix.md
@@ -2,4 +2,5 @@
 'mppx': patch
 ---
 
-Fixed credential metadata hydration to reject forged route scope metadata.
+Fixed bug where forged scope metadata could result in cross route bypass of requests.
+

--- a/.changeset/quiet-rings-fix.md
+++ b/.changeset/quiet-rings-fix.md
@@ -3,4 +3,3 @@
 ---
 
 Fixed bug where forged scope metadata could result in cross route bypass of requests.
-

--- a/src/Credential.test.ts
+++ b/src/Credential.test.ts
@@ -198,6 +198,29 @@ describe('deserialize', () => {
     expect(credential.challenge.request).toEqual({ amount: '1000' })
   })
 
+  test('security: drops injected meta when opaque is a string', () => {
+    const encoded = Base64.fromString(
+      JSON.stringify({
+        challenge: {
+          id: 'opaque123',
+          intent: 'charge',
+          meta: { _mppx_scope: 'GET /admin' },
+          method: 'tempo',
+          opaque: 'eyJfbXBweF9zY29wZSI6IkdFVCAvcHVibGljIn0',
+          realm: 'api.example.com',
+          request: 'eyJhbW91bnQiOiIxMDAwIn0',
+        },
+        payload: { signature: '0x1234' },
+      }),
+      { pad: false, url: true },
+    )
+
+    const credential = Credential.deserialize(`Payment ${encoded}`)
+
+    expect(credential.challenge.opaque).toBe('eyJfbXBweF9zY29wZSI6IkdFVCAvcHVibGljIn0')
+    expect(credential.challenge.meta).toBeUndefined()
+  })
+
   test('behavior: preserves non-json opaque string credentials', () => {
     const encoded = Base64.fromString(
       JSON.stringify({

--- a/src/Credential.ts
+++ b/src/Credential.ts
@@ -64,13 +64,14 @@ export function deserialize<payload = unknown>(value: string): Credential<payloa
     const json = Base64.toString(prefixMatch[1])
     const parsed = JSON.parse(json) as {
       challenge: Omit<Challenge.Challenge, 'meta' | 'opaque' | 'request'> & {
+        meta?: unknown
         opaque?: unknown
         request: string
       }
       payload: payload
       source?: string
     }
-    const { opaque: challengeOpaque, request, ...challengeFields } = parsed.challenge
+    const { opaque: challengeOpaque, request, meta: _meta, ...challengeFields } = parsed.challenge
     const { meta, opaque } = normalizeCredentialOpaque(challengeOpaque)
     const challenge = Challenge.Schema.parse({
       ...challengeFields,

--- a/src/server/Mppx.test.ts
+++ b/src/server/Mppx.test.ts
@@ -4415,6 +4415,30 @@ describe('verifyCredential', () => {
     )
   })
 
+  test('rejects direct credential objects with forged meta and valid opaque', async () => {
+    const mppx = Mppx.create({
+      methods: [alphaChargeServer],
+      realm,
+      secretKey,
+    })
+
+    const challenge = await mppx.challenge.alpha.charge({
+      ...challengeOpts,
+      scope: 'GET /public',
+    })
+    const credential = Credential.from({
+      challenge: {
+        ...challenge,
+        meta: { _mppx_scope: 'GET /admin' },
+      },
+      payload: { token: 'valid' },
+    })
+
+    await expect(mppx.verifyCredential(credential, { scope: 'GET /admin' })).rejects.toThrow(
+      "credential scope does not match this route's requirements",
+    )
+  })
+
   test('verifies route requirements using the echoed challenge realm when host was auto-detected', async () => {
     const mppx = Mppx.create({
       methods: [alphaChargeServer],

--- a/src/server/Mppx.ts
+++ b/src/server/Mppx.ts
@@ -1919,13 +1919,14 @@ function hydrateCredentialMeta<payload>(
   credential: Credential.Credential<payload>,
 ): Credential.Credential<payload> {
   const { challenge } = credential
-  if (challenge.meta !== undefined || challenge.opaque === undefined) return credential
+  if (challenge.opaque === undefined) return credential
+  const hydratedChallenge = Challenge.Schema.parse({
+    ...challenge,
+    meta: PaymentRequest.deserialize(challenge.opaque),
+  })
   return {
     ...credential,
-    challenge: {
-      ...challenge,
-      meta: PaymentRequest.deserialize(challenge.opaque) as Record<string, string>,
-    },
+    challenge: hydratedChallenge,
   }
 }
 


### PR DESCRIPTION
## Summary

Fixed credential deserialization and server metadata hydration so route scope metadata is derived from the signed opaque value instead of trusting injected credential metadata.

