### PR TITLE
feat(tempo): add `tempo.subscription.renew`; bump default fee payer gas

### DIFF
--- a/.changeset/subscription-renewal-context.md
+++ b/.changeset/subscription-renewal-context.md
@@ -1,0 +1,7 @@
+---
+'mppx': patch
+---
+
+Added `dev_second` subscription periods.
+Added `mppx.tempo.subscription.renew`.
+Raised default sponsor limits for subscription payments.

--- a/src/Method.ts
+++ b/src/Method.ts
@@ -129,9 +129,11 @@ export type Server<
   method extends Method = Method,
   defaults extends ExactPartial<z.input<method['schema']['request']>> = {},
   transportOverride = undefined,
+  extensions extends object = {},
 > = method & {
   authorize?: AuthorizeFn<method> | undefined
   defaults?: defaults | undefined
+  extensions?: extensions | undefined
   html?: Html.Options | undefined
   request?: RequestFn<method> | undefined
   respond?: RespondFn<method> | undefined
@@ -139,7 +141,7 @@ export type Server<
   transport?: transportOverride | undefined
   verify: VerifyFn<method>
 }
-export type AnyServer = Server<any, any, any>
+export type AnyServer = Server<any, any, any, any>
 
 /** Credential creation function for a single method. */
 export type CreateCredentialFn<method extends Method, context = unknown> = (
@@ -288,22 +290,34 @@ export function toServer<
   const method extends Method,
   const defaults extends RequestDefaults<method> = {},
   const transportOverride extends Transport.AnyTransport | undefined = undefined,
+  const extensions extends object = {},
 >(
   method: method,
-  options: toServer.Options<method, defaults, transportOverride>,
-): Server<method, defaults, transportOverride> {
-  const { authorize, defaults, html, request, respond, stableBinding, transport, verify } = options
-  return {
-    ...method,
+  options: toServer.Options<method, defaults, transportOverride, extensions>,
+): Server<method, defaults, transportOverride, extensions> {
+  const {
     authorize,
     defaults,
+    extensions,
     html,
     request,
     respond,
     stableBinding,
     transport,
     verify,
-  } as Server<method, defaults, transportOverride>
+  } = options
+  return {
+    ...method,
+    authorize,
+    defaults,
+    extensions,
+    html,
+    request,
+    respond,
+    stableBinding,
+    transport,
+    verify,
+  } as Server<method, defaults, transportOverride, extensions>
 }
 
 export declare namespace toServer {
@@ -311,9 +325,11 @@ export declare namespace toServer {
     method extends Method,
     defaults extends RequestDefaults<method> = {},
     transportOverride extends Transport.AnyTransport | undefined = undefined,
+    extensions extends object = {},
   > = {
     authorize?: AuthorizeFn<method> | undefined
     defaults?: defaults | undefined
+    extensions?: extensions | undefined
     html?: Html.Options | undefined
     request?: RequestFn<method> | undefined
     respond?: RespondFn<method> | undefined

--- a/src/middlewares/internal/mppx.test.ts
+++ b/src/middlewares/internal/mppx.test.ts
@@ -60,6 +60,20 @@ const betaMethod = Method.toServer(mockChargeB, {
   },
 })
 
+const alphaMethodWithExtension = Method.toServer<
+  typeof mockChargeA,
+  {},
+  undefined,
+  { renew: () => string }
+>(mockChargeA, {
+  extensions: {
+    renew: () => 'renewed',
+  },
+  async verify() {
+    return mockReceipt('alpha')
+  },
+})
+
 const challengeOpts = {
   amount: '1000',
   currency: '0x0000000000000000000000000000000000000001',
@@ -149,5 +163,15 @@ describe('wrap: nested handlers', () => {
 
     expect(wrapped.realm).toBe(realm)
     expect(wrapped.transport).toBe(mppx.transport)
+  })
+
+  test('method extensions are copied to wrapped handlers', () => {
+    const mppx = Mppx.create({ methods: [alphaMethodWithExtension], realm, secretKey }) as any
+
+    const wrapped = wrap(mppx, (_methodFn, _options) => 'wrapped') as any
+
+    expect(wrapped.charge.renew()).toBe('renewed')
+    expect(wrapped.alpha.charge.renew()).toBe('renewed')
+    expect(wrapped['alpha/charge'].renew()).toBe('renewed')
   })
 })

--- a/src/middlewares/internal/mppx.ts
+++ b/src/middlewares/internal/mppx.ts
@@ -11,9 +11,12 @@ type DiscoveryMeta = Pick<DiscoveryHandler, '_internal'>
 /** Recursively wraps nested handler objects one level deep. */
 type WrapNested<obj, handler> = {
   [key in keyof obj]: obj[key] extends (options: infer options) => any
-    ? (o: options) => handler & DiscoveryMeta
+    ? WrappedMethod<obj[key], options, handler>
     : obj[key]
 }
+
+type WrappedMethod<method, options, handler> = ((o: options) => handler & DiscoveryMeta) &
+  Omit<method, keyof Function>
 
 export type Wrap<mppx, handler> = {
   // `compose` is omitted — it returns a raw HTTP handler, not a
@@ -22,7 +25,7 @@ export type Wrap<mppx, handler> = {
   [key in keyof mppx as key extends 'compose' ? never : key]: key extends Mppx.ReservedKey
     ? mppx[key]
     : mppx[key] extends (options: infer options) => any
-      ? (o: options) => handler & DiscoveryMeta
+      ? WrappedMethod<mppx[key], options, handler>
       : mppx[key] extends Record<string, (options: any) => any>
         ? WrapNested<mppx[key], handler>
         : mppx[key]
@@ -50,6 +53,7 @@ export function wrap<mppx extends Mppx.Mppx<any, any>, handler>(
       if (configured._internal) handler._internal = configured._internal
       return handler
     }
+    Object.assign(wrapWithMeta, methodFn)
     result[key] = wrapWithMeta
     // Also set shorthand intent key if Mppx registered it (no collision)
     if (!reservedMppxKeys.has(mi.intent) && (mppx as any)[mi.intent])

--- a/src/server/Mppx.ts
+++ b/src/server/Mppx.ts
@@ -319,7 +319,8 @@ type UniqueIntentHandlers<
     Extract<methods[number], { intent: method_name }>,
     EffectiveTransportOf<Extract<methods[number], { intent: method_name }>, transport>,
     NonNullable<Extract<methods[number], { intent: method_name }>['defaults']>
-  >
+  > &
+    MethodExtensions<Extract<methods[number], { intent: method_name }>>
 }
 
 /** Nested handlers: `mppx.tempo.charge(...)`, grouped by method name then intent. */
@@ -332,7 +333,8 @@ type NestedHandlers<
       mi,
       EffectiveTransportOf<mi, transport>,
       NonNullable<mi['defaults']>
-    > & { _method: mi }
+    > &
+      MethodExtensions<mi> & { _method: mi }
   }
 }
 
@@ -344,9 +346,18 @@ type Handlers<
     mi,
     EffectiveTransportOf<mi, transport>,
     NonNullable<mi['defaults']>
-  >
+  > &
+    MethodExtensions<mi>
 } & UniqueIntentHandlers<methods, transport> &
   NestedHandlers<methods, transport>
+
+type MethodExtensions<method extends Method.AnyServer> = method extends {
+  extensions?: (infer extensions) | undefined
+}
+  ? NonNullable<extensions> extends object
+    ? NonNullable<extensions>
+    : {}
+  : {}
 
 /** Nested challenge generators: `mppx.challenge.tempo.charge(...)`. */
 type ChallengeHandlers<methods extends readonly Method.AnyServer[]> = {
@@ -407,7 +418,7 @@ export function create<
   assertNoReservedMppxKeys(methods as readonly Method.AnyServer[])
 
   for (const mi of methods) {
-    handlers[`${mi.name}/${mi.intent}`] = createMethodFn({
+    const fn = createMethodFn({
       authorize: mi.authorize as never,
       defaults: mi.defaults,
       method: mi,
@@ -420,6 +431,8 @@ export function create<
       transport: (mi.transport ?? transport) as never,
       verify: mi.verify as never,
     })
+    if (mi.extensions) Object.assign(fn, mi.extensions)
+    handlers[`${mi.name}/${mi.intent}`] = fn
   }
 
   // Also set shorthand intent key when there's no collision

--- a/src/tempo/Methods.test.ts
+++ b/src/tempo/Methods.test.ts
@@ -313,6 +313,23 @@ describe('subscription', () => {
     expect(request.periodCount).toBe(expected)
   })
 
+  test.each(['dev_second'] as const)(
+    'schema: accepts %s subscription periods for development and tests',
+    (periodUnit) => {
+      const request = Methods.subscription.schema.request.parse({
+        amount: '10',
+        currency: '0x20c0000000000000000000000000000000000001',
+        decimals: 6,
+        periodCount: '5',
+        periodUnit,
+        recipient: '0x1234567890abcdef1234567890abcdef12345678',
+        subscriptionExpires: '2026-01-01T00:00:00Z',
+      })
+
+      expect(request.periodUnit).toBe(periodUnit)
+    },
+  )
+
   test('schema: rejects non-numeric periodCount', () => {
     const result = Methods.subscription.schema.request.safeParse({
       amount: '10',

--- a/src/tempo/Methods.ts
+++ b/src/tempo/Methods.ts
@@ -19,8 +19,11 @@ const split = z.object({
 })
 
 const uint64Max = (1n << 64n) - 1n
-const secondsPerDay = 86_400n
-const secondsPerWeek = 604_800n
+const subscriptionPeriodUnitSeconds = {
+  dev_second: 1n,
+  day: 86_400n,
+  week: 604_800n,
+} satisfies Record<SubscriptionPeriodUnit, bigint>
 
 const normalizedAddress = z.pipe(
   z.address(),
@@ -46,7 +49,11 @@ const subscriptionExpires = z
     ),
   )
 
-const subscriptionPeriodUnits = ['day', 'week'] as const satisfies readonly SubscriptionPeriodUnit[]
+const subscriptionPeriodUnits = [
+  'dev_second',
+  'day',
+  'week',
+] as const satisfies readonly SubscriptionPeriodUnit[]
 const subscriptionPeriodUnit = z.enum(subscriptionPeriodUnits)
 
 const uint64String = z
@@ -82,7 +89,8 @@ function subscriptionPeriodFitsUint64(value: unknown) {
     periodUnit: SubscriptionPeriodUnit
   }
   try {
-    const unitSeconds = periodUnit === 'day' ? secondsPerDay : secondsPerWeek
+    const unitSeconds = subscriptionPeriodUnitSeconds[periodUnit]
+    if (unitSeconds === undefined) return false
     return BigInt(periodCount) * unitSeconds <= uint64Max
   } catch {
     return false

--- a/src/tempo/client/Subscription.test.ts
+++ b/src/tempo/client/Subscription.test.ts
@@ -4,7 +4,10 @@ import { privateKeyToAccount } from 'viem/accounts'
 import { describe, expect, test } from 'vp/test'
 
 import * as Methods from '../Methods.js'
-import { signSubscriptionKeyAuthorization } from '../subscription/KeyAuthorization.js'
+import {
+  signSubscriptionKeyAuthorization,
+  transferWithMemoSelector,
+} from '../subscription/KeyAuthorization.js'
 import type { SubscriptionAccessKey } from '../subscription/Types.js'
 import { subscription } from './Subscription.js'
 
@@ -142,12 +145,7 @@ describe('tempo.subscription client', () => {
       scopes: [
         {
           address: expect.stringMatching(/^0x[0-9a-fA-F]{40}$/),
-          selector: expect.stringMatching(/^0x/),
-          recipients: expect.any(Array),
-        },
-        {
-          address: expect.stringMatching(/^0x[0-9a-fA-F]{40}$/),
-          selector: expect.stringMatching(/^0x/),
+          selector: transferWithMemoSelector,
           recipients: expect.any(Array),
         },
       ],

--- a/src/tempo/server/Subscription.test.ts
+++ b/src/tempo/server/Subscription.test.ts
@@ -1395,11 +1395,8 @@ describe('tempo.subscription', () => {
       reference: hashStale,
     })
 
-    const result = await renew({
-      getClient: async () => client,
-      store,
+    const result = await mppx.tempo.subscription.renew({
       subscriptionId: record.subscriptionId,
-      waitForConfirmation: false,
     })
 
     expect(result?.receipt.reference).toBe(hashBackground)

--- a/src/tempo/server/Subscription.ts
+++ b/src/tempo/server/Subscription.ts
@@ -41,6 +41,7 @@ import type {
 } from '../subscription/Types.js'
 
 type SubscriptionRequest = ReturnType<typeof Methods.subscription.schema.request.parse>
+type RenewalHandler = NonNullable<subscription.Parameters['renew']>
 
 /**
  * Creates a Tempo subscription method for recurring TIP-20 token payments.
@@ -67,22 +68,25 @@ export function subscription<const parameters extends subscription.Parameters>(
     periodCount,
     periodUnit,
     subscriptionExpires,
-    waitForConfirmation = true,
   } = parameters
 
-  const store = SubscriptionStore.fromStore(rawStore, {
-    activationTimeoutMs: parameters.activationTimeoutMs,
-    renewalTimeoutMs: parameters.renewalTimeoutMs,
+  const { recipient } = Account.resolve(parameters)
+  const context = createContext(parameters, {
+    store: rawStore,
+    options: {
+      activationTimeoutMs: parameters.activationTimeoutMs,
+      renewalTimeoutMs: parameters.renewalTimeoutMs,
+    },
   })
-  const { feePayer, recipient } = Account.resolve(parameters)
-  const getClient = ClientResolver.getResolver({
-    chain: tempo_chain,
-    getClient: parameters.getClient,
-    rpcUrl: defaults.rpcUrl,
-  })
+  const { feePayer, feePayerPolicy, getClient, store, waitForConfirmation } = context
 
   type Defaults = subscription.DeriveDefaults<parameters>
-  return Method.toServer<typeof Methods.subscription, Defaults>(Methods.subscription, {
+  const method = Method.toServer<
+    typeof Methods.subscription,
+    Defaults,
+    undefined,
+    subscription.Extensions
+  >(Methods.subscription, {
     defaults: {
       amount,
       currency,
@@ -94,6 +98,19 @@ export function subscription<const parameters extends subscription.Parameters>(
       recipient,
       subscriptionExpires,
     } as unknown as Defaults,
+    extensions: {
+      renew: (parameters) =>
+        renewWithContext({
+          context: {
+            ...context,
+            feePayerPolicy: parameters.feePayerPolicy
+              ? resolveFeePayerPolicy(context.feePayerPolicy, parameters.feePayerPolicy)
+              : context.feePayerPolicy,
+            waitForConfirmation: parameters.waitForConfirmation ?? context.waitForConfirmation,
+          },
+          subscriptionId: parameters.subscriptionId,
+        }),
+    },
 
     async authorize({ input, request }) {
       const resolved = await parameters.resolve({ input, request })
@@ -107,7 +124,7 @@ export function subscription<const parameters extends subscription.Parameters>(
       if (periodIndex > subscription.lastChargedPeriod) {
         const renew = resolveRenewalHandler({
           feePayer,
-          feePayerPolicy: parameters.feePayerPolicy,
+          feePayerPolicy,
           getClient,
           parameters,
           store,
@@ -226,7 +243,9 @@ export function subscription<const parameters extends subscription.Parameters>(
         (declaredSource.chainId !== verified.source.chainId ||
           !isAddressEqual(declaredSource.address, verified.source.address))
       ) {
-        throw new VerificationFailedError({ reason: 'credential source does not match signature' })
+        throw new VerificationFailedError({
+          reason: 'credential source does not match signature',
+        })
       }
 
       const activation = await store.activate({
@@ -240,7 +259,7 @@ export function subscription<const parameters extends subscription.Parameters>(
               auto: {
                 challengeId: credential.challenge.id,
                 feePayer,
-                feePayerPolicy: parameters.feePayerPolicy,
+                feePayerPolicy,
                 getClient,
                 keyAuthorization: (credential.payload as SubscriptionCredentialPayload).signature,
                 realm: credential.challenge.realm,
@@ -290,6 +309,19 @@ export function subscription<const parameters extends subscription.Parameters>(
       return activation.result.receipt
     },
   })
+  return method
+}
+
+// Access-key provisioning can cost around 4M gas.
+const defaultFeePayerPolicy = {
+  maxGas: 5_000_000n,
+  maxTotalFee: 200_000_000_000_000_000n,
+} satisfies Partial<FeePayer.Policy>
+
+function resolveFeePayerPolicy(
+  ...policies: (Partial<FeePayer.Policy> | undefined)[]
+): Partial<FeePayer.Policy> {
+  return Object.assign({}, defaultFeePayerPolicy, ...policies)
 }
 
 function requestFromCaptured(capturedRequest: Method.CapturedRequest | undefined): Request {
@@ -702,25 +734,11 @@ function resolveRenewalHandler(parameters: {
   feePayer?: ReturnType<typeof Account.resolve>['feePayer'] | undefined
   feePayerPolicy?: Partial<FeePayer.Policy> | undefined
   getClient: (parameters: { chainId?: number | undefined }) => MaybePromise<ViemClient>
-  parameters: {
-    renew?:
-      | ((parameters: {
-          inFlightReference: string
-          periodIndex: number
-          subscription: SubscriptionRecord
-        }) => Promise<subscription.RenewalResult>)
-      | undefined
-  }
+  parameters: Pick<createContext.Parameters, 'renew'>
   store: SubscriptionStore.SubscriptionStore
   subscription: SubscriptionRecord
   waitForConfirmation: boolean
-}):
-  | ((parameters: {
-      inFlightReference: string
-      periodIndex: number
-      subscription: SubscriptionRecord
-    }) => Promise<subscription.RenewalResult>)
-  | undefined {
+}): RenewalHandler | undefined {
   const {
     feePayer,
     feePayerPolicy,
@@ -829,7 +847,7 @@ async function submitSubscriptionPayment(parameters: {
     // (without `feePayer: true`) so viem returns the chain's full
     // proof-inclusive gas estimate. With `feePayer: true` viem sets a
     // dummy sig + null feePayerSignature, dropping signature and key
-    // authorization verification costs — see chainConfig.js FIXME. We add
+    // authorization verification costs -- see chainConfig.js FIXME. We add
     // a small buffer for fee-payer overhead, then flip `feePayer = true`
     // and re-sign with the fee-payer-sponsored envelope.
     const prepared = await prepareTransactionRequest(client, {
@@ -895,31 +913,41 @@ function createSubscriptionId() {
  * Returns the renewal result if the subscription was overdue, or `null` if already current.
  */
 export async function renew(parameters: renew.Parameters): Promise<renew.Result | null> {
-  const { store: rawStore, waitForConfirmation = true } = parameters
-  const store = SubscriptionStore.fromStore(rawStore, {
-    renewalTimeoutMs: parameters.renewalTimeoutMs,
-  })
-  const getClient = ClientResolver.getResolver({
-    chain: tempo_chain,
-    getClient: parameters.getClient,
-    rpcUrl: defaults.rpcUrl,
+  const context = createContext(parameters, {
+    store: parameters.store,
+    options: {
+      renewalTimeoutMs: parameters.renewalTimeoutMs,
+    },
   })
 
-  const record = await store.get(parameters.subscriptionId)
+  return renewWithContext({
+    context,
+    subscriptionId: parameters.subscriptionId,
+  })
+}
+
+async function renewWithContext(parameters: {
+  context: createContext.Return
+  subscriptionId: string
+}): Promise<renew.Result | null> {
+  const { context, subscriptionId } = parameters
+  const record = await context.store.get(subscriptionId)
   if (!record) return null
   if (!isActive(record)) return null
-  const active = await store.getByKey(record.lookupKey)
+  const active = await context.store.getByKey(record.lookupKey)
   if (active?.subscriptionId !== record.subscriptionId) return null
 
   const periodIndex = getPeriodIndex(record)
   if (periodIndex <= record.lastChargedPeriod) return null
 
   const renew = resolveRenewalHandler({
-    getClient,
-    parameters,
-    store,
+    feePayer: context.feePayer,
+    feePayerPolicy: context.feePayerPolicy,
+    getClient: context.getClient,
+    parameters: context.parameters,
+    store: context.store,
     subscription: record,
-    waitForConfirmation,
+    waitForConfirmation: context.waitForConfirmation,
   })
   if (!renew) return null
 
@@ -927,35 +955,41 @@ export async function renew(parameters: renew.Parameters): Promise<renew.Result 
     expectedLookupKey: record.lookupKey,
     periodIndex,
     renew,
-    store,
+    store: context.store,
     subscription: record,
   })
-  return renewal?.status === 'renewed' ? renewal.result : null
+  if (renewal?.status !== 'renewed') return null
+
+  await context.parameters.hooks?.renewed?.({
+    periodIndex,
+    receipt: renewal.result.receipt,
+    subscription: renewal.result.subscription,
+  })
+  return renewal.result
 }
 
 export declare namespace renew {
   /** Parameters for renewing an overdue subscription outside the request path. */
-  type Parameters = {
-    /** The subscription to renew. */
-    subscriptionId: string
-    /** Billing callback — same signature as the `renew` hook on {@link subscription}. */
-    renew?:
-      | ((parameters: {
-          /** Stable idempotency/reconciliation reference persisted before the renewal hook runs. */
-          inFlightReference: string
-          periodIndex: number
-          subscription: SubscriptionRecord
-        }) => Promise<subscription.RenewalResult>)
-      | undefined
-    /** Store containing subscription records. */
-    store: Store.AtomicStore<Record<string, unknown>>
-    /**
-     * Milliseconds before an in-flight renewal lock can be replaced.
-     * Keeps concurrent renewal safe while allowing recovery from abandoned attempts.
-     */
-    renewalTimeoutMs?: number | undefined
-    waitForConfirmation?: boolean | undefined
-  } & Client.getResolver.Parameters
+  type Parameters = Account.resolve.Parameters &
+    Client.getResolver.Parameters & {
+      /** The subscription to renew. */
+      subscriptionId: string
+      /** Billing callback -- same signature as the `renew` hook on {@link subscription}. */
+      renew?: subscription.Parameters['renew']
+      /** Store containing subscription records. */
+      store: Store.AtomicStore<Record<string, unknown>>
+      /**
+       * Milliseconds before an in-flight renewal lock can be replaced.
+       * Keeps concurrent renewal safe while allowing recovery from abandoned attempts.
+       */
+      renewalTimeoutMs?: number | undefined
+      /**
+       * Override the fee-payer policy for sponsored subscription payments.
+       * Useful when the access key renewal tx requires more gas than the default policy allows.
+       */
+      feePayerPolicy?: Partial<FeePayer.Policy> | undefined
+      waitForConfirmation?: boolean | undefined
+    }
 
   /** Renewal result returned by {@link renew}. */
   type Result = subscription.RenewalResult
@@ -975,6 +1009,23 @@ export declare namespace subscription {
   type RenewalResult = {
     receipt: SubscriptionReceiptValue
     subscription: SubscriptionRecord
+  }
+
+  /** Parameters for renewing through a configured `mppx.tempo.subscription` handler. */
+  type RenewParameters = {
+    /** The subscription to renew. */
+    subscriptionId: string
+    /**
+     * Override the fee-payer policy for sponsored subscription payments.
+     * Useful when the access key renewal tx requires more gas than the default policy allows.
+     */
+    feePayerPolicy?: Partial<FeePayer.Policy> | undefined
+    waitForConfirmation?: boolean | undefined
+  }
+
+  /** Handler extensions attached to `mppx.tempo.subscription`. */
+  type Extensions = {
+    renew: (parameters: RenewParameters) => Promise<renew.Result | null>
   }
 
   /** Request defaults supported by the subscription method. */
@@ -1070,4 +1121,42 @@ export declare namespace subscription {
   > & {
     decimals: number
   }
+}
+
+function createContext<const parameters extends createContext.Parameters>(
+  parameters: parameters,
+  options: createContext.Options,
+) {
+  const { feePayer } = Account.resolve(parameters)
+  const store = SubscriptionStore.fromStore(options.store, options.options)
+  const getClient = ClientResolver.getResolver({
+    chain: tempo_chain,
+    getClient: parameters.getClient,
+    rpcUrl: defaults.rpcUrl,
+  })
+  return {
+    feePayer,
+    feePayerPolicy: resolveFeePayerPolicy(parameters.feePayerPolicy),
+    getClient,
+    parameters,
+    store,
+    waitForConfirmation: parameters.waitForConfirmation ?? true,
+  }
+}
+
+declare namespace createContext {
+  type Parameters = Account.resolve.Parameters &
+    Client.getResolver.Parameters & {
+      feePayerPolicy?: Partial<FeePayer.Policy> | undefined
+      hooks?: subscription.Parameters['hooks']
+      renew?: subscription.Parameters['renew']
+      waitForConfirmation?: boolean | undefined
+    }
+
+  type Options = {
+    store: Store.AtomicStore<Record<string, unknown>>
+    options?: SubscriptionStore.fromStore.Options | undefined
+  }
+
+  type Return = ReturnType<typeof createContext>
 }

--- a/src/tempo/subscription/KeyAuthorization.test.ts
+++ b/src/tempo/subscription/KeyAuthorization.test.ts
@@ -11,6 +11,8 @@ import {
   toSubscriptionExpiryDate,
   toSubscriptionExpirySeconds,
   toSubscriptionPeriodSeconds,
+  transferSelector,
+  transferWithMemoSelector,
   verifySubscriptionKeyAuthorization,
 } from './KeyAuthorization.js'
 import type { SubscriptionAccessKey } from './Types.js'
@@ -89,13 +91,12 @@ describe('tempo subscription key authorization', () => {
     const request = parseRequest()
 
     expect(getSubscriptionScopes(request)).toMatchObject([
-      { address: currency, recipients: [recipient] },
-      { address: currency, recipients: [recipient] },
+      { address: currency, recipients: [recipient], selector: transferWithMemoSelector },
     ])
     expect(getSubscriptionRpcAllowedCalls(request)).toMatchObject([
       {
         target: currency,
-        selectorRules: [{ recipients: [recipient] }, { recipients: [recipient] }],
+        selectorRules: [{ recipients: [recipient], selector: transferWithMemoSelector }],
       },
     ])
   })
@@ -158,7 +159,10 @@ describe('tempo subscription key authorization', () => {
     const authorization = KeyAuthorization.deserialize(payload.signature)
     const transferOnly = KeyAuthorization.serialize({
       ...authorization,
-      scopes: authorization.scopes?.slice(0, 1),
+      scopes: authorization.scopes?.map((scope) => ({
+        ...scope,
+        selector: transferSelector,
+      })),
     })
 
     expect(() =>
@@ -181,6 +185,11 @@ describe('tempo subscription key authorization', () => {
         periodUnit: 'day',
       }),
     ).toThrow('subscription period cannot be represented exactly by this Tempo client')
+  })
+
+  test('accepts dev-prefixed subscription periods for development and tests', () => {
+    expect(toSubscriptionPeriodSeconds({ periodCount: '15', periodUnit: 'dev_second' })).toBe(15)
+    expect(toSubscriptionPeriodSeconds({ periodCount: '120', periodUnit: 'dev_second' })).toBe(120)
   })
 
   test('rejects subscription expiries that cannot be represented by Tempo key authorizations', () => {

--- a/src/tempo/subscription/KeyAuthorization.ts
+++ b/src/tempo/subscription/KeyAuthorization.ts
@@ -12,12 +12,15 @@ import type {
 /** 4-byte selector for TIP-20 `transfer(address,uint256)`. */
 export const transferSelector = '0xa9059cbb'
 
-/** 4-byte selector for TIP-20 `transferWithMemo(address,uint256,bytes)`. */
+/** 4-byte selector for TIP-20 `transferWithMemo(address,uint256,bytes32)`. */
 export const transferWithMemoSelector = '0x95777d59'
 
 const uint64Max = (1n << 64n) - 1n
-const secondsPerDay = 86_400n
-const secondsPerWeek = 604_800n
+const subscriptionPeriodUnitSeconds = {
+  dev_second: 1n,
+  day: 86_400n,
+  week: 604_800n,
+} satisfies Record<SubscriptionPeriodUnit, bigint>
 
 type SubscriptionRequest = ReturnType<typeof Methods.subscription.schema.request.parse>
 type Authorization = KeyAuthorization.KeyAuthorization
@@ -63,11 +66,11 @@ export function toSubscriptionPeriodSeconds(request: {
   if (!/^[1-9]\d*$/.test(request.periodCount)) {
     throw new VerificationFailedError({ reason: 'periodCount is invalid' })
   }
-  if (request.periodUnit !== 'day' && request.periodUnit !== 'week') {
+  const unitSeconds = subscriptionPeriodUnitSeconds[request.periodUnit]
+  if (unitSeconds === undefined) {
     throw new VerificationFailedError({ reason: 'periodUnit is invalid' })
   }
 
-  const unitSeconds = request.periodUnit === 'day' ? secondsPerDay : secondsPerWeek
   const value = BigInt(request.periodCount) * unitSeconds
   if (value > uint64Max) {
     throw new VerificationFailedError({
@@ -115,11 +118,6 @@ export function getSubscriptionScopes(
   return [
     {
       address: currency,
-      selector: transferSelector,
-      recipients: [recipient],
-    },
-    {
-      address: currency,
       selector: transferWithMemoSelector,
       recipients: [recipient],
     },
@@ -130,15 +128,11 @@ export function getSubscriptionScopes(
 export function getSubscriptionRpcAllowedCalls(
   request: Pick<SubscriptionRequest, 'currency' | 'recipient'>,
 ) {
-  const [transfer, transferWithMemo] = getSubscriptionScopes(request)
+  const [transferWithMemo] = getSubscriptionScopes(request)
   return [
     {
       target: normalizeAddress(request.currency, 'currency'),
       selectorRules: [
-        {
-          selector: transfer.selector,
-          recipients: transfer.recipients,
-        },
         {
           selector: transferWithMemo.selector,
           recipients: transferWithMemo.recipients,
@@ -325,9 +319,9 @@ function assertAuthorizationScopes(
   scopes: readonly KeyAuthorization.Scope[] | undefined,
   request: Pick<SubscriptionRequest, 'currency' | 'recipient'>,
 ) {
-  if (!scopes || scopes.length < 1 || scopes.length > 2) {
+  if (!scopes || scopes.length !== 1) {
     throw new VerificationFailedError({
-      reason: 'keyAuthorization must contain recipient-scoped transfer calls',
+      reason: 'keyAuthorization must contain a recipient-scoped transferWithMemo call',
     })
   }
 
@@ -353,9 +347,6 @@ function assertAuthorizationScopes(
     }
   }
 
-  if (!seen.has(transferSelector)) {
-    throw new VerificationFailedError({ reason: 'keyAuthorization must allow transfer' })
-  }
   if (!seen.has(transferWithMemoSelector)) {
     throw new VerificationFailedError({ reason: 'keyAuthorization must allow transferWithMemo' })
   }

--- a/src/tempo/subscription/Types.ts
+++ b/src/tempo/subscription/Types.ts
@@ -1,7 +1,7 @@
 import type { Address } from 'viem'
 
-/** Tempo-supported subscription period units. The shared intent also defines `month`, but Tempo cannot represent calendar-month periods exactly. */
-export type SubscriptionPeriodUnit = 'day' | 'week'
+/** Tempo-supported subscription period units. Use `day` or `week` in production; `dev_*` units are for development and tests. */
+export type SubscriptionPeriodUnit = 'dev_second' | 'day' | 'week'
 
 /** Access key information used to authorize recurring Tempo payments. */
 export type SubscriptionAccessKey = {


### PR DESCRIPTION
- Adds `mppx.tempo.subscription.renew({ subscriptionId })` for background subscription renewals on a configured subscription handler. The handler keeps the registered store, client, fee payer, confirmation behavior, and hooks attached through framework wrappers.

  ```diff
  - await tempo.renewSubscription({
  -   ...billing,
  -   store,
  -   subscriptionId,
  - })
  + await mppx.tempo.subscription.renew({
  +   subscriptionId,
  + })
  ```

- Raises the default subscription fee payer policy to cover access-key provisioning, which can cost around 4M gas. Callers can still override `feePayerPolicy` per subscription renewal.

- Removes the extra `transfer` access-key authorization scope from subscriptions. Subscription access-key auth now only requests the `transferWithMemo` scope used for subscription settlement.
