### PR TITLE
fix(mcp): handle SDK payment results

### DIFF
--- a/.changeset/mcp-sdk-payment-results.md
+++ b/.changeset/mcp-sdk-payment-results.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed MCP SDK payment handling by returning parseable payment-required tool results and adding client wrapper aliases.

--- a/src/mcp-sdk/client/McpClient.test-d.ts
+++ b/src/mcp-sdk/client/McpClient.test-d.ts
@@ -20,6 +20,23 @@ describe('McpClient.wrap', () => {
     expectTypeOf(wrapped.callTool).returns.toExtend<Promise<McpClient.CallToolResult>>()
   })
 
+  test('aliases return wrapped client with callTool', () => {
+    const client = {} as Client
+    const methods = [
+      tempo({
+        account: {} as Account,
+      }),
+    ] as const
+
+    const withMppClient = McpClient.withMppClient(client, { methods })
+    const wrapMcpClientWithPayment = McpClient.wrapMcpClientWithPayment(client, { methods })
+
+    expectTypeOf(withMppClient.callTool).returns.toExtend<Promise<McpClient.CallToolResult>>()
+    expectTypeOf(wrapMcpClientWithPayment.callTool).returns.toExtend<
+      Promise<McpClient.CallToolResult>
+    >()
+  })
+
   test('preserves original client methods', () => {
     const client = {} as Client
     const wrapped = McpClient.wrap(client, {

--- a/src/mcp-sdk/client/McpClient.test.ts
+++ b/src/mcp-sdk/client/McpClient.test.ts
@@ -50,7 +50,7 @@ describe('McpClient.wrap', () => {
           recipient: accounts[0].address,
         })(extra)
 
-        if (result.status === 402) throw result.challenge
+        if (result.status === 402) return result.challenge
 
         return result.withReceipt({
           content: [{ type: 'text' as const, text: 'Premium tool executed' }],
@@ -86,6 +86,22 @@ describe('McpClient.wrap', () => {
     expect(result.receipt).toBeDefined()
     expect(result.receipt?.status).toBe('success')
     expect(result.receipt?.method).toBe('tempo')
+  })
+
+  test('default: alias handles payment and returns result with receipt', async () => {
+    const mcp = McpClient.withMppClient(client, {
+      methods: [
+        tempo_client.charge({
+          account: accounts[1],
+          getClient: () => testClient,
+        }),
+      ],
+    })
+
+    const result = await mcp.callTool({ name: 'premium_tool', arguments: {} })
+
+    expect(result.content).toEqual([{ type: 'text', text: 'Premium tool executed' }])
+    expect(result.receipt?.status).toBe('success')
   })
 
   test('default: account via context', async () => {
@@ -169,10 +185,16 @@ describe('McpClient.wrap', () => {
     })
 
     server.registerTool('tool_unknown_method', { description: 'Tool' }, async () => {
-      throw new McpError(core_Mcp.paymentRequiredCode, 'Payment Required', {
+      const paymentRequired = {
         httpStatus: 402,
         challenges: [{ ...challenge, method: 'unknown_method' }],
-      })
+      }
+
+      return {
+        structuredContent: paymentRequired,
+        content: [{ type: 'text' as const, text: JSON.stringify(paymentRequired) }],
+        isError: true,
+      }
     })
 
     const mcp = McpClient.wrap(client, {
@@ -203,10 +225,16 @@ describe('McpClient.wrap', () => {
     })
 
     server.registerTool('expired_tool', { description: 'Tool' }, async () => {
-      throw new McpError(core_Mcp.paymentRequiredCode, 'Payment Required', {
+      const paymentRequired = {
         httpStatus: 402,
         challenges: [challenge],
-      })
+      }
+
+      return {
+        structuredContent: paymentRequired,
+        content: [{ type: 'text' as const, text: JSON.stringify(paymentRequired) }],
+        isError: true,
+      }
     })
 
     const createCredential = vi.fn(async ({ challenge }) =>

--- a/src/mcp-sdk/client/McpClient.ts
+++ b/src/mcp-sdk/client/McpClient.ts
@@ -68,6 +68,18 @@ export function wrap<
           timeout !== undefined ? { timeout } : undefined,
         )
 
+        const challenges = getPaymentRequiredChallengesFromResult(result)
+        if (challenges)
+          return await payAndRetry({
+            challenges,
+            client,
+            context,
+            methods,
+            params,
+            paymentPreferences,
+            timeout,
+          })
+
         return {
           ...result,
           receipt: result._meta?.[core_Mcp.receiptMetaKey] as core_Mcp.Receipt | undefined,
@@ -79,46 +91,30 @@ export function wrap<
         const challenges = (error.data as { challenges?: Challenge.Challenge[] })?.challenges
         if (!challenges?.length) throw error
 
-        const selected = AcceptPayment.selectChallenge(
+        return await payAndRetry({
+          cause: error,
           challenges,
-          methods,
-          paymentPreferences.entries,
-        )
-        if (!selected) {
-          const available = challenges.map((c) => `${c.method}.${c.intent}`).join(', ')
-          const installed = methods.map((m) => `${m.name}.${m.intent}`).join(', ')
-          throw new Error(
-            `No compatible payment method. Server offers: ${available}. Client has: ${installed}`,
-            { cause: error },
-          )
-        }
-
-        const credential = await createCredential(selected.challenge, {
+          client,
           context,
           methods,
+          params,
+          paymentPreferences,
+          timeout,
         })
-        const parsed = Credential.deserialize(credential)
-
-        const retryResult = await client.callTool(
-          {
-            ...params,
-            _meta: {
-              ...params._meta,
-              [core_Mcp.credentialMetaKey]: parsed,
-            },
-          },
-          undefined,
-          timeout !== undefined ? { timeout } : undefined,
-        )
-
-        return {
-          ...retryResult,
-          receipt: retryResult._meta?.[core_Mcp.receiptMetaKey] as core_Mcp.Receipt | undefined,
-        }
       }
     },
   }
 }
+
+/**
+ * Alias for `wrap`, named for agent SDK integration guides.
+ */
+export const withMppClient = wrap
+
+/**
+ * Alias for `wrap`, matching common MCP payment wrapper naming.
+ */
+export const wrapMcpClientWithPayment = wrap
 
 /** Union of all context types from all methods that have context schemas. */
 type AnyContextFor<methods extends readonly AnyClient[]> = {
@@ -169,6 +165,90 @@ export function isPaymentRequiredError(
   if ((error as { code: unknown }).code !== core_Mcp.paymentRequiredCode) return false
   const data = (error as { data?: { challenges?: unknown } }).data
   return Array.isArray(data?.challenges) && data.challenges.length > 0
+}
+
+function getPaymentRequiredChallengesFromResult(
+  result: Awaited<ReturnType<Client['callTool']>>,
+): Challenge.Challenge[] | null {
+  if ((result as { isError?: boolean }).isError !== true) return null
+
+  const structured = (result as { structuredContent?: unknown }).structuredContent
+  const structuredChallenges = getPaymentRequiredChallengesFromObject(structured)
+  if (structuredChallenges) return structuredChallenges
+
+  const content = (result as { content?: readonly unknown[] }).content
+  const first = content?.[0]
+  if (
+    typeof first !== 'object' ||
+    first === null ||
+    (first as { type?: unknown }).type !== 'text' ||
+    typeof (first as { text?: unknown }).text !== 'string'
+  )
+    return null
+
+  try {
+    return getPaymentRequiredChallengesFromObject(JSON.parse((first as { text: string }).text))
+  } catch {
+    return null
+  }
+}
+
+function getPaymentRequiredChallengesFromObject(value: unknown): Challenge.Challenge[] | null {
+  if (typeof value !== 'object' || value === null) return null
+  if ((value as { httpStatus?: unknown }).httpStatus !== 402) return null
+  const challenges = (value as { challenges?: unknown }).challenges
+  if (!Array.isArray(challenges) || challenges.length === 0) return null
+  return challenges as Challenge.Challenge[]
+}
+
+async function payAndRetry<
+  const client extends Pick<Client, 'callTool'>,
+  const methods extends readonly Method.AnyClient[],
+>(parameters: {
+  cause?: unknown
+  challenges: readonly Challenge.Challenge[]
+  client: client
+  context: unknown
+  methods: methods
+  params: Parameters<wrap.McpClient<client, methods>['callTool']>[0]
+  paymentPreferences: ReturnType<typeof AcceptPayment.resolve>
+  timeout: number | undefined
+}): Promise<CallToolResult> {
+  const { cause, challenges, client, context, methods, params, paymentPreferences, timeout } =
+    parameters
+
+  const selected = AcceptPayment.selectChallenge(challenges, methods, paymentPreferences.entries)
+  if (!selected) {
+    const available = challenges.map((c) => `${c.method}.${c.intent}`).join(', ')
+    const installed = methods.map((m) => `${m.name}.${m.intent}`).join(', ')
+    throw new Error(
+      `No compatible payment method. Server offers: ${available}. Client has: ${installed}`,
+      cause !== undefined ? { cause } : undefined,
+    )
+  }
+
+  const credential = await createCredential(selected.challenge, {
+    context,
+    methods,
+  })
+  const parsed = Credential.deserialize(credential)
+
+  const retryResult = await client.callTool(
+    {
+      ...params,
+      _meta: {
+        ...params._meta,
+        [core_Mcp.credentialMetaKey]: parsed,
+      },
+    },
+    undefined,
+    timeout !== undefined ? { timeout } : undefined,
+  )
+
+  return {
+    ...retryResult,
+    receipt: retryResult._meta?.[core_Mcp.receiptMetaKey] as core_Mcp.Receipt | undefined,
+  }
 }
 
 /** @internal */

--- a/src/mcp-sdk/client/McpClient.unit.test.ts
+++ b/src/mcp-sdk/client/McpClient.unit.test.ts
@@ -1,0 +1,92 @@
+import { Credential, Mcp as core_Mcp, Method } from 'mppx'
+import { Methods } from 'mppx/tempo'
+import { describe, expect, test, vi } from 'vp/test'
+
+import * as McpClient from './McpClient.js'
+
+const challenge = {
+  id: 'test-challenge',
+  intent: 'charge',
+  method: 'tempo',
+  realm: 'api.example.com',
+  request: {
+    amount: '0',
+  },
+}
+
+describe('McpClient.wrap', () => {
+  test('handles MCP SDK structured payment-required tool results', async () => {
+    const createCredential = vi.fn(async ({ challenge }) =>
+      Credential.serialize({
+        challenge,
+        payload: { signature: '0xsignature', type: 'proof' },
+      }),
+    )
+    const callTool = vi
+      .fn()
+      .mockResolvedValueOnce({
+        structuredContent: { httpStatus: 402, challenges: [challenge] },
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({ httpStatus: 402, challenges: [challenge] }),
+          },
+        ],
+        isError: true,
+      })
+      .mockResolvedValueOnce({
+        _meta: {
+          [core_Mcp.receiptMetaKey]: {
+            challengeId: challenge.id,
+            method: 'tempo',
+            reference: challenge.id,
+            status: 'success',
+            timestamp: '2026-06-08T00:00:00.000Z',
+          },
+        },
+        content: [{ type: 'text', text: 'paid result' }],
+      })
+
+    const mcp = McpClient.withMppClient(
+      { callTool },
+      {
+        methods: [Method.toClient(Methods.charge, { createCredential })],
+      },
+    )
+
+    const result = await mcp.callTool({ name: 'paid_tool', arguments: {} })
+
+    expect(result.content).toEqual([{ type: 'text', text: 'paid result' }])
+    expect(result.receipt?.status).toBe('success')
+    expect(createCredential).toHaveBeenCalledWith({ challenge })
+    expect(callTool).toHaveBeenCalledTimes(2)
+    expect(callTool.mock.calls[1]?.[0]._meta?.[core_Mcp.credentialMetaKey]).toMatchObject({
+      challenge,
+      payload: { signature: '0xsignature', type: 'proof' },
+    })
+  })
+
+  test('ignores non-payment tool errors', async () => {
+    const callTool = vi.fn().mockResolvedValue({
+      content: [{ type: 'text', text: 'ordinary tool error' }],
+      isError: true,
+    })
+
+    const mcp = McpClient.wrap(
+      { callTool },
+      {
+        methods: [
+          Method.toClient(Methods.charge, {
+            createCredential: vi.fn(),
+          }),
+        ],
+      },
+    )
+
+    const result = await mcp.callTool({ name: 'broken_tool', arguments: {} })
+
+    expect(result.content).toEqual([{ type: 'text', text: 'ordinary tool error' }])
+    expect(result.receipt).toBeUndefined()
+    expect(callTool).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/mcp-sdk/server/Transport.ts
+++ b/src/mcp-sdk/server/Transport.ts
@@ -1,4 +1,4 @@
-import type { CallToolResult, McpError } from '@modelcontextprotocol/sdk/types.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 
 import type * as Credential from '../../Credential.js'
 import * as core_Mcp from '../../Mcp.js'
@@ -18,13 +18,13 @@ export type Extra = {
   [key: string]: unknown
 }
 
-export type McpSdk = Transport.Transport<Extra, McpError, CallToolResult>
+export type McpSdk = Transport.Transport<Extra, CallToolResult, CallToolResult>
 
 /**
  * MCP SDK transport for server-side payment handling with `@modelcontextprotocol/sdk`.
  *
  * - Reads credentials from `_meta["org.paymentauth/credential"]`
- * - Issues challenges as `McpError` with code `-32042` and challenge in `error.data`
+ * - Issues challenges as `isError: true` tool results with challenge data
  * - Attaches receipts via `_meta["org.paymentauth/receipt"]` on tool results
  *
  * @example
@@ -40,15 +40,13 @@ export type McpSdk = Transport.Transport<Extra, McpError, CallToolResult>
  *
  * server.registerTool('premium', { description: '...' }, async (extra) => {
  *   const result = await payment.charge({ request: { ... } })(extra)
- *   if (result.status === 402) throw result.challenge
+ *   if (result.status === 402) return result.challenge
  *   return result.withReceipt({ content: [...] })
  * })
  * ```
  */
 export function mcpSdk(): McpSdk {
-  let McpErrorClass: typeof McpError | undefined
-
-  return Transport.from<Extra, McpError, CallToolResult>({
+  return Transport.from<Extra, CallToolResult, CallToolResult>({
     name: 'mcp-sdk',
 
     captureRequest() {
@@ -68,24 +66,23 @@ export function mcpSdk(): McpSdk {
       return credential
     },
 
-    async respondChallenge({ challenge, error }) {
-      if (!McpErrorClass) {
-        try {
-          const mod = await import('@modelcontextprotocol/sdk/types.js')
-          McpErrorClass = mod.McpError
-        } catch (error) {
-          const err = new Error(
-            'Missing optional dependency "@modelcontextprotocol/sdk". Install it to use mppx MCP SDK transports.',
-          )
-          ;(err as Error & { cause?: unknown }).cause = error
-          throw err
-        }
-      }
-      return new McpErrorClass(core_Mcp.paymentRequiredCode, error?.message ?? 'Payment Required', {
+    respondChallenge({ challenge, error }) {
+      const paymentRequired = {
         httpStatus: 402,
         challenges: [challenge],
         ...(error && { problem: error.toProblemDetails(challenge.id) }),
-      })
+      }
+
+      return {
+        structuredContent: paymentRequired,
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(paymentRequired),
+          },
+        ],
+        isError: true,
+      }
     },
 
     respondReceipt({ receipt, response, challengeId }) {


### PR DESCRIPTION
## Summary

Fixed MCP SDK payment handling by returning parseable payment-required tool results from `Transport.mcpSdk()` and teaching `McpClient.wrap()` to pay from those structured results.

This also adds `withMppClient` and `wrapMcpClientWithPayment` aliases for agent SDK integrations.

## Why

The MPP MCP docs currently show:

```ts
const result = await mppx.charge({ amount: '0.01' })(extra)
if (result.status === 402) throw result.challenge
return result.withReceipt(...)
```

But with `@modelcontextprotocol/sdk@1.29.0`, `McpServer` catches thrown tool errors and converts them into a plain tool error result:

```json
{
  "content": [{ "type": "text", "text": "MCP error -32042: Payment is required (...)." }],
  "isError": true
}
```

That drops `error.data.challenges`, so `McpClient.wrap()` cannot create a Credential and retry.

## Repro

Broken flow against current `main`:

```bash
NODE_PATH=/Users/parv/tempo/mppx/node_modules \
  pnpm exec tsx /Users/parv/Documents/Codex/2026-06-08/i-ve-got-the-following-task/work/mcp-zero-proof-demo.ts
```

Observed output:

```json
{
  "content": [
    {
      "type": "text",
      "text": "MCP error -32042: Payment is required (Proof-only MCP demo)."
    }
  ]
}
```

Fixed flow against this branch:

```bash
NODE_PATH=/Users/parv/tempo/worktrees/mppx/mcp-sdk-compat/node_modules \
  pnpm exec tsx /Users/parv/Documents/Codex/2026-06-08/i-ve-got-the-following-task/work/mcp-zero-proof-demo-fixed.ts
```

Observed output:

```json
{
  "content": [
    {
      "type": "text",
      "text": "premium ok"
    }
  ],
  "receipt": {
    "method": "tempo",
    "status": "success"
  }
}
```

The fixed bare client response also preserves the Challenge in `structuredContent`:

```json
{
  "structuredContent": {
    "httpStatus": 402,
    "challenges": [
      {
        "method": "tempo",
        "intent": "charge",
        "realm": "mcp-demo.local"
      }
    ]
  },
  "isError": true
}
```

## Compatibility

This keeps `McpClient.wrap()` compatible with existing thrown `McpError(-32042)` payment responses while adding support for MCP SDK `isError` results with parseable Challenge data.

The server-side `Transport.mcpSdk()` Challenge output type changes from an `McpError` object to an MCP SDK `CallToolResult`. This matches how MCP SDK tool handlers actually return errors today, but developers currently using `throw result.challenge` should switch to `return result.challenge`.

## Validation

```bash
pnpm check
pnpm check:types
VITE_NODE_ENV=unit pnpm test src/mcp-sdk/client/McpClient.unit.test.ts
```

Full localnet MCP integration tests were not run because this machine could not start the Tempo localnet container runtime (`Could not find a working container runtime strategy`).
