### PR TITLE
fix: require expiring nonce for fee payer

### DIFF
--- a/.changeset/veria-306-expiring-nonce-key.md
+++ b/.changeset/veria-306-expiring-nonce-key.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Required expiring nonce keys for fee-sponsored transactions.

--- a/src/tempo/internal/fee-payer.test.ts
+++ b/src/tempo/internal/fee-payer.test.ts
@@ -443,7 +443,7 @@ describe('prepareSponsoredTransaction', () => {
     maxFeePerGas: 1_000_000_000n,
     maxPriorityFeePerGas: 1_000_000_000n,
     nonce: 1n,
-    nonceKey: 1n,
+    nonceKey: 'expiring',
     signature: { r: 1n, s: 1n, yParity: 0 } as any,
     validBefore: Math.floor(Date.now() / 1_000) + 300,
   } as const
@@ -458,6 +458,21 @@ describe('prepareSponsoredTransaction', () => {
         transaction: baseTransaction as any,
       }),
     ).not.toThrow()
+  })
+
+  test('error: rejects non-expiring nonce keys', () => {
+    expect(() =>
+      prepareSponsoredTransaction({
+        account: sponsor,
+        chainId: 42431,
+        details,
+        expectedFeeToken: bogus,
+        transaction: {
+          ...baseTransaction,
+          nonceKey: 1n,
+        } as any,
+      }),
+    ).toThrow('must use an expiring nonce')
   })
 
   test('accepts higher Moderato priority fees by default', () => {

--- a/src/tempo/internal/fee-payer.test.ts
+++ b/src/tempo/internal/fee-payer.test.ts
@@ -1,4 +1,4 @@
-import { encodeFunctionData } from 'viem'
+import { encodeFunctionData, maxUint256 } from 'viem'
 import { Abis, Addresses } from 'viem/tempo'
 import { describe, expect, test } from 'vp/test'
 
@@ -456,6 +456,21 @@ describe('prepareSponsoredTransaction', () => {
         details,
         expectedFeeToken: bogus,
         transaction: baseTransaction as any,
+      }),
+    ).not.toThrow()
+  })
+
+  test('accepts serialized expiring nonce key', () => {
+    expect(() =>
+      prepareSponsoredTransaction({
+        account: sponsor,
+        chainId: 42431,
+        details,
+        expectedFeeToken: bogus,
+        transaction: {
+          ...baseTransaction,
+          nonceKey: maxUint256,
+        } as any,
       }),
     ).not.toThrow()
   })

--- a/src/tempo/internal/fee-payer.ts
+++ b/src/tempo/internal/fee-payer.ts
@@ -2,7 +2,7 @@ import type { TempoAddress } from 'ox/tempo'
 import { TxEnvelopeTempo } from 'ox/tempo'
 import type { Hex } from 'viem'
 import type { Account } from 'viem'
-import { decodeFunctionData } from 'viem'
+import { decodeFunctionData, maxUint256 } from 'viem'
 import { Abis, Addresses, Transaction } from 'viem/tempo'
 
 import * as TempoAddress_internal from './address.js'
@@ -124,6 +124,10 @@ function getPolicy(chainId: number, overrides: Partial<Policy> | undefined): Pol
     maxTotalFee: overrides.maxTotalFee ?? base.maxTotalFee,
     maxValidityWindowSeconds: overrides.maxValidityWindowSeconds ?? base.maxValidityWindowSeconds,
   }
+}
+
+function isExpiringNonceKey(nonceKey: SponsoredTransaction['nonceKey']): boolean {
+  return nonceKey === 'expiring' || nonceKey === maxUint256
 }
 
 /** Validates that a set of transaction calls matches an allowed fee-payer pattern. */
@@ -358,7 +362,7 @@ export function prepareSponsoredTransaction(parameters: {
       maxPriorityFeePerGas: maxPriorityFeePerGas.toString(),
     })
 
-  if (nonceKey !== 'expiring') fail('fee-sponsored transaction must use an expiring nonce')
+  if (!isExpiringNonceKey(nonceKey)) fail('fee-sponsored transaction must use an expiring nonce')
   if (validBefore === undefined)
     fail('fee-sponsored transaction must declare validBefore for the expiring nonce')
   const validBeforeValue = validBefore

--- a/src/tempo/internal/fee-payer.ts
+++ b/src/tempo/internal/fee-payer.ts
@@ -358,7 +358,7 @@ export function prepareSponsoredTransaction(parameters: {
       maxPriorityFeePerGas: maxPriorityFeePerGas.toString(),
     })
 
-  if (nonceKey === undefined) fail('fee-sponsored transaction must use an expiring nonce')
+  if (nonceKey !== 'expiring') fail('fee-sponsored transaction must use an expiring nonce')
   if (validBefore === undefined)
     fail('fee-sponsored transaction must declare validBefore for the expiring nonce')
   const validBeforeValue = validBefore


### PR DESCRIPTION
## Summary

Explicitly require expiring nonce keys for fee-sponsored transactions.