### PR TITLE
docs: prefer nested server handlers

### DIFF
--- a/.changeset/document-nested-server-handlers.md
+++ b/.changeset/document-nested-server-handlers.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Updated public examples to prefer namespaced server handlers.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ const mppx = Mppx.create({
 })
 
 export async function handler(request: Request) {
-  const response = await mppx.charge({ amount: '1' })(request)
+  const response = await mppx.tempo.charge({ amount: '1' })(request)
 
   if (response.status === 402) return response.challenge
 
@@ -129,7 +129,7 @@ const proxy = Proxy.create({
     openai({
       apiKey: 'sk-...',
       routes: {
-        'POST /v1/chat/completions': mppx.charge({ amount: '0.05' }),
+        'POST /v1/chat/completions': mppx.tempo.charge({ amount: '0.05' }),
         'POST /v1/completions': mppx.tempo.session({
           amount: '0.0001',
           unitType: 'token',
@@ -140,7 +140,7 @@ const proxy = Proxy.create({
     stripe({
       apiKey: 'sk-...',
       routes: {
-        'POST /v1/charges': mppx.charge({ amount: '0.01' }),
+        'POST /v1/charges': mppx.tempo.charge({ amount: '0.01' }),
         'GET /v1/customers/:id': true,
       },
     }),

--- a/src/middlewares/elysia.ts
+++ b/src/middlewares/elysia.ts
@@ -25,7 +25,7 @@ export namespace Mppx {
    *
    * const app = new Elysia()
    *   .guard(
-   *     { beforeHandle: mppx.charge({ amount: '1' }) },
+   *     { beforeHandle: mppx.tempo.charge({ amount: '1' }) },
    *     (app) => app.get('/premium', () => ({ data: 'paid content' })),
    *   )
    * ```
@@ -45,14 +45,14 @@ export namespace Mppx {
  * @example
  * ```ts
  * import { Elysia } from 'elysia'
- * import { Mppx } from 'mppx/server'
+ * import { Mppx, tempo } from 'mppx/server'
  * import { payment } from 'mppx/elysia'
  *
  * const mppx = Mppx.create({ methods: [tempo()] })
  *
  * const app = new Elysia()
  *   .guard(
- *     { beforeHandle: payment(mppx.charge, { amount: '1' }) },
+ *     { beforeHandle: payment(mppx.tempo.charge, { amount: '1' }) },
  *     (app) => app.get('/premium', () => ({ data: 'paid content' })),
  *   )
  * ```

--- a/src/middlewares/express.ts
+++ b/src/middlewares/express.ts
@@ -25,7 +25,7 @@ export namespace Mppx {
    * const app = express()
    * const mppx = Mppx.create({ methods: [tempo()] })
    *
-   * app.get('/premium', mppx.charge({ amount: '1' }), (req, res) => {
+   * app.get('/premium', mppx.tempo.charge({ amount: '1' }), (req, res) => {
    *   res.json({ data: 'paid content' })
    * })
    * ```
@@ -46,13 +46,13 @@ export namespace Mppx {
  * @example
  * ```ts
  * import express from 'express'
- * import { Mppx } from 'mppx/server'
+ * import { Mppx, tempo } from 'mppx/server'
  * import { payment } from 'mppx/express'
  *
  * const mppx = Mppx.create({ methods: [tempo()] })
  *
  * const app = express()
- * app.get('/premium', payment(mppx.charge, { amount: '1' }), (req, res) => {
+ * app.get('/premium', payment(mppx.tempo.charge, { amount: '1' }), (req, res) => {
  *   res.json({ data: 'paid content' })
  * })
  * ```

--- a/src/middlewares/hono.ts
+++ b/src/middlewares/hono.ts
@@ -20,7 +20,7 @@ export namespace Mppx {
    * const app = new Hono()
    * const mppx = Mppx.create({ methods: [tempo()] })
    *
-   * app.get('/premium', mppx.charge({ amount: '1' }), (c) =>
+   * app.get('/premium', mppx.tempo.charge({ amount: '1' }), (c) =>
    *   c.json({ data: 'paid content' }),
    * )
    * ```
@@ -41,13 +41,13 @@ export namespace Mppx {
  * @example
  * ```ts
  * import { Hono } from 'hono'
- * import { Mppx } from 'mppx/server'
+ * import { Mppx, tempo } from 'mppx/server'
  * import { payment } from 'mppx/hono'
  *
  * const mppx = Mppx.create({ methods: [tempo()] })
  *
  * const app = new Hono()
- * app.get('/premium', payment(mppx.charge, { amount: '1' }), (c) =>
+ * app.get('/premium', payment(mppx.tempo.charge, { amount: '1' }), (c) =>
  *   c.json({ data: 'paid content' }),
  * )
  * ```

--- a/src/middlewares/nextjs.ts
+++ b/src/middlewares/nextjs.ts
@@ -20,7 +20,7 @@ export namespace Mppx {
    *
    * const mppx = Mppx.create({ methods: [tempo()] })
    *
-   * export const GET = mppx.charge({ amount: '1' })(() =>
+   * export const GET = mppx.tempo.charge({ amount: '1' })(() =>
    *   Response.json({ data: 'paid content' }),
    * )
    * ```
@@ -43,12 +43,12 @@ export namespace Mppx {
  * @example
  * ```ts
  * // app/api/premium/route.ts
- * import { Mppx } from 'mppx/server'
+ * import { Mppx, tempo } from 'mppx/server'
  * import { payment } from 'mppx/nextjs'
  *
  * const mppx = Mppx.create({ methods: [tempo()] })
  *
- * export const GET = payment(mppx.charge, { amount: '1' }, () =>
+ * export const GET = payment(mppx.tempo.charge, { amount: '1' }, () =>
  *   Response.json({ data: 'paid content' }),
  * )
  * ```

--- a/src/proxy/Proxy.ts
+++ b/src/proxy/Proxy.ts
@@ -35,7 +35,7 @@ export type Proxy = {
  *     openai({
  *       apiKey: 'sk-...',
  *       routes: {
- *         'POST /v1/chat/completions': mppx.charge({ amount: '0.05' }),
+ *         'POST /v1/chat/completions': mppx.tempo.charge({ amount: '0.05' }),
  *         'GET /v1/models': true,
  *       },
  *     }),

--- a/src/proxy/Service.ts
+++ b/src/proxy/Service.ts
@@ -78,7 +78,7 @@ export type From<
  *   baseUrl: 'https://api.example.com',
  *   bearer: 'sk-...',
  *   routes: {
- *     'POST /v1/generate': mppx.charge({ amount: '0.01' }),
+ *     'POST /v1/generate': mppx.tempo.charge({ amount: '0.01' }),
  *     'GET /v1/status': true,
  *   },
  * })

--- a/src/proxy/services/anthropic.ts
+++ b/src/proxy/services/anthropic.ts
@@ -11,8 +11,8 @@ import * as Service from '../Service.js'
  * anthropic({
  *   apiKey: 'sk-ant-...',
  *   routes: {
- *     'POST /v1/messages': mppx.charge({ amount: '0.03' }),
- *     'POST /v1/complete': mppx.charge({ amount: '0.02' }),
+ *     'POST /v1/messages': mppx.tempo.charge({ amount: '0.03' }),
+ *     'POST /v1/complete': mppx.tempo.charge({ amount: '0.02' }),
  *   },
  * })
  * ```

--- a/src/proxy/services/openai.ts
+++ b/src/proxy/services/openai.ts
@@ -11,7 +11,7 @@ import * as Service from '../Service.js'
  * openai({
  *   apiKey: 'sk-...',
  *   routes: {
- *     'POST /v1/chat/completions': mppx.charge({ amount: '0.05' }),
+ *     'POST /v1/chat/completions': mppx.tempo.charge({ amount: '0.05' }),
  *     'GET /v1/models': true,
  *   },
  * })

--- a/src/proxy/services/stripe.ts
+++ b/src/proxy/services/stripe.ts
@@ -11,7 +11,7 @@ import * as Service from '../Service.js'
  * stripe({
  *   apiKey: 'sk-...',
  *   routes: {
- *     'POST /v1/charges': mppx.charge({ amount: '1' }),
+ *     'POST /v1/charges': mppx.tempo.charge({ amount: '1' }),
  *     'GET /v1/customers/:id': true,
  *   },
  * })

--- a/src/server/Mppx.ts
+++ b/src/server/Mppx.ts
@@ -216,8 +216,8 @@ export type Mppx<
        *
        * app.get('/api/resource', async (req) => {
        *   const result = await mppx.compose(
-       *     ['tempo/charge', { amount: '100' }],
-       *     ['stripe/charge', { amount: '100' }],
+       *     [mppx.tempo.charge, { amount: '100' }],
+       *     [mppx.stripe.charge, { amount: '100' }],
        *   )(req)
        *   if (result.status === 402) return result.challenge
        *   return result.withReceipt(new Response('OK'))
@@ -2089,7 +2089,7 @@ declare namespace MethodFn {
       }
 }
 
-/** A configured handler — the return value of e.g. `mppx.charge({ ... })`. @internal */
+/** A configured handler — the return value of e.g. `mppx.tempo.charge({ ... })`. @internal */
 type ConfiguredHandler = ((input: Request) => Promise<MethodFn.Response<Transport.Http>>) & {
   _internal: {
     name: string
@@ -2165,8 +2165,8 @@ type ComposeEntry<methods extends readonly Method.AnyServer[]> =
  *
  * app.get('/api/resource', async (req) => {
  *   const result = await Mppx.compose(
- *     mppx['tempo/charge']({ amount: '100', currency: USDC, recipient: '0x...' }),
- *     mppx['stripe/charge']({ amount: '100', currency: 'usd' }),
+ *     mppx.tempo.charge({ amount: '100', currency: USDC, recipient: '0x...' }),
+ *     mppx.stripe.charge({ amount: '100', currency: 'usd' }),
  *   )(req)
  *   if (result.status === 402) return result.challenge
  *   return result.withReceipt(new Response('OK'))


### PR DESCRIPTION
## Summary

- Updated server, middleware, and proxy examples to use nested handler access like `mppx.tempo.charge(...)`
- Updated compose examples to use method references like `mppx.tempo.charge` and `mppx.stripe.charge`
- Removed shorthand handler examples from public docs and JSDoc

## Motivation

The nested handler form is clearer when multiple methods expose the same intent name, and it avoids teaching ambiguous shorthand as the default API shape.

## Key design considerations

- Kept the change documentation-only
- Preserved compatibility with existing shorthand APIs
- Updated both configured-handler and method-reference examples
