### PR TITLE
fix: add npm homepage and bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,10 @@
   "version": "0.6.31",
   "main": "./dist/index.js",
   "license": "MIT",
+  "homepage": "https://github.com/wevm/mppx#readme",
+  "bugs": {
+    "url": "https://github.com/wevm/mppx/issues"
+  },
   "files": [
     "CHANGELOG.md",
     "dist",


### PR DESCRIPTION
## Summary

- add `homepage` metadata pointing to the repository README
- add `bugs.url` metadata pointing to the issue tracker
