### PR TITLE
feat: simulate co-signed transaction before sponsored broadcast

### DIFF
--- a/.changeset/sponsor-presimulate-cosigned.md
+++ b/.changeset/sponsor-presimulate-cosigned.md
@@ -2,4 +2,4 @@
 'mppx': patch
 ---
 
-The Tempo fee-payer (sponsor) pre-broadcast simulation now simulates the co-signed transaction the sponsor actually broadcasts — with the concrete fee payer and chosen fee token — instead of the pre-cosign `0x78` envelope. This catches reverts in the exact transaction the sponsor pays gas for, and fails closed (no broadcast) when the simulation reverts.
+The Tempo fee-payer (sponsor) pre-broadcast simulation now simulates the co-signed transaction the sponsor actually broadcasts — with the concrete fee payer and chosen fee token — instead of the pre-cosign `0x78` envelope, for both local and hosted (`feePayerUrl`) fee payers. This catches reverts in the exact transaction the sponsor pays gas for, and fails closed (no broadcast) when the simulation reverts.

--- a/.changeset/sponsor-presimulate-cosigned.md
+++ b/.changeset/sponsor-presimulate-cosigned.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+The Tempo fee-payer (sponsor) pre-broadcast simulation now simulates the co-signed transaction the sponsor actually broadcasts — with the concrete fee payer and chosen fee token — instead of the pre-cosign `0x78` envelope. This catches reverts in the exact transaction the sponsor pays gas for, and fails closed (no broadcast) when the simulation reverts.

--- a/src/tempo/internal/fee-payer.test.ts
+++ b/src/tempo/internal/fee-payer.test.ts
@@ -1,3 +1,5 @@
+import { Address, Secp256k1 } from 'ox'
+import { TxEnvelopeTempo } from 'ox/tempo'
 import { encodeFunctionData, maxUint256, toHex } from 'viem'
 import { Abis, Addresses, Transaction } from 'viem/tempo'
 import { afterEach, describe, expect, test, vi } from 'vp/test'
@@ -499,20 +501,68 @@ describe('fillHostedFeePayerTransaction', () => {
   } as const
 
   test('uses hosted fillTransaction and preserves sender-committed fields', async () => {
+    // Sign over the payload built from the actual RPC request body so this
+    // verifies recovery parity with the real request shape.
+    const sponsorPrivateKey =
+      '0x0000000000000000000000000000000000000000000000000000000000000042' as const
+    const sponsorAddress = Address.fromPublicKey(
+      Secp256k1.getPublicKey({ privateKey: sponsorPrivateKey }),
+    )
+    let realFeePayerSignature: ReturnType<typeof Secp256k1.sign> | undefined
+
     const calls: { init?: RequestInit | undefined; input: RequestInfo | URL }[] = []
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       calls.push({ init, input })
+      const rpc = JSON.parse(init!.body as string).params[0]
+      const quantity = (value: unknown) =>
+        value === undefined ? undefined : BigInt(value as string)
+      realFeePayerSignature = Secp256k1.sign({
+        payload: TxEnvelopeTempo.getFeePayerSignPayload(
+          TxEnvelopeTempo.from({
+            accessList: rpc.accessList,
+            calls: rpc.calls.map(({ value, ...call }: any) => ({
+              ...call,
+              ...(value && value !== '0x' ? { value: BigInt(value) } : {}),
+            })),
+            chainId: hostedTransaction.chainId,
+            feeToken: defaults.tokens.pathUsd,
+            from: rpc.from,
+            ...(quantity(rpc.gas) !== undefined ? { gas: quantity(rpc.gas) } : {}),
+            ...(rpc.keyAuthorization !== undefined
+              ? { keyAuthorization: rpc.keyAuthorization }
+              : {}),
+            ...(quantity(rpc.maxFeePerGas) !== undefined
+              ? { maxFeePerGas: quantity(rpc.maxFeePerGas) }
+              : {}),
+            ...(quantity(rpc.maxPriorityFeePerGas) !== undefined
+              ? { maxPriorityFeePerGas: quantity(rpc.maxPriorityFeePerGas) }
+              : {}),
+            ...(quantity(rpc.nonce) !== undefined ? { nonce: quantity(rpc.nonce) } : {}),
+            ...(quantity(rpc.nonceKey) !== undefined ? { nonceKey: quantity(rpc.nonceKey) } : {}),
+            type: 'tempo',
+            ...(rpc.validAfter !== undefined ? { validAfter: Number(BigInt(rpc.validAfter)) } : {}),
+            ...(rpc.validBefore !== undefined
+              ? { validBefore: Number(BigInt(rpc.validBefore)) }
+              : {}),
+          } as any) as any,
+          { sender: rpc.from },
+        ),
+        privateKey: sponsorPrivateKey,
+      })
       return new Response(
-        JSON.stringify({
-          result: {
-            tx: {
-              feePayerSignature,
-              feeToken: defaults.tokens.pathUsd,
-              gas: '0x1',
-              maxFeePerGas: '0x2',
+        JSON.stringify(
+          {
+            result: {
+              tx: {
+                feePayerSignature: realFeePayerSignature,
+                feeToken: defaults.tokens.pathUsd,
+                gas: '0x1',
+                maxFeePerGas: '0x2',
+              },
             },
           },
-        }),
+          (_key, value) => (typeof value === 'bigint' ? toHex(value) : value),
+        ),
       )
     })
     vi.stubGlobal('fetch', fetchMock)
@@ -523,10 +573,8 @@ describe('fillHostedFeePayerTransaction', () => {
       url: 'https://sponsor.example/tp_key',
     })
 
-    // Surfaces the sponsor's chosen feeToken/feePayerSignature so callers can
-    // pre-broadcast simulate the co-signed transaction.
     expect(result.feeToken).toBe(defaults.tokens.pathUsd)
-    expect(result.feePayerSignature).toEqual(feePayerSignature)
+    expect(result.feePayer.toLowerCase()).toBe(sponsorAddress.toLowerCase())
     const serialized = result.serializedTransaction
 
     expect(fetchMock).toHaveBeenCalledOnce()
@@ -560,7 +608,8 @@ describe('fillHostedFeePayerTransaction', () => {
     expect(transaction.maxFeePerGas).toBe(hostedTransaction.maxFeePerGas)
     expect(transaction.calls).toEqual(hostedTransaction.calls)
     expect(transaction.feeToken).toBe(defaults.tokens.pathUsd)
-    expect(transaction.feePayerSignature).toEqual(feePayerSignature)
+    expect(BigInt(transaction.feePayerSignature!.r)).toBe(realFeePayerSignature!.r)
+    expect(BigInt(transaction.feePayerSignature!.s)).toBe(realFeePayerSignature!.s)
   })
 
   test('error: requires hosted fee payer to return a feeToken', async () => {

--- a/src/tempo/internal/fee-payer.test.ts
+++ b/src/tempo/internal/fee-payer.test.ts
@@ -517,11 +517,17 @@ describe('fillHostedFeePayerTransaction', () => {
     })
     vi.stubGlobal('fetch', fetchMock)
 
-    const serialized = await fillHostedFeePayerTransaction({
+    const result = await fillHostedFeePayerTransaction({
       allowedFeeTokens: defaultAllowedFeeTokens(defaults.chainId.mainnet),
       transaction: hostedTransaction as any,
       url: 'https://sponsor.example/tp_key',
     })
+
+    // Surfaces the sponsor's chosen feeToken/feePayerSignature so callers can
+    // pre-broadcast simulate the co-signed transaction.
+    expect(result.feeToken).toBe(defaults.tokens.pathUsd)
+    expect(result.feePayerSignature).toEqual(feePayerSignature)
+    const serialized = result.serializedTransaction
 
     expect(fetchMock).toHaveBeenCalledOnce()
     expect(calls[0]!.input).toBe('https://sponsor.example/tp_key')

--- a/src/tempo/internal/fee-payer.ts
+++ b/src/tempo/internal/fee-payer.ts
@@ -173,6 +173,10 @@ function hostedFeePayerRequest(transaction: SponsoredTransaction) {
  * Co-signs a sender-signed partial sponsorship envelope using a hosted
  * fee-payer endpoint without letting the endpoint mutate sender-committed
  * transaction fields.
+ *
+ * @returns The serialized co-signed transaction plus the sponsor's chosen
+ *   `feeToken` and `feePayerSignature`, so callers can pre-broadcast simulate
+ *   the exact transaction the sponsor broadcasts.
  */
 export async function fillHostedFeePayerTransaction(parameters: {
   allowedFeeTokens: readonly TempoAddress.Address[]
@@ -207,12 +211,22 @@ export async function fillHostedFeePayerTransaction(parameters: {
 
   assertAllowedFeeToken({ feeToken: filled.feeToken }, allowedFeeTokens)
 
-  return Transaction.serialize({
-    ...transaction,
-    feePayer: true,
-    feePayerSignature: filled.feePayerSignature,
-    feeToken: filled.feeToken,
-  } as never)
+  const feePayerSignature = filled.feePayerSignature
+  const feeToken = filled.feeToken
+
+  // Return the sponsor's chosen `feeToken` and `feePayerSignature` alongside
+  // the serialized envelope so the caller can pre-broadcast simulate the
+  // co-signed transaction (concrete fee settlement), not just the calls.
+  return {
+    feePayerSignature,
+    feeToken,
+    serializedTransaction: await Transaction.serialize({
+      ...transaction,
+      feePayer: true,
+      feePayerSignature,
+      feeToken,
+    } as never),
+  }
 }
 
 /** Returns a transaction shape suitable for pre-broadcast simulation. */

--- a/src/tempo/internal/fee-payer.ts
+++ b/src/tempo/internal/fee-payer.ts
@@ -1,3 +1,4 @@
+import { Secp256k1 } from 'ox'
 import type { TempoAddress } from 'ox/tempo'
 import { TxEnvelopeTempo } from 'ox/tempo'
 import type { Hex } from 'viem'
@@ -174,9 +175,9 @@ function hostedFeePayerRequest(transaction: SponsoredTransaction) {
  * fee-payer endpoint without letting the endpoint mutate sender-committed
  * transaction fields.
  *
- * @returns The serialized co-signed transaction plus the sponsor's chosen
- *   `feeToken` and `feePayerSignature`, so callers can pre-broadcast simulate
- *   the exact transaction the sponsor broadcasts.
+ * @returns The serialized co-signed transaction plus the sponsor's recovered
+ *   `feePayer` address and chosen `feeToken`, so callers can pre-broadcast
+ *   simulate the exact transaction the sponsor broadcasts.
  */
 export async function fillHostedFeePayerTransaction(parameters: {
   allowedFeeTokens: readonly TempoAddress.Address[]
@@ -214,11 +215,32 @@ export async function fillHostedFeePayerTransaction(parameters: {
   const feePayerSignature = filled.feePayerSignature
   const feeToken = filled.feeToken
 
-  // Return the sponsor's chosen `feeToken` and `feePayerSignature` alongside
-  // the serialized envelope so the caller can pre-broadcast simulate the
-  // co-signed transaction (concrete fee settlement), not just the calls.
+  // Recover the concrete sponsor address so the simulation can use a concrete
+  // `feePayer` (the node rejects `eth_call` with `feePayer: true`).
+  const feePayer = (() => {
+    try {
+      return Secp256k1.recoverAddress({
+        payload: TxEnvelopeTempo.getFeePayerSignPayload(
+          TxEnvelopeTempo.from({
+            ...transaction,
+            feePayerSignature: undefined,
+            feeToken,
+            signature: undefined,
+          } as never),
+          { sender: transaction.from as never },
+        ),
+        signature: feePayerSignature as never,
+      })
+    } catch {
+      throw new FeePayerValidationError(
+        'hosted fee payer returned an invalid feePayerSignature',
+        {},
+      )
+    }
+  })()
+
   return {
-    feePayerSignature,
+    feePayer,
     feeToken,
     serializedTransaction: await Transaction.serialize({
       ...transaction,

--- a/src/tempo/server/Charge.test.ts
+++ b/src/tempo/server/Charge.test.ts
@@ -1604,6 +1604,228 @@ describe('tempo', () => {
       httpServer.close()
     })
 
+    test('behavior: fee payer pre-broadcast simulation targets the co-signed transaction', async () => {
+      // The pre-broadcast simulation must reflect the FINAL co-signed envelope
+      // (concrete sponsor fee payer), not the pre-cosign 0x78 (`feePayer: true`).
+      const callRequests: any[] = []
+      const interceptingClient = createClient({
+        account: accounts[0],
+        chain: client.chain,
+        transport: custom({
+          async request(args: any) {
+            if (args.method === 'eth_call') callRequests.push(args.params?.[0])
+            return client.transport.request(args)
+          },
+        }),
+      })
+
+      const serverWithTrace = Mppx_server.create({
+        methods: [
+          tempo_server.charge({
+            getClient() {
+              return interceptingClient
+            },
+            currency: asset,
+            account: accounts[0],
+          }),
+        ],
+        realm,
+        secretKey,
+      })
+
+      const mppx = Mppx_client.create({
+        polyfill: false,
+        methods: [
+          tempo_client({
+            account: accounts[1],
+            getClient() {
+              return client
+            },
+          }),
+        ],
+      })
+
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await Mppx_server.toNodeListener(
+          serverWithTrace.charge({
+            feePayer: accounts[0],
+            amount: '1',
+            currency: asset,
+            recipient: accounts[0].address,
+          }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
+      })
+
+      const challengeResponse = await fetch(httpServer.url)
+      const credential = await mppx.createCredential(challengeResponse)
+      callRequests.length = 0
+
+      const authResponse = await fetch(httpServer.url, {
+        headers: { Authorization: credential },
+      })
+      expect(authResponse.status).toBe(200)
+
+      expect(callRequests.length).toBeGreaterThan(0)
+      const simRequest = callRequests[0]
+      // The co-signed envelope names a concrete sponsor as fee payer. The
+      // pre-cosign 0x78 instead carries `feePayer: true`; asserting the address
+      // proves we simulate the transaction the sponsor actually broadcasts.
+      expect(simRequest.feePayer).not.toBe(true)
+      expect(typeof simRequest.feePayer).toBe('string')
+      expect((simRequest.feePayer as string).toLowerCase()).toBe(accounts[0].address.toLowerCase())
+      // Execution runs as the sender, not the sponsor.
+      expect((simRequest.from as string).toLowerCase()).toBe(accounts[1].address.toLowerCase())
+      expect(simRequest.calls?.length).toBeGreaterThan(0)
+
+      httpServer.close()
+    })
+
+    test('behavior: fee payer fails closed when pre-broadcast simulation reverts', async () => {
+      // A reverting pre-broadcast simulation must abort before broadcast so the
+      // sponsor never pays gas for a transaction that would revert.
+      const rpcMethods: string[] = []
+      const interceptingClient = createClient({
+        account: accounts[0],
+        chain: client.chain,
+        transport: custom({
+          async request(args: any) {
+            rpcMethods.push(args.method)
+            if (args.method === 'eth_call')
+              throw new Error('execution reverted: simulation fixture')
+            return client.transport.request(args)
+          },
+        }),
+      })
+
+      const serverWithRevert = Mppx_server.create({
+        methods: [
+          tempo_server.charge({
+            getClient() {
+              return interceptingClient
+            },
+            currency: asset,
+            account: accounts[0],
+          }),
+        ],
+        realm,
+        secretKey,
+      })
+
+      const mppx = Mppx_client.create({
+        polyfill: false,
+        methods: [
+          tempo_client({
+            account: accounts[1],
+            getClient() {
+              return client
+            },
+          }),
+        ],
+      })
+
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await Mppx_server.toNodeListener(
+          serverWithRevert.charge({
+            feePayer: accounts[0],
+            amount: '1',
+            currency: asset,
+            recipient: accounts[0].address,
+          }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
+      })
+
+      const challengeResponse = await fetch(httpServer.url)
+      const credential = await mppx.createCredential(challengeResponse)
+      rpcMethods.length = 0
+
+      const authResponse = await fetch(httpServer.url, {
+        headers: { Authorization: credential },
+      })
+
+      // Fails closed: not successful, and the transaction is never broadcast.
+      expect(authResponse.status).not.toBe(200)
+      expect(rpcMethods).toContain('eth_call')
+      expect(rpcMethods).not.toContain('eth_sendRawTransactionSync')
+      expect(rpcMethods).not.toContain('eth_sendRawTransaction')
+
+      httpServer.close()
+    })
+
+    test('behavior: fee payer fails closed when simulation reverts (optimistic mode)', async () => {
+      const rpcMethods: string[] = []
+      const interceptingClient = createClient({
+        account: accounts[0],
+        chain: client.chain,
+        transport: custom({
+          async request(args: any) {
+            rpcMethods.push(args.method)
+            if (args.method === 'eth_call')
+              throw new Error('execution reverted: simulation fixture')
+            return client.transport.request(args)
+          },
+        }),
+      })
+
+      const serverNoWait = Mppx_server.create({
+        methods: [
+          tempo_server.charge({
+            getClient() {
+              return interceptingClient
+            },
+            currency: asset,
+            account: accounts[0],
+            waitForConfirmation: false,
+          }),
+        ],
+        realm,
+        secretKey,
+      })
+
+      const mppx = Mppx_client.create({
+        polyfill: false,
+        methods: [
+          tempo_client({
+            account: accounts[1],
+            getClient() {
+              return client
+            },
+          }),
+        ],
+      })
+
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await Mppx_server.toNodeListener(
+          serverNoWait.charge({
+            feePayer: accounts[0],
+            amount: '1',
+            currency: asset,
+            recipient: accounts[0].address,
+          }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
+      })
+
+      const challengeResponse = await fetch(httpServer.url)
+      const credential = await mppx.createCredential(challengeResponse)
+      rpcMethods.length = 0
+
+      const authResponse = await fetch(httpServer.url, {
+        headers: { Authorization: credential },
+      })
+
+      expect(authResponse.status).not.toBe(200)
+      expect(rpcMethods).toContain('eth_call')
+      expect(rpcMethods).not.toContain('eth_sendRawTransaction')
+      expect(rpcMethods).not.toContain('eth_sendRawTransactionSync')
+
+      httpServer.close()
+    })
+
     test('behavior: fee payer rejects concurrent in-flight transactions from one sender', async () => {
       let releaseSimulation!: () => void
       let resolveSimulationStarted!: () => void

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -441,17 +441,13 @@ export function charge<const parameters extends charge.Parameters>(
                   transaction,
                   url: feePayerUrl,
                 })
-                // Simulate the co-signed envelope the hosted sponsor
-                // broadcasts: the sender executes (`account`/`from`) while the
-                // sponsor's chosen `feeToken` settles fees. Keeping
-                // `feePayerSignature` is required — viem strips `feeToken` from
-                // the `eth_call` request when `feePayer === true` and no
-                // `feePayerSignature` is present.
+                // Simulate the co-signed envelope (concrete fee payer + chosen
+                // fee token), mirroring the local-sponsor path.
                 simulationRequest = {
                   ...transaction,
                   account: transaction.from,
-                  feePayer: true,
-                  feePayerSignature: hosted.feePayerSignature,
+                  feePayer: hosted.feePayer,
+                  feePayerSignature: undefined,
                   feeToken: hosted.feeToken,
                   signature: undefined,
                 }

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -435,12 +435,28 @@ export function charge<const parameters extends charge.Parameters>(
                 }
                 return signTransaction(client, sponsored as never)
               }
-              if (feePayerUrl && isFeePayerTx)
-                return FeePayer.fillHostedFeePayerTransaction({
+              if (feePayerUrl && isFeePayerTx) {
+                const hosted = await FeePayer.fillHostedFeePayerTransaction({
                   allowedFeeTokens,
                   transaction,
                   url: feePayerUrl,
                 })
+                // Simulate the co-signed envelope the hosted sponsor
+                // broadcasts: the sender executes (`account`/`from`) while the
+                // sponsor's chosen `feeToken` settles fees. Keeping
+                // `feePayerSignature` is required — viem strips `feeToken` from
+                // the `eth_call` request when `feePayer === true` and no
+                // `feePayerSignature` is present.
+                simulationRequest = {
+                  ...transaction,
+                  account: transaction.from,
+                  feePayer: true,
+                  feePayerSignature: hosted.feePayerSignature,
+                  feeToken: hosted.feeToken,
+                  signature: undefined,
+                }
+                return hosted.serializedTransaction
+              }
               return serializedTransaction
             })()
 

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -403,6 +403,15 @@ export function charge<const parameters extends charge.Parameters>(
             const expectedFeeToken = defaults.currency[chainId as keyof typeof defaults.currency]
             const resolvedFeeToken = transaction.feeToken ?? expectedFeeToken
 
+            // Request for the pre-broadcast simulation; for sponsored payments
+            // this is overwritten below with the co-signed shape.
+            let simulationRequest: Record<string, unknown> = {
+              ...transaction,
+              account: transaction.from,
+              calls: transaction.calls,
+              feePayerSignature: undefined,
+            }
+
             const serializedTransaction_final = await (async () => {
               if (feePayerAccount && methodDetails?.feePayer !== false) {
                 const sponsored = FeePayer.prepareSponsoredTransaction({
@@ -417,18 +426,25 @@ export function charge<const parameters extends charge.Parameters>(
                     ...(resolvedFeeToken ? { feeToken: resolvedFeeToken } : {}),
                   },
                 })
+                // `account` is the sender (eth_call `from`); `feePayer` is the
+                // sponsor that pays gas.
+                simulationRequest = {
+                  ...sponsored,
+                  account: transaction.from,
+                  feePayer: feePayerAccount.address,
+                  feePayerSignature: undefined,
+                  signature: undefined,
+                }
                 return signTransaction(client, sponsored as never)
               }
               return serializedTransaction
             })()
 
+            // Pre-broadcast simulation: fail closed before broadcast so the
+            // sponsor never pays gas for a transaction that would revert.
+            await viem_call(client, simulationRequest as never)
+
             if (waitForConfirmation) {
-              await viem_call(client, {
-                ...transaction,
-                account: transaction.from,
-                calls: transaction.calls,
-                feePayerSignature: undefined,
-              } as never)
               const receipt = await sendRawTransactionSync(client, {
                 serializedTransaction: serializedTransaction_final,
               })
@@ -458,15 +474,9 @@ export function charge<const parameters extends charge.Parameters>(
               return toReceipt(receipt)
             }
 
-            // Optimistic path: simulate to catch obvious reverts, then broadcast
-            // without waiting for on-chain confirmation. The returned receipt
-            // assumes success — callers opt into this risk via waitForConfirmation: false.
-            await viem_call(client, {
-              ...transaction,
-              account: transaction.from,
-              calls: transaction.calls,
-              feePayerSignature: undefined,
-            } as never)
+            // Optimistic path: broadcast without waiting for confirmation
+            // (simulation above already ran). The returned receipt assumes
+            // success — callers opt in via waitForConfirmation: false.
             const reference = await sendRawTransaction(client, {
               serializedTransaction: serializedTransaction_final,
             })


### PR DESCRIPTION
The Tempo fee-payer pre-broadcast simulation now simulates the co-signed transaction the sponsor actually broadcasts (concrete fee payer + chosen fee token) instead of the pre-cosign `0x78` envelope, and fails closed (no broadcast) when the simulation reverts. Adds revert and ABI conformance fixtures.