### PR TITLE
Support hosted Tempo fee payer fills and make feePayer tokens more flexible

### DIFF
--- a/src/tempo/internal/fee-payer.test.ts
+++ b/src/tempo/internal/fee-payer.test.ts
@@ -1,11 +1,16 @@
-import { encodeFunctionData, maxUint256 } from 'viem'
-import { Abis, Addresses } from 'viem/tempo'
-import { describe, expect, test } from 'vp/test'
+import { encodeFunctionData, maxUint256, toHex } from 'viem'
+import { Abis, Addresses, Transaction } from 'viem/tempo'
+import { afterEach, describe, expect, test, vi } from 'vp/test'
 
+import * as defaults from './defaults.js'
 import {
+  assertAllowedFeeToken,
   callScopes,
+  defaultAllowedFeeTokens,
   FeePayerValidationError,
+  fillHostedFeePayerTransaction,
   prepareSponsoredTransaction,
+  simulationTransaction,
   validateCalls,
 } from './fee-payer.js'
 import * as Selectors from './selectors.js'
@@ -19,7 +24,16 @@ const swapData = encodeFunctionData({
   functionName: 'swapExactAmountOut',
   args: [swapTokenIn, swapTokenOut, 100n, 100n],
 })
+const feePayerSignature = {
+  r: '0x0000000000000000000000000000000000000000000000000000000000000002',
+  s: '0x0000000000000000000000000000000000000000000000000000000000000003',
+  yParity: 1,
+}
 const sponsor = { address: bogus, type: 'local' } as any
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
 
 describe('callScopes', () => {
   test('has 4 allowed patterns', () => {
@@ -423,6 +437,216 @@ describe('validateCalls', () => {
   })
 })
 
+describe('fee token allowlist', () => {
+  test('includes pathUSD and the chain default currency', () => {
+    expect(defaultAllowedFeeTokens(defaults.chainId.mainnet)).toEqual([
+      defaults.tokens.pathUsd,
+      defaults.tokens.usdc,
+    ])
+  })
+
+  test('dedupes when pathUSD is the chain default currency', () => {
+    expect(defaultAllowedFeeTokens(defaults.chainId.testnet)).toEqual([defaults.tokens.pathUsd])
+  })
+
+  test('accepts allowlisted fee tokens', () => {
+    expect(() =>
+      assertAllowedFeeToken(
+        { feeToken: defaults.tokens.usdc },
+        defaultAllowedFeeTokens(defaults.chainId.mainnet),
+      ),
+    ).not.toThrow()
+  })
+
+  test('error: rejects non-string fee tokens', () => {
+    expect(() =>
+      assertAllowedFeeToken({ feeToken: 1n }, defaultAllowedFeeTokens(defaults.chainId.mainnet)),
+    ).toThrow('feeToken is invalid')
+  })
+
+  test('error: rejects fee tokens outside the allowlist', () => {
+    expect(() =>
+      assertAllowedFeeToken(
+        { feeToken: swapTokenIn },
+        defaultAllowedFeeTokens(defaults.chainId.mainnet),
+      ),
+    ).toThrow('feeToken is not allowed')
+  })
+})
+
+describe('fillHostedFeePayerTransaction', () => {
+  const hostedTransaction = {
+    accessList: [],
+    calls: [
+      {
+        data: encodeFunctionData({
+          abi: Abis.tip20,
+          functionName: 'transfer',
+          args: [bogus, 100n],
+        }),
+        to: bogus,
+      },
+    ],
+    chainId: defaults.chainId.mainnet,
+    from: bogus,
+    gas: 150_000n,
+    maxFeePerGas: 1_000_000_000n,
+    maxPriorityFeePerGas: 0n,
+    nonce: 1n,
+    nonceKey: maxUint256,
+    signature: { r: 1n, s: 1n, yParity: 0 } as any,
+    validBefore: Math.floor(Date.now() / 1_000) + 300,
+  } as const
+
+  test('uses hosted fillTransaction and preserves sender-committed fields', async () => {
+    const calls: { init?: RequestInit | undefined; input: RequestInfo | URL }[] = []
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ init, input })
+      return new Response(
+        JSON.stringify({
+          result: {
+            tx: {
+              feePayerSignature,
+              feeToken: defaults.tokens.pathUsd,
+              gas: '0x1',
+              maxFeePerGas: '0x2',
+            },
+          },
+        }),
+      )
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const serialized = await fillHostedFeePayerTransaction({
+      allowedFeeTokens: defaultAllowedFeeTokens(defaults.chainId.mainnet),
+      transaction: hostedTransaction as any,
+      url: 'https://sponsor.example/tp_key',
+    })
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    expect(calls[0]!.input).toBe('https://sponsor.example/tp_key')
+    const body = JSON.parse(calls[0]!.init!.body as string)
+    expect(body).toMatchObject({
+      jsonrpc: '2.0',
+      method: 'eth_fillTransaction',
+    })
+    expect(body.params[0]).toMatchObject({
+      calls: hostedTransaction.calls.map((call) => ({
+        data: call.data,
+        to: call.to,
+        value: '0x',
+      })),
+      feePayer: true,
+      from: hostedTransaction.from,
+      gas: toHex(hostedTransaction.gas),
+      maxFeePerGas: toHex(hostedTransaction.maxFeePerGas),
+      maxPriorityFeePerGas: toHex(hostedTransaction.maxPriorityFeePerGas),
+      nonce: toHex(hostedTransaction.nonce),
+      nonceKey: toHex(hostedTransaction.nonceKey),
+      type: '0x76',
+      validBefore: toHex(hostedTransaction.validBefore),
+    })
+
+    const transaction: Transaction.TransactionSerializableTempo = Transaction.deserialize(
+      serialized as Transaction.TransactionSerializedTempo,
+    )
+    expect(transaction.gas).toBe(hostedTransaction.gas)
+    expect(transaction.maxFeePerGas).toBe(hostedTransaction.maxFeePerGas)
+    expect(transaction.calls).toEqual(hostedTransaction.calls)
+    expect(transaction.feeToken).toBe(defaults.tokens.pathUsd)
+    expect(transaction.feePayerSignature).toEqual(feePayerSignature)
+  })
+
+  test('error: requires hosted fee payer to return a feeToken', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ result: { tx: { feePayerSignature } } }))),
+    )
+
+    await expect(
+      fillHostedFeePayerTransaction({
+        allowedFeeTokens: defaultAllowedFeeTokens(defaults.chainId.mainnet),
+        transaction: hostedTransaction as any,
+        url: 'https://sponsor.example/tp_key',
+      }),
+    ).rejects.toThrow('did not return a feeToken')
+  })
+
+  test('error: rejects hosted feeToken outside the allowlist', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              result: { tx: { feePayerSignature, feeToken: swapTokenIn } },
+            }),
+          ),
+      ),
+    )
+
+    await expect(
+      fillHostedFeePayerTransaction({
+        allowedFeeTokens: defaultAllowedFeeTokens(defaults.chainId.mainnet),
+        transaction: hostedTransaction as any,
+        url: 'https://sponsor.example/tp_key',
+      }),
+    ).rejects.toThrow('feeToken is not allowed')
+  })
+
+  test('error: surfaces hosted fee payer errors', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ error: { message: 'Invalid or revoked API key' } }), {
+            status: 401,
+          }),
+      ),
+    )
+
+    await expect(
+      fillHostedFeePayerTransaction({
+        allowedFeeTokens: defaultAllowedFeeTokens(defaults.chainId.mainnet),
+        transaction: hostedTransaction as any,
+        url: 'https://sponsor.example/tp_key',
+      }),
+    ).rejects.toThrow('Invalid or revoked API key')
+  })
+})
+
+describe('simulationTransaction', () => {
+  test('strips signed fee-payer fields for sponsored preflight simulation', () => {
+    const transaction = {
+      calls: [{ to: bogus }],
+      feePayerSignature,
+      from: bogus,
+    }
+
+    expect(simulationTransaction(transaction as any, { feePayer: true })).toEqual({
+      account: bogus,
+      calls: transaction.calls,
+    })
+  })
+
+  test('preserves non-sponsored transaction fields except feePayerSignature', () => {
+    const transaction = {
+      calls: [{ to: bogus }],
+      feePayerSignature,
+      from: bogus,
+      gas: 1n,
+    }
+
+    expect(simulationTransaction(transaction as any, { feePayer: false })).toEqual({
+      account: bogus,
+      calls: transaction.calls,
+      from: bogus,
+      gas: 1n,
+      feePayerSignature: undefined,
+    })
+  })
+})
+
 describe('prepareSponsoredTransaction', () => {
   const baseTransaction = {
     accessList: [],
@@ -454,7 +678,7 @@ describe('prepareSponsoredTransaction', () => {
         account: sponsor,
         chainId: 42431,
         details,
-        expectedFeeToken: bogus,
+        allowedFeeTokens: [bogus],
         transaction: baseTransaction as any,
       }),
     ).not.toThrow()
@@ -466,7 +690,7 @@ describe('prepareSponsoredTransaction', () => {
         account: sponsor,
         chainId: 42431,
         details,
-        expectedFeeToken: bogus,
+        allowedFeeTokens: [bogus],
         transaction: {
           ...baseTransaction,
           nonceKey: maxUint256,
@@ -481,7 +705,7 @@ describe('prepareSponsoredTransaction', () => {
         account: sponsor,
         chainId: 42431,
         details,
-        expectedFeeToken: bogus,
+        allowedFeeTokens: [bogus],
         transaction: {
           ...baseTransaction,
           nonceKey: 1n,
@@ -496,7 +720,7 @@ describe('prepareSponsoredTransaction', () => {
         account: sponsor,
         chainId: 42431,
         details,
-        expectedFeeToken: bogus,
+        allowedFeeTokens: [bogus],
         transaction: {
           ...baseTransaction,
           gas: 626_497n,
@@ -513,7 +737,7 @@ describe('prepareSponsoredTransaction', () => {
         account: sponsor,
         chainId: 4217,
         details,
-        expectedFeeToken: bogus,
+        allowedFeeTokens: [bogus],
         policy: { maxPriorityFeePerGas: 50_000_000_000n },
         transaction: {
           ...baseTransaction,
@@ -532,7 +756,7 @@ describe('prepareSponsoredTransaction', () => {
         account: sponsor,
         chainId: 4217,
         details,
-        expectedFeeToken: bogus,
+        allowedFeeTokens: [bogus],
         policy: { maxPriorityFeePerGas: 20_000_000_000n },
         transaction: {
           ...baseTransaction,
@@ -551,7 +775,7 @@ describe('prepareSponsoredTransaction', () => {
         account: sponsor,
         chainId: 4217,
         details,
-        expectedFeeToken: bogus,
+        allowedFeeTokens: [bogus],
         policy: { maxPriorityFeePerGas: undefined } as any,
         transaction: {
           ...baseTransaction,
@@ -578,7 +802,7 @@ describe('prepareSponsoredTransaction', () => {
       account: sponsor,
       chainId: 42431,
       details,
-      expectedFeeToken: bogus,
+      allowedFeeTokens: [bogus],
       transaction: { ...baseTransaction, keyAuthorization } as any,
     }) as { keyAuthorization?: unknown }
 
@@ -591,7 +815,7 @@ describe('prepareSponsoredTransaction', () => {
         account: sponsor,
         chainId: 42431,
         details,
-        expectedFeeToken: bogus,
+        allowedFeeTokens: [bogus],
         transaction: { ...baseTransaction, unexpectedField: 'ignored' } as any,
       }),
     ).toThrow('contains unsupported fields')
@@ -603,7 +827,7 @@ describe('prepareSponsoredTransaction', () => {
         account: sponsor,
         chainId: 42431,
         details,
-        expectedFeeToken: bogus,
+        allowedFeeTokens: [bogus],
         transaction: {
           ...baseTransaction,
           feePayerSignature: { r: 2n, s: 3n, yParity: 1 },
@@ -618,7 +842,7 @@ describe('prepareSponsoredTransaction', () => {
         account: sponsor,
         chainId: 42431,
         details,
-        expectedFeeToken: bogus,
+        allowedFeeTokens: [bogus],
         transaction: {
           ...baseTransaction,
           maxFeePerGas: 200_000_000_000n,
@@ -633,7 +857,7 @@ describe('prepareSponsoredTransaction', () => {
         account: sponsor,
         chainId: 42431,
         details,
-        expectedFeeToken: bogus,
+        allowedFeeTokens: [bogus],
         transaction: {
           ...baseTransaction,
           gas: 1_500_000n,
@@ -649,7 +873,7 @@ describe('prepareSponsoredTransaction', () => {
         account: sponsor,
         chainId: 42431,
         details,
-        expectedFeeToken: '0x0000000000000000000000000000000000000002',
+        allowedFeeTokens: ['0x0000000000000000000000000000000000000002'],
         transaction: baseTransaction as any,
       }),
     ).toThrow('feeToken is not allowed')
@@ -661,7 +885,7 @@ describe('prepareSponsoredTransaction', () => {
         account: sponsor,
         chainId: 42431,
         details,
-        expectedFeeToken: bogus,
+        allowedFeeTokens: [bogus],
         transaction: {
           ...baseTransaction,
           validBefore: Math.floor(Date.now() / 1_000) + 3_600,

--- a/src/tempo/internal/fee-payer.ts
+++ b/src/tempo/internal/fee-payer.ts
@@ -2,7 +2,7 @@ import type { TempoAddress } from 'ox/tempo'
 import { TxEnvelopeTempo } from 'ox/tempo'
 import type { Hex } from 'viem'
 import type { Account } from 'viem'
-import { decodeFunctionData, maxUint256 } from 'viem'
+import { decodeFunctionData, maxUint256, toHex } from 'viem'
 import { Abis, Addresses, Transaction } from 'viem/tempo'
 
 import * as TempoAddress_internal from './address.js'
@@ -42,6 +42,16 @@ export type Policy = {
 // for that function's return type so this helper stays aligned with upstream
 // Tempo transaction fields.
 type SponsoredTransaction = ReturnType<(typeof Transaction)['deserialize']>
+
+type HostedFeePayerFillResponse = {
+  error?: { message?: string | undefined } | undefined
+  result?: {
+    tx?: {
+      feePayerSignature?: unknown
+      feeToken?: unknown
+    }
+  }
+}
 
 type ExpectedTransfer = {
   amount: string
@@ -91,6 +101,137 @@ const supportedTransactionKeys = new Set<string>([
   ...rejectedTransactionKeys,
   ...rewrittenTransactionKeys,
 ])
+
+function pushAllowedFeeToken(tokens: TempoAddress.Address[], token: string | undefined) {
+  if (!token) return
+  const normalized = token as TempoAddress.Address
+  if (tokens.some((existing) => TempoAddress_internal.isEqual(existing, normalized))) return
+  tokens.push(normalized)
+}
+
+/** Returns fee tokens that mppx allows sponsored transactions to charge. */
+export function defaultAllowedFeeTokens(chainId: number | undefined) {
+  const tokens: TempoAddress.Address[] = []
+  pushAllowedFeeToken(tokens, defaults.tokens.pathUsd)
+  pushAllowedFeeToken(tokens, defaults.currency[chainId as keyof typeof defaults.currency])
+  return tokens
+}
+
+/** Rejects a sponsored fee token outside the server's allowlist. */
+export function assertAllowedFeeToken(
+  transaction: { feeToken?: unknown },
+  allowedFeeTokens: readonly TempoAddress.Address[],
+) {
+  const { feeToken } = transaction
+  if (feeToken === undefined) return
+  if (typeof feeToken !== 'string')
+    throw new FeePayerValidationError('fee-sponsored transaction feeToken is invalid', {})
+  const normalized = feeToken as TempoAddress.Address
+  if (!allowedFeeTokens.some((allowed) => TempoAddress_internal.isEqual(allowed, normalized)))
+    throw new FeePayerValidationError('fee-sponsored transaction feeToken is not allowed', {
+      feeToken,
+    })
+}
+
+function hostedFeePayerRequest(transaction: SponsoredTransaction) {
+  return {
+    ...(transaction.accessList?.length ? { accessList: transaction.accessList } : {}),
+    calls: transaction.calls.map(
+      (call: {
+        data?: `0x${string}` | undefined
+        to?: TempoAddress.Address | undefined
+        value?: bigint | undefined
+      }) => ({
+        ...(call.to ? { to: call.to } : {}),
+        ...(call.data ? { data: call.data } : {}),
+        value: call.value === undefined ? '0x' : toHex(call.value),
+      }),
+    ),
+    feePayer: true,
+    from: transaction.from,
+    ...(transaction.gas !== undefined ? { gas: toHex(transaction.gas) } : {}),
+    ...(transaction.keyAuthorization !== undefined
+      ? { keyAuthorization: transaction.keyAuthorization }
+      : {}),
+    ...(transaction.maxFeePerGas !== undefined
+      ? { maxFeePerGas: toHex(transaction.maxFeePerGas) }
+      : {}),
+    ...(transaction.maxPriorityFeePerGas !== undefined
+      ? { maxPriorityFeePerGas: toHex(transaction.maxPriorityFeePerGas) }
+      : {}),
+    nonce: toHex(transaction.nonce ?? 0),
+    ...(transaction.nonceKey !== undefined ? { nonceKey: toHex(transaction.nonceKey) } : {}),
+    type: '0x76',
+    ...(transaction.validAfter !== undefined ? { validAfter: toHex(transaction.validAfter) } : {}),
+    ...(transaction.validBefore !== undefined
+      ? { validBefore: toHex(transaction.validBefore) }
+      : {}),
+  }
+}
+
+/**
+ * Co-signs a sender-signed partial sponsorship envelope using a hosted
+ * fee-payer endpoint without letting the endpoint mutate sender-committed
+ * transaction fields.
+ */
+export async function fillHostedFeePayerTransaction(parameters: {
+  allowedFeeTokens: readonly TempoAddress.Address[]
+  transaction: SponsoredTransaction
+  url: string
+}) {
+  const { allowedFeeTokens, transaction, url } = parameters
+  const response = await fetch(url, {
+    body: JSON.stringify(
+      {
+        id: 1,
+        jsonrpc: '2.0',
+        method: 'eth_fillTransaction',
+        params: [hostedFeePayerRequest(transaction)],
+      },
+      (_key, value) => (typeof value === 'bigint' ? toHex(value) : value),
+    ),
+    headers: { 'content-type': 'application/json' },
+    method: 'POST',
+  })
+  const payload = (await response.json().catch(async () => ({
+    error: { message: await response.text() },
+  }))) as HostedFeePayerFillResponse
+  const filled = payload.result?.tx
+  if (!response.ok || payload.error || !filled?.feePayerSignature)
+    throw new FeePayerValidationError(
+      payload.error?.message ?? 'hosted fee payer failed to sponsor transaction',
+      {},
+    )
+  if (typeof filled.feeToken !== 'string')
+    throw new FeePayerValidationError('hosted fee payer did not return a feeToken', {})
+
+  assertAllowedFeeToken({ feeToken: filled.feeToken }, allowedFeeTokens)
+
+  return Transaction.serialize({
+    ...transaction,
+    feePayer: true,
+    feePayerSignature: filled.feePayerSignature,
+    feeToken: filled.feeToken,
+  } as never)
+}
+
+/** Returns a transaction shape suitable for pre-broadcast simulation. */
+export function simulationTransaction(
+  transaction: SponsoredTransaction,
+  options: { feePayer: boolean },
+) {
+  if (options.feePayer)
+    return {
+      account: transaction.from,
+      calls: transaction.calls,
+    }
+  return {
+    ...transaction,
+    account: transaction.from,
+    calls: transaction.calls,
+    feePayerSignature: undefined,
+  }
+}
 
 /**
  * maxTotalFee must be high enough to cover `transferWithMemo` and
@@ -258,20 +399,20 @@ export function validateCalls(
 
 export function prepareSponsoredTransaction(parameters: {
   account: Account
+  allowedFeeTokens?: readonly TempoAddress.Address[] | undefined
   challengeExpires?: string | undefined
   chainId: number
   details: Record<string, string>
-  expectedFeeToken?: TempoAddress.Address | undefined
   now?: Date | undefined
   policy?: Partial<Policy> | undefined
   transaction: SponsoredTransaction
 }) {
   const {
     account,
+    allowedFeeTokens,
     challengeExpires,
     chainId,
     details,
-    expectedFeeToken,
     now = new Date(),
     policy: policyOverrides,
     transaction,
@@ -392,7 +533,12 @@ export function prepareSponsoredTransaction(parameters: {
   })()
 
   if (normalizedFeeToken !== undefined) {
-    if (expectedFeeToken && !TempoAddress_internal.isEqual(normalizedFeeToken, expectedFeeToken))
+    if (
+      allowedFeeTokens &&
+      !allowedFeeTokens.some((allowed) =>
+        TempoAddress_internal.isEqual(normalizedFeeToken, allowed),
+      )
+    )
       fail('fee-sponsored transaction feeToken is not allowed', {
         feeToken: normalizedFeeToken,
       })

--- a/src/tempo/legacy/session/Chain.ts
+++ b/src/tempo/legacy/session/Chain.ts
@@ -610,8 +610,8 @@ export async function broadcastOpenTransaction(
       reason: 'open transaction does not match claimed channelId',
     })
 
-  const resolvedFeeToken =
-    transaction.feeToken ?? defaults.currency[client.chain?.id as keyof typeof defaults.currency]
+  const defaultFeeToken = defaults.currency[client.chain?.id as keyof typeof defaults.currency]
+  const resolvedFeeToken = transaction.feeToken ?? defaultFeeToken
 
   const pendingOnChain = {
     finalized: false,
@@ -635,10 +635,10 @@ export async function broadcastOpenTransaction(
 
       const sponsored = FeePayer.prepareSponsoredTransaction({
         account: feePayer,
+        allowedFeeTokens: defaultFeeToken ? [defaultFeeToken] : undefined,
         challengeExpires,
         chainId: client.chain!.id,
         details: { channelId, currency, recipient },
-        expectedFeeToken: defaults.currency[client.chain?.id as keyof typeof defaults.currency],
         policy: feePayerPolicy,
         transaction: {
           ...transaction,
@@ -774,9 +774,10 @@ export async function broadcastTopUpTransaction(
           reason: 'transaction does not contain a valid escrow topUp call',
         })
 
-      const expectedFeeToken = defaults.currency[client.chain?.id as keyof typeof defaults.currency]
+      const defaultFeeToken = defaults.currency[client.chain?.id as keyof typeof defaults.currency]
       const sponsored = FeePayer.prepareSponsoredTransaction({
         account: feePayer,
+        allowedFeeTokens: defaultFeeToken ? [defaultFeeToken] : undefined,
         challengeExpires,
         chainId: client.chain!.id,
         details: {
@@ -784,12 +785,11 @@ export async function broadcastTopUpTransaction(
           channelId,
           currency,
         },
-        expectedFeeToken,
         policy: feePayerPolicy,
         transaction: {
           ...transaction,
-          ...((transaction.feeToken ?? expectedFeeToken)
-            ? { feeToken: transaction.feeToken ?? expectedFeeToken }
+          ...((transaction.feeToken ?? defaultFeeToken)
+            ? { feeToken: transaction.feeToken ?? defaultFeeToken }
             : {}),
         },
       })

--- a/src/tempo/server/Charge.test.ts
+++ b/src/tempo/server/Charge.test.ts
@@ -3,8 +3,7 @@ import { Mppx as Mppx_client, tempo as tempo_client } from 'mppx/client'
 import { Mppx as Mppx_server, tempo as tempo_server } from 'mppx/server'
 import { P256, type Hex, WebAuthnP256 } from 'ox'
 import { SignatureEnvelope, TxEnvelopeTempo } from 'ox/tempo'
-import { Handler } from 'tempo.ts/server'
-import { createClient, custom, encodeFunctionData, parseUnits } from 'viem'
+import { createClient, custom, encodeFunctionData, parseSignature, parseUnits } from 'viem'
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
 import {
   getTransactionReceipt,
@@ -26,6 +25,7 @@ import { accounts, asset, chain, client, fundAccount, http } from '~test/tempo/v
 
 import * as Store from '../../Store.js'
 import * as Attribution from '../Attribution.js'
+import * as defaults from '../internal/defaults.js'
 import * as Proof from '../internal/proof.js'
 
 const realm = 'api.example.com'
@@ -1816,11 +1816,64 @@ describe('tempo', () => {
     })
 
     test('behavior: fee payer URL (withFeePayer transport)', async () => {
-      const feePayerHandler = Handler.feePayer({
-        account: accounts[0],
-        client,
+      const feePayerRequests: any[] = []
+      const feePayerServer = await Http.createServer(async (req, res) => {
+        let requestBody = ''
+        for await (const chunk of req) requestBody += chunk
+        const request = JSON.parse(requestBody)
+        feePayerRequests.push(request)
+
+        const transaction = request.params[0]
+        const quantity = (value: unknown) =>
+          value === undefined ? undefined : BigInt(value as string | number | bigint | boolean)
+        const envelope = TxEnvelopeTempo.from({
+          accessList: transaction.accessList,
+          calls: transaction.calls.map(({ value, ...call }: any) => ({
+            ...call,
+            ...(value && value !== '0x' ? { value: BigInt(value) } : {}),
+          })),
+          chainId: chain.id,
+          feeToken: defaults.tokens.pathUsd,
+          from: transaction.from,
+          ...(quantity(transaction.gas) !== undefined ? { gas: quantity(transaction.gas) } : {}),
+          ...(quantity(transaction.maxFeePerGas) !== undefined
+            ? { maxFeePerGas: quantity(transaction.maxFeePerGas) }
+            : {}),
+          ...(quantity(transaction.maxPriorityFeePerGas) !== undefined
+            ? { maxPriorityFeePerGas: quantity(transaction.maxPriorityFeePerGas) }
+            : {}),
+          ...(quantity(transaction.nonce) !== undefined
+            ? { nonce: quantity(transaction.nonce) }
+            : {}),
+          ...(quantity(transaction.nonceKey) !== undefined
+            ? { nonceKey: quantity(transaction.nonceKey) }
+            : {}),
+          type: 'tempo',
+          ...(transaction.validAfter ? { validAfter: Number(BigInt(transaction.validAfter)) } : {}),
+          ...(transaction.validBefore
+            ? { validBefore: Number(BigInt(transaction.validBefore)) }
+            : {}),
+        })
+        const hash = TxEnvelopeTempo.getFeePayerSignPayload(envelope, {
+          sender: transaction.from,
+        })
+        const { r, s, yParity } = parseSignature(await accounts[0].sign!({ hash }))
+        const feePayerSignature = { r, s, yParity }
+
+        res.setHeader('content-type', 'application/json')
+        res.end(
+          JSON.stringify({
+            id: request.id,
+            jsonrpc: '2.0',
+            result: {
+              tx: {
+                feePayerSignature,
+                feeToken: defaults.tokens.pathUsd,
+              },
+            },
+          }),
+        )
       })
-      const feePayerServer = await Http.createServer(feePayerHandler.listener)
 
       const serverWithFeePayer = Mppx_server.create({
         methods: [
@@ -1858,6 +1911,7 @@ describe('tempo', () => {
 
       const response = await mppx.fetch(httpServer.url)
       expect(response.status).toBe(200)
+      expect(feePayerRequests.map(({ method }) => method)).toEqual(['eth_fillTransaction'])
 
       const receipt = Receipt.fromResponse(response)
       expect(receipt.status).toBe('success')

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -400,35 +400,39 @@ export function charge<const parameters extends charge.Parameters>(
               )
             }
 
-            const expectedFeeToken = defaults.currency[chainId as keyof typeof defaults.currency]
-            const resolvedFeeToken = transaction.feeToken ?? expectedFeeToken
+            const allowedFeeTokens = FeePayer.defaultAllowedFeeTokens(chainId)
+            if (isFeePayerTx) FeePayer.assertAllowedFeeToken(transaction, allowedFeeTokens)
 
             const serializedTransaction_final = await (async () => {
               if (feePayerAccount && methodDetails?.feePayer !== false) {
                 const sponsored = FeePayer.prepareSponsoredTransaction({
                   account: feePayerAccount,
+                  allowedFeeTokens,
                   challengeExpires: expires,
                   chainId: chainId ?? client.chain!.id,
                   details: { amount, currency, recipient },
-                  expectedFeeToken,
                   policy: feePayerPolicy,
                   transaction: {
                     ...transaction,
-                    ...(resolvedFeeToken ? { feeToken: resolvedFeeToken } : {}),
+                    feeToken: transaction.feeToken ?? defaults.tokens.pathUsd,
                   },
                 })
                 return signTransaction(client, sponsored as never)
               }
+              if (feePayerUrl && isFeePayerTx)
+                return FeePayer.fillHostedFeePayerTransaction({
+                  allowedFeeTokens,
+                  transaction,
+                  url: feePayerUrl,
+                })
               return serializedTransaction
             })()
 
             if (waitForConfirmation) {
-              await viem_call(client, {
-                ...transaction,
-                account: transaction.from,
-                calls: transaction.calls,
-                feePayerSignature: undefined,
-              } as never)
+              await viem_call(
+                client,
+                FeePayer.simulationTransaction(transaction, { feePayer: isFeePayerTx }),
+              )
               const receipt = await sendRawTransactionSync(client, {
                 serializedTransaction: serializedTransaction_final,
               })
@@ -461,12 +465,10 @@ export function charge<const parameters extends charge.Parameters>(
             // Optimistic path: simulate to catch obvious reverts, then broadcast
             // without waiting for on-chain confirmation. The returned receipt
             // assumes success — callers opt into this risk via waitForConfirmation: false.
-            await viem_call(client, {
-              ...transaction,
-              account: transaction.from,
-              calls: transaction.calls,
-              feePayerSignature: undefined,
-            } as never)
+            await viem_call(
+              client,
+              FeePayer.simulationTransaction(transaction, { feePayer: isFeePayerTx }),
+            )
             const reference = await sendRawTransaction(client, {
               serializedTransaction: serializedTransaction_final,
             })

--- a/src/tempo/session/precompile/Chain.ts
+++ b/src/tempo/session/precompile/Chain.ts
@@ -619,10 +619,10 @@ export type SendCredentialTransactionParameters = {
   chainId: number
   /** viem client used to submit the transaction. */
   client: TransactionClient
+  /** Fee tokens allowed by the server for sponsored transactions. */
+  allowedFeeTokens?: readonly Address[] | undefined
   /** Human-readable transaction details used by fee-payer policy hooks. */
   details: Record<string, string>
-  /** Fee token expected by the server for sponsored transactions. */
-  expectedFeeToken?: Address | undefined
   /** Fee-payer account used to co-sign Tempo transactions. */
   feePayer?: Account | undefined
   /** Optional fee-payer policy enforced before co-signing. */
@@ -641,8 +641,8 @@ export async function sendCredentialTransaction(parameters: SendCredentialTransa
     challengeExpires,
     chainId,
     client,
+    allowedFeeTokens,
     details,
-    expectedFeeToken,
     feePayer,
     feePayerPolicy,
     label,
@@ -663,14 +663,14 @@ export async function sendCredentialTransaction(parameters: SendCredentialTransa
 
   const sponsored = FeePayer.prepareSponsoredTransaction({
     account: feePayer,
+    allowedFeeTokens,
     challengeExpires,
     chainId,
     details,
-    expectedFeeToken,
     policy: feePayerPolicy,
     transaction: {
       ...transaction,
-      ...(expectedFeeToken ? { feeToken: transaction.feeToken ?? expectedFeeToken } : {}),
+      ...(allowedFeeTokens?.[0] ? { feeToken: transaction.feeToken ?? allowedFeeTokens[0] } : {}),
     },
   })
   const serialized = await signTempoTransaction(client, sponsored)
@@ -783,12 +783,12 @@ export async function broadcastOpenTransaction(
     challengeExpires: parameters.challengeExpires,
     chainId: parameters.chainId,
     client: parameters.client,
+    allowedFeeTokens: [parameters.expectedCurrency],
     details: {
       channelId: parameters.expectedChannelId,
       currency: parameters.expectedCurrency,
       recipient: parameters.expectedPayee,
     },
-    expectedFeeToken: parameters.expectedCurrency,
     feePayer: parameters.feePayer,
     feePayerPolicy: parameters.feePayerPolicy,
     label: 'open',
@@ -877,12 +877,12 @@ export async function broadcastTopUpTransaction(
     challengeExpires: parameters.challengeExpires,
     chainId: parameters.chainId,
     client: parameters.client,
+    allowedFeeTokens: [parameters.expectedCurrency],
     details: {
       additionalDeposit: parameters.additionalDeposit.toString(),
       channelId: parameters.expectedChannelId,
       currency: parameters.expectedCurrency,
     },
-    expectedFeeToken: parameters.expectedCurrency,
     feePayer: parameters.feePayer,
     feePayerPolicy: parameters.feePayerPolicy,
     label: 'topUp',


### PR DESCRIPTION
## Summary

- add hosted Tempo fee-payer fill support for sender-signed sponsored charge transactions
- validate sponsored fee tokens against pathUSD and chain default currency
- simulate sponsored charge transactions without fee-payer-only fields
- add coverage for hosted fill handling, fee-token validation, and charge fee-payer URL flow
