### PR TITLE
feat: verify Tempo subscription transfers credit recipient

### DIFF
--- a/.changeset/verify-subscription-renewal-transfer.md
+++ b/.changeset/verify-subscription-renewal-transfer.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Hardened confirmed Tempo subscription settlement against T6 (TIP-1028) receive policies. Activation and renewal payments that wait for confirmation now verify that a TIP-20 `TransferWithMemo` log credits the intended recipient for the expected amount with the generated settlement memo, instead of trusting transaction success alone. Transfers held by a receiver's receive policy (redirected to `ReceivePolicyGuard`) are now rejected rather than treated as paid, and the memo binding excludes unrelated transfer effects in the same receipt. Documented that the optimistic `waitForConfirmation: false` mode cannot prove recipient credit under T6.

--- a/src/tempo/server/Subscription.test.ts
+++ b/src/tempo/server/Subscription.test.ts
@@ -1,8 +1,17 @@
 import { Challenge, Credential, Receipt } from 'mppx'
 import { Mppx } from 'mppx/server'
 import { KeyAuthorization } from 'ox/tempo'
-import { createClient, custom } from 'viem'
+import {
+  createClient,
+  custom,
+  decodeFunctionData,
+  encodeAbiParameters,
+  encodeEventTopics,
+  type Address,
+  type Hex,
+} from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
+import { Abis, Transaction } from 'viem/tempo'
 import { tempo as tempo_chain } from 'viem/tempo/chains'
 import { describe, expect, test } from 'vp/test'
 
@@ -110,6 +119,109 @@ function createBillingClient(hashes: readonly string[]) {
         if (method === 'eth_chainId') return `0x${chainId.toString(16)}`
         if (method === 'eth_call') return '0x'
         if (method === 'eth_sendRawTransaction') return hashes[nextHash++] ?? hashActivate
+        throw new Error(`unexpected rpc method: ${method}`)
+      },
+    }),
+  })
+  return { client, rpcMethods }
+}
+
+const confirmedBlockHash = `0x${'f'.repeat(64)}` as const
+// Canonical TIP-1028 ReceivePolicyGuard precompile address.
+const receivePolicyGuard = '0xB10C000000000000000000000000000000000000' as Address
+
+/**
+ * Mock client whose `eth_sendRawTransactionSync` returns a confirmed receipt
+ * with a `TransferWithMemo` log derived from the broadcast transaction.
+ *
+ * `redirectTo` simulates a T6 (TIP-1028) held transfer (credits the guard, not
+ * the recipient); `addUnrelatedTransfer` adds a memo-less `Transfer` to the
+ * recipient. By default only the renewal (second) broadcast is affected so
+ * activation succeeds; `redirectActivation` also holds the first broadcast.
+ */
+function createConfirmingBillingClient(options?: {
+  addUnrelatedTransfer?: boolean
+  redirectActivation?: boolean
+  redirectTo?: Address
+}) {
+  const rpcMethods: string[] = []
+  let broadcastIndex = 0
+  const client = createClient({
+    chain: { ...tempo_chain, id: chainId },
+    transport: custom({
+      async request({ method, params }) {
+        rpcMethods.push(method)
+        if (method === 'eth_chainId') return `0x${chainId.toString(16)}`
+        if (method === 'eth_call') return '0x'
+        if (method === 'eth_sendRawTransactionSync') {
+          const index = broadcastIndex++
+          const isRenewal = index >= 1
+          const serialized = (params as [Hex])[0]
+          const transaction = Transaction.deserialize(
+            serialized as Transaction.TransactionSerializedTempo,
+          ) as unknown as {
+            from: Address
+            calls: readonly { data: Hex; to: Address }[]
+          }
+          const call = transaction.calls[0]!
+          const { args } = decodeFunctionData({
+            abi: Abis.tip20,
+            data: call.data,
+          })
+          const [recipient, amount, memo] = args as [Address, bigint, Hex]
+          const shouldRedirect = options?.redirectTo && (isRenewal || options?.redirectActivation)
+          const creditedTo = shouldRedirect ? options!.redirectTo! : recipient
+          const hash = `0x${index.toString(16).padStart(64, '0')}` as Hex
+          const baseLog = {
+            blockHash: confirmedBlockHash,
+            blockNumber: '0x1',
+            data: encodeAbiParameters([{ type: 'uint256' }], [amount]),
+            logIndex: '0x0',
+            removed: false,
+            transactionHash: hash,
+            transactionIndex: '0x0',
+          } as const
+          const logs: unknown[] = [
+            {
+              ...baseLog,
+              address: call.to,
+              topics: encodeEventTopics({
+                abi: Abis.tip20,
+                args: { from: transaction.from, memo, to: creditedTo },
+                eventName: 'TransferWithMemo',
+              }),
+            },
+          ]
+          // Memo-less Transfer to the recipient: must not satisfy the check.
+          if (isRenewal && options?.addUnrelatedTransfer) {
+            logs.push({
+              ...baseLog,
+              address: call.to,
+              logIndex: '0x1',
+              topics: encodeEventTopics({
+                abi: Abis.tip20,
+                args: { from: transaction.from, to: recipient },
+                eventName: 'Transfer',
+              }),
+            })
+          }
+          return {
+            blockHash: confirmedBlockHash,
+            blockNumber: '0x1',
+            contractAddress: null,
+            cumulativeGasUsed: '0x0',
+            effectiveGasPrice: '0x0',
+            from: transaction.from,
+            gasUsed: '0x0',
+            logs,
+            logsBloom: `0x${'0'.repeat(512)}`,
+            status: '0x1',
+            to: call.to,
+            transactionHash: hash,
+            transactionIndex: '0x0',
+            type: '0x0',
+          }
+        }
         throw new Error(`unexpected rpc method: ${method}`)
       },
     }),
@@ -355,6 +467,147 @@ describe('tempo.subscription', () => {
     expect(receipt.reference).toBe(hashRenewed)
     expect(rpcMethods.filter((method) => method === 'eth_sendRawTransaction')).toHaveLength(2)
     expect((await subscriptions.get(record.subscriptionId))?.lastChargedPeriod).toBeGreaterThan(0)
+  })
+
+  async function activateConfirmedSubscription(parameters: {
+    client: ReturnType<typeof createConfirmingBillingClient>['client']
+    store: ReturnType<typeof Store.memory>
+  }) {
+    const { client, store } = parameters
+    const method = subscription({
+      amount: subscriptionAmount,
+      chainId,
+      currency: subscriptionCurrency,
+      getClient: async () => client,
+      periodCount: subscriptionPeriodCount,
+      periodUnit: subscriptionPeriodUnit,
+      recipient: subscriptionRecipient,
+      resolve: async () => ({ key: subscriptionKey }),
+      store,
+      subscriptionExpires: activeSubscriptionExpires,
+    })
+    const mppx = Mppx.create({ methods: [method], realm, secretKey })
+    const challengeResult = await mppx.tempo.subscription({})(
+      new Request('https://example.com/resource'),
+    )
+    if (challengeResult.status !== 402) throw new Error('expected activation challenge')
+    const challenge = Challenge.fromResponse(challengeResult.challenge)
+    const accessKey = (
+      challenge.request as ReturnType<typeof Methods.subscription.schema.request.parse>
+    ).methodDetails?.accessKey
+    if (!accessKey) throw new Error('expected generated access key')
+    const credential = await createCredential(challenge, rootAccount.address, accessKey)
+    const activated = await mppx.tempo.subscription({})(
+      new Request('https://example.com/resource', {
+        headers: { Authorization: Credential.serialize(credential) },
+      }),
+    )
+    expect(activated.status).toBe(200)
+    return { mppx }
+  }
+
+  test('renews when the confirmed receipt credits the recipient', async () => {
+    const store = Store.memory()
+    const subscriptions = SubscriptionStore.fromStore(store)
+    const { client } = createConfirmingBillingClient()
+    const { mppx } = await activateConfirmedSubscription({ client, store })
+
+    const record = await subscriptions.getByKey(subscriptionKey)
+    if (!record) throw new Error('expected subscription record')
+    await subscriptions.put({
+      ...record,
+      billingAnchor: new Date(Date.now() - 3 * subscriptionPeriodMilliseconds).toISOString(),
+      lastChargedPeriod: 0,
+    })
+
+    const renewed = await mppx.tempo.subscription({})(new Request('https://example.com/resource'))
+    expect(renewed.status).toBe(200)
+    expect((await subscriptions.get(record.subscriptionId))?.lastChargedPeriod).toBeGreaterThan(0)
+  })
+
+  test('rejects renewal when a receive policy holds the confirmed transfer', async () => {
+    const store = Store.memory()
+    const subscriptions = SubscriptionStore.fromStore(store)
+    const { client } = createConfirmingBillingClient({ redirectTo: receivePolicyGuard })
+    const { mppx } = await activateConfirmedSubscription({ client, store })
+
+    const record = await subscriptions.getByKey(subscriptionKey)
+    if (!record) throw new Error('expected subscription record')
+    await subscriptions.put({
+      ...record,
+      billingAnchor: new Date(Date.now() - 3 * subscriptionPeriodMilliseconds).toISOString(),
+      lastChargedPeriod: 0,
+    })
+
+    const renewed = await mppx.tempo.subscription({})(new Request('https://example.com/resource'))
+    expect(renewed.status).toBe(402)
+    // The held renewal must not advance the billing period.
+    expect((await subscriptions.get(record.subscriptionId))?.lastChargedPeriod).toBe(0)
+  })
+
+  test('rejects a held renewal even when a memo-less Transfer credits the recipient', async () => {
+    const store = Store.memory()
+    const subscriptions = SubscriptionStore.fromStore(store)
+    // Settlement is held, but the receipt also has a memo-less Transfer to the
+    // recipient; the memo-bound check must still reject it.
+    const { client } = createConfirmingBillingClient({
+      addUnrelatedTransfer: true,
+      redirectTo: receivePolicyGuard,
+    })
+    const { mppx } = await activateConfirmedSubscription({ client, store })
+
+    const record = await subscriptions.getByKey(subscriptionKey)
+    if (!record) throw new Error('expected subscription record')
+    await subscriptions.put({
+      ...record,
+      billingAnchor: new Date(Date.now() - 3 * subscriptionPeriodMilliseconds).toISOString(),
+      lastChargedPeriod: 0,
+    })
+
+    const renewed = await mppx.tempo.subscription({})(new Request('https://example.com/resource'))
+    expect(renewed.status).toBe(402)
+    expect((await subscriptions.get(record.subscriptionId))?.lastChargedPeriod).toBe(0)
+  })
+
+  test('rejects activation when a receive policy holds the confirmed transfer', async () => {
+    const store = Store.memory()
+    const subscriptions = SubscriptionStore.fromStore(store)
+    const { client } = createConfirmingBillingClient({
+      redirectActivation: true,
+      redirectTo: receivePolicyGuard,
+    })
+    const method = subscription({
+      amount: subscriptionAmount,
+      chainId,
+      currency: subscriptionCurrency,
+      getClient: async () => client,
+      periodCount: subscriptionPeriodCount,
+      periodUnit: subscriptionPeriodUnit,
+      recipient: subscriptionRecipient,
+      resolve: async () => ({ key: subscriptionKey }),
+      store,
+      subscriptionExpires: activeSubscriptionExpires,
+    })
+    const mppx = Mppx.create({ methods: [method], realm, secretKey })
+    const challengeResult = await mppx.tempo.subscription({})(
+      new Request('https://example.com/resource'),
+    )
+    if (challengeResult.status !== 402) throw new Error('expected activation challenge')
+    const challenge = Challenge.fromResponse(challengeResult.challenge)
+    const generatedAccessKey = (
+      challenge.request as ReturnType<typeof Methods.subscription.schema.request.parse>
+    ).methodDetails?.accessKey
+    if (!generatedAccessKey) throw new Error('expected generated access key')
+    const credential = await createCredential(challenge, rootAccount.address, generatedAccessKey)
+    const activated = await mppx.tempo.subscription({})(
+      new Request('https://example.com/resource', {
+        headers: { Authorization: Credential.serialize(credential) },
+      }),
+    )
+
+    expect(activated.status).toBe(402)
+    // A held activation must not persist an active subscription.
+    expect(await subscriptions.getByKey(subscriptionKey)).toBeNull()
   })
 
   test('returns a management response while renewal is already in flight', async () => {

--- a/src/tempo/server/Subscription.ts
+++ b/src/tempo/server/Subscription.ts
@@ -1,6 +1,13 @@
 import { Base64 } from 'ox'
 import { KeyAuthorization } from 'ox/tempo'
-import { encodeFunctionData, isAddressEqual, type Address, type Client as ViemClient } from 'viem'
+import {
+  encodeFunctionData,
+  isAddressEqual,
+  parseEventLogs,
+  type Address,
+  type Client as ViemClient,
+  type TransactionReceipt,
+} from 'viem'
 import {
   call as viem_call,
   prepareTransactionRequest,
@@ -884,6 +891,8 @@ async function submitSubscriptionPayment(parameters: {
   } as never)
 
   if (!waitForConfirmation) {
+    // Optimistic mode has no receipt to inspect, so it cannot detect a T6
+    // (TIP-1028) held transfer. Use `waitForConfirmation: true` for T6-safe proof.
     return sendRawTransaction(client, {
       serializedTransaction: serializedTransaction as Transaction.TransactionSerializedTempo,
     })
@@ -897,7 +906,48 @@ async function submitSubscriptionPayment(parameters: {
       reason: `subscription transaction reverted: ${receipt.transactionHash}`,
     })
   }
+  assertSubscriptionTransfer(receipt, {
+    amount: BigInt(request.amount),
+    currency: request.currency as Address,
+    memo,
+    recipient: request.recipient as Address,
+  })
   return receipt.transactionHash
+}
+
+/**
+ * Asserts a confirmed subscription payment credited the recipient.
+ *
+ * Transaction success alone is not proof: under Tempo T6 (TIP-1028) a recipient
+ * receive policy can hold the funds in `ReceivePolicyGuard` while the tx still
+ * succeeds. Settlement always emits one `transferWithMemo(recipient, amount,
+ * memo)`, so this requires a matching `TransferWithMemo` log on the expected
+ * token. A held transfer fails because its `to` is the guard, and the memo
+ * binding excludes unrelated transfer effects in the same receipt.
+ */
+function assertSubscriptionTransfer(
+  receipt: TransactionReceipt,
+  parameters: { amount: bigint; currency: Address; memo: `0x${string}`; recipient: Address },
+): void {
+  const { amount, currency, memo, recipient } = parameters
+  const credited = parseEventLogs({
+    abi: Abis.tip20,
+    eventName: 'TransferWithMemo',
+    logs: receipt.logs,
+  }).some(
+    (log) =>
+      isAddressEqual(log.address, currency) &&
+      isAddressEqual(log.args.to, recipient) &&
+      log.args.amount === amount &&
+      log.args.memo.toLowerCase() === memo.toLowerCase(),
+  )
+  if (!credited) {
+    throw new VerificationFailedError({
+      reason:
+        `subscription transfer was not credited to the recipient ` +
+        `(funds may have been held by a receive policy): ${receipt.transactionHash}`,
+    })
+  }
 }
 
 function createSubscriptionId() {


### PR DESCRIPTION
Under Tempo T6 (TIP-1028), a blocked transfer still succeeds but funds go to `ReceivePolicyGuard`. Confirmed subscription activation/renewal now checks the `TransferWithMemo` log actually credits the recipient instead of trusting tx success.