### PR TITLE
feat: add tempo common method alias

### DIFF
--- a/.changeset/tempo-common-alias.md
+++ b/.changeset/tempo-common-alias.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added `tempo.common()` as an explicit alias for the Tempo charge and session method bundle.

--- a/src/tempo/client/Methods.ts
+++ b/src/tempo/client/Methods.ts
@@ -14,14 +14,14 @@ const sessionLegacyClient = Object.assign(sessionLegacy_, { method: sessionLegac
 export { sessionClient as session }
 
 /**
- * Creates both Tempo `charge` and `session` client methods from shared parameters.
+ * Creates the common Tempo `charge` and `session` client methods from shared parameters.
  *
  * @example
  * ```ts
  * import { Mppx, tempo } from 'mppx/client'
  *
  * const mppx = Mppx.create({
- *   methods: [tempo({ account })],
+ *   methods: [tempo.common({ account })],
  * })
  * ```
  */
@@ -34,6 +34,8 @@ export namespace tempo {
 
   /** Creates a Tempo `charge` client method for one-time TIP-20 token transfers. */
   export const charge = charge_
+  /** Creates the common Tempo `charge` and `session` client methods from shared parameters. */
+  export const common = tempo
   /** Creates a TIP-1034 client method for Mppx registration. Use `tempo.session.manager()` for direct lifecycle control. */
   export const session = sessionClient
   /** @deprecated Use `tempo.session()` for the TIP-1034 session client method. */

--- a/src/tempo/server/Methods.ts
+++ b/src/tempo/server/Methods.ts
@@ -49,14 +49,14 @@ function createSessionMethod<const parameters extends tempo.Parameters>(
 }
 
 /**
- * Creates both Tempo `charge` and `session` methods from shared parameters.
+ * Creates the common Tempo `charge` and `session` methods from shared parameters.
  *
  * @example
  * ```ts
  * import { Mppx, tempo } from 'mppx/server'
  *
  * const mppx = Mppx.create({
- *   methods: [tempo({ currency: '0x...', recipient: '0x...' })],
+ *   methods: [tempo.common({ currency: '0x...', recipient: '0x...' })],
  * })
  * ```
  */
@@ -69,6 +69,8 @@ export namespace tempo {
 
   /** Creates a Tempo `charge` method for one-time TIP-20 token transfers. */
   export const charge = charge_
+  /** Creates the common Tempo `charge` and `session` methods from shared parameters. */
+  export const common = tempo
   /** Creates a TIP-1034 Tempo `session` method for session-based TIP-20 token payments. */
   export const session = sessionServer
   /** @deprecated Use `tempo.session()` for the TIP-1034 session server method. */


### PR DESCRIPTION
## Summary

- Added `tempo.common()` as an explicit alias for the Tempo charge and session method bundle.
- Updated Tempo method examples to use `tempo.common()` when demonstrating the bundled helper.
- Added a patch changeset for the new public alias.

## Motivation

`tempo()` remains supported, but the name can imply all Tempo capabilities. `tempo.common()` makes the charge+session bundle explicit while preserving compatibility.

## Key design considerations

- Kept `tempo()` behavior unchanged.
- Did not include subscriptions in the common bundle.
- Added only an alias, so existing imports and method arrays continue to work.
