### PR TITLE
docs: update proxy route examples

### DIFF
--- a/.changeset/update-proxy-route-docs.md
+++ b/.changeset/update-proxy-route-docs.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Updated proxy route examples to use current route handler APIs.

--- a/README.md
+++ b/README.md
@@ -126,15 +126,18 @@ const proxy = Proxy.create({
       apiKey: 'sk-...',
       routes: {
         'POST /v1/chat/completions': mppx.charge({ amount: '0.05' }),
-        'POST /v1/completions': mppx.stream({ amount: '0.0001' }),
-        'GET /v1/models': mppx.free(),
+        'POST /v1/completions': mppx.tempo.session({
+          amount: '0.0001',
+          unitType: 'token',
+        }),
+        'GET /v1/models': true,
       },
     }),
     stripe({
       apiKey: 'sk-...',
       routes: {
         'POST /v1/charges': mppx.charge({ amount: '0.01' }),
-        'GET /v1/customers/:id': mppx.free(),
+        'GET /v1/customers/:id': true,
       },
     }),
   ],
@@ -155,7 +158,7 @@ This exposes the following routes:
 | Route                              | Pricing                      |
 | ---------------------------------- | ---------------------------- |
 | `POST /openai/v1/chat/completions` | charge **$0.005**            |
-| `POST /openai/v1/completions`      | stream **$0.0001 per token** |
+| `POST /openai/v1/completions`      | session **$0.0001 per token** |
 | `GET /openai/v1/models`            | free                         |
 | `POST /stripe/v1/charges`          | charge **$0.01**             |
 | `GET /stripe/v1/customers/:id`     | free                         |


### PR DESCRIPTION
## Summary

- Replaced stale `mppx.stream()` and `mppx.free()` README usage with current proxy route shapes.
- Updated the proxy pricing table to describe session-based per-token pricing.

## Motivation

The README proxy example should match the current public API so users can copy it without hitting missing methods.

## Key design considerations

- Kept the existing proxy example structure.
- Used `true` for free passthrough routes, matching the current `Service.Endpoint` API.
