### PR TITLE
fix: generate html before typecheck

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "scripts": {
-    "build": "node --import tsx scripts/build:html.ts && zile",
+    "build": "pnpm build:html && zile",
+    "build:html": "node --import tsx scripts/build:html.ts",
     "changeset:publish": "zile publish:prepare && changeset publish && zile publish:post",
     "changeset:version": "changeset version && vp fmt .",
     "check": "vp lint --fix && vp fmt --write .",
     "check:ci": "vp lint && vp fmt --check .",
-    "check:types": "tsgo -b",
+    "check:types": "pnpm build:html && tsgo -b",
     "check:types:html": "tsgo -p src/tempo/server/internal/html/tsconfig.json && tsgo -p src/stripe/server/internal/html/tsconfig.json",
     "check:types:examples": "pnpm -r --filter './examples/**' run check:types",
     "deps": "pnpx taze -r --no-ignore-other-workspaces --ignore-paths node_modules",


### PR DESCRIPTION
## Summary

- Added a reusable `build:html` script.
- Updated `build` and `check:types` to generate HTML artifacts before dependent commands run.
