### PR TITLE
feat: add mcp client wrapper aliases

### DIFF
--- a/.changeset/agent-sdk-mcp-wrappers.md
+++ b/.changeset/agent-sdk-mcp-wrappers.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added MCP client wrapper aliases for agent SDK integrations.

--- a/src/mcp-sdk/client/McpClient.test-d.ts
+++ b/src/mcp-sdk/client/McpClient.test-d.ts
@@ -3,6 +3,7 @@ import { tempo } from 'mppx/client'
 import type { Account } from 'viem'
 import { describe, expectTypeOf, test } from 'vp/test'
 
+import { withMppClient, wrapMcpClientWithPayment } from './index.js'
 import * as McpClient from './McpClient.js'
 
 describe('McpClient.wrap', () => {
@@ -18,6 +19,27 @@ describe('McpClient.wrap', () => {
 
     expectTypeOf(wrapped.callTool).toBeFunction()
     expectTypeOf(wrapped.callTool).returns.toExtend<Promise<McpClient.CallToolResult>>()
+  })
+
+  test('aliases return wrapped client with callTool', () => {
+    const client = {} as Client
+    const methods = [
+      tempo({
+        account: {} as Account,
+      }),
+    ] as const
+
+    const withMpp = McpClient.withMppClient(client, { methods })
+    const wrappedWithPayment = McpClient.wrapMcpClientWithPayment(client, { methods })
+    const topLevelWithMpp = withMppClient(client, { methods })
+    const topLevelWrappedWithPayment = wrapMcpClientWithPayment(client, { methods })
+
+    expectTypeOf(withMpp.callTool).returns.toExtend<Promise<McpClient.CallToolResult>>()
+    expectTypeOf(wrappedWithPayment.callTool).returns.toExtend<Promise<McpClient.CallToolResult>>()
+    expectTypeOf(topLevelWithMpp.callTool).returns.toExtend<Promise<McpClient.CallToolResult>>()
+    expectTypeOf(topLevelWrappedWithPayment.callTool).returns.toExtend<
+      Promise<McpClient.CallToolResult>
+    >()
   })
 
   test('preserves original client methods', () => {

--- a/src/mcp-sdk/client/McpClient.ts
+++ b/src/mcp-sdk/client/McpClient.ts
@@ -120,6 +120,36 @@ export function wrap<
   }
 }
 
+/**
+ * Alias for `wrap`.
+ *
+ * @example
+ * ```ts
+ * import { tempo } from 'mppx/client'
+ * import { withMppClient } from 'mppx/mcp-sdk/client'
+ *
+ * const mcp = withMppClient(client, {
+ *   methods: tempo({ account }),
+ * })
+ * ```
+ */
+export const withMppClient = wrap
+
+/**
+ * Alias for `wrap`.
+ *
+ * @example
+ * ```ts
+ * import { tempo } from 'mppx/client'
+ * import { wrapMcpClientWithPayment } from 'mppx/mcp-sdk/client'
+ *
+ * const mcp = wrapMcpClientWithPayment(client, {
+ *   methods: tempo({ account }),
+ * })
+ * ```
+ */
+export const wrapMcpClientWithPayment = wrap
+
 /** Union of all context types from all methods that have context schemas. */
 type AnyContextFor<methods extends readonly AnyClient[]> = {
   [key in keyof methods]: methods[key] extends Method.Client<any, infer context>

--- a/src/mcp-sdk/client/McpClient.unit.test.ts
+++ b/src/mcp-sdk/client/McpClient.unit.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'vp/test'
+
+import { withMppClient, wrapMcpClientWithPayment } from './index.js'
+import * as McpClient from './McpClient.js'
+
+describe('MCP client wrapper aliases', () => {
+  test('exports aliases for the canonical wrapper', () => {
+    expect(McpClient.withMppClient).toBe(McpClient.wrap)
+    expect(McpClient.wrapMcpClientWithPayment).toBe(McpClient.wrap)
+    expect(withMppClient).toBe(McpClient.wrap)
+    expect(wrapMcpClientWithPayment).toBe(McpClient.wrap)
+  })
+})

--- a/src/mcp-sdk/client/index.ts
+++ b/src/mcp-sdk/client/index.ts
@@ -1,2 +1,4 @@
 export * as tempo from '../../tempo/client/index.js'
+export { withMppClient, wrapMcpClientWithPayment } from './McpClient.js'
+export type { CallToolResult } from './McpClient.js'
 export * as McpClient from './McpClient.js'


### PR DESCRIPTION
## Summary

- Add `withMppClient` and `wrapMcpClientWithPayment` aliases for `McpClient.wrap`
- Export the helpers from `mppx/mcp-sdk/client` for agent SDK integration guides
- Add type and runtime alias coverage

## Context

mppx already supports paid MCP tool calls through `McpClient.wrap`. This PR keeps that implementation as the canonical path and adds named helpers that are easier to use in agent SDK integration guides.

## Usage

Before:

```ts
import { McpClient } from "mppx/mcp-sdk/client"

const paidMcp = McpClient.wrap(mcpClient, {
  methods,
})
```

After:

```ts
const paidMcp = withMppClient(mcpClient, { methods })
```

`wrapMcpClientWithPayment(mcpClient, { methods })` is also available from the same entrypoint.

## Validation

- `pnpm check`
- `pnpm check:types`
- `VITE_NODE_ENV=unit pnpm test --project node src/mcp-sdk/client/McpClient.unit.test.ts`

Note: `pnpm check:types` still emits existing `ox`/`viem` Tempo channel bundler warnings, but exits successfully.
