### PR TITLE
fix: handle SSE voucher updates as management

### DIFF
--- a/.changeset/sse-session-voucher-management.md
+++ b/.changeset/sse-session-voucher-management.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed SSE session voucher updates being charged as content requests.

--- a/src/tempo/server/Session.test.ts
+++ b/src/tempo/server/Session.test.ts
@@ -4484,7 +4484,7 @@ describe.runIf(isLocalnet)('session', () => {
         if (result.status === 402) return result.challenge
 
         if (action === 'voucher') {
-          return new Response(null, { status: 200 })
+          return result.withReceipt()
         }
 
         if (request.headers.get('Accept')?.includes('text/event-stream')) {
@@ -4562,7 +4562,7 @@ describe.runIf(isLocalnet)('session', () => {
         if (result.status === 402) return result.challenge
 
         if (action === 'voucher') {
-          return new Response(null, { status: 200 })
+          return result.withReceipt()
         }
 
         if (request.headers.get('Accept')?.includes('text/event-stream')) {
@@ -4730,7 +4730,7 @@ describe.runIf(isLocalnet)('session', () => {
         if (result.status === 402) return result.challenge
 
         if (action === 'voucher') {
-          return new Response(null, { status: 200 })
+          return result.withReceipt()
         }
 
         if (request.headers.get('Accept')?.includes('text/event-stream')) {

--- a/src/tempo/server/Session.ts
+++ b/src/tempo/server/Session.ts
@@ -285,7 +285,8 @@ export function session<const parameters extends session.Parameters>(
       if (
         envelope &&
         isSessionContentRequest(envelope.capturedRequest) &&
-        (payload.action === 'open' || payload.action === 'voucher')
+        (payload.action === 'open' ||
+          (payload.action === 'voucher' && !isSseNegotiationRequest(envelope.capturedRequest)))
       ) {
         const charged = await charge(
           store,
@@ -315,15 +316,21 @@ export function session<const parameters extends session.Parameters>(
     // updates; billable requests fall through to the application handler.
     respond({ credential, envelope, input }) {
       const { payload } = credential as Credential.Credential<SessionCredentialPayload>
+      const request = envelope?.capturedRequest ?? captureRequestBodyProbe(input)
 
       if (payload.action === 'close') return new Response(null, { status: 204 })
       if (payload.action === 'topUp') return new Response(null, { status: 204 })
+      if (parameters.sse && payload.action === 'voucher' && isSseNegotiationRequest(request))
+        return new Response(null, { status: 204 })
 
-      const request = envelope?.capturedRequest ?? captureRequestBodyProbe(input)
       if (isSessionContentRequest(request)) return undefined
       return new Response(null, { status: 204 })
     },
   })
+}
+
+function isSseNegotiationRequest(input: Pick<Method.CapturedRequest, 'headers'>): boolean {
+  return input.headers.get('Accept')?.includes('text/event-stream') ?? false
 }
 
 export declare namespace session {


### PR DESCRIPTION
## Summary

- Treat SSE session voucher updates as management responses instead of content requests
- Add regression coverage for streamed sessions resuming after voucher updates