### PR TITLE
fix: bump hono to patched version

### DIFF
--- a/.changeset/fix-hono-audit.md
+++ b/.changeset/fix-hono-audit.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Updated Hono dependencies to patched versions.

--- a/examples/x402-mpp/package.json
+++ b/examples/x402-mpp/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@types/node": "25.6.0",
     "@typescript/native-preview": "7.0.0-dev.20260323.1",
-    "hono": "4.12.23",
+    "hono": "4.12.25",
     "mppx": "latest",
     "tsx": "4.22.4",
     "typescript": "~6.0.3",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "express": "^5.2.1",
     "fast-check": "^4.8.0",
     "file-type": "22.0.1",
-    "hono": "4.12.23",
+    "hono": "4.12.25",
     "isows": "^1.0.7",
     "playwright": "^1.60.0",
     "prool": "^0.2.4",
@@ -200,7 +200,7 @@
     "@modelcontextprotocol/sdk": ">=1.25.0",
     "elysia": ">=1",
     "express": ">=5",
-    "hono": ">=4.12.18",
+    "hono": ">=4.12.25",
     "viem": ">=2.51.0"
   },
   "peerDependenciesMeta": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,7 +63,7 @@ importers:
         version: 2.31.0(@types/node@25.6.0)
       '@hono/node-server':
         specifier: 2.0.4
-        version: 2.0.4(hono@4.12.23)
+        version: 2.0.4(hono@4.12.25)
       '@modelcontextprotocol/sdk':
         specifier: 1.29.0
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
@@ -101,8 +101,8 @@ importers:
         specifier: 21.3.2
         version: 21.3.2
       hono:
-        specifier: 4.12.23
-        version: 4.12.23
+        specifier: 4.12.25
+        version: 4.12.25
       isows:
         specifier: ^1.0.7
         version: 1.0.7(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
@@ -372,8 +372,8 @@ importers:
         specifier: 7.0.0-dev.20260323.1
         version: 7.0.0-dev.20260323.1
       hono:
-        specifier: 4.12.23
-        version: 4.12.23
+        specifier: 4.12.25
+        version: 4.12.25
       mppx:
         specifier: workspace:*
         version: link:../..
@@ -2969,8 +2969,8 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.23:
-    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
+  hono@4.12.25:
+    resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
     engines: {node: '>=16.9.0'}
 
   http-errors@2.0.1:
@@ -4568,13 +4568,13 @@ snapshots:
       protobufjs: 7.6.3
       yargs: 17.7.2
 
-  '@hono/node-server@1.19.14(hono@4.12.23)':
+  '@hono/node-server@1.19.14(hono@4.12.25)':
     dependencies:
-      hono: 4.12.23
+      hono: 4.12.25
 
-  '@hono/node-server@2.0.4(hono@4.12.23)':
+  '@hono/node-server@2.0.4(hono@4.12.25)':
     dependencies:
-      hono: 4.12.23
+      hono: 4.12.25
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -4776,7 +4776,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.23)
+      '@hono/node-server': 1.19.14(hono@4.12.25)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -4786,7 +4786,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.23
+      hono: 4.12.25
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -5624,7 +5624,7 @@ snapshots:
 
   accounts@0.14.6(@types/react@19.2.15)(@wagmi/core@3.5.0)(react@19.2.6)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.6))(viem@2.51.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.16):
     dependencies:
-      hono: 4.12.23
+      hono: 4.12.25
       idb-keyval: 6.2.5
       mipd: 0.0.7(typescript@5.9.3)
       mppx: 'link:'
@@ -6494,7 +6494,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.23: {}
+  hono@4.12.25: {}
 
   http-errors@2.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

- Bumped the root `hono` dev dependency to `4.12.25`
- Raised the `hono` peer dependency floor to the patched version
- Updated the `examples/x402-mpp` Hono pin and regenerated the lockfile
- Added a patch changeset

## Motivation

Fixes the `pnpm audit --ignore-registry-errors` failure reported in https://github.com/wevm/mppx/actions/runs/27688574292/job/81893355209?pr=554 for Hono advisories patched in `4.12.25`.

## Key design considerations

- Kept the fix scoped to the vulnerable Hono dependency path
- Updated the peer floor so consumers do not satisfy the optional peer with an audited vulnerable version
- Left unrelated dependencies unchanged
