### PR TITLE
fix: validate relay-sponsored session calls

### DIFF
--- a/.changeset/veria-292-session-fee-payer-validation.md
+++ b/.changeset/veria-292-session-fee-payer-validation.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Applied strict session fee-payer call validation to relay-sponsored transactions.

--- a/src/tempo/server/Session.ts
+++ b/src/tempo/server/Session.ts
@@ -226,6 +226,7 @@ export function session<const parameters extends session.Parameters>(
             payload,
             methodDetails,
             resolvedFeePayer,
+            methodDetails.feePayer === true,
             feePayerPolicy,
             waitForConfirmation,
           )
@@ -240,6 +241,7 @@ export function session<const parameters extends session.Parameters>(
             payload,
             methodDetails,
             resolvedFeePayer,
+            methodDetails.feePayer === true,
             feePayerPolicy,
           )
           lastOnChainVerified.set(sessionReceipt.channelId, Date.now())
@@ -635,6 +637,7 @@ async function handleOpen(
   payload: SessionCredentialPayload & { action: 'open' },
   methodDetails: SessionMethodDetails,
   feePayer: viem_Account | undefined,
+  isSponsored: boolean,
   feePayerPolicy: session.FeePayerPolicy | undefined,
   waitForConfirmation: boolean,
 ): Promise<SessionReceipt> {
@@ -687,6 +690,7 @@ async function handleOpen(
     challengeExpires: challenge.expires,
     feePayerPolicy,
     feePayer,
+    isSponsored,
     beforeBroadcast: async (pendingOnChain) => {
       await validateOpenVoucher(pendingOnChain)
     },
@@ -772,6 +776,7 @@ async function handleTopUp(
   payload: SessionCredentialPayload & { action: 'topUp' },
   methodDetails: SessionMethodDetails,
   feePayer: viem_Account | undefined,
+  isSponsored: boolean,
   feePayerPolicy: session.FeePayerPolicy | undefined,
 ): Promise<SessionReceipt> {
   const channelId = ChannelStore.normalizeChannelId(payload.channelId)
@@ -793,6 +798,7 @@ async function handleTopUp(
     challengeExpires: challenge.expires,
     feePayerPolicy,
     feePayer,
+    isSponsored,
   })
 
   const updated = await store.updateChannel(channelId, (current) => {

--- a/src/tempo/session/Chain.test.ts
+++ b/src/tempo/session/Chain.test.ts
@@ -310,7 +310,7 @@ describe.runIf(isLocalnet)('on-chain', () => {
       expect(result.onChain.finalized).toBe(false)
     })
 
-    test('fee-payer: rejects unauthorized calls', async () => {
+    test('fee-payer relay: rejects unauthorized open calls', async () => {
       const salt = nextSalt()
       const deposit = 5_000_000n
 
@@ -349,7 +349,7 @@ describe.runIf(isLocalnet)('on-chain', () => {
           channelId,
           recipient,
           currency,
-          feePayer: accounts[0],
+          isSponsored: true,
         }),
       ).rejects.toThrow('fee-sponsored open transaction contains an unauthorized call')
     })
@@ -798,7 +798,7 @@ describe.runIf(isLocalnet)('on-chain', () => {
       expect(result.newDeposit).toBe(deposit + topUpAmount)
     })
 
-    test('fee-payer: rejects unauthorized calls', async () => {
+    test('fee-payer relay: rejects unauthorized topUp calls', async () => {
       const salt = nextSalt()
       const deposit = 5_000_000n
       const topUpAmount = 3_000_000n
@@ -847,7 +847,7 @@ describe.runIf(isLocalnet)('on-chain', () => {
           currency: asset,
           declaredDeposit: topUpAmount,
           previousDeposit: deposit,
-          feePayer: accounts[0],
+          isSponsored: true,
         }),
       ).rejects.toThrow('fee-sponsored topUp transaction contains an unauthorized call')
     })

--- a/src/tempo/session/Chain.ts
+++ b/src/tempo/session/Chain.ts
@@ -466,6 +466,7 @@ export async function broadcastOpenTransaction(parameters: {
   challengeExpires?: string | undefined
   feePayerPolicy?: Partial<FeePayer.Policy> | undefined
   feePayer?: Account | undefined
+  isSponsored?: boolean | undefined
   beforeBroadcast?: ((onChain: OnChainChannel) => Promise<void> | void) | undefined
   /** When false, simulates instead of waiting for confirmation and returns derived on-chain state. @default true */
   waitForConfirmation?: boolean | undefined
@@ -480,11 +481,12 @@ export async function broadcastOpenTransaction(parameters: {
     challengeExpires,
     feePayerPolicy,
     feePayer,
+    isSponsored = Boolean(feePayer),
     beforeBroadcast,
     waitForConfirmation = true,
   } = parameters
 
-  if (feePayer && !FeePayer.isTempoTransaction(serializedTransaction))
+  if (isSponsored && !FeePayer.isTempoTransaction(serializedTransaction))
     throw new BadRequestError({
       reason: 'Only Tempo (0x76/0x78) transactions are supported',
     })
@@ -493,11 +495,11 @@ export async function broadcastOpenTransaction(parameters: {
     serializedTransaction as Transaction.TransactionSerializedTempo,
   )
 
-  if (feePayer) assertSenderSigned(transaction)
+  if (isSponsored) assertSenderSigned(transaction)
 
   const calls = transaction.calls ?? []
 
-  const sponsoredOpenCall = feePayer
+  const sponsoredOpenCall = isSponsored
     ? validateSponsoredOpenCalls({
         calls,
         currency,
@@ -669,6 +671,7 @@ export async function broadcastTopUpTransaction(parameters: {
   challengeExpires?: string | undefined
   feePayerPolicy?: Partial<FeePayer.Policy> | undefined
   feePayer?: Account | undefined
+  isSponsored?: boolean | undefined
 }): Promise<{ txHash: Hex; newDeposit: bigint }> {
   const {
     client,
@@ -681,9 +684,10 @@ export async function broadcastTopUpTransaction(parameters: {
     challengeExpires,
     feePayerPolicy,
     feePayer,
+    isSponsored = Boolean(feePayer),
   } = parameters
 
-  if (feePayer && !FeePayer.isTempoTransaction(serializedTransaction))
+  if (isSponsored && !FeePayer.isTempoTransaction(serializedTransaction))
     throw new BadRequestError({
       reason: 'Only Tempo (0x76/0x78) transactions are supported',
     })
@@ -692,11 +696,11 @@ export async function broadcastTopUpTransaction(parameters: {
     serializedTransaction as Transaction.TransactionSerializedTempo,
   )
 
-  if (feePayer) assertSenderSigned(transaction)
+  if (isSponsored) assertSenderSigned(transaction)
 
   const calls = transaction.calls ?? []
 
-  const sponsoredTopUpCall = feePayer
+  const sponsoredTopUpCall = isSponsored
     ? validateSponsoredTopUpCalls({
         calls,
         currency,


### PR DESCRIPTION
## Summary

Applies strict session fee-payer call validation to relay-sponsored transactions.