### PR TITLE
fix: collapse tempo transfer log effects

### DIFF
--- a/.changeset/fair-phones-travel.md
+++ b/.changeset/fair-phones-travel.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed Tempo charge hash receipt verification to collapse paired transfer logs before matching expected transfers.

--- a/src/tempo/server/Charge.test.ts
+++ b/src/tempo/server/Charge.test.ts
@@ -3947,6 +3947,72 @@ describe('tempo', () => {
       httpServer.close()
     })
 
+    test('server rejects hash transfers that reuse one transferWithMemo for duplicate expected transfers', async () => {
+      const validatingServer = Mppx_server.create({
+        methods: [
+          tempo_server.charge({
+            getClient() {
+              return client
+            },
+            currency: asset,
+            account: accounts[0],
+            validateSender() {
+              return true
+            },
+          }),
+        ],
+        realm,
+        secretKey,
+      })
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await Mppx_server.toNodeListener(
+          validatingServer.charge({
+            amount: '2',
+            currency: asset,
+            recipient: accounts[0].address,
+            splits: [{ amount: '1', recipient: accounts[0].address }],
+          }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
+      })
+
+      const response = await fetch(httpServer.url)
+      expect(response.status).toBe(402)
+
+      const challenge = Challenge.fromResponse(response, {
+        methods: [tempo_client.charge()],
+      })
+      const memo = Attribution.encode({ challengeId: challenge.id, serverId: challenge.realm })
+      const splits = challenge.request.methodDetails?.splits ?? []
+      const primaryAmount = BigInt(challenge.request.amount) - BigInt(splits[0]!.amount)
+
+      const { receipt } = await Actions.token.transferSync(client, {
+        account: accounts[1],
+        amount: primaryAmount,
+        memo: memo as Hex.Hex,
+        to: challenge.request.recipient as Hex.Hex,
+        token: challenge.request.currency as Hex.Hex,
+      })
+
+      const credential = Credential.from({
+        challenge,
+        payload: { hash: receipt.transactionHash, type: 'hash' as const },
+        source: `did:pkh:eip155:${chain.id}:${accounts[2].address}`,
+      })
+
+      {
+        const response = await fetch(httpServer.url, {
+          headers: { Authorization: Credential.serialize(credential) },
+        })
+        expect(response.status).toBe(402)
+        const body = (await response.json()) as { detail: string }
+        expect(body.detail).toContain('no matching transfer found')
+      }
+
+      httpServer.close()
+    })
+
     test('server skips validateSender when hash transfer source already matches', async () => {
       const validatingServer = Mppx_server.create({
         methods: [

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -717,21 +717,7 @@ async function assertTransferLogs(
     validateSender?: charge.ValidateSender | undefined
   },
 ): Promise<TransferLog[]> {
-  const transferLogs = parseEventLogs({
-    abi: Abis.tip20,
-    eventName: 'Transfer',
-    logs: receipt.logs,
-  }).map((log) => ({ ...log, kind: 'transfer' as const }))
-
-  const memoLogs = parseEventLogs({
-    abi: Abis.tip20,
-    eventName: 'TransferWithMemo',
-    logs: receipt.logs,
-  }).map((log) => ({ ...log, kind: 'memo' as const }))
-
-  // Prefer memo logs so allowAnyMemo matches TransferWithMemo before Transfer,
-  // preserving the memo for challenge binding verification.
-  const logs = [...memoLogs, ...transferLogs]
+  const logs = getTransferLogEffects(receipt)
   const used = new Set<number>()
   const matched: TransferLog[] = []
 
@@ -783,6 +769,87 @@ async function assertTransferLogs(
   }
 
   return matched
+}
+
+type ParsedTransferLog =
+  | {
+      kind: 'transfer'
+      args: { from: `0x${string}`; to: `0x${string}`; amount: bigint }
+      address: `0x${string}`
+      logIndex: number
+    }
+  | {
+      kind: 'memo'
+      args: { from: `0x${string}`; to: `0x${string}`; amount: bigint; memo: `0x${string}` }
+      address: `0x${string}`
+      logIndex: number
+    }
+
+function getTransferLogEffects(receipt: TransactionReceipt): TransferLog[] {
+  const transferLogs = parseEventLogs({
+    abi: Abis.tip20,
+    eventName: 'Transfer',
+    logs: receipt.logs,
+  }).map(
+    (log) =>
+      ({
+        address: log.address,
+        args: log.args,
+        kind: 'transfer',
+        logIndex: log.logIndex,
+      }) as ParsedTransferLog,
+  )
+
+  const memoLogs = parseEventLogs({
+    abi: Abis.tip20,
+    eventName: 'TransferWithMemo',
+    logs: receipt.logs,
+  }).map(
+    (log) =>
+      ({
+        address: log.address,
+        args: log.args,
+        kind: 'memo',
+        logIndex: log.logIndex,
+      }) as ParsedTransferLog,
+  )
+
+  const logs = [...transferLogs, ...memoLogs].sort((a, b) => a.logIndex - b.logIndex)
+  const effects: TransferLog[] = []
+
+  for (let index = 0; index < logs.length; index++) {
+    const log = logs[index]!
+    const next = logs[index + 1]
+    if (next && log.kind !== next.kind && isSameTransferLog(log, next)) {
+      const memoLog = log.kind === 'memo' ? log : next.kind === 'memo' ? next : undefined
+      if (!memoLog) continue
+      effects.push({
+        address: memoLog.address,
+        args: memoLog.args,
+        kind: 'memo',
+      })
+      index++
+      continue
+    }
+
+    effects.push({
+      address: log.address,
+      args: log.args,
+      kind: log.kind,
+    } as TransferLog)
+  }
+
+  return effects
+}
+
+function isSameTransferLog(a: ParsedTransferLog, b: ParsedTransferLog): boolean {
+  return (
+    TempoAddress.isEqual(a.address, b.address) &&
+    TempoAddress.isEqual(a.args.from, b.args.from) &&
+    TempoAddress.isEqual(a.args.to, b.args.to) &&
+    a.args.amount === b.args.amount &&
+    Math.abs(a.logIndex - b.logIndex) === 1
+  )
 }
 
 async function isValidTransferSender(parameters: {


### PR DESCRIPTION
## Summary

Fix Tempo charge hash receipt verification to collapse paired transfer logs before matching expected transfers.