### PR TITLE
Add `secretKey` to session SSE `server.ts` example

### DIFF
--- a/examples/session/sse/src/server.ts
+++ b/examples/session/sse/src/server.ts
@@ -90,6 +90,11 @@ const store = Store.memory()
 
 // Mppx Server Instance
 
+// `Mppx.create()` requires a secret key so challenge IDs can be verified
+// statelessly. The example ships with a default demo key so `pnpm dev` works
+// out of the box, but still allows override via `MPP_SECRET_KEY`.
+const secretKey = process.env.MPP_SECRET_KEY ?? 'mppx-demo-websocket-secret'
+
 //
 // `Mppx.create()` assembles the payment handler from method intents.
 //
@@ -112,6 +117,7 @@ const store = Store.memory()
 //       Authorization header to configure the SSE metering loop
 //
 const mppx = Mppx.create({
+  secretKey,
   methods: [
     tempo.session({
       // The server's account — where settled funds are transferred to.

--- a/examples/session/sse/src/server.ts
+++ b/examples/session/sse/src/server.ts
@@ -93,7 +93,7 @@ const store = Store.memory()
 // `Mppx.create()` requires a secret key so challenge IDs can be verified
 // statelessly. The example ships with a default demo key so `pnpm dev` works
 // out of the box, but still allows override via `MPP_SECRET_KEY`.
-const secretKey = process.env.MPP_SECRET_KEY ?? 'mppx-demo-websocket-secret'
+const secretKey = process.env.MPP_SECRET_KEY ?? 'mppx-demo-sse-secret'
 
 //
 // `Mppx.create()` assembles the payment handler from method intents.


### PR DESCRIPTION
Prevents error thrown when attempting to run server.ts without setting MPP_SECRET_KEY as an environment variable.

```
Error: Missing secret key. Set the MPP_SECRET_KEY environment variable or pass `secretKey` to Mppx.create().
```

The [session WebSocket example](https://github.com/wevm/mppx/blob/main/examples/session/ws/src/server.ts#L51-L54) uses the same pattern. I copied it from there. It makes it easier to get started testing.