### PR TITLE
docs: use PaymentRequest export in examples

### DIFF
--- a/.changeset/document-payment-request-name.md
+++ b/.changeset/document-payment-request-name.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Corrected PaymentRequest documentation examples to use the exported namespace name.

--- a/src/PaymentRequest.ts
+++ b/src/PaymentRequest.ts
@@ -9,9 +9,9 @@ import type * as z from './zod.js'
  *
  * @example
  * ```ts
- * import { Request } from 'mppx'
+ * import { PaymentRequest } from 'mppx'
  *
- * const request: Request.Request = {
+ * const request: PaymentRequest.Request = {
  *   amount: '1000000',
  *   currency: '0x20c0000000000000000000000000000000000001',
  *   recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00',
@@ -29,9 +29,9 @@ export type Request<request extends Record<string, unknown> = Record<string, unk
  *
  * @example
  * ```ts
- * import { Request } from 'mppx'
+ * import { PaymentRequest } from 'mppx'
  *
- * const request = Request.deserialize(serialized)
+ * const request = PaymentRequest.deserialize(serialized)
  * ```
  */
 export function deserialize(encoded: string): Request {
@@ -47,9 +47,9 @@ export function deserialize(encoded: string): Request {
  *
  * @example
  * ```ts
- * import { Request } from 'mppx'
+ * import { PaymentRequest } from 'mppx'
  *
- * const request = Request.from({
+ * const request = PaymentRequest.from({
  *   amount: '1000000',
  *   currency: '0x20c0000000000000000000000000000000000001',
  *   recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00',
@@ -69,10 +69,10 @@ export function from<const request extends Request>(request: request): request {
  *
  * @example
  * ```ts
- * import { Request } from 'mppx'
+ * import { PaymentRequest } from 'mppx'
  * import { Methods } from 'mppx/tempo'
  *
- * const request = Request.fromMethod(Methods.charge, {
+ * const request = PaymentRequest.fromMethod(Methods.charge, {
  *   amount: '1000000',
  *   currency: '0x20c0000000000000000000000000000000000001',
  *   recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00',
@@ -96,9 +96,9 @@ export function fromMethod<const method extends Method.Method>(
  *
  * @example
  * ```ts
- * import { Request } from 'mppx'
+ * import { PaymentRequest } from 'mppx'
  *
- * const serialized = Request.serialize(request)
+ * const serialized = PaymentRequest.serialize(request)
  * // => "eyJhbW91bnQiOiIxMDAwMDAwIiwiY3VycmVuY3kiOiIweC4uLiJ9"
  * ```
  */


### PR DESCRIPTION
## Summary

- Updated `PaymentRequest` JSDoc examples to import the actual root export.
- Replaced stale `Request.*` references with `PaymentRequest.*` in examples.

## Motivation

The root package exports the payment request helpers as `PaymentRequest`, while `Request` is also used by server-side HTTP helpers. The examples should avoid that ambiguity.

## Key design considerations

- Kept the runtime API unchanged.
- Limited changes to documentation comments for the existing public module.
