### PR TITLE
fix: require captured request for session verification

### DIFF
--- a/.changeset/veria-226-session-verify-captured-request.md
+++ b/.changeset/veria-226-session-verify-captured-request.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Required captured request context for standalone Tempo session verification.

--- a/src/server/Mppx.test.ts
+++ b/src/server/Mppx.test.ts
@@ -4899,7 +4899,17 @@ describe('verifyCredential', () => {
     const openCredential = Credential.deserialize(serializedOpenCredential)
     expect(openCredential.payload).toMatchObject({ action: 'open' })
 
-    const openReceipt = await server.verifyCredential(serializedOpenCredential)
+    const managementRequest = {
+      headers: new Headers(),
+      hasBody: false,
+      method: 'POST',
+      url: new URL(httpServer.url),
+    } as const
+
+    const openReceipt = await server.verifyCredential(serializedOpenCredential, {
+      capturedRequest: managementRequest,
+      request: { amount: '1', unitType: 'request' },
+    })
 
     expect(openReceipt.status).toBe('success')
     expect(openReceipt.method).toBe('tempo')
@@ -4911,7 +4921,10 @@ describe('verifyCredential', () => {
     const voucherCredential = Credential.deserialize(serializedVoucherCredential)
     expect(voucherCredential.payload).toMatchObject({ action: 'voucher' })
 
-    const voucherReceipt = await server.verifyCredential(serializedVoucherCredential)
+    const voucherReceipt = await server.verifyCredential(serializedVoucherCredential, {
+      capturedRequest: managementRequest,
+      request: { amount: '1', unitType: 'request' },
+    })
 
     expect(voucherReceipt.status).toBe('success')
     expect(voucherReceipt.method).toBe('tempo')
@@ -4955,7 +4968,15 @@ describe('verifyCredential', () => {
     const serializedOpenCredential = await clientMppx.createCredential(
       openChallengeResponse.challenge,
     )
-    await server.verifyCredential(serializedOpenCredential)
+    await server.verifyCredential(serializedOpenCredential, {
+      capturedRequest: {
+        headers: new Headers(),
+        hasBody: false,
+        method: 'POST',
+        url: new URL('https://example.com/session'),
+      },
+      request: { amount: '1', unitType: 'request' },
+    })
 
     const voucherChallengeResponse = await route(new Request('https://example.com/session'))
     expect(voucherChallengeResponse.status).toBe(402)
@@ -5073,5 +5094,53 @@ describe('verifyCredential', () => {
     const receipt = await mppx.verifyCredential(serialized)
 
     expect(receipt.status).toBe('success')
+  })
+
+  test('standalone tempo session verification requires capturedRequest for billable credentials', async () => {
+    const tempoSession = Method.from({
+      name: 'tempo',
+      intent: 'session',
+      schema: {
+        credential: {
+          payload: z.discriminatedUnion('action', [
+            z.object({ action: z.literal('open'), token: z.string() }),
+            z.object({ action: z.literal('voucher'), token: z.string() }),
+            z.object({ action: z.literal('topUp'), token: z.string() }),
+            z.object({ action: z.literal('close'), token: z.string() }),
+          ]),
+        },
+        request: z.object({
+          amount: z.string(),
+          currency: z.string(),
+          recipient: z.string(),
+          unitType: z.string(),
+        }),
+      },
+    })
+    let verifyCalled = false
+    const server = Mppx.create({
+      methods: [
+        Method.toServer(tempoSession, {
+          async verify() {
+            verifyCalled = true
+            return mockReceipt('tempo-session')
+          },
+        }),
+      ],
+      realm,
+      secretKey,
+    })
+    const challenge = await server.challenge.tempo.session({
+      amount: '1',
+      currency: 'USD',
+      recipient: 'merchant',
+      unitType: 'request',
+    })
+    const credential = Credential.serialize(
+      Credential.from({ challenge, payload: { action: 'voucher', token: 'valid' } }),
+    )
+
+    await expect(server.verifyCredential(credential)).rejects.toThrow('requires capturedRequest')
+    expect(verifyCalled).toBe(false)
   })
 })

--- a/src/server/Mppx.test.ts
+++ b/src/server/Mppx.test.ts
@@ -4322,6 +4322,17 @@ describe('verifyCredential', () => {
     recipient: '0x0000000000000000000000000000000000000002',
   }
 
+  const sessionRouteRequest = { amount: '1', unitType: 'request' } as const
+
+  function capturedRequest(url: string, method = 'GET'): Method.CapturedRequest {
+    return {
+      headers: new Headers(),
+      hasBody: false,
+      method,
+      url: new URL(url),
+    }
+  }
+
   test('verifies a serialized credential string (charge)', async () => {
     verifyArgs = undefined
     const mppx = Mppx.create({
@@ -4899,16 +4910,12 @@ describe('verifyCredential', () => {
     const openCredential = Credential.deserialize(serializedOpenCredential)
     expect(openCredential.payload).toMatchObject({ action: 'open' })
 
-    const managementRequest = {
-      headers: new Headers(),
-      hasBody: false,
-      method: 'POST',
-      url: new URL(httpServer.url),
-    } as const
+    // POST is treated as session management, not a billable content request.
+    const managementRequest = capturedRequest(httpServer.url, 'POST')
 
     const openReceipt = await server.verifyCredential(serializedOpenCredential, {
       capturedRequest: managementRequest,
-      request: { amount: '1', unitType: 'request' },
+      request: sessionRouteRequest,
     })
 
     expect(openReceipt.status).toBe('success')
@@ -4923,7 +4930,7 @@ describe('verifyCredential', () => {
 
     const voucherReceipt = await server.verifyCredential(serializedVoucherCredential, {
       capturedRequest: managementRequest,
-      request: { amount: '1', unitType: 'request' },
+      request: sessionRouteRequest,
     })
 
     expect(voucherReceipt.status).toBe('success')
@@ -4969,13 +4976,8 @@ describe('verifyCredential', () => {
       openChallengeResponse.challenge,
     )
     await server.verifyCredential(serializedOpenCredential, {
-      capturedRequest: {
-        headers: new Headers(),
-        hasBody: false,
-        method: 'POST',
-        url: new URL('https://example.com/session'),
-      },
-      request: { amount: '1', unitType: 'request' },
+      capturedRequest: capturedRequest('https://example.com/session', 'POST'),
+      request: sessionRouteRequest,
     })
 
     const voucherChallengeResponse = await route(new Request('https://example.com/session'))
@@ -4985,21 +4987,17 @@ describe('verifyCredential', () => {
     const serializedVoucherCredential = await clientMppx.createCredential(
       voucherChallengeResponse.challenge,
     )
-    const contentRequest = {
-      headers: new Headers(),
-      hasBody: false,
-      method: 'GET',
-      url: new URL('https://example.com/session'),
-    } as const
-    const routeRequest = { amount: '1', unitType: 'request' } as const
+    // GET is treated as a billable content request, so repeated voucher
+    // verification must consume additional session units.
+    const contentRequest = capturedRequest('https://example.com/session')
 
     const firstReceipt = (await server.verifyCredential(serializedVoucherCredential, {
       capturedRequest: contentRequest,
-      request: routeRequest,
+      request: sessionRouteRequest,
     })) as SessionReceipt
     const secondReceipt = (await server.verifyCredential(serializedVoucherCredential, {
       capturedRequest: contentRequest,
-      request: routeRequest,
+      request: sessionRouteRequest,
     })) as SessionReceipt
 
     expect(BigInt(firstReceipt.spent)).toBeGreaterThan(0n)
@@ -5096,51 +5094,54 @@ describe('verifyCredential', () => {
     expect(receipt.status).toBe('success')
   })
 
-  test('standalone tempo session verification requires capturedRequest for billable credentials', async () => {
-    const tempoSession = Method.from({
-      name: 'tempo',
-      intent: 'session',
-      schema: {
-        credential: {
-          payload: z.discriminatedUnion('action', [
-            z.object({ action: z.literal('open'), token: z.string() }),
-            z.object({ action: z.literal('voucher'), token: z.string() }),
-            z.object({ action: z.literal('topUp'), token: z.string() }),
-            z.object({ action: z.literal('close'), token: z.string() }),
-          ]),
-        },
-        request: z.object({
-          amount: z.string(),
-          currency: z.string(),
-          recipient: z.string(),
-          unitType: z.string(),
-        }),
-      },
-    })
-    let verifyCalled = false
-    const server = Mppx.create({
-      methods: [
-        Method.toServer(tempoSession, {
-          async verify() {
-            verifyCalled = true
-            return mockReceipt('tempo-session')
+  test.each(['open', 'voucher'] as const)(
+    'standalone tempo session verification requires capturedRequest for %s credentials',
+    async (action) => {
+      const tempoSession = Method.from({
+        name: 'tempo',
+        intent: 'session',
+        schema: {
+          credential: {
+            payload: z.discriminatedUnion('action', [
+              z.object({ action: z.literal('open'), token: z.string() }),
+              z.object({ action: z.literal('voucher'), token: z.string() }),
+              z.object({ action: z.literal('topUp'), token: z.string() }),
+              z.object({ action: z.literal('close'), token: z.string() }),
+            ]),
           },
-        }),
-      ],
-      realm,
-      secretKey,
-    })
-    const challenge = await server.challenge.tempo.session({
-      amount: '1',
-      currency: 'USD',
-      recipient: 'merchant',
-      unitType: 'request',
-    })
-    const credential = Credential.serialize(
-      Credential.from({ challenge, payload: { action: 'voucher', token: 'valid' } }),
-    )
+          request: z.object({
+            amount: z.string(),
+            currency: z.string(),
+            recipient: z.string(),
+            unitType: z.string(),
+          }),
+        },
+      })
+      let verifyCalled = false
+      const server = Mppx.create({
+        methods: [
+          Method.toServer(tempoSession, {
+            async verify() {
+              verifyCalled = true
+              return mockReceipt('tempo-session')
+            },
+          }),
+        ],
+        realm,
+        secretKey,
+      })
+      const challenge = await server.challenge.tempo.session({
+        amount: '1',
+        currency: 'USD',
+        recipient: 'merchant',
+        unitType: 'request',
+      })
+      const credential = Credential.serialize(
+        Credential.from({ challenge, payload: { action, token: 'valid' } }),
+      )
 
-    await expect(server.verifyCredential(credential)).rejects.toThrow('requires capturedRequest')
-    expect(verifyCalled).toBe(false)
-  })
+      await expect(server.verifyCredential(credential)).rejects.toThrow('requires capturedRequest')
+      expect(verifyCalled).toBe(false)
+    },
+  )
 })

--- a/src/server/Mppx.ts
+++ b/src/server/Mppx.ts
@@ -255,6 +255,7 @@ export type Mppx<
      * const receipt = await mppx.verifyCredential('eyJjaGFsbGVuZ2...')
      * const receipt = await mppx.verifyCredential(credential)
      * const receipt = await mppx.verifyCredential(credential, { request: { amount: '1000' } })
+     * const receipt = await mppx.verifyCredential(credential, { capturedRequest: request })
      * ```
      */
     verifyCredential(
@@ -561,6 +562,24 @@ export function create<
         submittedChallenge: credential.challenge,
       })
       throw e
+    }
+
+    if (
+      options?.capturedRequest === undefined &&
+      requiresCapturedRequestForStandaloneVerify(parsedCredential)
+    ) {
+      const error = new Errors.BadRequestError({
+        reason:
+          'standalone tempo.session verification requires capturedRequest for open and voucher credentials',
+      })
+      await emitStandalonePaymentFailed({
+        challenge: credential.challenge,
+        credential: parsedCredential,
+        error,
+        request: credential.challenge.request as Record<string, unknown>,
+        submittedChallenge: credential.challenge,
+      })
+      throw error
     }
 
     const expectedMeta = Scope.merge({ meta: options?.meta, scope: options?.scope })
@@ -1941,6 +1960,13 @@ function hydrateCredentialMeta<payload>(
     ...credential,
     challenge: hydratedChallenge,
   }
+}
+
+function requiresCapturedRequestForStandaloneVerify(credential: Credential.Credential): boolean {
+  if (credential.challenge.method !== 'tempo') return false
+  if (credential.challenge.intent !== 'session') return false
+  const action = (credential.payload as { action?: unknown }).action
+  return action === 'open' || action === 'voucher'
 }
 
 function withParsedCredentialPayload<payload>(

--- a/src/server/Mppx.ts
+++ b/src/server/Mppx.ts
@@ -564,6 +564,9 @@ export function create<
       throw e
     }
 
+    // tempo.session bills open/voucher credentials only when the submitted
+    // request is a content request. Standalone verification has no transport
+    // input, so callers must provide the captured request snapshot explicitly.
     if (
       options?.capturedRequest === undefined &&
       requiresCapturedRequestForStandaloneVerify(parsedCredential)
@@ -1963,10 +1966,12 @@ function hydrateCredentialMeta<payload>(
 }
 
 function requiresCapturedRequestForStandaloneVerify(credential: Credential.Credential): boolean {
-  if (credential.challenge.method !== 'tempo') return false
-  if (credential.challenge.intent !== 'session') return false
   const action = (credential.payload as { action?: unknown }).action
-  return action === 'open' || action === 'voucher'
+  return (
+    credential.challenge.method === 'tempo' &&
+    credential.challenge.intent === 'session' &&
+    (action === 'open' || action === 'voucher')
+  )
 }
 
 function withParsedCredentialPayload<payload>(


### PR DESCRIPTION
## Summary

Requires captured request context for standalone Tempo session voucher and open verification.