### PR TITLE
feat: export evm charge helper

### DIFF
--- a/.changeset/evm-root-charge-helper.md
+++ b/.changeset/evm-root-charge-helper.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added the root EVM charge method export for direct `mppx/evm` helper access.

--- a/src/evm/PublicInterface.test-d.ts
+++ b/src/evm/PublicInterface.test-d.ts
@@ -37,6 +37,11 @@ describe('evm public interface', () => {
     expectTypeOf(clientChains.baseSepolia).toMatchTypeOf<number>()
   })
 
+  test('exports root EVM charge method definition', () => {
+    expectTypeOf(evmRoot.charge.name).toEqualTypeOf<'evm'>()
+    expectTypeOf(evmRoot.charge.intent).toEqualTypeOf<'charge'>()
+  })
+
   test('server charge works through subpath exports and tuple helper', () => {
     const direct = serverCharge({
       currency: serverAssets.base.USDC,

--- a/src/evm/index.ts
+++ b/src/evm/index.ts
@@ -4,6 +4,7 @@ export * as Methods from './Methods.js'
 export * as Types from './Types.js'
 export * as assets from './Assets.js'
 export * as chains from './Chains.js'
+export { charge } from './Methods.js'
 export * from './Types.js'
 export type {
   ExactEip3009Transfer,


### PR DESCRIPTION
## Summary

- Added root EVM `charge` method export for direct `mppx/evm` helper access.
- Added public interface type coverage for the root EVM charge export.