### PR TITLE
feat(session): resolveAccount hook for voucher signer selection

### DIFF
--- a/.changeset/session-resolve-account.md
+++ b/.changeset/session-resolve-account.md
@@ -1,0 +1,5 @@
+---
+'mppx': minor
+---
+
+Added a `resolveAccount` hook to `tempo.session()` so a wallet can choose which account/access key signs vouchers for a given challenge scope, using the locally cached channel entry or server `recoverContext`. Resume/recover is gated by a payer- and signer-aware check, so a stored channel the resolved account cannot sign for opens fresh instead of producing an invalid voucher. Generalized voucher signing and verification to accept any TIP-1020 primitive signature (secp256k1, p256, webAuthn), rejecting keychain wrappers, multisig, and magic-suffixed encodings.

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -18,5 +18,6 @@ export {
   type ChannelStore,
   type JsonChannelKv,
 } from '../tempo/session/client/ChannelStore.js'
+export type { ResolveAccount, ResolveAccountInfo } from '../tempo/session/client/Session.js'
 export * as Mppx from './Mppx.js'
 export * as Transport from './Transport.js'

--- a/src/tempo/session/client/Session.test.ts
+++ b/src/tempo/session/client/Session.test.ts
@@ -262,6 +262,60 @@ describe('precompile client session', () => {
     expect(payload.descriptor.operator.toLowerCase()).toBe(operator.toLowerCase())
   })
 
+  test('resolveAccount selects a delegated access key as the channel signer', async () => {
+    // Same root account, but with voucher signing delegated to an access key.
+    const accessKeyAddress = '0x0000000000000000000000000000000000000009' as Address
+    const accessKey = Object.assign({}, account, { accessKeyAddress })
+
+    const seen: Array<{ entry: unknown; payer: Address }> = []
+    const method = session({
+      account,
+      decimals: 0,
+      getClient: () => client,
+      resolveAccount(info) {
+        seen.push({ entry: info.entry, payer: info.payer })
+        return accessKey
+      },
+    })
+
+    const open = deserialize(
+      await method.createCredential({ challenge: makeChallenge(), context: {} }),
+    )
+
+    expect(open.action).toBe('open')
+    // Channel is opened with the access key as its descriptor authorizedSigner.
+    if (open.action !== 'open') throw new Error('expected open payload')
+    expect(open.descriptor.authorizedSigner).toBe(accessKeyAddress)
+    // First call sees no cached entry; the default payer is the root account.
+    expect(seen[0]?.entry).toBeUndefined()
+    expect(seen[0]?.payer.toLowerCase()).toBe(account.address.toLowerCase())
+
+    // Resume: the cached entry was signed by the same access key, so it vouchers.
+    const next = deserialize(
+      await method.createCredential({ challenge: makeChallenge(), context: {} }),
+    )
+    expect(next.action).toBe('voucher')
+    expect(seen[1]?.entry).toBeDefined()
+  })
+
+  test('falls back to the default account when resolveAccount returns undefined', async () => {
+    const method = session({
+      account,
+      decimals: 0,
+      getClient: () => client,
+      resolveAccount: () => undefined,
+    })
+
+    const open = deserialize(
+      await method.createCredential({ challenge: makeChallenge(), context: {} }),
+    )
+
+    expect(open.action).toBe('open')
+    if (open.action !== 'open') throw new Error('expected open payload')
+    // Root account signs: descriptor authorizedSigner is the payer address.
+    expect(open.descriptor.authorizedSigner.toLowerCase()).toBe(account.address.toLowerCase())
+  })
+
   test('tracks cumulative amount and calls onChannelUpdate in auto mode', async () => {
     const updates: bigint[] = []
     const method = session({

--- a/src/tempo/session/client/Session.ts
+++ b/src/tempo/session/client/Session.ts
@@ -1,7 +1,9 @@
-import { type Address, parseUnits } from 'viem'
+import { type Account as ViemAccount, type Address, parseUnits } from 'viem'
 import { tempo as tempo_chain } from 'viem/chains'
 
+import type * as Challenge from '../../../Challenge.js'
 import * as Constants from '../../../Constants.js'
+import type { MaybePromise } from '../../../internal/types.js'
 import * as Method from '../../../Method.js'
 import * as Account from '../../../viem/Account.js'
 import * as Client from '../../../viem/Client.js'
@@ -11,13 +13,50 @@ import * as Methods from '../../Methods.js'
 import { serializeCredential, type ChannelEntry } from './ChannelOps.js'
 import { createChannelStore, type ChannelStore } from './ChannelStore.js'
 import {
+  type DescriptorSessionContext,
   executeCredentialPlan,
   planCredential,
   resolveChallengeContext,
+  resolveRecoverContext,
   sessionContextSchema,
 } from './CredentialState.js'
 
 export { sessionContextSchema, type SessionContext } from './CredentialState.js'
+
+/**
+ * Resolved payment scope of a session challenge, plus the channel state already
+ * known locally or hinted by the server, handed to {@link session.Parameters.resolveAccount}
+ * so a wallet can choose which key signs vouchers for this scope.
+ */
+export type ResolveAccountInfo = {
+  /** Default account resolved from method/context (the payer; usually a `json-rpc` root). */
+  account: ViemAccount
+  /** Chain ID the challenge settles on. */
+  chainId: number
+  /** Deserialized 402 challenge. */
+  challenge: Challenge.Challenge
+  /** Channel cached locally for this scope, when one exists. */
+  entry?: ChannelEntry | undefined
+  /** Escrow precompile the channel is opened against. */
+  escrow: Address
+  /** Payment-scope key (see {@link channelKey}). */
+  key: string
+  /** Payee (recipient) advertised by the challenge. */
+  payee: Address
+  /** Payer address (the default account's address). */
+  payer: Address
+  /** Descriptor recovery context derived from caller context or a server snapshot, when present. */
+  recoverContext?: DescriptorSessionContext | undefined
+  /** Token (currency) advertised by the challenge. */
+  token: Address
+}
+
+/**
+ * Resolves the account that signs vouchers for a session challenge. Return a
+ * concrete account (e.g. a delegated access key) to sign with it, or `undefined`
+ * to use the default {@link ResolveAccountInfo.account}.
+ */
+export type ResolveAccount = (info: ResolveAccountInfo) => MaybePromise<ViemAccount | undefined>
 
 /**
  * Creates the low-level TIP-1034 session payment method for use with `Mppx.create()`.
@@ -36,6 +75,7 @@ export function session(parameters: session.Parameters = {}) {
     getClient: getClientParameter,
     maxDeposit: maxDepositParameter,
     onChannelUpdate,
+    resolveAccount,
   } = parameters
   const getClient = Client.getResolver({
     chain: tempo_chain,
@@ -67,7 +107,7 @@ export function session(parameters: session.Parameters = {}) {
         escrowOverride,
         getClient,
       })
-      const account = getAccount(resolved.client, context)
+      const account_default = getAccount(resolved.client, context)
 
       // Manual actions, caller-supplied channels, and challenges an opened
       // local channel can serve stay local (the wallet would strand its deposit).
@@ -77,6 +117,25 @@ export function session(parameters: session.Parameters = {}) {
         context?.channelId !== undefined
       const entry = await store.get(resolved.key)
       const openedLocally = entry?.opened
+
+      // Let the caller choose which key signs vouchers for this scope (e.g. a
+      // delegated access key for resume, or a fresh-open key), given the channel
+      // state already known locally or hinted by the server. `undefined` keeps
+      // the default account. `planCredential` drops a resume/recover the resolved
+      // account cannot sign for and opens fresh instead.
+      const account =
+        (await resolveAccount?.({
+          account: account_default,
+          chainId: resolved.chainId,
+          challenge,
+          entry,
+          escrow: resolved.escrow,
+          key: resolved.key,
+          payee: resolved.payee,
+          payer: account_default.address,
+          recoverContext: resolveRecoverContext({ context, snapshot: resolved.snapshot }),
+          token: resolved.token,
+        })) ?? account_default
 
       // Wallet-native MPP: ask a JSON-RPC wallet to satisfy automatic-mode
       // challenges via `wallet_authorizeChallenge` before falling back to local planning.
@@ -123,5 +182,12 @@ export declare namespace session {
       maxDeposit?: string | undefined
       /** Called whenever channel state changes. */
       onChannelUpdate?: ((entry: ChannelEntry) => void) | undefined
+      /**
+       * Resolves the account that signs vouchers for a given challenge scope,
+       * letting a wallet pick a delegated access key (to resume without prompting
+       * the root key, or to open a fresh channel) based on the local/server
+       * channel state. Return `undefined` to use the default account.
+       */
+      resolveAccount?: ResolveAccount | undefined
     }
 }

--- a/src/tempo/session/client/index.ts
+++ b/src/tempo/session/client/index.ts
@@ -1,4 +1,5 @@
 export { session } from './Session.js'
+export type { ResolveAccount, ResolveAccountInfo } from './Session.js'
 export { sessionManager } from './SessionManager.js'
 export * as Machine from './Runtime.js'
 export { deserializeSnapshot, serializeSnapshot } from '../Snapshot.js'

--- a/src/tempo/session/precompile/Voucher.test.ts
+++ b/src/tempo/session/precompile/Voucher.test.ts
@@ -271,7 +271,7 @@ describe('Precompile Voucher', () => {
     ).toBe(false)
   })
 
-  test('sign rejects p256 keychain access-key voucher delegation explicitly', async () => {
+  test('signs and verifies p256 access-key voucher as a primitive', async () => {
     const rootAccount = TempoAccount.fromSecp256k1(Secp256k1.randomPrivateKey())
     const accessKey = TempoAccount.fromP256(P256.randomPrivateKey(), {
       access: rootAccount,
@@ -281,16 +281,57 @@ describe('Precompile Voucher', () => {
       transport: http('http://127.0.0.1'),
     })
 
-    await expect(
-      signVoucher(
-        accessKeyClient,
-        accessKey,
-        { channelId, cumulativeAmount },
+    const signature = await signVoucher(
+      accessKeyClient,
+      accessKey,
+      { channelId, cumulativeAmount },
+      escrowContract,
+      chainId,
+      accessKey.accessKeyAddress,
+    )
+
+    // Access keys sign the raw voucher digest, yielding a p256 primitive
+    // (no keychain wrapper).
+    expect(SignatureEnvelope.from(signature as SignatureEnvelope.Serialized).type).toBe('p256')
+
+    expect(
+      verifyVoucher(
         escrowContract,
         chainId,
+        { channelId, cumulativeAmount, signature },
         accessKey.accessKeyAddress,
       ),
-    ).rejects.toThrow('TIP-1034 voucher signing only supports secp256k1 voucher signatures.')
+    ).toBe(true)
+  })
+
+  test('signs and verifies webAuthn root voucher as a primitive', async () => {
+    const webAuthnAccount = TempoAccount.fromHeadlessWebAuthn(P256.randomPrivateKey(), {
+      origin: 'https://example.com',
+      rpId: 'example.com',
+    })
+    const webAuthnClient = createClient({
+      account: webAuthnAccount,
+      transport: http('http://127.0.0.1'),
+    })
+
+    const signature = await signVoucher(
+      webAuthnClient,
+      webAuthnAccount,
+      { channelId, cumulativeAmount },
+      escrowContract,
+      chainId,
+    )
+
+    expect(SignatureEnvelope.from(signature as SignatureEnvelope.Serialized).type).toBe('webAuthn')
+
+    expect(
+      verifyVoucher(
+        escrowContract,
+        chainId,
+        { channelId, cumulativeAmount, signature },
+        webAuthnAccount.address,
+      ),
+    ).toBe(true)
   })
 
   test('domain and type match TIP-1034', () => {

--- a/src/tempo/session/precompile/Voucher.ts
+++ b/src/tempo/session/precompile/Voucher.ts
@@ -1,4 +1,3 @@
-import { Signature } from 'ox'
 import { Channel, SignatureEnvelope } from 'ox/tempo'
 import type { Account, Address, Client, Hex } from 'viem'
 import { hashTypedData } from 'viem'
@@ -45,6 +44,27 @@ function getVoucherDigest(chainId: number, voucher: Voucher): Hex {
   }) as Hex
 }
 
+/** EIP-712 / canonical digest a voucher signature is verified against. */
+function getVoucherPayload(verifyingContract: Address, chainId: number, voucher: Voucher): Hex {
+  if (verifyingContract.toLowerCase() === Channel.address.toLowerCase())
+    return getVoucherDigest(chainId, voucher)
+  return hashTypedData({
+    domain: getVoucherDomain(verifyingContract, chainId),
+    types: voucherTypes,
+    primaryType: 'Voucher',
+    message: voucher,
+  })
+}
+
+/**
+ * Whether a signature envelope type is a TIP-1020 primitive (secp256k1, p256,
+ * webAuthn). The TIP-1020 Signature Verification Precompile only verifies these
+ * primitives for vouchers — keychain wrappers and multisig are rejected.
+ */
+function isPrimitive(type: string): boolean {
+  return (SignatureEnvelope.types as readonly string[]).includes(type)
+}
+
 function signCanonicalTempoVoucher(
   account: Account,
   parameters: {
@@ -65,6 +85,11 @@ function signCanonicalTempoVoucher(
 
 /**
  * Sign a voucher with an account.
+ *
+ * Returns a TIP-1020 primitive signature (secp256k1, p256, or webAuthn). Access
+ * keys sign the raw voucher digest, so they produce a primitive directly.
+ * Keychain wrappers and multisig signatures are rejected — the TIP-1020
+ * Signature Verification Precompile only verifies primitive voucher signatures.
  */
 export async function signVoucher(
   client: Client,
@@ -94,19 +119,20 @@ export async function signVoucher(
   })()
 
   const envelope = SignatureEnvelope.from(signature as SignatureEnvelope.Serialized)
-  if (envelope.type === 'keychain' && envelope.inner.type === 'secp256k1')
-    return Signature.toHex(envelope.inner.signature)
-  if (envelope.type === 'keychain' || envelope.type !== 'secp256k1')
-    throw new Error('TIP-1034 voucher signing only supports secp256k1 voucher signatures.')
+  if (!isPrimitive(envelope.type))
+    throw new Error(
+      `TIP-1034 vouchers require a TIP-1020 primitive signature (secp256k1, p256, or webAuthn); received "${envelope.type}".`,
+    )
 
-  return signature
+  return SignatureEnvelope.serialize(envelope)
 }
 
 /**
  * Verify a voucher signature matches the expected signer.
  *
- * Only accepts raw secp256k1 signatures — the escrow contract verifies
- * via ecrecover. Keychain, p256, and webAuthn signatures are rejected.
+ * Accepts TIP-1020 primitive signatures (secp256k1, p256, webAuthn), which the
+ * TIP-1020 Signature Verification Precompile verifies on-chain. Keychain
+ * wrappers, multisig, and magic-suffixed encodings are rejected.
  */
 export function verifyVoucher(
   escrowContract: Address,
@@ -117,25 +143,12 @@ export function verifyVoucher(
   try {
     const envelope = SignatureEnvelope.from(voucher.signature as SignatureEnvelope.Serialized)
 
-    // Reject keychain signatures — the escrow contract verifies raw ECDSA
-    // signatures against authorizedSigner, not keychain-wrapped ones.
-    if (envelope.type === 'keychain') return false
-    if (envelope.type !== 'secp256k1') return false
+    if (!isPrimitive(envelope.type)) return false
+    // Reject magic-suffixed or otherwise non-canonical encodings.
     if (SignatureEnvelope.serialize(envelope).toLowerCase() !== voucher.signature.toLowerCase())
       return false
 
-    const payload =
-      escrowContract.toLowerCase() === Channel.address.toLowerCase()
-        ? getVoucherDigest(chainId, voucher)
-        : hashTypedData({
-            domain: getVoucherDomain(escrowContract, chainId),
-            types: voucherTypes,
-            primaryType: 'Voucher',
-            message: {
-              channelId: voucher.channelId,
-              cumulativeAmount: voucher.cumulativeAmount,
-            },
-          })
+    const payload = getVoucherPayload(escrowContract, chainId, voucher)
     const signer = SignatureEnvelope.extractAddress({ payload, signature: envelope })
     const valid = SignatureEnvelope.verify(envelope, { address: signer, payload })
     return valid && TempoAddress.isEqual(signer, expectedSigner)


### PR DESCRIPTION
## Summary
Add a `resolveAccount` hook to `tempo.session()` so a wallet can choose which account/access key signs vouchers for a given challenge scope, and generalize voucher signing to accept any TIP-1020 primitive signature.

> Stacked on #563 (pluggable channel store). Review/merge that first; this branch bases on it.

## Motivation
The channel store (#563) lets a wallet persist and read session channel state. This builds on it: when a 402 challenge comes in, the wallet should pick *which* key signs vouchers for that scope — resume with the access key that signed the stored channel, open fresh with a reusable access key, or fall back to the root — based on the local entry or a server `recoverContext`. mppx can't make that policy call; it needs a hook.

## Changes
- Add `resolveAccount` hook to `tempo.session()` (`src/tempo/session/client/Session.ts`): called after the challenge scope + cached `entry` / server `recoverContext` are resolved, it returns the account that signs vouchers, or `undefined` for the default. Export `ResolveAccount` / `ResolveAccountInfo` from `mppx/client` and `Tempo.Session.Client`.
- Gate automatic resume/recover with a payer- and signer-aware check so a stored channel the resolved account cannot sign for opens fresh instead of producing an invalid voucher.
- Generalize voucher signing/verification to accept any TIP-1020 primitive signature (secp256k1, p256, webAuthn) instead of secp256k1-only, rejecting keychain wrappers, multisig, and magic-suffixed encodings (`src/tempo/session/precompile/Voucher.ts`).

## Testing
- `pnpm check:types` — clean
- `VITE_TEMPO_NETWORK=none pnpm test run src/tempo/session/` — 194 passed, including `resolveAccount` selection/fallback and primitive-voucher tests
- Validated end-to-end against the Tempo accounts SDK (access-key signer selection + localnet session resume across restart) via a local patch.
