### PR TITLE
test(tempo): cover access key authorizations

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "testcontainers": "^11.14.0",
     "tsx": "^4.21.0",
     "typescript": "~6.0.3",
-    "viem": "^2.51.0",
+    "viem": "^2.51.3",
     "vite": "^8.0.10",
     "vp": "npm:vite-plus@~0.1.17",
     "ws": "^8.20.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,7 @@ overrides:
   protobufjs@<=7.5.7: 7.5.8
   uuid@<14.0.0: 14.0.0
   fast-uri@<=3.1.1: ^3.1.2
+  tmp@<0.2.6: 0.2.6
 
 importers:
 
@@ -4001,8 +4002,8 @@ packages:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
     engines: {node: ^20.0.0 || >=22.0.0}
 
-  tmp@0.2.5:
-    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+  tmp@0.2.6:
+    resolution: {integrity: sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==}
     engines: {node: '>=14.14'}
 
   to-regex-range@5.0.1:
@@ -7735,7 +7736,7 @@ snapshots:
       properties-reader: 3.0.1
       ssh-remote-port-forward: 1.0.4
       tar-fs: 3.1.2
-      tmp: 0.2.5
+      tmp: 0.2.6
       undici: 7.25.0
     transitivePeerDependencies:
       - bare-abort-controller
@@ -7760,7 +7761,7 @@ snapshots:
 
   tinypool@2.1.0: {}
 
-  tmp@0.2.5: {}
+  tmp@0.2.6: {}
 
   to-regex-range@5.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   vitest: npm:@voidzero-dev/vite-plus-test@~0.1.17
   typescript: ~5.9.3
   ox: 0.14.24
-  viem: ^2.51.0
+  viem: ^2.51.3
   path-to-regexp@<8.4.0: 8.4.0
   tar@<=7.5.10: 7.5.11
   '@modelcontextprotocol/sdk@>=1.10.0 <=1.25.3': 1.26.0
@@ -107,7 +107,7 @@ importers:
         version: 1.0.1
       tempo.ts:
         specifier: ^0.14.2
-        version: 0.14.2(typescript@5.9.3)(viem@2.51.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(zod@4.4.3)
+        version: 0.14.2(typescript@5.9.3)(viem@2.51.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(zod@4.4.3)
       testcontainers:
         specifier: ^11.14.0
         version: 11.14.0
@@ -118,8 +118,8 @@ importers:
         specifier: ~5.9.3
         version: 5.9.3
       viem:
-        specifier: ^2.51.0
-        version: 2.51.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+        specifier: ^2.51.3
+        version: 2.51.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       vite:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(tsx@4.21.0)(yaml@2.8.4)
@@ -154,8 +154,8 @@ importers:
         specifier: ~5.9.3
         version: 5.9.3
       viem:
-        specifier: ^2.51.0
-        version: 2.51.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+        specifier: ^2.51.3
+        version: 2.51.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       vite:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(tsx@4.22.3)(yaml@2.8.4)
@@ -184,11 +184,11 @@ importers:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
       viem:
-        specifier: ^2.51.0
-        version: 2.51.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+        specifier: ^2.51.3
+        version: 2.51.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       wagmi:
         specifier: ^3.6.13
-        version: 3.6.13(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.10(react@19.2.6))(@types/react@19.2.14)(accounts@0.10.2)(react@19.2.6)(typescript@5.9.3)(viem@2.51.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
+        version: 3.6.13(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.10(react@19.2.6))(@types/react@19.2.14)(accounts@0.10.2)(react@19.2.6)(typescript@5.9.3)(viem@2.51.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
     devDependencies:
       '@types/react':
         specifier: ^19.2.14
@@ -230,8 +230,8 @@ importers:
         specifier: ~5.9.3
         version: 5.9.3
       viem:
-        specifier: ^2.51.0
-        version: 2.51.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+        specifier: ^2.51.3
+        version: 2.51.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       vite:
         specifier: latest
         version: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.3)(yaml@2.8.4)
@@ -257,8 +257,8 @@ importers:
         specifier: ~5.9.3
         version: 5.9.3
       viem:
-        specifier: ^2.51.0
-        version: 2.51.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+        specifier: ^2.51.3
+        version: 2.51.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       vite:
         specifier: latest
         version: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.3)(yaml@2.8.4)
@@ -290,8 +290,8 @@ importers:
         specifier: ~5.9.3
         version: 5.9.3
       viem:
-        specifier: ^2.51.0
-        version: 2.51.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+        specifier: ^2.51.3
+        version: 2.51.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       vite:
         specifier: latest
         version: 8.0.14(@types/node@25.6.0)(esbuild@0.28.0)(tsx@4.21.0)(yaml@2.8.4)
@@ -347,8 +347,8 @@ importers:
         specifier: ~5.9.3
         version: 5.9.3
       viem:
-        specifier: ^2.51.0
-        version: 2.51.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+        specifier: ^2.51.3
+        version: 2.51.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       vite:
         specifier: latest
         version: 8.0.14(@types/node@25.6.2)(esbuild@0.28.0)(tsx@4.21.0)(yaml@2.8.4)
@@ -366,13 +366,13 @@ importers:
     dependencies:
       accounts:
         specifier: 0.10.2
-        version: 0.10.2(@types/react@19.2.14)(@wagmi/core@3.4.10)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.51.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.13)
+        version: 0.10.2(@types/react@19.2.14)(@wagmi/core@3.4.10)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.51.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.13)
       mppx:
         specifier: workspace:*
         version: link:../../../../..
       viem:
-        specifier: ^2.51.0
-        version: 2.51.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+        specifier: ^2.51.3
+        version: 2.51.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
 
 packages:
 
@@ -2180,7 +2180,7 @@ packages:
       accounts: ~0.10
       porto: ~0.2.35
       typescript: ~5.9.3
-      viem: ^2.51.0
+      viem: ^2.51.3
     peerDependenciesMeta:
       '@base-org/account':
         optional: true
@@ -2207,7 +2207,7 @@ packages:
       '@tanstack/query-core': '>=5.0.0'
       accounts: ~0.8.1
       typescript: ~5.9.3
-      viem: ^2.51.0
+      viem: ^2.51.3
     peerDependenciesMeta:
       '@tanstack/query-core':
         optional: true
@@ -2254,7 +2254,7 @@ packages:
       expo-secure-store: ^55.0.12
       expo-web-browser: ^55.0.13
       react: '>=18'
-      viem: ^2.51.0
+      viem: ^2.51.3
       wagmi: '>=0.0.0'
     peerDependenciesMeta:
       '@react-native-async-storage/async-storage':
@@ -3971,7 +3971,7 @@ packages:
   tempo.ts@0.14.2:
     resolution: {integrity: sha512-N4UkP2X/KDLmYUEIEWUDAk1m/USbKMzTjjUz1m0LwrIEVfoDlcSbBRc9jp14gLZcJVDlnq+fWHFVcH+GdrySgQ==}
     peerDependencies:
-      viem: ^2.51.0
+      viem: ^2.51.3
     peerDependenciesMeta:
       viem:
         optional: true
@@ -4127,8 +4127,8 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  viem@2.51.0:
-    resolution: {integrity: sha512-8C0Ca+eEapXE29vHMUW59NqKENl1X4s9P6xSNC9Nvw6EvAeAhn/LNUlgztk6TOw7KN1Gzz5a/n9Wv4okUfmY9g==}
+  viem@2.51.3:
+    resolution: {integrity: sha512-DA4EbrsvatzzLo6MwcWWiv6kI6dIr3I9HH9B6qsJaClN/s0AjIDUz5RIxl+VmGrovIUCcIvG8744yuGH7d37zw==}
     peerDependencies:
       typescript: ~5.9.3
     peerDependenciesMeta:
@@ -4232,7 +4232,7 @@ packages:
       '@tanstack/react-query': '>=5.0.0'
       react: '>=18'
       typescript: ~5.9.3
-      viem: ^2.51.0
+      viem: ^2.51.3
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -5785,23 +5785,23 @@ snapshots:
   '@voidzero-dev/vite-plus-win32-x64-msvc@0.1.18':
     optional: true
 
-  '@wagmi/connectors@8.0.12(@wagmi/core@3.4.10)(accounts@0.10.2)(typescript@5.9.3)(viem@2.51.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))':
+  '@wagmi/connectors@8.0.12(@wagmi/core@3.4.10)(accounts@0.10.2)(typescript@5.9.3)(viem@2.51.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))':
     dependencies:
-      '@wagmi/core': 3.4.10(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@0.10.2)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.51.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
-      viem: 2.51.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@wagmi/core': 3.4.10(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@0.10.2)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.51.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
+      viem: 2.51.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
     optionalDependencies:
-      accounts: 0.10.2(@types/react@19.2.14)(@wagmi/core@3.4.10)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.51.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.13)
+      accounts: 0.10.2(@types/react@19.2.14)(@wagmi/core@3.4.10)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.51.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.13)
       typescript: 5.9.3
 
-  '@wagmi/core@3.4.10(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@0.10.2)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.51.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))':
+  '@wagmi/core@3.4.10(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@0.10.2)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.51.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.9.3)
-      viem: 2.51.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      viem: 2.51.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       zustand: 5.0.0(@types/react@19.2.14)(react@19.2.6)(use-sync-external-store@1.4.0(react@19.2.6))
     optionalDependencies:
       '@tanstack/query-core': 5.100.10
-      accounts: 0.10.2(@types/react@19.2.14)(@wagmi/core@3.4.10)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.51.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.13)
+      accounts: 0.10.2(@types/react@19.2.14)(@wagmi/core@3.4.10)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.51.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.13)
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@types/react'
@@ -5828,7 +5828,7 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
-  accounts@0.10.2(@types/react@19.2.14)(@wagmi/core@3.4.10)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.51.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.13):
+  accounts@0.10.2(@types/react@19.2.14)(@wagmi/core@3.4.10)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.51.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.13):
     dependencies:
       hono: 4.12.22
       idb-keyval: 6.2.2
@@ -5839,10 +5839,10 @@ snapshots:
       zod: 4.4.3
       zustand: 5.0.13(@types/react@19.2.14)(react@19.2.6)(use-sync-external-store@1.4.0(react@19.2.6))
     optionalDependencies:
-      '@wagmi/core': 3.4.10(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@0.10.2)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.51.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
+      '@wagmi/core': 3.4.10(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@0.10.2)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.51.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
       react: 19.2.6
-      viem: 2.51.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
-      wagmi: 3.6.13(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.10(react@19.2.6))(@types/react@19.2.14)(accounts@0.10.2)(react@19.2.6)(typescript@5.9.3)(viem@2.51.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
+      viem: 2.51.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      wagmi: 3.6.13(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.10(react@19.2.6))(@types/react@19.2.14)(accounts@0.10.2)(react@19.2.6)(typescript@5.9.3)(viem@2.51.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -7708,12 +7708,12 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  tempo.ts@0.14.2(typescript@5.9.3)(viem@2.51.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(zod@4.4.3):
+  tempo.ts@0.14.2(typescript@5.9.3)(viem@2.51.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(zod@4.4.3):
     dependencies:
       '@remix-run/fetch-router': 0.17.0
       ox: 0.14.24(typescript@5.9.3)(zod@4.4.3)
     optionalDependencies:
-      viem: 2.51.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      viem: 2.51.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
     transitivePeerDependencies:
       - typescript
       - zod
@@ -7861,7 +7861,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  viem@2.51.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3):
+  viem@2.51.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
@@ -7995,14 +7995,14 @@ snapshots:
       tsx: 4.22.3
       yaml: 2.8.4
 
-  wagmi@3.6.13(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.10(react@19.2.6))(@types/react@19.2.14)(accounts@0.10.2)(react@19.2.6)(typescript@5.9.3)(viem@2.51.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)):
+  wagmi@3.6.13(@tanstack/query-core@5.100.10)(@tanstack/react-query@5.100.10(react@19.2.6))(@types/react@19.2.14)(accounts@0.10.2)(react@19.2.6)(typescript@5.9.3)(viem@2.51.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)):
     dependencies:
       '@tanstack/react-query': 5.100.10(react@19.2.6)
-      '@wagmi/connectors': 8.0.12(@wagmi/core@3.4.10)(accounts@0.10.2)(typescript@5.9.3)(viem@2.51.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
-      '@wagmi/core': 3.4.10(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@0.10.2)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.51.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
+      '@wagmi/connectors': 8.0.12(@wagmi/core@3.4.10)(accounts@0.10.2)(typescript@5.9.3)(viem@2.51.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
+      '@wagmi/core': 3.4.10(@tanstack/query-core@5.100.10)(@types/react@19.2.14)(accounts@0.10.2)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.51.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
       react: 19.2.6
       use-sync-external-store: 1.4.0(react@19.2.6)
-      viem: 2.51.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      viem: 2.51.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,7 +14,7 @@ overrides:
   vitest: 'npm:@voidzero-dev/vite-plus-test@~0.1.17'
   typescript: '~5.9.3'
   ox: '0.14.24'
-  viem: '^2.51.0'
+  viem: '^2.51.3'
   path-to-regexp@<8.4.0: '8.4.0'
   tar@<=7.5.10: '7.5.11'
   '@modelcontextprotocol/sdk@>=1.10.0 <=1.25.3': '1.26.0'
@@ -53,4 +53,4 @@ allowBuilds:
 minimumReleaseAgeExclude:
   - fast-uri@3.1.2
   - ox@0.14.24
-  - viem@2.51.0
+  - viem@2.51.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,6 +38,7 @@ overrides:
   protobufjs@<=7.5.7: '7.5.8'
   uuid@<14.0.0: '14.0.0'
   fast-uri@<=3.1.1: ^3.1.2
+  tmp@<0.2.6: '0.2.6'
 
 nodeOptions: '--disable-warning=ExperimentalWarning --disable-warning=DeprecationWarning'
 
@@ -53,4 +54,5 @@ allowBuilds:
 minimumReleaseAgeExclude:
   - fast-uri@3.1.2
   - ox@0.14.24
+  - tmp@0.2.6
   - viem@2.51.3

--- a/src/tempo/AccessKeyAuthorization.test.ts
+++ b/src/tempo/AccessKeyAuthorization.test.ts
@@ -1,0 +1,231 @@
+import { Challenge, Credential } from 'mppx'
+import { type Address, createClient, custom, type Hex } from 'viem'
+import {
+  Account as TempoAccount,
+  KeyAuthorizationManager,
+  Secp256k1,
+  Transaction,
+} from 'viem/tempo'
+import { beforeAll, describe, expect, test } from 'vp/test'
+import { nodeEnv } from '~test/config.js'
+import { deployEscrow, openChannel } from '~test/tempo/session.js'
+import { asset as currency, chain, http } from '~test/tempo/viem.js'
+
+import { createOpenPayload } from './client/ChannelOps.js'
+import { charge } from './client/Charge.js'
+import * as Methods from './Methods.js'
+import { closeOnChain, settleOnChain } from './session/Chain.js'
+import { signVoucher } from './session/Voucher.js'
+
+type ChargeCredentialPayload =
+  | { hash: Hex; type: 'hash' }
+  | { signature: Hex; type: 'proof' | 'transaction' }
+
+const rootAccount = TempoAccount.fromSecp256k1(
+  '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+)
+const recipient = '0x2222222222222222222222222222222222222222' as Address
+
+type ChargeRequest = ReturnType<typeof Methods.charge.schema.request.parse>
+
+function createChargeChallenge(
+  overrides: Partial<Parameters<typeof Methods.charge.schema.request.parse>[0]> = {},
+): Challenge.Challenge<ChargeRequest, 'charge', 'tempo'> {
+  const request = Methods.charge.schema.request.parse({
+    amount: '1000000',
+    chainId: chain.id,
+    currency,
+    decimals: 6,
+    recipient,
+    ...overrides,
+  })
+  return Challenge.from({
+    id: 'test-challenge-id',
+    intent: 'charge',
+    method: 'tempo',
+    realm: 'api.example.com',
+    request,
+  }) as Challenge.Challenge<ChargeRequest, 'charge', 'tempo'>
+}
+
+async function createAccessKeyClient() {
+  const keyAuthorizationManager = KeyAuthorizationManager.memory()
+  const accessKey = TempoAccount.fromSecp256k1(Secp256k1.randomPrivateKey(), {
+    access: rootAccount,
+    keyAuthorizationManager,
+  })
+  const keyAuthorization = await rootAccount.signKeyAuthorization(
+    {
+      accessKeyAddress: accessKey.accessKeyAddress,
+      keyType: accessKey.keyType,
+    },
+    {
+      chainId: BigInt(chain.id),
+    },
+  )
+  await keyAuthorizationManager.set(
+    {
+      accessKey: accessKey.accessKeyAddress,
+      address: rootAccount.address,
+      chainId: chain.id,
+    },
+    keyAuthorization,
+  )
+
+  const signedTransactions: Transaction.TransactionSerializedTempo[] = []
+  const rpcClient = createClient({ chain, transport: http() })
+
+  const client = createClient({
+    account: accessKey,
+    chain,
+    transport: custom({
+      async request({ method, params }: { method: string; params?: readonly unknown[] }) {
+        if (method === 'eth_sendRawTransaction' || method === 'eth_sendRawTransactionSync')
+          signedTransactions.push(params?.[0] as Transaction.TransactionSerializedTempo)
+        return rpcClient.request({ method, params } as never)
+      },
+    }),
+  })
+
+  return { accessKey, client, keyAuthorization, signedTransactions }
+}
+
+function expectTransactionKeyAuthorization(
+  serializedTransaction: Hex,
+  keyAuthorization: Awaited<ReturnType<typeof rootAccount.signKeyAuthorization>>,
+) {
+  const transaction = Transaction.deserialize(
+    serializedTransaction as Transaction.TransactionSerializedTempo,
+  )
+  expect(transaction.keyAuthorization).toEqual(keyAuthorization)
+}
+
+async function createChannelForPayee(payee: Address, escrowContract: Address) {
+  const payer = rootAccount
+  const { channelId } = await openChannel({
+    deposit: 10_000_000n,
+    escrow: escrowContract,
+    payee,
+    payer,
+    salt: Secp256k1.randomPrivateKey(),
+    token: currency,
+  })
+  const cumulativeAmount = 1_000_000n
+  const signature = await signVoucher(
+    createClient({ account: payer, chain, transport: http() }),
+    payer,
+    { channelId, cumulativeAmount },
+    escrowContract,
+    chain.id,
+  )
+
+  return { channelId, cumulativeAmount, escrowContract, signature }
+}
+
+describe.runIf(nodeEnv === 'localnet')('Tempo access-key authorization attachment', () => {
+  let escrowContract: Address
+
+  beforeAll(async () => {
+    escrowContract = await deployEscrow()
+  })
+
+  test('tempo.charge pull signs a prepared transaction with keyAuthorization', async () => {
+    const { accessKey, client, keyAuthorization } = await createAccessKeyClient()
+    const method = charge({
+      account: accessKey,
+      getClient: () => client,
+      mode: 'pull',
+    })
+
+    const credential = Credential.deserialize<ChargeCredentialPayload>(
+      await method.createCredential({
+        challenge: createChargeChallenge({ supportedModes: ['pull'] }),
+        context: {},
+      }),
+    )
+
+    expect(credential.payload.type).toBe('transaction')
+    if (credential.payload.type !== 'transaction') throw new Error('unexpected credential type')
+    expectTransactionKeyAuthorization(credential.payload.signature as Hex, keyAuthorization)
+  })
+
+  test('tempo.charge push fallback sends a prepared transaction with keyAuthorization', async () => {
+    const { accessKey, client, keyAuthorization, signedTransactions } =
+      await createAccessKeyClient()
+    const method = charge({
+      account: accessKey,
+      getClient: () => client,
+      mode: 'push',
+    })
+
+    const credential = Credential.deserialize<ChargeCredentialPayload>(
+      await method.createCredential({
+        challenge: createChargeChallenge({ supportedModes: ['push'] }),
+        context: {},
+      }),
+    )
+
+    expect(credential.payload.type).toBe('hash')
+    expect(signedTransactions).toHaveLength(1)
+    expectTransactionKeyAuthorization(signedTransactions[0]!, keyAuthorization)
+  })
+
+  test('tempo.session open signs a prepared transaction with keyAuthorization', async () => {
+    const { accessKey, client, keyAuthorization } = await createAccessKeyClient()
+
+    const { payload } = await createOpenPayload(client, accessKey, {
+      chainId: chain.id,
+      currency,
+      deposit: 5_000_000n,
+      escrowContract,
+      initialAmount: 1_000_000n,
+      payee: recipient,
+    })
+
+    expect(payload.action).toBe('open')
+    if (payload.action !== 'open') throw new Error('unexpected payload action')
+    expectTransactionKeyAuthorization(payload.transaction, keyAuthorization)
+  })
+
+  test('tempo.session settle sends a prepared transaction with keyAuthorization', async () => {
+    const { accessKey, client, keyAuthorization, signedTransactions } =
+      await createAccessKeyClient()
+    const channel = await createChannelForPayee(rootAccount.address, escrowContract)
+
+    const hash = await settleOnChain(
+      client,
+      channel.escrowContract,
+      {
+        channelId: channel.channelId,
+        cumulativeAmount: channel.cumulativeAmount,
+        signature: channel.signature,
+      },
+      { account: accessKey },
+    )
+
+    expect(hash).toMatch(/^0x[0-9a-f]{64}$/)
+    expect(signedTransactions).toHaveLength(1)
+    expectTransactionKeyAuthorization(signedTransactions[0]!, keyAuthorization)
+  })
+
+  test('tempo.session close sends a prepared transaction with keyAuthorization', async () => {
+    const { accessKey, client, keyAuthorization, signedTransactions } =
+      await createAccessKeyClient()
+    const channel = await createChannelForPayee(rootAccount.address, escrowContract)
+
+    const hash = await closeOnChain(
+      client,
+      channel.escrowContract,
+      {
+        channelId: channel.channelId,
+        cumulativeAmount: channel.cumulativeAmount,
+        signature: channel.signature,
+      },
+      { account: accessKey },
+    )
+
+    expect(hash).toMatch(/^0x[0-9a-f]{64}$/)
+    expect(signedTransactions).toHaveLength(1)
+    expectTransactionKeyAuthorization(signedTransactions[0]!, keyAuthorization)
+  })
+})


### PR DESCRIPTION
## Summary
Bump viem + Add test coverage for all MPP payment paths that tests that access key accounts using a key authorization manager will attach the key authorization on the first transaction.

## Motivation
Previously access keys accounts could only be used if previously registered onchain. The latest version of viem allows access key accounts to attach an authorization manager that viem will use to attach authorization during prepareTransactionRequest.

## Changes
- Updated viem to 2.51.3 in package.json and pnpm-workspace.yaml which had a fix for failing getMetadata calls when sent from an unauthorized access key account
- Added src/tempo/AccessKeyAuthorization.test.ts for charge pull, charge push fallback, session open, session settle, and session close.
- Asserted generated Tempo transactions include the pending keyAuthorization from KeyAuthorizationManager.

## Testing
- CI=true ./node_modules/.bin/vp test src/tempo/AccessKeyAuthorization.test.ts
- CI=true pnpm check:types
- CI=true pnpm check