### PR TITLE
fix: escape challenge quoted strings

### DIFF
--- a/.changeset/fix-challenge-quoted-string-format.md
+++ b/.changeset/fix-challenge-quoted-string-format.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed WWW-Authenticate challenge serialization to escape quoted-string values and reject CRLF.

--- a/src/Challenge.test.ts
+++ b/src/Challenge.test.ts
@@ -453,6 +453,34 @@ describe('serialize', () => {
     expect(header).toContain('digest="sha-256=abc"')
     expect(header).toContain('expires="2025-01-06T12:00:00Z"')
   })
+
+  test('behavior: escapes quoted-string values', () => {
+    const challenge = Challenge.from({
+      id: 'abc123',
+      realm: 'api.example.com',
+      method: 'tempo',
+      intent: 'charge',
+      request: { amount: '1000000' },
+      description: 'Pay "premium" path C:\\tempo\\api',
+    })
+
+    const header = Challenge.serialize(challenge)
+    expect(header).toContain('description="Pay \\"premium\\" path C:\\\\tempo\\\\api"')
+    expect(Challenge.deserialize(header).description).toBe('Pay "premium" path C:\\tempo\\api')
+  })
+
+  test('error: rejects CRLF in quoted-string values', () => {
+    const challenge = Challenge.from({
+      id: 'abc123',
+      realm: 'api.example.com',
+      method: 'tempo',
+      intent: 'charge',
+      request: { amount: '1000000' },
+      description: 'Line one\r\nLine two',
+    })
+
+    expect(() => Challenge.serialize(challenge)).toThrow('Invalid quoted-string value.')
+  })
 })
 
 describe('deserialize', () => {

--- a/src/Challenge.ts
+++ b/src/Challenge.ts
@@ -294,21 +294,28 @@ export declare namespace fromMethod {
  */
 export function serialize(challenge: Challenge): string {
   const parts = [
-    `id="${challenge.id}"`,
-    `realm="${challenge.realm}"`,
-    `method="${challenge.method}"`,
-    `intent="${challenge.intent}"`,
-    `request="${PaymentRequest.serialize(challenge.request)}"`,
+    authParam('id', challenge.id),
+    authParam('realm', challenge.realm),
+    authParam('method', challenge.method),
+    authParam('intent', challenge.intent),
+    authParam('request', PaymentRequest.serialize(challenge.request)),
   ]
 
-  if (challenge.description !== undefined) parts.push(`description="${challenge.description}"`)
-  if (challenge.digest !== undefined) parts.push(`digest="${challenge.digest}"`)
-  if (challenge.expires !== undefined) parts.push(`expires="${challenge.expires}"`)
-  if (challenge.opaque !== undefined) parts.push(`opaque="${challenge.opaque}"`)
+  if (challenge.description !== undefined)
+    parts.push(authParam('description', challenge.description))
+  if (challenge.digest !== undefined) parts.push(authParam('digest', challenge.digest))
+  if (challenge.expires !== undefined) parts.push(authParam('expires', challenge.expires))
+  if (challenge.opaque !== undefined) parts.push(authParam('opaque', challenge.opaque))
   else if (challenge.meta !== undefined)
-    parts.push(`opaque="${PaymentRequest.serialize(challenge.meta)}"`)
+    parts.push(authParam('opaque', PaymentRequest.serialize(challenge.meta)))
 
   return `Payment ${parts.join(', ')}`
+}
+
+/** @internal */
+function authParam(name: string, value: string): string {
+  if (/[\r\n]/.test(value)) throw new Error('Invalid quoted-string value.')
+  return `${name}="${value.replaceAll('\\', '\\\\').replaceAll('"', '\\"')}"`
 }
 
 /**


### PR DESCRIPTION
## Summary

- Escapes quotes and backslashes in WWW-Authenticate challenge auth-param values.
- Rejects CRLF in serialized quoted-string values.
- Adds Challenge tests plus a patch changeset.

This unblocks M7 conformance vectors in mpp-tools.