### PR TITLE
fix(cli): default account funding to testnet

### DIFF
--- a/.changeset/fund-command-testnet-default.md
+++ b/.changeset/fund-command-testnet-default.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Defaulted account faucet funding to testnet unless a network or RPC URL was specified.

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -32,6 +32,7 @@ import {
   printResponseHeaders,
   prompt,
   resolveChain,
+  resolveFundingNetwork,
   resolveRpcUrl,
 } from './utils.js'
 
@@ -704,8 +705,9 @@ const account = Cli.create('account', {
       const addrDisplay = explorerUrl
         ? link(`${explorerUrl}/address/${acct.address}`, acct.address)
         : acct.address
-      const rpcUrl = resolveRpcUrl(c.options.rpcUrl, { network: c.options.network })
-      resolveChain({ network: c.options.network, rpcUrl })
+      const fundingNetwork = resolveFundingNetwork(c.options)
+      const rpcUrl = resolveRpcUrl(c.options.rpcUrl, { network: fundingNetwork })
+      resolveChain({ network: fundingNetwork, rpcUrl })
         .then((chain) => createClient({ chain, transport: http(rpcUrl) }))
         .then((client) =>
           import('viem/tempo').then(({ Actions }) =>
@@ -715,6 +717,11 @@ const account = Cli.create('account', {
       return outputResult(c, { address: acct.address, name: resolvedName }, () => {
         console.log(`Account "${resolvedName}" saved to keychain.`)
         console.log(pc.dim(`Address ${addrDisplay}`))
+        console.log(
+          pc.dim(
+            `Fund testnet tokens: mppx account fund --account ${resolvedName} --network testnet`,
+          ),
+        )
       })
     },
   })
@@ -840,8 +847,9 @@ const account = Cli.create('account', {
           return c.error({ code: 'ACCOUNT_NOT_FOUND', message: 'No account found.', exitCode: 69 })
       }
       const acct = privateKeyToAccount(key as `0x${string}`)
-      const rpcUrl = resolveRpcUrl(c.options.rpcUrl, { network: c.options.network })
-      const chain = await resolveChain({ network: c.options.network, rpcUrl })
+      const fundingNetwork = resolveFundingNetwork(c.options)
+      const rpcUrl = resolveRpcUrl(c.options.rpcUrl, { network: fundingNetwork })
+      const chain = await resolveChain({ network: fundingNetwork, rpcUrl })
       const client = createClient({ chain, transport: http(rpcUrl) })
       if (!structured) console.log(`Funding "${accountName}" on ${chainName(chain)}`)
       try {
@@ -864,14 +872,18 @@ const account = Cli.create('account', {
           },
         )
       } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
         if (structured)
           return c.error({
             code: 'FUNDING_FAILED',
-            message: err instanceof Error ? err.message : String(err),
+            message,
             exitCode: 1,
           })
-        console.error('Funding failed:', err instanceof Error ? err.message : err)
-        return undefined as never
+        return c.error({
+          code: 'FUNDING_FAILED',
+          message: `Funding failed: ${message}`,
+          exitCode: 1,
+        })
       }
     },
   })

--- a/src/cli/utils.test.ts
+++ b/src/cli/utils.test.ts
@@ -1,7 +1,7 @@
 import { tempo as tempoMainnet, tempoModerato } from 'viem/tempo/chains'
 import { afterEach, describe, expect, test } from 'vp/test'
 
-import { networkRpcUrls, resolveChain, resolveRpcUrl } from './utils.js'
+import { networkRpcUrls, resolveChain, resolveFundingNetwork, resolveRpcUrl } from './utils.js'
 
 describe('resolveRpcUrl', () => {
   afterEach(() => {
@@ -49,6 +49,30 @@ describe('resolveRpcUrl', () => {
     process.env.MPPX_RPC_URL = '  '
     process.env.RPC_URL = 'https://rpc.example.com'
     expect(resolveRpcUrl()).toBe('https://rpc.example.com')
+  })
+})
+
+describe('resolveFundingNetwork', () => {
+  afterEach(() => {
+    delete process.env.MPPX_RPC_URL
+    delete process.env.RPC_URL
+  })
+
+  test('defaults faucet funding to testnet', () => {
+    expect(resolveFundingNetwork()).toBe('testnet')
+  })
+
+  test('keeps explicit network selection', () => {
+    expect(resolveFundingNetwork({ network: 'mainnet' })).toBe('mainnet')
+  })
+
+  test('does not override explicit rpc url', () => {
+    expect(resolveFundingNetwork({ rpcUrl: 'https://explicit.example.com' })).toBeUndefined()
+  })
+
+  test('does not override env rpc urls', () => {
+    process.env.MPPX_RPC_URL = 'https://env.example.com'
+    expect(resolveFundingNetwork()).toBeUndefined()
   })
 })
 

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -242,6 +242,16 @@ export function resolveRpcUrl(
   )
 }
 
+/** Select the default network for faucet funding without overriding explicit RPC configuration. */
+export function resolveFundingNetwork(
+  options: { network?: Network | undefined; rpcUrl?: string | undefined } = {},
+): Network | undefined {
+  if (options.network) return options.network
+  if (options.rpcUrl) return undefined
+  if (process.env.MPPX_RPC_URL?.trim() || process.env.RPC_URL?.trim()) return undefined
+  return 'testnet'
+}
+
 export async function resolveChain(
   opts: { network?: Network | undefined; rpcUrl?: string | undefined } = {},
 ): Promise<Chain> {


### PR DESCRIPTION
## Summary
- default account faucet funding to testnet when no network or RPC URL is specified
- print a testnet funding command after account creation
- return `FUNDING_FAILED` with exit code 1 for unstructured funding failures

## Why
`account fund` is described as a testnet faucet command, but without `--network testnet` it currently resolves to mainnet. In a before smoke test, `mppx account fund` printed `Funding ... on mainnet`, failed against `https://rpc.tempo.xyz`, and still exited with status 0.

## Validation
- `pnpm check`
- `pnpm check:types`
- `VITE_NODE_ENV=unit pnpm test --project cli src/cli/utils.test.ts`
- Fixed smoke: `pnpm mppx account create --account abc`; `pnpm mppx account fund --account abc` printed `Funding ... on testnet` and completed successfully; account deleted
- Explicit-mainnet failure smoke: `pnpm mppx account fund --account abc --network mainnet` returned `FUNDING_FAILED` and exited 1; account deleted

Note: plain `pnpm test src/cli/utils.test.ts` without `VITE_NODE_ENV=unit` still tries to start Tempo localnet in this environment and fails with missing container runtime.