### PR TITLE
fix: prevent SSE voucher posts from consuming charges

### DIFF
--- a/.changeset/fix-sse-session-vouchers.md
+++ b/.changeset/fix-sse-session-vouchers.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed SSE session accounting so voucher management posts no longer consumed stream charges.

--- a/examples/session/sse/src/server.ts
+++ b/examples/session/sse/src/server.ts
@@ -44,12 +44,13 @@ const currency = '0x20c0000000000000000000000000000000000000' as const
 // SSE event for each token, and the client must respond with an updated
 // cumulative voucher covering this amount before the next token is sent.
 const pricePerToken = '0.000075'
+const suggestedDeposit = '1'
 
 // Viem Client
 //
 // The viem client MUST have an `account` attached. This is critical because
 // the server needs to sign on-chain transactions when closing/settling
-// payment channels and co-signing fee-payer transactions.
+// payment channels.
 const client = createClient({
   account,
   chain: Chain.testnet,
@@ -126,13 +127,9 @@ const mppx = Mppx.create({
       account,
       // The TIP-20 token to accept payment in.
       currency,
-      // Enable fee-sponsored transactions. When true, the server co-signs
-      // the client's channel-open transaction so the protocol covers gas
-      // fees instead of the client paying them.
-      feePayer: true,
       // Returns an account-bearing viem client for on-chain operations:
-      // broadcasting channel-open txs, verifying channel state, and
-      // submitting close/settle transactions.
+      // broadcasting client-signed channel-open txs, verifying channel state,
+      // and submitting close/settle transactions.
       getClient: () => client,
       // Shared store so mid-stream voucher POSTs update the same state
       // that `stream.charge()` reads from.
@@ -140,7 +137,7 @@ const mppx = Mppx.create({
       // SSE transport for streaming. The session method detects the SSE
       // transport and wires up Tempo metering (per-token charging, voucher
       // handling) automatically using the shared storage.
-      sse: { poll: true },
+      sse: true,
     }),
   ],
 })
@@ -207,6 +204,7 @@ export async function handler(request: Request): Promise<Response | null> {
     // describing what phase we're in and how to respond.
     const result = await mppx.session({
       amount: pricePerToken,
+      suggestedDeposit,
       unitType: 'token',
     })(request)
 
@@ -244,7 +242,12 @@ export async function handler(request: Request): Promise<Response | null> {
     // After all tokens are yielded, the transport automatically appends a
     // final `event: payment-receipt` SSE event with the settlement details.
     //
-    return result.withReceipt(generateTokens(prompt))
+    return result.withReceipt(async function* (stream) {
+      for await (const token of generateTokens(prompt)) {
+        await stream.charge()
+        yield token
+      }
+    })
   }
 
   // Return null for unrecognized paths (framework can handle 404).
@@ -328,8 +331,7 @@ async function* generateTokens(prompt: string): AsyncGenerator<string> {
 //
 // Log the server's recipient address (where settled funds go) and fund it
 // via the testnet faucet. The server account needs a small amount of native
-// tokens (for gas) to settle channels on-chain, though in production the
-// `feePayer` option can be used to have the protocol cover gas.
+// tokens (for gas) to settle channels on-chain.
 console.log(`Server recipient: ${account.address}`)
 await Actions.faucet.fundSync(client, { account, timeout: 30_000 })
 console.log('Server account funded')

--- a/src/tempo/session/server/Settlement.test.ts
+++ b/src/tempo/session/server/Settlement.test.ts
@@ -1,11 +1,14 @@
 import type { Hex } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { describe, expect, test } from 'vp/test'
+import { describe, expect, test, vi } from 'vp/test'
 
 import * as Challenge from '../../../Challenge.js'
 import type * as Credential from '../../../Credential.js'
+import type * as Method from '../../../Method.js'
+import { createSessionReceipt } from '../precompile/Protocol.js'
 import type * as ChannelStore from './ChannelStore.js'
 import {
+  applyVerifiedHttpAccounting,
   isSettlementDue,
   readRequestFeePayer,
   resolveCredentialFeePayer,
@@ -145,6 +148,90 @@ describe('FeePayerResolution', () => {
         }),
       ).toBe(defaultFeePayer)
     })
+  })
+})
+
+describe('applyVerifiedHttpAccounting', () => {
+  const channelId = '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex
+
+  function receipt() {
+    return createSessionReceipt({
+      acceptedCumulative: 200n,
+      challengeId: 'challenge-1',
+      channelId,
+      spent: 0n,
+      units: 0,
+    })
+  }
+
+  function capturedRequest(overrides: Partial<Method.CapturedRequest>): Method.CapturedRequest {
+    return {
+      hasBody: false,
+      headers: new Headers(),
+      method: 'GET',
+      url: new URL('https://api.example.com/session'),
+      ...overrides,
+    }
+  }
+
+  function chargedChannel(): ChannelStore.State {
+    return {
+      channelId,
+      spent: 75n,
+      units: 1,
+    } as ChannelStore.State
+  }
+
+  test('precharges SSE GET content and marks the receipt as prepaid', async () => {
+    const charge = vi.fn(async () => chargedChannel())
+    const markPrepaidReceipt = vi.fn((value) => value)
+
+    await applyVerifiedHttpAccounting({
+      capturedRequest: capturedRequest({ method: 'GET' }),
+      charge,
+      getRequestAmount: () => 75n,
+      markPrepaidReceipt,
+      payloadAction: 'voucher',
+      receipt: receipt(),
+      settleCharged: async () => undefined,
+      sseEnabled: true,
+    })
+
+    expect(charge).toHaveBeenCalledWith(channelId, 75n)
+    expect(markPrepaidReceipt).toHaveBeenCalledOnce()
+  })
+
+  test('does not charge SSE voucher management POSTs', async () => {
+    const charge = vi.fn(async () => chargedChannel())
+
+    const result = await applyVerifiedHttpAccounting({
+      capturedRequest: capturedRequest({ hasBody: true, method: 'POST' }),
+      charge,
+      getRequestAmount: () => 75n,
+      payloadAction: 'voucher',
+      receipt: receipt(),
+      settleCharged: async () => undefined,
+      sseEnabled: true,
+    })
+
+    expect(charge).not.toHaveBeenCalled()
+    expect(result.spent).toBe('0')
+  })
+
+  test('keeps non-SSE POST content accounting unchanged', async () => {
+    const charge = vi.fn(async () => chargedChannel())
+
+    await applyVerifiedHttpAccounting({
+      capturedRequest: capturedRequest({ hasBody: true, method: 'POST' }),
+      charge,
+      getRequestAmount: () => 75n,
+      payloadAction: 'voucher',
+      receipt: receipt(),
+      settleCharged: async () => undefined,
+      sseEnabled: false,
+    })
+
+    expect(charge).toHaveBeenCalledWith(channelId, 75n)
   })
 })
 

--- a/src/tempo/session/server/Settlement.ts
+++ b/src/tempo/session/server/Settlement.ts
@@ -262,8 +262,9 @@ export async function applyVerifiedHttpAccounting(
 ): Promise<SessionReceipt> {
   const { capturedRequest, payloadAction, receipt, sseEnabled } = parameters
   if (!capturedRequest) return receipt
-  if (!isSessionContentRequest(capturedRequest)) return receipt
   if (payloadAction !== 'open' && payloadAction !== 'voucher') return receipt
+  if (sseEnabled && capturedRequest.method === 'POST') return receipt
+  if (!isSessionContentRequest(capturedRequest)) return receipt
 
   const requestAmount = parameters.getRequestAmount()
   const charged = await parameters.charge(receipt.channelId, requestAmount)


### PR DESCRIPTION
## Summary

- Prevented SSE session voucher management POSTs from being counted as billable content charges.
- Updated the SSE session example to use explicit per-token stream charges with the TIP-1034 session flow.
- Added a patch changeset for the session accounting fix.

## Motivation

SSE voucher updates are management traffic. Counting them as content charges consumed voucher headroom before the stream could commit its reserved charge, which could terminate the stream.

## Key design considerations

- Preserved non-SSE POST content accounting.
- Kept SSE content precharge behavior for GET streams.
- Removed default fee sponsorship from the example so the funded client pays channel-open gas.