### PR TITLE
fix: Stripe charge externalId binding

### DIFF
--- a/src/stripe/client/Charge.test.ts
+++ b/src/stripe/client/Charge.test.ts
@@ -14,7 +14,7 @@ const dummyClientCharge = clientCharge_({
   paymentMethod: 'pm_test',
 })
 
-async function createChallenge() {
+async function createChallenge(request: { externalId?: string } = {}) {
   const server = Mppx_server.create({
     methods: [
       stripe_server.charge({
@@ -27,7 +27,7 @@ async function createChallenge() {
     secretKey,
   })
 
-  const handle = server.charge({ amount: '100', currency: 'usd', decimals: 2 })
+  const handle = server.charge({ amount: '100', currency: 'usd', decimals: 2, ...request })
   const result = await handle(new Request('https://example.com'))
   if (result.status !== 402) throw new Error('Expected 402')
   return Challenge.fromResponse(result.challenge, { methods: [dummyClientCharge] })
@@ -121,18 +121,33 @@ describe('stripe.charge client param', () => {
     expect(parsed.payload).toMatchObject({ spt: 'spt_test_123' })
   })
 
-  test('behavior: includes externalId in credential payload', async () => {
+  test('behavior: echoes request-bound externalId in credential payload', async () => {
     const charge = stripe.charge({
       createToken: async () => 'spt_test_123',
-      externalId: 'order_456',
       paymentMethod: 'pm_card_visa',
     })
 
-    const challenge = await createChallenge()
+    const challenge = await createChallenge({ externalId: 'order_456' })
     const credential = await charge.createCredential({ challenge, context: {} })
     const parsed = Credential.deserialize(credential)
     expect(parsed.payload).toMatchObject({
       externalId: 'order_456',
+      spt: 'spt_test_123',
+    })
+  })
+
+  test('behavior: request-bound externalId overrides local externalId', async () => {
+    const charge = stripe.charge({
+      createToken: async () => 'spt_test_123',
+      externalId: 'client_order_999',
+      paymentMethod: 'pm_card_visa',
+    })
+
+    const challenge = await createChallenge({ externalId: 'server_order_456' })
+    const credential = await charge.createCredential({ challenge, context: {} })
+    const parsed = Credential.deserialize(credential)
+    expect(parsed.payload).toMatchObject({
+      externalId: 'server_order_456',
       spt: 'spt_test_123',
     })
   })

--- a/src/stripe/client/Charge.ts
+++ b/src/stripe/client/Charge.ts
@@ -55,6 +55,8 @@ export function charge(parameters: charge.Parameters) {
 
       const amount = challenge.request.amount as string
       const currency = challenge.request.currency as string
+      const requestExternalId =
+        typeof challenge.request.externalId === 'string' ? challenge.request.externalId : undefined
       const networkId = challenge.request.methodDetails?.networkId as string | undefined
       if (!networkId) throw new Error('networkId is required in challenge.methodDetails')
       const metadata = challenge.request.methodDetails?.metadata as
@@ -81,11 +83,13 @@ export function charge(parameters: charge.Parameters) {
         paymentMethod,
       })
 
+      const payloadExternalId = requestExternalId ?? externalId
+
       return Credential.serialize({
         challenge,
         payload: {
           spt,
-          ...(externalId ? { externalId } : {}),
+          ...(payloadExternalId !== undefined ? { externalId: payloadExternalId } : {}),
         },
       })
     },
@@ -98,7 +102,7 @@ export declare namespace charge {
     client?: StripeJs | undefined
     /** Called when a Stripe challenge is received. Create an SPT to retry. */
     createToken: (parameters: OnChallengeParameters) => Promise<string>
-    /** Optional client-side external reference ID for the credential payload. */
+    /** Optional fallback external reference ID. A request-bound externalId is echoed and takes precedence. */
     externalId?: string | undefined
     /** Default payment method ID. Overridden by `context.paymentMethod`. */
     paymentMethod?: string | undefined

--- a/src/stripe/server/Charge.test.ts
+++ b/src/stripe/server/Charge.test.ts
@@ -1,4 +1,4 @@
-import { Challenge, Credential } from 'mppx'
+import { Challenge, Credential, Receipt } from 'mppx'
 import { Mppx, stripe } from 'mppx/server'
 import { afterEach, describe, expect, test, vi } from 'vp/test'
 import * as Http from '~test/Http.js'
@@ -241,6 +241,119 @@ describe('stripe.charge with client', () => {
     expect(body.get('transfer_data[amount]')).toBe('88')
     expect(body.get('transfer_data[destination]')).toBe('acct_destination')
     expect(body.get('transfer_group')).toBe('order_123')
+  })
+
+  test('security: attributes receipt externalId from the server-bound request', async () => {
+    const { client } = createMockStripeClient()
+    const server = Mppx.create({
+      methods: [
+        stripe.charge({
+          client,
+          networkId: 'internal',
+          paymentMethodTypes: ['card'],
+        }),
+      ],
+      realm,
+      secretKey,
+    })
+
+    const handle = server.charge({
+      amount: '1',
+      currency: 'usd',
+      decimals: 2,
+      externalId: 'server-order-123',
+    })
+    const firstResult = await handle(new Request('https://example.com'))
+    expect(firstResult.status).toBe(402)
+    if (firstResult.status !== 402) throw new Error()
+
+    const credential = Credential.from({
+      challenge: Challenge.fromResponse(firstResult.challenge),
+      payload: { spt: 'spt_test_token', externalId: 'server-order-123' },
+    })
+    const result = await handle(
+      new Request('https://example.com', {
+        headers: { Authorization: Credential.serialize(credential) },
+      }),
+    )
+
+    expect(result.status).toBe(200)
+    if (result.status !== 200) throw new Error()
+    const receipt = Receipt.fromResponse(result.withReceipt(new Response('OK')))
+    expect(receipt.externalId).toBe('server-order-123')
+  })
+
+  test('security: rejects forged Stripe credential externalId', async () => {
+    const { client, create } = createMockStripeClient()
+    const server = Mppx.create({
+      methods: [
+        stripe.charge({
+          client,
+          networkId: 'internal',
+          paymentMethodTypes: ['card'],
+        }),
+      ],
+      realm,
+      secretKey,
+    })
+
+    const handle = server.charge({
+      amount: '1',
+      currency: 'usd',
+      decimals: 2,
+      externalId: 'server-order-123',
+    })
+    const firstResult = await handle(new Request('https://example.com'))
+    expect(firstResult.status).toBe(402)
+    if (firstResult.status !== 402) throw new Error()
+
+    const credential = Credential.from({
+      challenge: Challenge.fromResponse(firstResult.challenge),
+      payload: { spt: 'spt_test_token', externalId: 'attacker-order-999' },
+    })
+    const result = await handle(
+      new Request('https://example.com', {
+        headers: { Authorization: Credential.serialize(credential) },
+      }),
+    )
+
+    expect(result.status).toBe(402)
+    expect(create).not.toHaveBeenCalled()
+  })
+
+  test('security: ignores payload-only Stripe credential externalId', async () => {
+    const { client } = createMockStripeClient()
+    const server = Mppx.create({
+      methods: [
+        stripe.charge({
+          client,
+          networkId: 'internal',
+          paymentMethodTypes: ['card'],
+        }),
+      ],
+      realm,
+      secretKey,
+    })
+
+    const handle = server.charge({ amount: '1', currency: 'usd', decimals: 2 })
+    const firstResult = await handle(new Request('https://example.com'))
+    expect(firstResult.status).toBe(402)
+    if (firstResult.status !== 402) throw new Error()
+
+    const credential = Credential.from({
+      challenge: Challenge.fromResponse(firstResult.challenge),
+      payload: { spt: 'spt_test_token', externalId: 'attacker-order-999' },
+    })
+    const result = await handle(
+      new Request('https://example.com', {
+        headers: { Authorization: Credential.serialize(credential) },
+      }),
+    )
+
+    expect(result.status).toBe(200)
+    if (result.status !== 200) throw new Error()
+    const receipt = Receipt.fromResponse(result.withReceipt(new Response('OK')))
+    expect(receipt.externalId).toBeUndefined()
   })
 
   test('error: surfaces Connect PaymentIntent creation failures', async () => {

--- a/src/stripe/server/Charge.ts
+++ b/src/stripe/server/Charge.ts
@@ -1,6 +1,10 @@
 import type * as Challenge from '../../Challenge.js'
 import type * as Credential from '../../Credential.js'
-import { PaymentActionRequiredError, VerificationFailedError } from '../../Errors.js'
+import {
+  InvalidChallengeError,
+  PaymentActionRequiredError,
+  VerificationFailedError,
+} from '../../Errors.js'
 import * as Expires from '../../Expires.js'
 import type { LooseOmit, MaybePromise, OneOf } from '../../internal/types.js'
 import * as Method from '../../Method.js'
@@ -112,6 +116,13 @@ export function charge<const parameters extends charge.Parameters>(parameters: p
         spt: string
         externalId?: string
       }
+      const requestExternalId = resolvedRequest.externalId
+      if (requestExternalId !== undefined && credentialExternalId !== requestExternalId) {
+        throw new InvalidChallengeError({
+          id: challenge.id,
+          reason: 'credential externalId does not match this route request',
+        })
+      }
 
       const userMetadata = resolvedRequest.methodDetails?.metadata as
         | Record<string, string>
@@ -156,7 +167,7 @@ export function charge<const parameters extends charge.Parameters>(parameters: p
         status: 'success',
         timestamp: new Date().toISOString(),
         reference: pi.id,
-        ...(credentialExternalId ? { externalId: credentialExternalId } : {}),
+        ...(requestExternalId !== undefined ? { externalId: requestExternalId } : {}),
       } as const
     },
   })


### PR DESCRIPTION
## Summary

- Source Stripe receipt `externalId` from the HMAC-bound request, not credential payload.
- Reject missing/mismatched credential echoes when the request binds `externalId`.
- Echo request-bound `externalId` in the client helper and add focused tests.

Towards OSS-324, blocks https://github.com/tempoxyz/mpp-tools/pull/29

## Testing

- `VITE_TEMPO_NETWORK=none pnpm test src/stripe/client/Charge.test.ts src/stripe/server/Charge.test.ts src/stripe/Charge.integration.test.ts`
- `pnpm check`
- `pnpm check:types`

-> Local `mpp-tools` (https://github.com/tempoxyz/mpp-tools/pull/29) Stripe externalId vector: 5/5 passed.
