### PR TITLE
fix: preserve charge constraint defaults

### DIFF
--- a/.changeset/veria-140-charge-default-constraints.md
+++ b/.changeset/veria-140-charge-default-constraints.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Preserved charge supported modes and split payment defaults in challenges.

--- a/src/tempo/server/Charge.test.ts
+++ b/src/tempo/server/Charge.test.ts
@@ -3654,6 +3654,57 @@ describe('tempo', () => {
       })
       expect(challenge.request.methodDetails?.supportedModes).toEqual(['pull'])
     })
+
+    test('challenge contains supportedModes from method defaults', async () => {
+      const handler = Mppx_server.create({
+        methods: [
+          tempo_server.charge({
+            getClient: () => client,
+            account: accounts[0].address,
+            currency: asset,
+            supportedModes: ['pull'],
+          }),
+        ],
+        realm,
+        secretKey,
+      })
+
+      const result = await handler.charge({ amount: '1' })(new Request('https://example.com'))
+      expect(result.status).toBe(402)
+      if (result.status !== 402) throw new Error()
+
+      const challenge = Challenge.fromResponse(result.challenge, {
+        methods: [tempo_client.charge()],
+      })
+      expect(challenge.request.methodDetails?.supportedModes).toEqual(['pull'])
+    })
+
+    test('challenge contains splits from method defaults', async () => {
+      const split = { amount: '0.2', recipient: accounts[2].address }
+      const handler = Mppx_server.create({
+        methods: [
+          tempo_server.charge({
+            getClient: () => client,
+            account: accounts[0].address,
+            currency: asset,
+            splits: [split],
+          }),
+        ],
+        realm,
+        secretKey,
+      })
+
+      const result = await handler.charge({ amount: '1' })(new Request('https://example.com'))
+      expect(result.status).toBe(402)
+      if (result.status !== 402) throw new Error()
+
+      const challenge = Challenge.fromResponse(result.challenge, {
+        methods: [tempo_client.charge()],
+      })
+      expect(challenge.request.methodDetails?.splits).toEqual([
+        { amount: '200000', recipient: split.recipient },
+      ])
+    })
   })
 
   describe('attribution memo', () => {

--- a/src/tempo/server/Charge.test.ts
+++ b/src/tempo/server/Charge.test.ts
@@ -3679,6 +3679,24 @@ describe('tempo', () => {
       expect(challenge.request.methodDetails?.supportedModes).toEqual(['pull'])
     })
 
+    test('stable binding contains supportedModes', () => {
+      const method = tempo_server.charge({
+        getClient: () => client,
+        account: accounts[0].address,
+        currency: asset,
+      })
+      const request = method.schema.request.parse({
+        amount: '1',
+        currency: asset,
+        decimals: 6,
+        supportedModes: ['pull'],
+      })
+
+      expect(method.stableBinding?.(request)).toMatchObject({
+        supportedModes: ['pull'],
+      })
+    })
+
     test('challenge contains splits from method defaults', async () => {
       const split = { amount: '0.2', recipient: accounts[2].address }
       const handler = Mppx_server.create({

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -102,6 +102,8 @@ export function charge<const parameters extends charge.Parameters>(
       supportedModes,
     } as unknown as Defaults,
 
+    stableBinding: chargeBinding,
+
     html: html
       ? {
           config: {},
@@ -581,6 +583,32 @@ export declare namespace charge {
   }
 
   type FeePayerPolicy = Partial<FeePayer.Policy>
+}
+
+type ChargeRequest = z.output<typeof Methods.charge.schema.request>
+
+function chargeBinding(request: ChargeRequest) {
+  // Exhaustively destructure so new charge request fields require an explicit binding decision.
+  const { amount, currency, description, externalId, methodDetails, recipient, ...requestRest } =
+    request
+  requestRest satisfies Record<string, never>
+
+  const { chainId, feePayer, memo, splits, supportedModes, ...methodDetailsRest } =
+    methodDetails ?? {}
+  methodDetailsRest satisfies Record<string, never>
+  void feePayer
+
+  return {
+    amount,
+    chainId,
+    currency,
+    description,
+    externalId,
+    memo,
+    recipient,
+    splits,
+    supportedModes,
+  }
 }
 
 type ExpectedTransfer = {

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -63,6 +63,8 @@ export function charge<const parameters extends charge.Parameters>(
     feePayerPolicy,
     html,
     memo,
+    splits,
+    supportedModes,
     validateSender,
     waitForConfirmation = true,
   } = parameters
@@ -96,6 +98,8 @@ export function charge<const parameters extends charge.Parameters>(
       externalId,
       memo,
       recipient,
+      splits,
+      supportedModes,
     } as unknown as Defaults,
 
     html: html


### PR DESCRIPTION
## Summary

Preserves charge supported modes and split payment defaults in generated challenges.