### PR TITLE
docs: show required mpp secret key

### DIFF
--- a/.changeset/document-secret-key-examples.md
+++ b/.changeset/document-secret-key-examples.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Documented explicit server secret key configuration in README examples.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ const mppx = Mppx.create({
       recipient: '0x742d35Cc6634c0532925a3b844bC9e7595F8fE00',
     }),
   ],
+  secretKey: process.env.MPP_SECRET_KEY!,
 })
 
 export async function handler(request: Request) {
@@ -118,7 +119,10 @@ npm i -g mppx
 import { openai, stripe, Proxy } from 'mppx/proxy'
 import { Mppx, tempo } from 'mppx/server'
 
-const mppx = Mppx.create({ methods: [tempo()] })
+const mppx = Mppx.create({
+  methods: [tempo()],
+  secretKey: process.env.MPP_SECRET_KEY!,
+})
 
 const proxy = Proxy.create({
   services: [


### PR DESCRIPTION
## Summary

- Added `secretKey: process.env.MPP_SECRET_KEY!` to README server examples.
- Updated the proxy README example to use the same explicit server secret configuration.

## Motivation

`Mppx.create()` requires a server secret key for HMAC-bound challenges. The README examples should be copy-paste runnable and show the secure configuration path.

## Key design considerations

- Kept the change documentation-only.
- Used the existing `MPP_SECRET_KEY` environment variable convention.
