### PR TITLE
fix: preserve ES2020 challenge header types

### DIFF
--- a/.changeset/fix-challenge-header-es2020.md
+++ b/.changeset/fix-challenge-header-es2020.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed challenge header serialization type checking for ES2020 TypeScript targets.

--- a/src/Challenge.ts
+++ b/src/Challenge.ts
@@ -315,7 +315,7 @@ export function serialize(challenge: Challenge): string {
 /** @internal */
 function authParam(name: string, value: string): string {
   if (/[\r\n]/.test(value)) throw new Error('Invalid quoted-string value.')
-  return `${name}="${value.replaceAll('\\', '\\\\').replaceAll('"', '\\"')}"`
+  return `${name}="${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
 }
 
 /**


### PR DESCRIPTION
Summary
- Replaced challenge quoted-string escaping with regex replacements so ES2020 TypeScript targets do not require String.prototype.replaceAll.
- Added a patch changeset for the CI type-check fix.