### PR TITLE
fix: declare @stripe/stripe-js dependency for src-condition consumers

### DIFF
--- a/.changeset/stripe-js-types-dependency.md
+++ b/.changeset/stripe-js-types-dependency.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Declared `@stripe/stripe-js` as a dependency so the shipped sources type-check for consumers resolving the `src` export condition. The import is type-only, so no runtime code is added.

--- a/package.json
+++ b/package.json
@@ -204,6 +204,7 @@
     }
   },
   "dependencies": {
+    "@stripe/stripe-js": "9.7.0",
     "incur": "^0.4.8",
     "ox": "0.14.27",
     "zod": "^4.4.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
 
   .:
     dependencies:
+      '@stripe/stripe-js':
+        specifier: 9.7.0
+        version: 9.7.0
       incur:
         specifier: ^0.4.8
         version: 0.4.8


### PR DESCRIPTION
## Summary

Declare `@stripe/stripe-js` as a dependency. `src/stripe/server/internal/html/types.ts` re-exports types from it, but the package was only declared in the private nested `@mppx/stripe-html` workspace package:

- Consumers compiling with the `src` export condition (e.g. `customConditions: ["src"]`) resolve mppx's shipped sources and fail with TS2307.
- `types`-condition consumers silently degrade the published Stripe option types (`StripePaymentElementOptions`, etc.) to `any` under `skipLibCheck` — `dist/stripe/server/internal/html/types.d.ts` carries the same bare import.

The import is type-only, so there is no runtime or bundle impact.

## Validation

- `pnpm check:types`, `pnpm install` (lockfile converges, no drift)
- Scratch consumer with `customConditions: ["src"]` importing `mppx/client` + `mppx/stripe/client` typechecks clean with this change; fails with TS2307 without it.
