### PR TITLE
feat: add tempo session playground

### DIFF
--- a/examples/session/playground/README.md
+++ b/examples/session/playground/README.md
@@ -1,0 +1,19 @@
+# Tempo Session Playground
+
+Browser playground for the TIP-1034 `tempo.session` flow.
+
+This example is precompile-only. Choose one backend with
+`VITE_TEMPO_NETWORK=localnet|moderato`. Localnet means a Docker Tempo node that
+exposes TIP-1034. If the configured RPC returns no data for TIP-1034 ABI calls,
+the UI reports that state and paid session actions fail with a 503.
+
+```bash
+docker run -d --name mppx-session-localnet -p 18545:54515 ghcr.io/tempoxyz/tempo:latest node --authrpc.port 54545 --datadir /tmp/mppx-session-localnet --dev --dev.block-time 200ms --dev.mnemonic 'test test test test test test test test test test test junk' --engine.disable-precompile-cache --engine.legacy-state-root --faucet.address 0x20c0000000000000000000000000000000000000 0x20c0000000000000000000000000000000000001 0x20c0000000000000000000000000000000000002 0x20c0000000000000000000000000000000000003 --faucet.amount 1000000000000 --faucet.enabled --faucet.private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --http.addr 0.0.0.0 --http.api all --http.corsdomain '*' --http.port 54515 --port 54525 --ws.port 54535
+VITE_TEMPO_NETWORK=localnet VITE_RPC_URL=http://localhost:18545 pnpm dev:example session/playground
+VITE_TEMPO_NETWORK=moderato pnpm dev:example session/playground
+```
+
+Open the printed URL, fund the generated demo wallet, start a session, and
+crank it with incremental clicks. On reload, the session manager automatically
+uses same-route `HEAD` bootstrap plus its local channel store to hydrate from
+server channel state before continuing or closing.

--- a/examples/session/playground/index.html
+++ b/examples/session/playground/index.html
@@ -1,0 +1,150 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tempo Session Playground</title>
+    <script type="module" src="/src/client.ts"></script>
+  </head>
+  <body>
+    <main class="shell">
+      <header class="topbar">
+        <div>
+          <p id="network-eyebrow" class="eyebrow">Tempo</p>
+          <h1>Session Playground</h1>
+        </div>
+        <div id="mode-label" class="network">Checking session mode</div>
+      </header>
+
+      <section class="grid">
+        <section class="panel controls">
+          <div class="account-row">
+            <div>
+              <label>Client</label>
+              <code id="account">loading...</code>
+            </div>
+            <button id="new-wallet" class="ghost">New wallet</button>
+          </div>
+
+          <div class="meter">
+            <div>
+              <label>Balance</label>
+              <strong id="balance">-</strong>
+            </div>
+            <div>
+              <label>Channel</label>
+              <strong id="channel">none</strong>
+            </div>
+            <div>
+              <label>Spent</label>
+              <strong id="spent">0 pathUSD</strong>
+            </div>
+            <div>
+              <label>Deposit</label>
+              <strong id="deposit">0 pathUSD</strong>
+            </div>
+            <div>
+              <label>Voucher</label>
+              <strong id="cumulative">0 pathUSD</strong>
+            </div>
+          </div>
+
+          <div class="actions">
+            <button id="fund">Fund wallet</button>
+            <button id="start">Start session</button>
+            <button id="crank">Crank session</button>
+            <button id="top-up">Top up</button>
+            <button id="close" class="danger">Close</button>
+          </div>
+        </section>
+
+        <section class="panel controls">
+          <div class="section-title">
+            <h2>Auto-Managed Flow</h2>
+            <button id="auto-close" class="ghost">Close auto</button>
+          </div>
+
+          <div class="meter">
+            <div>
+              <label>Auto Channel</label>
+              <strong id="auto-channel">none</strong>
+            </div>
+            <div>
+              <label>Auto Clicks</label>
+              <strong id="auto-clicks">0</strong>
+            </div>
+            <div>
+              <label>Auto Spent</label>
+              <strong id="auto-spent">0 pathUSD</strong>
+            </div>
+            <div>
+              <label>Auto Deposit</label>
+              <strong id="auto-deposit">0 pathUSD</strong>
+            </div>
+            <div>
+              <label>Auto Voucher</label>
+              <strong id="auto-cumulative">0 pathUSD</strong>
+            </div>
+          </div>
+
+          <div class="actions auto-actions">
+            <button id="auto-click">Auto click</button>
+            <button id="auto-run">Run 12 auto clicks</button>
+          </div>
+        </section>
+
+        <section class="panel controls">
+          <div class="section-title">
+            <h2>SSE Stream</h2>
+            <button id="sse-close" class="ghost">Close SSE</button>
+          </div>
+
+          <div class="meter">
+            <div>
+              <label>SSE Channel</label>
+              <strong id="sse-channel">none</strong>
+            </div>
+            <div>
+              <label>SSE Tokens</label>
+              <strong id="sse-tokens">0</strong>
+            </div>
+            <div>
+              <label>SSE Spent</label>
+              <strong id="sse-spent">0 pathUSD</strong>
+            </div>
+            <div>
+              <label>SSE Deposit</label>
+              <strong id="sse-deposit">0 pathUSD</strong>
+            </div>
+            <div>
+              <label>SSE Voucher</label>
+              <strong id="sse-cumulative">0 pathUSD</strong>
+            </div>
+          </div>
+
+          <div class="actions">
+            <button id="sse-start">Start SSE stream</button>
+          </div>
+
+          <pre id="sse-output" class="stream-output"></pre>
+        </section>
+
+        <section class="panel">
+          <div class="section-title">
+            <h2>Session State</h2>
+            <button id="refresh" class="ghost">Refresh</button>
+          </div>
+          <pre id="state"></pre>
+        </section>
+
+        <section class="panel log-panel">
+          <div class="section-title">
+            <h2>Events</h2>
+            <button id="clear-log" class="ghost">Clear</button>
+          </div>
+          <ol id="log"></ol>
+        </section>
+      </section>
+    </main>
+  </body>
+</html>

--- a/examples/session/playground/package.json
+++ b/examples/session/playground/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "session-playground",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "check:types": "tsgo -b",
+    "dev": "vite"
+  },
+  "dependencies": {
+    "@remix-run/node-fetch-server": "latest",
+    "@types/node": "latest",
+    "@typescript/native-preview": "latest",
+    "mppx": "latest",
+    "typescript": "latest",
+    "viem": "^2.50.4",
+    "vite": "latest"
+  }
+}

--- a/examples/session/playground/src/client.ts
+++ b/examples/session/playground/src/client.ts
@@ -1,0 +1,432 @@
+import { tempo } from 'mppx/client'
+import { createClient, http, type Hex } from 'viem'
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
+import { Actions } from 'viem/tempo'
+
+import { chain, networkName, rpcUrl, transportOptions } from './config.js'
+
+import './style.css'
+
+const storageKey = 'mppx.session.playground.privateKey'
+const sessionStoragePrefix = 'mppx.session.playground.channel'
+const currency = '0x20c0000000000000000000000000000000000001' as const
+const decimals = 6
+const tokenSymbol = 'pathUSD'
+const topUpAmount = '0.0005'
+
+let privateKey = localStorage.getItem(storageKey) as Hex | null
+if (!privateKey) {
+  privateKey = generatePrivateKey()
+  localStorage.setItem(storageKey, privateKey)
+}
+
+let account = privateKeyToAccount(privateKey)
+let client = createTempoClient()
+let session = createSession('manual')
+let autoSession = createSession('auto')
+let sseSession = createSession('sse')
+let clicks = 0
+let autoClicks = 0
+let sseTokens = 0
+let latestSpent = 0n
+let autoLatestSpent = 0n
+let sseLatestSpent = 0n
+let controlsBusy = false
+
+const elements = {
+  account: byId('account'),
+  autoChannel: byId('auto-channel'),
+  autoClick: button('auto-click'),
+  autoClicks: byId('auto-clicks'),
+  autoClose: button('auto-close'),
+  autoCumulative: byId('auto-cumulative'),
+  autoDeposit: byId('auto-deposit'),
+  autoRun: button('auto-run'),
+  autoSpent: byId('auto-spent'),
+  balance: byId('balance'),
+  channel: byId('channel'),
+  clearLog: button('clear-log'),
+  close: button('close'),
+  crank: button('crank'),
+  cumulative: byId('cumulative'),
+  deposit: byId('deposit'),
+  fund: button('fund'),
+  log: document.querySelector<HTMLOListElement>('#log')!,
+  modeLabel: byId('mode-label'),
+  networkEyebrow: byId('network-eyebrow'),
+  newWallet: button('new-wallet'),
+  refresh: button('refresh'),
+  spent: byId('spent'),
+  start: button('start'),
+  state: byId('state'),
+  sseChannel: byId('sse-channel'),
+  sseClose: button('sse-close'),
+  sseCumulative: byId('sse-cumulative'),
+  sseDeposit: byId('sse-deposit'),
+  sseOutput: document.querySelector<HTMLPreElement>('#sse-output')!,
+  sseSpent: byId('sse-spent'),
+  sseStart: button('sse-start'),
+  sseTokens: byId('sse-tokens'),
+  topUp: button('top-up'),
+}
+
+elements.fund.onclick = () => run('fund wallet', fundWallet)
+elements.start.onclick = () => run('start session', () => crank({ start: true }))
+elements.crank.onclick = () => run('crank session', () => crank())
+elements.topUp.onclick = () => run('top up session', topUpSession)
+elements.close.onclick = () => run('close session', closeSession)
+elements.autoClick.onclick = () => run('auto click', autoClick)
+elements.autoRun.onclick = () => run('auto run', autoRun)
+elements.autoClose.onclick = () => run('auto close', closeAutoSession)
+elements.sseStart.onclick = () => run('SSE stream', runSseStream)
+elements.sseClose.onclick = () => run('SSE close', closeSseSession)
+elements.refresh.onclick = () => run('refresh', refresh)
+elements.clearLog.onclick = () => {
+  elements.log.replaceChildren()
+}
+elements.newWallet.onclick = () =>
+  run('new wallet', async () => {
+    privateKey = generatePrivateKey()
+    localStorage.setItem(storageKey, privateKey)
+    account = privateKeyToAccount(privateKey)
+    client = createTempoClient()
+    clearSessionStores()
+    session = createSession('manual')
+    autoSession = createSession('auto')
+    sseSession = createSession('sse')
+    clicks = 0
+    autoClicks = 0
+    sseTokens = 0
+    latestSpent = 0n
+    autoLatestSpent = 0n
+    sseLatestSpent = 0n
+    elements.sseOutput.textContent = ''
+    log(`created ${short(account.address)}`)
+    await refresh()
+  })
+
+await checkHealth()
+await refresh()
+
+function createTempoClient() {
+  return createClient({
+    account,
+    chain,
+    pollingInterval: 1_000,
+    transport: http(rpcUrl, transportOptions),
+  })
+}
+
+type StoredSessionChannel =
+  NonNullable<Parameters<typeof tempo.session>[0]['sessionStore']> extends {
+    set(channel: infer channel): unknown
+  }
+    ? channel
+    : never
+
+function createSession(scope: string) {
+  return tempo.session({
+    account,
+    bootstrap: true,
+    client,
+    decimals,
+    maxDeposit: '0.002',
+    sessionStore: localSessionStore(scope),
+  })
+}
+
+function localSessionStore(scope: string) {
+  const key = `${sessionStoragePrefix}.${account.address}.${scope}`
+  return {
+    get() {
+      const value = localStorage.getItem(key)
+      return value ? (JSON.parse(value) as StoredSessionChannel) : null
+    },
+    set(channel: StoredSessionChannel) {
+      localStorage.setItem(key, JSON.stringify(channel))
+    },
+    delete() {
+      localStorage.removeItem(key)
+    },
+  }
+}
+
+function clearSessionStores() {
+  for (const key of Object.keys(localStorage)) {
+    if (key.startsWith(sessionStoragePrefix)) localStorage.removeItem(key)
+  }
+}
+
+async function fundWallet() {
+  const response = await fetch('/api/fund', {
+    body: JSON.stringify({ address: account.address }),
+    headers: { 'Content-Type': 'application/json' },
+    method: 'POST',
+  })
+  if (!response.ok) throw new Error(await readError(response))
+  log(`funded ${short(account.address)}`)
+  await refresh()
+}
+
+async function checkHealth() {
+  const response = await fetch('/api/health')
+  if (!response.ok) return
+  const health = (await response.json()) as { precompileAvailable?: boolean; network?: string }
+  if (health.precompileAvailable === false) {
+    log('Explorer has TIP-1034 metadata, but this RPC returns no data for TIP-1034 calls', 'error')
+  }
+  if (health.network) log(`connected to ${health.network}`)
+}
+
+async function crank(options: { start?: boolean } = {}) {
+  const nextClicks = clicks + 1
+  const response = await session.fetch(clickUrl(nextClicks))
+  if (!response.ok) throw new Error(await readError(response))
+  const body = (await response.json()) as { click: number; message: string; price: string }
+  if (response.receipt) {
+    latestSpent = BigInt(response.receipt.spent)
+    clicks = response.receipt.units ?? nextClicks
+  } else {
+    clicks = nextClicks
+  }
+  log(`${options.start ? 'started' : 'cranked'}: ${body.message}`)
+  await refresh()
+}
+
+async function autoClick() {
+  const nextClicks = autoClicks + 1
+  const response = await autoSession.fetch(clickUrl(nextClicks))
+  if (!response.ok) throw new Error(await readError(response))
+  const body = (await response.json()) as { click: number; message: string; price: string }
+  if (response.receipt) {
+    autoLatestSpent = BigInt(response.receipt.spent)
+    autoClicks = response.receipt.units ?? nextClicks
+  } else {
+    autoClicks = nextClicks
+  }
+  log(`auto: ${body.message}`)
+  await refresh()
+}
+
+async function autoRun() {
+  const target = autoClicks + 12
+  while (autoClicks < target) await autoClick()
+}
+
+async function runSseStream() {
+  elements.sseOutput.textContent = ''
+  sseTokens = 0
+  sseLatestSpent = 0n
+
+  const stream = await sseSession.sse(streamUrl(), {
+    onReceipt(receipt) {
+      sseLatestSpent = BigInt(receipt.spent)
+      if (typeof receipt.units === 'number') sseTokens = receipt.units
+    },
+  })
+
+  for await (const token of stream) {
+    elements.sseOutput.textContent += token
+    sseTokens += 1
+    await refresh()
+  }
+
+  log(`SSE streamed ${sseTokens} chunks`)
+  await refresh()
+}
+
+async function closeSession() {
+  const receipt = await session.close()
+  if (!receipt) {
+    log('nothing to close')
+    return
+  }
+  latestSpent = BigInt(receipt.spent)
+  log(`closed ${short(receipt.channelId)} at ${formatAmount(BigInt(receipt.spent))}`)
+  await refresh()
+}
+
+async function closeAutoSession() {
+  const receipt = await autoSession.close()
+  if (!receipt) {
+    log('nothing to close for auto flow')
+    return
+  }
+  autoLatestSpent = BigInt(receipt.spent)
+  log(`closed auto ${short(receipt.channelId)} at ${formatAmount(BigInt(receipt.spent))}`)
+  await refresh()
+}
+
+async function closeSseSession() {
+  const receipt = await sseSession.close()
+  if (!receipt) {
+    log('nothing to close for SSE flow')
+    return
+  }
+  sseLatestSpent = BigInt(receipt.spent)
+  log(`closed SSE ${short(receipt.channelId)} at ${formatAmount(BigInt(receipt.spent))}`)
+  await refresh()
+}
+
+async function topUpSession() {
+  const receipt = await session.topUp(topUpAmount)
+  if (receipt) latestSpent = BigInt(receipt.spent)
+  log(
+    `topped up ${topUpAmount} ${tokenSymbol}${receipt?.txHash ? ` (${short(receipt.txHash)})` : ''}`,
+  )
+  await refresh()
+}
+
+async function refresh() {
+  elements.account.textContent = account.address
+  elements.networkEyebrow.textContent = networkName
+  elements.modeLabel.textContent = `${networkName} / TIP-1034 precompile`
+  elements.balance.textContent = await getBalance().catch((error) =>
+    error instanceof Error ? error.message : 'unavailable',
+  )
+  elements.channel.textContent = short(session.channelId)
+  elements.spent.textContent = formatAmount(latestSpent)
+  elements.deposit.textContent = formatAmount(depositOf(session))
+  elements.cumulative.textContent = formatAmount(session.cumulative)
+  elements.autoChannel.textContent = short(autoSession.channelId)
+  elements.autoClicks.textContent = String(autoClicks)
+  elements.autoSpent.textContent = formatAmount(autoLatestSpent)
+  elements.autoDeposit.textContent = formatAmount(depositOf(autoSession))
+  elements.autoCumulative.textContent = formatAmount(autoSession.cumulative)
+  elements.sseChannel.textContent = short(sseSession.channelId)
+  elements.sseTokens.textContent = String(sseTokens)
+  elements.sseSpent.textContent = formatAmount(sseLatestSpent)
+  elements.sseDeposit.textContent = formatAmount(depositOf(sseSession))
+  elements.sseCumulative.textContent = formatAmount(sseSession.cumulative)
+  elements.state.textContent = JSON.stringify(
+    {
+      manual: {
+        manager: session.state,
+        opened: session.opened,
+        channelId: session.channelId,
+        clicks,
+      },
+      auto: {
+        manager: autoSession.state,
+        opened: autoSession.opened,
+        channelId: autoSession.channelId,
+        clicks: autoClicks,
+      },
+      sse: {
+        manager: sseSession.state,
+        opened: sseSession.opened,
+        channelId: sseSession.channelId,
+        tokens: sseTokens,
+      },
+    },
+    null,
+    2,
+  )
+  applyControlState()
+}
+
+function clickUrl(nextClicks = clicks) {
+  const url = new URL('/api/click', window.location.origin)
+  url.searchParams.set('count', String(nextClicks))
+  return url
+}
+
+function streamUrl() {
+  const url = new URL('/api/stream', window.location.origin)
+  url.searchParams.set('prompt', 'automatic SSE top-up')
+  return url
+}
+
+async function getBalance() {
+  const value = await Actions.token.getBalance(client, { account, token: currency })
+  return formatAmount(value)
+}
+
+async function run(label: string, action: () => Promise<void>) {
+  setDisabled(true)
+  try {
+    await action()
+  } catch (error) {
+    log(`${label} failed: ${error instanceof Error ? error.message : String(error)}`, 'error')
+  } finally {
+    setDisabled(false)
+  }
+}
+
+function setDisabled(disabled: boolean) {
+  controlsBusy = disabled
+  applyControlState()
+}
+
+function applyControlState() {
+  const allButtons = [
+    elements.autoClick,
+    elements.autoClose,
+    elements.autoRun,
+    elements.close,
+    elements.crank,
+    elements.fund,
+    elements.newWallet,
+    elements.refresh,
+    elements.sseClose,
+    elements.sseStart,
+    elements.start,
+    elements.topUp,
+  ]
+  for (const element of allButtons) element.disabled = controlsBusy
+  if (controlsBusy) return
+
+  elements.start.disabled = session.opened
+  elements.crank.disabled = !session.opened
+  elements.topUp.disabled = !session.opened
+  elements.close.disabled = !session.opened
+
+  elements.autoClose.disabled = !autoSession.opened
+
+  elements.sseStart.disabled = sseSession.opened
+  elements.sseClose.disabled = !sseSession.opened
+}
+
+function depositOf(manager: ReturnType<typeof createSession>) {
+  const state = manager.state
+  if ('deposit' in state) return BigInt(state.deposit)
+  return 0n
+}
+
+async function readError(response: Response) {
+  const body = await response.text()
+  if (!body) return `${response.status} ${response.statusText}`
+  try {
+    const data = JSON.parse(body) as { detail?: string; error?: string; title?: string }
+    return data.detail ?? data.error ?? data.title ?? body
+  } catch {
+    return body
+  }
+}
+
+function log(message: string, type: 'info' | 'error' = 'info') {
+  const item = document.createElement('li')
+  item.className = type
+  item.textContent = `${new Date().toLocaleTimeString()}  ${message}`
+  elements.log.prepend(item)
+}
+
+function formatAmount(value: bigint) {
+  const base = 10n ** BigInt(decimals)
+  const whole = value / base
+  const fraction = (value % base).toString().padStart(decimals, '0').replace(/0+$/, '')
+  return `${whole}${fraction ? `.${fraction}` : ''} ${tokenSymbol}`
+}
+
+function short(value: string | null | undefined) {
+  if (!value) return 'none'
+  return `${value.slice(0, 6)}...${value.slice(-4)}`
+}
+
+function byId(id: string) {
+  return document.getElementById(id)!
+}
+
+function button(id: string) {
+  return document.getElementById(id) as HTMLButtonElement
+}

--- a/examples/session/playground/src/config.ts
+++ b/examples/session/playground/src/config.ts
@@ -1,0 +1,23 @@
+import { tempoLocalnet, tempoModerato } from 'viem/tempo/chains'
+
+const env =
+  import.meta.env ??
+  (typeof process !== 'undefined'
+    ? (process.env as Partial<Record<keyof ImportMetaEnv, string>>)
+    : {})
+
+type TempoNetwork = 'localnet' | 'moderato'
+
+function parseNetwork(value: string | undefined): TempoNetwork {
+  if (value === undefined || value === '' || value === 'localnet') return 'localnet'
+  if (value === 'moderato' || value === 'devnet') return 'moderato'
+  throw new Error(`Unsupported Tempo network "${value}". Use "localnet" or "moderato".`)
+}
+
+export const tempoNetwork = parseNetwork(env.VITE_TEMPO_NETWORK)
+export const rpcUrl = env.VITE_RPC_URL || undefined
+
+export const chain = tempoNetwork === 'localnet' ? tempoLocalnet : tempoModerato
+export const isLocalnet = chain.id === tempoLocalnet.id
+export const networkName = isLocalnet ? 'Tempo Localnet' : 'Tempo Moderato'
+export const transportOptions = isLocalnet ? { retryCount: 0, timeout: 60_000 } : undefined

--- a/examples/session/playground/src/server.ts
+++ b/examples/session/playground/src/server.ts
@@ -1,0 +1,232 @@
+import { Mppx, Store, tempo } from 'mppx/server'
+import { Session } from 'mppx/tempo'
+import { createClient, http, isAddress, type Address, type Hex } from 'viem'
+import { generatePrivateKey, mnemonicToAccount, privateKeyToAccount } from 'viem/accounts'
+import { readContract, waitForTransactionReceipt } from 'viem/actions'
+import { Actions } from 'viem/tempo'
+
+import { chain, isLocalnet, networkName, rpcUrl, transportOptions } from './config.js'
+
+const account = isLocalnet
+  ? mnemonicToAccount('test test test test test test test test test test test junk')
+  : privateKeyToAccount(generatePrivateKey())
+const currency = '0x20c0000000000000000000000000000000000001' as const
+const pricePerClick = '0.00005'
+const pricePerStreamToken = '0.00005'
+const localnetFundAmount = 10_000_000_000n
+const store = Store.memory()
+const latestChannelByPayer = new Map<string, Hex>()
+let precompileAvailable: Promise<boolean> | null = null
+
+const client = createClient({
+  account,
+  chain,
+  pollingInterval: 1_000,
+  transport: http(rpcUrl, transportOptions),
+})
+
+type StoredSessionChannel = {
+  channelId: Hex
+  deposit: bigint
+  descriptor?: { payer?: Address | undefined } | undefined
+  finalized: boolean
+  highestVoucherAmount: bigint
+  spent: bigint
+  units: number
+}
+
+type PayloadWithPayerDescriptor = {
+  descriptor?: { payer?: unknown } | undefined
+}
+
+const mppx = Mppx.create({
+  methods: [
+    tempo.session({
+      account,
+      chainId: chain.id,
+      currency,
+      getClient: () => client,
+      recipient: account.address,
+      bootstrap: true,
+      resolveChannelId({ source }) {
+        const payer = sourceAddress(source)
+        return payer ? latestChannelByPayer.get(payer.toLowerCase()) : undefined
+      },
+      settlementSchedule: { units: 10 },
+      sse: { poll: true },
+      store,
+    }),
+  ],
+  secretKey: 'session-playground-secret',
+})
+
+mppx.onPaymentSuccess(trackLatestChannel)
+
+async function trackLatestChannel({
+  credential,
+  receipt,
+}: {
+  credential?: { payload?: unknown } | undefined
+  receipt: { method: string; channelId?: Hex | undefined }
+}) {
+  if (receipt.method !== 'tempo' || !('channelId' in receipt)) return
+  const channelId = receipt.channelId
+  if (!channelId) return
+  const channel = (await store.get(channelId)) as StoredSessionChannel | null
+  const payer = payloadPayer(credential?.payload) ?? channel?.descriptor?.payer
+  if (payer && channelId) latestChannelByPayer.set(payer.toLowerCase(), channelId)
+}
+
+function payloadPayer(payload: unknown): Address | undefined {
+  if (!payload || typeof payload !== 'object') return undefined
+  const descriptor = (payload as PayloadWithPayerDescriptor).descriptor
+  return typeof descriptor?.payer === 'string' && isAddress(descriptor.payer)
+    ? descriptor.payer
+    : undefined
+}
+
+void fundServer()
+
+export async function handler(request: Request): Promise<Response | null> {
+  const url = new URL(request.url)
+
+  if (url.pathname === '/api/health') {
+    return Response.json({
+      ok: true,
+      server: account.address,
+      chainId: chain.id,
+      network: networkName,
+      rpcUrl: rpcUrl ?? null,
+      precompileAvailable: await hasPrecompile(),
+    })
+  }
+
+  if (url.pathname === '/api/fund' && request.method === 'POST') {
+    const { address } = (await request.json().catch(() => ({}))) as { address?: string }
+    if (!address || !isAddress(address)) {
+      return Response.json({ error: 'address required' }, { status: 400 })
+    }
+    await fundAddress(address)
+    return Response.json({ funded: address })
+  }
+
+  if (url.pathname === '/api/click') {
+    if (!(await hasPrecompile())) {
+      return Response.json(
+        {
+          error:
+            'TIP-1034 channel escrow precompile metadata exists in the explorer, but the configured RPC returned no data for TIP-1034 ABI calls.',
+        },
+        { status: 503 },
+      )
+    }
+    const result = await mppx.session({
+      amount: pricePerClick,
+      suggestedDeposit: '0.0005',
+      unitType: 'click',
+    })(request)
+
+    if (result.status === 402) return result.challenge
+    if (request.method === 'HEAD') return result.withReceipt(new Response(null, { status: 204 }))
+
+    const count = Number(url.searchParams.get('count') ?? '1')
+    return result.withReceipt(
+      Response.json({
+        click: count,
+        message: `charged click ${count}`,
+        price: pricePerClick,
+      }),
+    )
+  }
+
+  if (url.pathname === '/api/stream') {
+    if (!(await hasPrecompile())) {
+      return Response.json(
+        {
+          error:
+            'TIP-1034 channel escrow precompile metadata exists in the explorer, but the configured RPC returned no data for TIP-1034 ABI calls.',
+        },
+        { status: 503 },
+      )
+    }
+
+    const result = await mppx.session({
+      amount: pricePerStreamToken,
+      suggestedDeposit: '0.00025',
+      unitType: 'token',
+    })(request)
+
+    if (result.status === 402) return result.challenge
+    if (request.method !== 'GET') return result.withReceipt(new Response(null, { status: 204 }))
+
+    const prompt = url.searchParams.get('prompt') ?? 'SSE demo'
+    const tokens = async function* () {
+      for (const token of streamTokens(prompt)) {
+        yield token
+      }
+    }
+    return result.withReceipt(tokens())
+  }
+
+  return null
+}
+
+function streamTokens(prompt: string): string[] {
+  return [
+    'Streaming',
+    ' payments',
+    ' for',
+    ' "',
+    prompt,
+    '"',
+    ' charge',
+    ' each',
+    ' chunk',
+    ' and',
+    ' top',
+    ' up',
+    ' automatically.',
+  ]
+}
+
+function sourceAddress(source: string | undefined): Address | undefined {
+  const address = source?.split(':').at(-1)
+  return address && isAddress(address) ? address : undefined
+}
+
+async function fundServer() {
+  console.log(`Playground server payee: ${account.address}`)
+  if (!isLocalnet) await Actions.faucet.fundSync(client, { account, timeout: 30_000 })
+  console.log(`Playground server funded on ${networkName}`)
+  if (!(await hasPrecompile())) {
+    console.warn(
+      'TIP-1034 channel escrow precompile metadata exists in the explorer, but this RPC returned no data for TIP-1034 ABI calls.',
+    )
+  }
+}
+
+async function fundAddress(address: Address) {
+  if (!isLocalnet) {
+    await Actions.faucet.fundSync(client, { account: address, timeout: 30_000 })
+    return
+  }
+
+  const hash = await Actions.token.transfer(client, {
+    account,
+    amount: localnetFundAmount,
+    chain,
+    to: address,
+    token: currency,
+  })
+  await waitForTransactionReceipt(client, { hash })
+}
+
+function hasPrecompile() {
+  return (precompileAvailable ??= readContract(client, {
+    address: Session.Precompile.Constants.tip20ChannelEscrow,
+    abi: Session.Precompile.escrowAbi,
+    functionName: 'CLOSE_GRACE_PERIOD',
+  })
+    .then(() => true)
+    .catch(() => false))
+}

--- a/examples/session/playground/src/style.css
+++ b/examples/session/playground/src/style.css
@@ -1,0 +1,232 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  background: #f6f7f9;
+  color: #16181d;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    sans-serif;
+  margin: 0;
+}
+
+button,
+code,
+pre {
+  font: inherit;
+}
+
+button {
+  background: #155dfc;
+  border: 1px solid #155dfc;
+  border-radius: 6px;
+  color: #fff;
+  cursor: pointer;
+  font-weight: 650;
+  min-height: 40px;
+  padding: 0 14px;
+}
+
+button:hover:not(:disabled) {
+  background: #0f46c6;
+}
+
+button:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
+button.ghost {
+  background: #fff;
+  border-color: #ccd2dc;
+  color: #20242c;
+}
+
+button.danger {
+  background: #b42318;
+  border-color: #b42318;
+}
+
+.shell {
+  margin: 0 auto;
+  max-width: 1180px;
+  padding: 28px;
+}
+
+.topbar {
+  align-items: end;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 22px;
+}
+
+.eyebrow,
+label {
+  color: #596173;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0;
+  margin: 0 0 6px;
+  text-transform: uppercase;
+}
+
+h1,
+h2 {
+  letter-spacing: 0;
+  margin: 0;
+}
+
+h1 {
+  font-size: 34px;
+}
+
+h2 {
+  font-size: 17px;
+}
+
+.network {
+  background: #eaf1ff;
+  border: 1px solid #c7d8ff;
+  border-radius: 6px;
+  color: #113b91;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 8px 10px;
+}
+
+.grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(320px, 0.95fr) minmax(360px, 1.05fr);
+}
+
+.panel {
+  background: #fff;
+  border: 1px solid #d9dee8;
+  border-radius: 8px;
+  padding: 18px;
+}
+
+.controls {
+  display: grid;
+  gap: 18px;
+}
+
+.account-row,
+.section-title {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+}
+
+code {
+  color: #313846;
+  display: block;
+  font-family: 'SFMono-Regular', Consolas, monospace;
+  font-size: 13px;
+  overflow-wrap: anywhere;
+}
+
+.meter {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: 1fr 1fr;
+}
+
+.meter > div {
+  border: 1px solid #e0e5ee;
+  border-radius: 6px;
+  min-height: 76px;
+  padding: 12px;
+}
+
+.meter strong {
+  display: block;
+  font-size: 15px;
+  overflow-wrap: anywhere;
+}
+
+.actions {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: 1fr 1fr;
+}
+
+.actions button {
+  width: 100%;
+}
+
+pre {
+  background: #10151f;
+  border-radius: 6px;
+  color: #d8e1f0;
+  font-family: 'SFMono-Regular', Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  margin: 14px 0 0;
+  min-height: 310px;
+  overflow: auto;
+  padding: 14px;
+}
+
+.stream-output {
+  background: #f7f9fc;
+  color: #20242c;
+  min-height: 116px;
+  white-space: pre-wrap;
+}
+
+.log-panel {
+  grid-column: 1 / -1;
+}
+
+ol {
+  display: grid;
+  gap: 8px;
+  list-style: none;
+  margin: 14px 0 0;
+  max-height: 260px;
+  overflow: auto;
+  padding: 0;
+}
+
+li {
+  background: #f7f9fc;
+  border: 1px solid #e2e7f0;
+  border-radius: 6px;
+  font-family: 'SFMono-Regular', Consolas, monospace;
+  font-size: 12px;
+  padding: 9px 10px;
+}
+
+li.error {
+  background: #fff1f0;
+  border-color: #ffc9c4;
+  color: #8f1f16;
+}
+
+@media (max-width: 820px) {
+  .shell {
+    padding: 18px;
+  }
+
+  .topbar,
+  .account-row,
+  .section-title {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .grid,
+  .meter,
+  .actions {
+    grid-template-columns: 1fr;
+  }
+}

--- a/examples/session/playground/src/vite-env.d.ts
+++ b/examples/session/playground/src/vite-env.d.ts
@@ -1,0 +1,10 @@
+declare module '*.css'
+
+interface ImportMetaEnv {
+  readonly VITE_RPC_URL?: string | undefined
+  readonly VITE_TEMPO_NETWORK?: 'localnet' | 'moderato' | 'devnet' | undefined
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/examples/session/playground/tsconfig.json
+++ b/examples/session/playground/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ESNext",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"]
+}

--- a/examples/session/playground/vite.config.ts
+++ b/examples/session/playground/vite.config.ts
@@ -1,0 +1,54 @@
+import path from 'node:path'
+
+import { createRequest, sendResponse } from '@remix-run/node-fetch-server'
+import { defineConfig } from 'vite'
+
+const root = path.resolve(import.meta.dirname, '../../..')
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      'mppx/client': path.resolve(root, 'src/client'),
+      'mppx/server': path.resolve(root, 'src/server'),
+      'mppx/tempo': path.resolve(root, 'src/tempo'),
+      mppx: path.resolve(root, 'src'),
+    },
+  },
+  plugins: [
+    {
+      name: 'playground-api',
+      configureServer(server) {
+        // oxlint-disable-next-line no-async-endpoint-handlers
+        server.middlewares.use(async (req, res, next) => {
+          try {
+            const request = createRequest(req, res)
+            const { handler } = await server.ssrLoadModule('/src/server.ts')
+            const response = await handler(request)
+            if (response) {
+              await sendResponse(res, response)
+              return
+            }
+            next()
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error)
+            if (res.headersSent) {
+              console.error(message)
+              return
+            }
+            await sendResponse(res, Response.json({ error: message }, { status: 500 }))
+          }
+        })
+
+        server.httpServer?.once('listening', () => {
+          const addr = server.httpServer!.address()
+          const host =
+            typeof addr === 'object' && addr ? `localhost:${addr.port}` : 'localhost:5173'
+          setTimeout(() => {
+            console.log('\n  Tempo session playground:')
+            console.log(`  http://${host}/\n`)
+          }, 100)
+        })
+      },
+    },
+  ],
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,6 +237,30 @@ importers:
         specifier: latest
         version: 8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0)
 
+  examples/session/playground:
+    dependencies:
+      '@remix-run/node-fetch-server':
+        specifier: latest
+        version: 0.13.3
+      '@types/node':
+        specifier: latest
+        version: 25.9.2
+      '@typescript/native-preview':
+        specifier: latest
+        version: 7.0.0-dev.20260607.1
+      mppx:
+        specifier: workspace:*
+        version: link:../../..
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+      viem:
+        specifier: ^2.51.3
+        version: 2.51.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      vite:
+        specifier: latest
+        version: 8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0)
+
   examples/session/sse:
     dependencies:
       '@remix-run/node-fetch-server':


### PR DESCRIPTION
## Summary

- Added a Tempo session playground example for HTTP, SSE, WebSocket, top-up, and bootstrap flows
- Added localnet/moderato configuration and README instructions for running the playground
- Added the playground workspace package and lockfile importer
