### PR TITLE
feat: add client-side Tempo chain pinning

### DIFF
--- a/.changeset/tempo-client-chain-pinning.md
+++ b/.changeset/tempo-client-chain-pinning.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added client-side Tempo chain pinning. `tempo.charge({ expectedChainId })` rejects charge challenges whose `methodDetails.chainId` conflicts with the configured chain ID, and signs on the pinned chain when the challenge omits it.

--- a/src/tempo/client/Charge.test.ts
+++ b/src/tempo/client/Charge.test.ts
@@ -123,4 +123,89 @@ describe('tempo.charge client', () => {
       vi.resetModules()
     }
   })
+
+  describe('chain pinning', () => {
+    const client = createClient({
+      account,
+      chain: tempoLocalnet,
+      transport: http('http://127.0.0.1'),
+    })
+
+    test('rejects a challenge whose chainId conflicts with the pin', async () => {
+      const getClient = vi.fn(() => client)
+      const method = charge({
+        account,
+        expectedChainId: 42431,
+        getClient,
+      })
+
+      await expect(
+        method.createCredential({
+          challenge: createChallenge({ chainId: 1 }),
+          context: {},
+        }),
+      ).rejects.toThrow('Chain ID mismatch: expected 42431, got 1.')
+
+      // The mismatch is rejected before resolving a client or signing.
+      expect(getClient).not.toHaveBeenCalled()
+    })
+
+    test('accepts a challenge whose chainId matches the pin', async () => {
+      const chainId = 42431
+      const method = charge({
+        account,
+        expectedChainId: chainId,
+        getClient: () => client,
+      })
+
+      const credential = Credential.deserialize(
+        await method.createCredential({
+          challenge: createChallenge({ chainId }),
+          context: {},
+        }),
+      )
+
+      expect(credential.source).toBe(`did:pkh:eip155:${chainId}:${account.address}`)
+    })
+
+    test('signs on the pin when the challenge omits chainId', async () => {
+      let requestedChainId: number | undefined
+      const chainId = 42431
+      const method = charge({
+        account,
+        expectedChainId: chainId,
+        getClient: (parameters) => {
+          requestedChainId = parameters.chainId
+          return client
+        },
+      })
+
+      const credential = Credential.deserialize(
+        await method.createCredential({
+          challenge: createChallenge(),
+          context: {},
+        }),
+      )
+
+      expect(requestedChainId).toBe(chainId)
+      expect(credential.source).toBe(`did:pkh:eip155:${chainId}:${account.address}`)
+    })
+
+    test('unpinned client accepts any challenge chainId', async () => {
+      const chainId = 1
+      const method = charge({
+        account,
+        getClient: () => client,
+      })
+
+      const credential = Credential.deserialize(
+        await method.createCredential({
+          challenge: createChallenge({ chainId }),
+          context: {},
+        }),
+      )
+
+      expect(credential.source).toBe(`did:pkh:eip155:${chainId}:${account.address}`)
+    })
+  })
 })

--- a/src/tempo/client/Charge.ts
+++ b/src/tempo/client/Charge.ts
@@ -51,9 +51,20 @@ export function charge(parameters: charge.Parameters = {}) {
     }),
 
     async createCredential({ challenge, context }) {
+      // Chain pinning: reject a challenge whose chain ID conflicts with the
+      // pinned one, and sign on the pin when the challenge omits a chain ID.
       const challengeChainId = challenge.request.methodDetails?.chainId
-      const client = await getClient({ chainId: challengeChainId })
-      const chainId = challengeChainId ?? client.chain?.id
+      if (
+        parameters.expectedChainId !== undefined &&
+        challengeChainId !== undefined &&
+        challengeChainId !== parameters.expectedChainId
+      )
+        throw new Error(
+          `Chain ID mismatch: expected ${parameters.expectedChainId}, got ${challengeChainId}.`,
+        )
+      const resolvedChainId = challengeChainId ?? parameters.expectedChainId
+      const client = await getClient({ chainId: resolvedChainId })
+      const chainId = resolvedChainId ?? client.chain?.id
       if (chainId === undefined)
         throw new Error('No `chainId` provided. Pass a chain ID in the challenge or client.')
 
@@ -198,6 +209,12 @@ export declare namespace charge {
     autoSwap?: AutoSwap | undefined
     /** Client identifier used to derive the client fingerprint in attribution memos. */
     clientId?: string | undefined
+    /**
+     * Chain ID this client is willing to pay on. When set, the client rejects
+     * any challenge whose `methodDetails.chainId` differs, and signs on this
+     * chain when the challenge omits a chain ID.
+     */
+    expectedChainId?: number | undefined
     /**
      * Allowlist of expected split recipient addresses. When set, the client
      * rejects any challenge whose split recipients are not in this list.


### PR DESCRIPTION
Adds `tempo.charge({ expectedChainId })` so clients can pin the chain they'll pay on. Rejects charge challenges whose `methodDetails.chainId` conflicts, and signs on the pin when the challenge omits it. Matches the mpp-go conformance ABI.

Part of OSS-306