### PR TITLE
docs: deprecate uppercase asset aliases

### DIFF
--- a/.changeset/deprecate-uppercase-aliases.md
+++ b/.changeset/deprecate-uppercase-aliases.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Deprecated uppercase asset and chain aliases in favor of lowercase exports.

--- a/src/evm/client/index.ts
+++ b/src/evm/client/index.ts
@@ -1,4 +1,5 @@
 export * as assets from '../Assets.js'
+/** @deprecated Use `chains` instead. */
 export * as Chains from '../Chains.js'
 export * as chains from '../Chains.js'
 export { charge } from './Charge.js'

--- a/src/evm/index.ts
+++ b/src/evm/index.ts
@@ -1,4 +1,6 @@
+/** @deprecated Use `assets` instead. */
 export * as Assets from './Assets.js'
+/** @deprecated Use `chains` instead. */
 export * as Chains from './Chains.js'
 export * as Methods from './Methods.js'
 export * as Types from './Types.js'

--- a/src/evm/server/index.ts
+++ b/src/evm/server/index.ts
@@ -1,4 +1,5 @@
 export * as assets from '../Assets.js'
+/** @deprecated Use `chains` instead. */
 export * as Chains from '../Chains.js'
 export * as chains from '../Chains.js'
 export { charge } from './Charge.js'

--- a/src/x402/index.ts
+++ b/src/x402/index.ts
@@ -1,3 +1,4 @@
+/** @deprecated Use `assets` instead. */
 export * as Assets from './Assets.js'
 export * as Header from './Header.js'
 export * as Types from './Types.js'


### PR DESCRIPTION
## Summary

- Marked uppercase EVM asset and chain namespace aliases as deprecated.
- Marked the uppercase x402 asset namespace alias as deprecated.

## Motivation

The lowercase `assets` and `chains` exports are the canonical ergonomic API. Deprecating duplicate uppercase aliases simplifies autocomplete and docs without removing compatibility.

## Key design considerations

- Kept all existing exports available.
- Limited the change to JSDoc deprecation annotations.
