### PR TITLE
feat: settle MCP payments in the payment-aware fetch

### DIFF
--- a/.changeset/payment-aware-fetch-mcp.md
+++ b/.changeset/payment-aware-fetch-mcp.md
@@ -1,0 +1,5 @@
+---
+'mppx': minor
+---
+
+Settled MCP-over-HTTP payment challenges in the same payment-aware fetch as HTTP `402`s, so `Transport.http()` can extract JSON-RPC `-32042` challenges and retry with credentials in MCP metadata.

--- a/package.json
+++ b/package.json
@@ -219,6 +219,7 @@
   },
   "dependencies": {
     "@stripe/stripe-js": "9.8.0",
+    "eventsource-parser": "3.0.6",
     "incur": "^0.4.8",
     "ox": "0.14.29",
     "zod": "^4.4.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,9 @@ importers:
       '@stripe/stripe-js':
         specifier: 9.8.0
         version: 9.8.0
+      eventsource-parser:
+        specifier: 3.0.6
+        version: 3.0.6
       incur:
         specifier: ^0.4.8
         version: 0.4.8

--- a/src/client/Mppx.ts
+++ b/src/client/Mppx.ts
@@ -187,8 +187,8 @@ export function create<
       options?: createCredential.Options<FlattenMethods<methods>>,
     ) {
       const challenges = transport.getChallenges
-        ? transport.getChallenges(response as never)
-        : [transport.getChallenge(response as never)]
+        ? await transport.getChallenges(response as never)
+        : [await transport.getChallenge(response as never)]
       const preferences = resolveChallengePreferences(acceptPayment.entries, options?.acceptPayment)
 
       let challenge: Challenge.Challenge | undefined

--- a/src/client/Transport.test.ts
+++ b/src/client/Transport.test.ts
@@ -4,6 +4,8 @@ import { Methods } from 'mppx/tempo'
 import { Header as x402_Header, Types as x402_Types, type PaymentRequired } from 'mppx/x402'
 import { describe, expect, test } from 'vp/test'
 
+import * as x402_ChallengeBrand from '../x402/internal/ChallengeBrand.js'
+
 const realm = 'api.example.com'
 const secretKey = 'test-secret-key'
 
@@ -138,13 +140,13 @@ describe('http', () => {
         }),
         name: 'Payment auth and x402 challenges when both are present',
       },
-    ])('returns $name', ({ expectedIds, expectedMethods, headers }) => {
+    ])('returns $name', async ({ expectedIds, expectedMethods, headers }) => {
       const transport = Transport.http()
       const response = new Response(null, {
         status: 402,
         headers: headers(),
       })
-      const challenges = transport.getChallenges?.(response) ?? []
+      const challenges = (await transport.getChallenges?.(response)) ?? []
 
       expect(challenges.map((entry) => entry.id)).toEqual(expectedIds)
       expect(challenges.map((entry) => entry.method)).toEqual(expectedMethods)
@@ -159,20 +161,6 @@ describe('http', () => {
         expectedHeader: 'Authorization',
         expectedValue: Credential.serialize(credential),
         name: 'Payment auth credential for Payment auth challenge',
-      },
-      {
-        challenge: Transport.http().getChallenges!(
-          new Response(null, {
-            status: 402,
-            headers: {
-              'PAYMENT-REQUIRED': x402_Header.encodePaymentRequired(x402PaymentRequired),
-            },
-          }),
-        )[0],
-        credential: 'x402-signature',
-        expectedHeader: 'PAYMENT-SIGNATURE',
-        expectedValue: 'x402-signature',
-        name: 'raw x402 credential for x402 challenge',
       },
       {
         challenge,
@@ -197,6 +185,24 @@ describe('http', () => {
       expect(headers.get(expectedHeader)).toBe(expectedValue)
     })
 
+    test('writes x402 credentials for x402 challenges from the same transport', () => {
+      const transport = Transport.http()
+      const [x402Challenge] = transport.getChallenges!(
+        new Response(null, {
+          status: 402,
+          headers: {
+            'PAYMENT-REQUIRED': x402_Header.encodePaymentRequired(x402PaymentRequired),
+          },
+        }),
+      ) as Challenge.Challenge[]
+
+      const result = transport.setCredential({}, 'x402-signature', { challenge: x402Challenge })
+      const headers = result.headers as Headers
+
+      expect(headers.get('Authorization')).toBeNull()
+      expect(headers.get(x402_Types.paymentSignatureHeader)).toBe('x402-signature')
+    })
+
     test('does not treat unbranded Payment-auth challenges as x402', () => {
       const transport = Transport.http()
       const untrustedChallenge = Challenge.from({
@@ -216,16 +222,53 @@ describe('http', () => {
       expect(headers.get(x402_Types.paymentSignatureHeader)).toBeNull()
     })
 
-    test('removes stale credential headers before setting the retry credential', () => {
+    test('routes JSON-RPC requests with native 402 challenges through Authorization', () => {
       const transport = Transport.http()
-      const x402Challenge = Transport.http().getChallenges!(
+      const jsonRpcRequest = {
+        method: 'POST',
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: {} }),
+      } satisfies RequestInit
+      const [nativeChallenge] = transport.getChallenges!(
+        new Response(null, {
+          status: 402,
+          headers: { 'WWW-Authenticate': Challenge.serialize(challenge) },
+        }),
+        jsonRpcRequest,
+      ) as Challenge.Challenge[]
+
+      const result = transport.setCredential(jsonRpcRequest, 'credential', {
+        challenge: nativeChallenge,
+      })
+      const headers = new Headers(result.headers)
+
+      expect(headers.get('Authorization')).toBe('credential')
+      expect(result.body).toBe(jsonRpcRequest.body)
+    })
+
+    test('marks x402 challenges with the brand the evm charge client reads', async () => {
+      // Provenance guard: `evm/client/Charge.ts` recognizes x402 challenges via the same
+      // brand the x402 adapter stamps. If the marking site drifts, EVM x402 charges misroute.
+      const [x402Challenge] = await Transport.http().getChallenges!(
         new Response(null, {
           status: 402,
           headers: {
             'PAYMENT-REQUIRED': x402_Header.encodePaymentRequired(x402PaymentRequired),
           },
         }),
-      )[0]
+      )
+      expect(x402_ChallengeBrand.is(x402Challenge)).toBe(true)
+    })
+
+    test('removes stale credential headers before setting the retry credential', async () => {
+      const transport = Transport.http()
+      const [x402Challenge] = await transport.getChallenges!(
+        new Response(null, {
+          status: 402,
+          headers: {
+            'PAYMENT-REQUIRED': x402_Header.encodePaymentRequired(x402PaymentRequired),
+          },
+        }),
+      )
 
       const result = transport.setCredential(
         {
@@ -258,6 +301,158 @@ describe('http', () => {
   })
 })
 
+describe('http (MCP-over-HTTP)', () => {
+  // An MCP-over-HTTP call: a JSON-RPC POST whose response carries the -32042 challenge.
+  const jsonRpcRequest = {
+    method: 'POST',
+    headers: { accept: 'application/json, text/event-stream' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'premium' },
+    }),
+  } satisfies RequestInit
+  const errorMessage = {
+    jsonrpc: '2.0',
+    id: 1,
+    error: {
+      code: Mcp.paymentRequiredCode,
+      message: 'Payment Required',
+      data: { challenges: [challenge] },
+    },
+  }
+  const jsonBody = () =>
+    new Response(JSON.stringify(errorMessage), { headers: { 'content-type': 'application/json' } })
+  const sseBody = () =>
+    new Response(`event: message\ndata: ${JSON.stringify(errorMessage)}\n\n`, {
+      headers: { 'content-type': 'text/event-stream' },
+    })
+
+  test('detects -32042 in a JSON body (JSON-RPC request)', async () => {
+    expect(await Transport.http().isPaymentRequired(jsonBody(), jsonRpcRequest)).toBe(true)
+  })
+  test('ignores a JSON-RPC response for a different request id', async () => {
+    const response = new Response(JSON.stringify({ ...errorMessage, id: 2 }), {
+      headers: { 'content-type': 'application/json' },
+    })
+
+    expect(await Transport.http().isPaymentRequired(response, jsonRpcRequest)).toBe(false)
+  })
+  test('detects -32042 in an SSE body', async () => {
+    expect(await Transport.http().isPaymentRequired(sseBody(), jsonRpcRequest)).toBe(true)
+  })
+  test('does not scan past the first SSE data event', async () => {
+    const notification = { jsonrpc: '2.0', method: 'notifications/progress', params: {} }
+    const response = new Response(
+      `event: message\ndata: ${JSON.stringify(notification)}\n\n` +
+        `event: message\ndata: ${JSON.stringify(errorMessage)}\n\n`,
+      { headers: { 'content-type': 'text/event-stream' } },
+    )
+
+    expect(await Transport.http().isPaymentRequired(response, jsonRpcRequest)).toBe(false)
+  })
+  test('detects -32042 in an open SSE stream without waiting for stream close', async () => {
+    const encoder = new TextEncoder()
+    let timeout: ReturnType<typeof setTimeout> | undefined
+    const openSse = new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(
+            encoder.encode(`event: message\ndata: ${JSON.stringify(errorMessage)}\n\n`),
+          )
+        },
+      }),
+      { headers: { 'content-type': 'text/event-stream' } },
+    )
+
+    try {
+      const result = await Promise.race([
+        Transport.http().isPaymentRequired(openSse, jsonRpcRequest),
+        new Promise<'timeout'>((resolve) => {
+          timeout = setTimeout(() => resolve('timeout'), 100)
+        }),
+      ])
+
+      expect(result).toBe(true)
+    } finally {
+      if (timeout) clearTimeout(timeout)
+    }
+  })
+  test('does not read the body for a non-JSON-RPC request', async () => {
+    expect(
+      await Transport.http().isPaymentRequired(sseBody(), { method: 'POST', body: 'plain' }),
+    ).toBe(false)
+  })
+  test('does not treat generic JSON-RPC as MCP-over-HTTP', async () => {
+    const request = {
+      method: 'POST',
+      headers: { accept: 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'eth_call', params: [] }),
+    } satisfies RequestInit
+
+    expect(await Transport.http().isPaymentRequired(sseBody(), request)).toBe(false)
+  })
+  test('ignores a 200 success', async () => {
+    const ok = new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result: {} }), {
+      headers: { 'content-type': 'application/json' },
+    })
+    expect(await Transport.http().isPaymentRequired(ok, jsonRpcRequest)).toBe(false)
+  })
+  test('getChallenges extracts the MCP challenge (via the mcp protocol)', async () => {
+    const challenges = await Transport.http().getChallenges!(sseBody(), jsonRpcRequest)
+    expect(challenges.map((entry) => entry.id)).toEqual([challenge.id])
+  })
+  test('setCredential routes the MCP challenge into the JSON-RPC _meta', async () => {
+    const transport = Transport.http()
+    const [mcpChallenge] = await transport.getChallenges!(sseBody(), jsonRpcRequest)
+    const result = transport.setCredential(jsonRpcRequest, Credential.serialize(credential), {
+      challenge: mcpChallenge,
+    }) as RequestInit
+    const parsed = JSON.parse(result.body as string)
+    expect(parsed.params['_meta'][Mcp.credentialMetaKey]).toMatchObject({
+      payload: { type: 'transaction' },
+    })
+  })
+  test('detects -32042 in a JSON body containing a "data:" substring', async () => {
+    const body = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      error: {
+        code: Mcp.paymentRequiredCode,
+        message: 'Payment Required',
+        data: { challenges: [{ ...challenge, realm: 'data:text/plain,x' }] },
+      },
+    })
+    const response = new Response(body, { headers: { 'content-type': 'application/json' } })
+    expect(await Transport.http().isPaymentRequired(response, jsonRpcRequest)).toBe(true)
+  })
+  test('ignores malformed payment challenge data', async () => {
+    const response = new Response(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        error: {
+          code: Mcp.paymentRequiredCode,
+          message: 'Payment Required',
+          data: { challenges: [{ ...challenge, realm: undefined }] },
+        },
+      }),
+      { headers: { 'content-type': 'application/json' } },
+    )
+
+    expect(await Transport.http().isPaymentRequired(response, jsonRpcRequest)).toBe(false)
+  })
+  test('detects -32042 for any JSON-RPC method (no method allowlist)', async () => {
+    const request = {
+      method: 'POST',
+      headers: { accept: 'application/json, text/event-stream' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'custom/paidMethod', params: {} }),
+    } satisfies RequestInit
+    expect(await Transport.http().isPaymentRequired(sseBody(), request)).toBe(true)
+  })
+})
+
 describe('mcp', () => {
   const mcpRequest: Mcp.Request = {
     method: 'tools/call',
@@ -266,183 +461,35 @@ describe('mcp', () => {
     },
   }
 
-  describe('isPaymentRequired', () => {
-    test('returns true for payment required error', () => {
-      const transport = Transport.mcp()
-      const response: Mcp.Response = {
-        jsonrpc: '2.0',
-        id: 1,
-        error: {
-          code: Mcp.paymentRequiredCode,
-          message: 'Payment Required',
-          data: {
-            httpStatus: 402,
-            challenges: [challenge],
-          },
-        },
-      }
+  const mcpResponse: Mcp.Response = {
+    jsonrpc: '2.0',
+    id: 1,
+    error: {
+      code: Mcp.paymentRequiredCode,
+      message: 'Payment Required',
+      data: {
+        httpStatus: 402,
+        challenges: [challenge],
+      },
+    },
+  }
 
-      expect(transport.isPaymentRequired(response)).toBe(true)
-    })
+  test('extracts payment-required challenges from JSON-RPC errors', async () => {
+    const transport = Transport.mcp()
 
-    test('returns false for success response', () => {
-      const transport = Transport.mcp()
-      const response: Mcp.Response = {
-        jsonrpc: '2.0',
-        id: 1,
-        result: { content: [] },
-      }
-
-      expect(transport.isPaymentRequired(response)).toBe(false)
-    })
-
-    test('returns false for other error codes', () => {
-      const transport = Transport.mcp()
-      const response: Mcp.Response = {
-        jsonrpc: '2.0',
-        id: 1,
-        error: {
-          code: -32600,
-          message: 'Invalid Request',
-        },
-      }
-
-      expect(transport.isPaymentRequired(response)).toBe(false)
-    })
+    expect(await transport.isPaymentRequired(mcpResponse)).toBe(true)
+    expect((await transport.getChallenges?.(mcpResponse))?.map((entry) => entry.id)).toEqual([
+      challenge.id,
+    ])
   })
 
-  describe('getChallenge', () => {
-    test('default', () => {
-      const transport = Transport.mcp()
-      const response: Mcp.Response = {
-        jsonrpc: '2.0',
-        id: 1,
-        error: {
-          code: Mcp.paymentRequiredCode,
-          message: 'Payment Required',
-          data: {
-            httpStatus: 402,
-            challenges: [challenge],
-          },
-        },
-      }
+  test('sets credentials in JSON-RPC _meta', () => {
+    const result = Transport.mcp().setCredential(mcpRequest, Credential.serialize(credential))
 
-      expect(transport.getChallenge(response)).toMatchObject({
-        expires: '2025-01-01T00:00:00.000Z',
-        id: expect.any(String),
-        intent: 'charge',
-        method: 'tempo',
-        realm: 'api.example.com',
-        request: {
-          amount: '1000',
-          currency: '0x20c0000000000000000000000000000000000001',
-          recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00',
-        },
-      })
-    })
-
-    test('throws for success response', () => {
-      const transport = Transport.mcp()
-      const response: Mcp.Response = {
-        jsonrpc: '2.0',
-        id: 1,
-        result: { content: [] },
-      }
-
-      expect(() => transport.getChallenge(response)).toThrow('Response is not an error')
-    })
-
-    test('throws when no challenges in error', () => {
-      const transport = Transport.mcp()
-      const response: Mcp.Response = {
-        jsonrpc: '2.0',
-        id: 1,
-        error: {
-          code: Mcp.paymentRequiredCode,
-          message: 'Payment Required',
-          data: {
-            httpStatus: 402,
-            challenges: [],
-          },
-        },
-      }
-
-      expect(() => transport.getChallenge(response)).toThrow('No challenge in error response')
-    })
-  })
-
-  describe('getChallenges', () => {
-    test('returns all MCP challenges', () => {
-      const transport = Transport.mcp()
-      const response: Mcp.Response = {
-        jsonrpc: '2.0',
-        id: 1,
-        error: {
-          code: Mcp.paymentRequiredCode,
-          message: 'Payment Required',
-          data: {
-            httpStatus: 402,
-            challenges: [challenge, { ...challenge, id: 'alternate', method: 'stripe' }],
-          },
-        },
-      }
-
-      expect(transport.getChallenges?.(response).map((entry) => entry.id)).toEqual([
-        challenge.id,
-        'alternate',
-      ])
-    })
-  })
-
-  describe('setCredential', () => {
-    test('default', () => {
-      const transport = Transport.mcp()
-      const serialized = Credential.serialize(credential)
-
-      expect(transport.setCredential(mcpRequest, serialized)).toMatchObject({
-        method: 'tools/call',
-        params: {
-          _meta: {
-            'org.paymentauth/credential': {
-              challenge: {
-                expires: '2025-01-01T00:00:00.000Z',
-                id: expect.any(String),
-                intent: 'charge',
-                method: 'tempo',
-                realm: 'api.example.com',
-                request: {
-                  amount: '1000',
-                  currency: '0x20c0000000000000000000000000000000000001',
-                  recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00',
-                },
-              },
-              payload: {
-                signature: '0xabc123',
-                type: 'transaction',
-              },
-            },
-          },
-          name: 'test-tool',
-        },
-      })
-    })
-
-    test('preserves existing _meta', () => {
-      const transport = Transport.mcp()
-      const serialized = Credential.serialize(credential)
-      const requestWithMeta: Mcp.Request = {
-        ...mcpRequest,
-        params: {
-          ...mcpRequest.params,
-          _meta: {
-            existingKey: 'existingValue',
-          },
-        },
-      }
-
-      const result = transport.setCredential(requestWithMeta, serialized)
-
-      expect(result.params?._meta?.existingKey).toBe('existingValue')
+    expect(result.params?.['_meta']?.[Mcp.credentialMetaKey]).toMatchObject({
+      payload: {
+        type: 'transaction',
+      },
     })
   })
 })

--- a/src/client/Transport.ts
+++ b/src/client/Transport.ts
@@ -1,18 +1,11 @@
 import * as Challenge from '../Challenge.js'
-import * as Constants from '../Constants.js'
 import * as Credential from '../Credential.js'
 import * as Mcp from '../Mcp.js'
-import * as x402_Header from '../x402/Header.js'
-import * as x402_ChallengeBrand from '../x402/internal/ChallengeBrand.js'
-import * as x402_Types from '../x402/Types.js'
-
-const paymentRequiredStatus = 402
-const credentialHeaders = [
-  Constants.Headers.authorization,
-  x402_Types.paymentRequiredHeader,
-  x402_Types.paymentResponseHeader,
-  x402_Types.paymentSignatureHeader,
-]
+import { mcp as mcpProtocol } from './internal/protocols/Mcp.js'
+import { mpp as mppProtocol } from './internal/protocols/Mpp.js'
+import type { Protocol } from './internal/protocols/Protocol.js'
+import { paymentRequiredStatus } from './internal/protocols/Shared.js'
+import { x402 as x402Protocol } from './internal/protocols/X402.js'
 
 /**
  * Client-side transport adapter.
@@ -23,12 +16,21 @@ const credentialHeaders = [
 export type Transport<in out request = unknown, in out response = unknown> = {
   /** Transport name for identification. */
   name: string
-  /** Checks if a response indicates payment is required. */
-  isPaymentRequired: (response: response) => boolean
+  /**
+   * Checks if a response indicates payment is required. May inspect the request (to gate
+   * body reads) and be async (to read a response body).
+   */
+  isPaymentRequired: (response: response, request?: request) => boolean | Promise<boolean>
   /** Extracts all challenges from a payment-required response, when the transport supports multiple offers. */
-  getChallenges?: (response: response) => Challenge.Challenge[]
+  getChallenges?: (
+    response: response,
+    request?: request,
+  ) => Challenge.Challenge[] | Promise<Challenge.Challenge[]>
   /** Extracts the challenge from a payment-required response. */
-  getChallenge: (response: response) => Challenge.Challenge
+  getChallenge: (
+    response: response,
+    request?: request,
+  ) => Challenge.Challenge | Promise<Challenge.Challenge>
   /** Attaches a credential to a request. */
   setCredential: (
     request: request,
@@ -74,87 +76,79 @@ export function from<request, response>(
   return transport
 }
 
-/**
- * HTTP transport for client-side payment handling.
- *
- * - Detects payment required via 402 status
- * - Extracts Payment auth challenges from `WWW-Authenticate`
- * - Falls back to x402 exact challenges from `PAYMENT-REQUIRED`
- * - Sends credentials via `Authorization` or `PAYMENT-SIGNATURE`
- */
-export function http() {
+/** HTTP transport that composes payment protocols while keeping `fetch` as the single boundary. */
+export function http(): Transport<RequestInit, Response> {
+  const protocols: readonly Protocol[] = [mppProtocol(), x402Protocol(), mcpProtocol()]
+  const protocolForChallenge = new WeakMap<Challenge.Challenge, Protocol>()
+
+  const remember = (protocol: Protocol, challenges: Challenge.Challenge[]) => {
+    for (const challenge of challenges) protocolForChallenge.set(challenge, protocol)
+    return challenges
+  }
+
+  // Collect every protocol offer. Header-only 402 paths stay synchronous; MCP returns a promise
+  // only when it has to inspect a JSON-RPC/SSE body.
+  const collect = (
+    response: Response,
+    request?: RequestInit,
+  ): Challenge.Challenge[] | Promise<Challenge.Challenge[]> => {
+    const collectFrom = (
+      index: number,
+      collected: Challenge.Challenge[],
+    ): Challenge.Challenge[] | Promise<Challenge.Challenge[]> => {
+      for (let i = index; i < protocols.length; i++) {
+        const protocol = protocols[i]!
+        const challenges = protocol.getChallenges(response, request)
+        if (challenges instanceof Promise)
+          return challenges.then((list) =>
+            collectFrom(i + 1, [...collected, ...remember(protocol, list)]),
+          )
+        collected.push(...remember(protocol, challenges))
+      }
+      return collected
+    }
+    return collectFrom(0, [])
+  }
+
   return from<RequestInit, Response>({
     name: 'http',
 
-    isPaymentRequired(response) {
-      return response.status === paymentRequiredStatus
+    isPaymentRequired(response, request) {
+      if (response.status === paymentRequiredStatus) return true // HTTP 402 — sync fast path
+      const challenges = collect(response, request)
+      return challenges instanceof Promise
+        ? challenges.then((list) => list.length > 0)
+        : challenges.length > 0
     },
 
-    getChallenges(response) {
-      return paymentRequiredChallenges(response)
+    getChallenges(response, request) {
+      return collect(response, request)
     },
 
-    getChallenge(response) {
-      const challenge = paymentRequiredChallenges(response)[0]
-      if (!challenge) throw new Error('No challenge in response.')
-      return challenge
+    getChallenge(response, request) {
+      const pick = (challenges: Challenge.Challenge[]): Challenge.Challenge => {
+        const challenge = challenges[0]
+        if (!challenge) throw new Error('No challenge in response.')
+        return challenge
+      }
+      const challenges = collect(response, request)
+      return challenges instanceof Promise ? challenges.then(pick) : pick(challenges)
     },
 
     setCredential(request, credential, options) {
-      const headers = new Headers(request.headers)
-      for (const header of credentialHeaders) headers.delete(header)
-      if (isX402Challenge(options?.challenge)) {
-        headers.set(x402_Types.paymentSignatureHeader, credential)
-      } else {
-        headers.set(Constants.Headers.authorization, credential)
-      }
-      return { ...request, headers }
+      const protocol = options?.challenge ? protocolForChallenge.get(options.challenge) : undefined
+      const fallback = protocols[0]
+      if (!protocol && !fallback) throw new Error('No protocol to attach the credential.')
+      return (protocol ?? fallback)!.setCredential(request, credential)
     },
   })
 }
 
-function paymentRequiredChallenges(response: Response): Challenge.Challenge[] {
-  return [
-    ...(response.headers.has(Constants.Headers.wwwAuthenticate)
-      ? Challenge.fromResponseList(response)
-      : []),
-    ...x402Challenges(response),
-  ]
-}
-
-function x402Challenges(response: Response): Challenge.Challenge[] {
-  const header = response.headers.get(x402_Types.paymentRequiredHeader)
-  if (!header) return []
-  const paymentRequired = x402_Header.decodePaymentRequired(header)
-  if (response.url && paymentRequired.resource.url !== response.url)
-    throw new Error('x402 payment-required resource does not match response URL.')
-  return paymentRequired.accepts.map((accepted, index) =>
-    x402_ChallengeBrand.mark(
-      Challenge.from({
-        id: `${x402_Types.syntheticChallengeIdPrefix}${index}`,
-        intent: x402_Types.exactIntent,
-        method: x402_Types.paymentMethod,
-        realm: new URL(paymentRequired.resource.url).host,
-        request: {
-          ...accepted,
-          ...(paymentRequired.extensions ? { extensions: paymentRequired.extensions } : {}),
-          resource: paymentRequired.resource,
-        },
-      }),
-    ),
-  )
-}
-
-function isX402Challenge(challenge: Challenge.Challenge | undefined): boolean {
-  return x402_ChallengeBrand.is(challenge)
-}
-
 /**
- * MCP transport for client-side payment handling.
+ * MCP protocol transport for direct JSON-RPC objects.
  *
- * - Detects payment required via error code -32042
- * - Extracts challenges from `error.data.challenges[0]`
- * - Sends credentials via `_meta["org.paymentauth/credential"]`
+ * Prefer {@link http} for MCP-over-HTTP fetches; this remains for callers that already operate on
+ * parsed MCP request/response objects.
  */
 export function mcp() {
   return from<Mcp.Request, Mcp.Response>({
@@ -184,8 +178,8 @@ export function mcp() {
         ...request,
         params: {
           ...request.params,
-          _meta: {
-            ...request.params?._meta,
+          ['_meta']: {
+            ...request.params?.['_meta'],
             [Mcp.credentialMetaKey]: parsed,
           },
         },

--- a/src/client/internal/Fetch.test.ts
+++ b/src/client/internal/Fetch.test.ts
@@ -1,6 +1,7 @@
-import { Challenge, Errors, Receipt } from 'mppx'
+import { Challenge, Credential, Errors, Mcp, Receipt } from 'mppx'
 import { tempo } from 'mppx/client'
 import { Mppx as Mppx_server, tempo as tempo_server } from 'mppx/server'
+import { Header as x402_Header, Types as x402_Types, type PaymentRequired } from 'mppx/x402'
 import { createClient, defineChain } from 'viem'
 import { describe, expect, test, vi } from 'vp/test'
 import * as Http from '~test/Http.js'
@@ -334,6 +335,21 @@ const noopMethod = {
   createCredential: async () => 'credential',
 } as any
 
+const x402PaymentRequired = {
+  accepts: [
+    {
+      amount: '10000',
+      asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+      maxTimeoutSeconds: 60,
+      network: 'eip155:84532',
+      payTo: '0x209693Bc6afc0C5328bA36FaF03C514EF312287C',
+      scheme: x402_Types.schemes[0],
+    },
+  ],
+  resource: { url: 'https://example.com/api' },
+  x402Version: 2,
+} satisfies PaymentRequired
+
 /** Builds a valid 402 response with a WWW-Authenticate header. */
 function make402(overrides?: { expires?: string; intent?: string; method?: string }) {
   const method = overrides?.method ?? 'test'
@@ -347,6 +363,19 @@ function make402(overrides?: { expires?: string; intent?: string; method?: strin
   return new Response(null, {
     status: 402,
     headers: { 'WWW-Authenticate': header },
+  })
+}
+
+function makeCombined402() {
+  const response = make402()
+  const headers = new Headers(response.headers)
+  headers.set(
+    x402_Types.paymentRequiredHeader,
+    x402_Header.encodePaymentRequired(x402PaymentRequired),
+  )
+  return new Response(null, {
+    status: 402,
+    headers,
   })
 }
 
@@ -667,6 +696,182 @@ describe('Fetch.from: 402 retry path', () => {
     const retryInit = calls[1]!.init as Record<string, unknown>
     const headers = new Headers(retryInit.headers as HeadersInit)
     expect(headers.get('Authorization')).toBe('credential')
+  })
+
+  test('chooses native Payment-auth from combined MPP and x402 HTTP 402 offers', async () => {
+    let callCount = 0
+    const calls: { init: RequestInit | undefined }[] = []
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      calls.push({ init })
+      callCount++
+      if (callCount === 1) return makeCombined402()
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [noopMethod],
+    })
+
+    const response = await fetch('https://example.com/api')
+
+    expect(response.status).toBe(200)
+    expect(calls).toHaveLength(2)
+    const retryHeaders = new Headers(calls[1]!.init?.headers)
+    expect(retryHeaders.get('Authorization')).toBe('credential')
+    expect(retryHeaders.get(x402_Types.paymentSignatureHeader)).toBeNull()
+  })
+
+  test('settles MCP-over-HTTP JSON-RPC payment challenges at the fetch boundary', async () => {
+    const mcpChallenge = Challenge.from({
+      id: 'mcp-challenge',
+      intent: 'test',
+      method: 'test',
+      realm: 'test',
+      request: { amount: '1' },
+    })
+    const method = {
+      ...noopMethod,
+      createCredential: async ({ challenge }: { challenge: Challenge.Challenge }) =>
+        Credential.serialize({ challenge, payload: { source: 'mcp' } }),
+    }
+    const initialBody = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'paid-tool' },
+    })
+    let callCount = 0
+    const calls: { init: RequestInit | undefined }[] = []
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      calls.push({ init })
+      callCount++
+      if (callCount === 1)
+        return Response.json({
+          jsonrpc: '2.0',
+          id: 1,
+          error: {
+            code: Mcp.paymentRequiredCode,
+            message: 'Payment Required',
+            data: { challenges: [mcpChallenge] },
+          },
+        })
+
+      const body = JSON.parse(init?.body as string)
+      expect(new Headers(init?.headers).get('Authorization')).toBeNull()
+      expect(body.params['_meta'][Mcp.credentialMetaKey]).toMatchObject({
+        payload: { source: 'mcp' },
+      })
+      return Response.json({ ok: true })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [method],
+    })
+
+    const response = await fetch('https://example.com/mcp', {
+      method: 'POST',
+      headers: { accept: 'application/json, text/event-stream' },
+      body: initialBody,
+    })
+
+    expect(response.status).toBe(200)
+    expect(calls).toHaveLength(2)
+  })
+
+  test('settles MCP-over-HTTP when the JSON-RPC request body is carried by Request input', async () => {
+    const mcpChallenge = Challenge.from({
+      id: 'mcp-request-input-challenge',
+      intent: 'test',
+      method: 'test',
+      realm: 'test',
+      request: { amount: '1' },
+    })
+    const method = {
+      ...noopMethod,
+      createCredential: async ({ challenge }: { challenge: Challenge.Challenge }) =>
+        Credential.serialize({ challenge, payload: { source: 'request-input' } }),
+    }
+    const initialBody = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'paid-tool' },
+    })
+    let callCount = 0
+    const calls: { init: RequestInit | undefined; input: RequestInfo | URL }[] = []
+    const mockFetch: typeof globalThis.fetch = async (input, init) => {
+      calls.push({ input, init })
+      callCount++
+      if (callCount === 1) {
+        expect(input).toBeInstanceOf(Request)
+        expect(await (input as Request).text()).toBe(initialBody)
+        return Response.json({
+          jsonrpc: '2.0',
+          id: 1,
+          error: {
+            code: Mcp.paymentRequiredCode,
+            message: 'Payment Required',
+            data: { challenges: [mcpChallenge] },
+          },
+        })
+      }
+
+      const body = JSON.parse(init?.body as string)
+      expect(body.params['_meta'][Mcp.credentialMetaKey]).toMatchObject({
+        payload: { source: 'request-input' },
+      })
+      return Response.json({ ok: true })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [method],
+    })
+    const request = new Request('https://example.com/mcp', {
+      method: 'POST',
+      headers: { accept: 'application/json, text/event-stream' },
+      body: initialBody,
+    })
+
+    const response = await fetch(request)
+
+    expect(response.status).toBe(200)
+    expect(calls).toHaveLength(2)
+    expect(calls[1]?.input).toBe(request)
+  })
+
+  test('settles native HTTP 402 when a POST body is carried by Request input', async () => {
+    const initialBody = JSON.stringify({ ok: true })
+    let callCount = 0
+    const calls: { init: RequestInit | undefined; input: RequestInfo | URL }[] = []
+    const mockFetch: typeof globalThis.fetch = async (input, init) => {
+      calls.push({ input, init })
+      callCount++
+      const request = input instanceof Request && !init ? input : new Request(input, init)
+      expect(await request.text()).toBe(initialBody)
+      if (callCount === 1) return make402()
+
+      expect(request.headers.get('Authorization')).toBe('credential')
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [noopMethod],
+    })
+    const request = new Request('https://example.com/api', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: initialBody,
+    })
+
+    const response = await fetch(request)
+
+    expect(response.status).toBe(200)
+    expect(calls).toHaveLength(2)
+    expect(calls[1]?.input).toBe(request)
   })
 
   test('sends credential retry to the final same-origin 402 response URL', async () => {

--- a/src/client/internal/Fetch.ts
+++ b/src/client/internal/Fetch.ts
@@ -176,6 +176,7 @@ export function from<const methods extends readonly Method.AnyClient[]>(
     const callerHeaders = getCallerHeaders(input, init?.headers)
     const hasExplicitAcceptPayment = callerHeaders.has(Constants.Headers.acceptPayment)
     const paymentPreferences = resolvePaymentPreferences(callerHeaders, resolvedAcceptPayment)
+    const capturedBody = captureRequestBody(input, init, callerHeaders)
     const initialRequest = prepareInitialRequest(
       input,
       init,
@@ -184,9 +185,10 @@ export function from<const methods extends readonly Method.AnyClient[]>(
       hasExplicitAcceptPayment,
       acceptPaymentPolicy,
     )
-    const response = await baseFetch(initialRequest.input, initialRequest.init)
+    const response = await baseFetch(cloneRequestInput(initialRequest.input), initialRequest.init)
+    const transportRequest = withCapturedBody(initialRequest.init, await capturedBody)
 
-    if (!transport.isPaymentRequired(response)) return response
+    if (!(await transport.isPaymentRequired(response, transportRequest as never))) return response
 
     // Only extract context for payment handling after confirming 402.
     const context = (init as Record<string, unknown> | undefined)?.context
@@ -194,7 +196,7 @@ export function from<const methods extends readonly Method.AnyClient[]>(
       context: _,
       orderChallenges: requestOrderChallenges,
       ...fetchInit
-    } = (initialRequest.init ?? {}) as Record<string, unknown>
+    } = (transportRequest ?? {}) as Record<string, unknown>
 
     let challenge: Challenge.Challenge | undefined
     let challenges: readonly Challenge.Challenge[] | undefined
@@ -202,8 +204,8 @@ export function from<const methods extends readonly Method.AnyClient[]>(
 
     try {
       challenges = transport.getChallenges
-        ? transport.getChallenges(response)
-        : [transport.getChallenge(response)]
+        ? await transport.getChallenges(response, transportRequest as never)
+        : [await transport.getChallenge(response, transportRequest as never)]
 
       const candidates = AcceptPayment.selectChallengeCandidates(
         challenges,
@@ -666,7 +668,13 @@ function snapshotInit<methods extends readonly Method.AnyClient[]>(
 }
 
 function snapshotInput(input: RequestInfo | URL | undefined): RequestInfo | URL | undefined {
-  if (input instanceof Request) return input.clone()
+  if (input instanceof Request) {
+    try {
+      return input.clone()
+    } catch {
+      return input
+    }
+  }
   if (input instanceof URL) return new URL(input)
   return input
 }
@@ -738,6 +746,35 @@ function prepareInitialRequest<methods extends readonly Method.AnyClient[]>(
   }
 }
 
+function captureRequestBody<methods extends readonly Method.AnyClient[]>(
+  input: RequestInfo | URL,
+  init: from.RequestInit<methods> | undefined,
+  headers: Headers,
+): Promise<string | undefined> | undefined {
+  if (!(input instanceof Request) || init?.body !== undefined || !input.body || input.bodyUsed)
+    return undefined
+  if (!headers.has('mcp-method')) {
+    const accept = headers.get('accept')?.toLowerCase() ?? ''
+    if (!accept.includes('application/json') || !accept.includes('text/event-stream'))
+      return undefined
+  }
+  try {
+    return input
+      .clone()
+      .text()
+      .catch(() => undefined)
+  } catch {
+    return undefined
+  }
+}
+
+function withCapturedBody<methods extends readonly Method.AnyClient[]>(
+  init: from.RequestInit<methods> | undefined,
+  body: string | undefined,
+): from.RequestInit<methods> | undefined {
+  return body === undefined ? init : ({ ...init, body } as from.RequestInit<methods>)
+}
+
 /** @internal */
 function getCallerHeaders(input: RequestInfo | URL, headers: HeadersInit | undefined): Headers {
   if (headers) return new Headers(headers)
@@ -751,6 +788,15 @@ function unwrapFetch(fetch: typeof globalThis.fetch): typeof globalThis.fetch {
     current = current[MPPX_FETCH_WRAPPER] as WrappedFetch
   }
   return current as typeof globalThis.fetch
+}
+
+function cloneRequestInput(input: RequestInfo | URL): RequestInfo | URL {
+  if (!(input instanceof Request) || !input.body || input.bodyUsed) return input
+  try {
+    return input.clone()
+  } catch {
+    return input
+  }
 }
 
 /** @internal */

--- a/src/client/internal/protocols/Mcp.test.ts
+++ b/src/client/internal/protocols/Mcp.test.ts
@@ -1,0 +1,220 @@
+import { Challenge, Mcp } from 'mppx'
+import { Methods } from 'mppx/tempo'
+import { describe, expect, test } from 'vp/test'
+
+import { mcp } from './Mcp.js'
+
+const challenge = Challenge.fromMethod(Methods.charge, {
+  realm: 'api.example.com',
+  secretKey: 'test-secret-key',
+  expires: '2025-01-01T00:00:00.000Z',
+  request: {
+    amount: '0.001',
+    currency: '0x20c0000000000000000000000000000000000001',
+    decimals: 6,
+    recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00',
+  },
+})
+
+const paymentRequired = {
+  jsonrpc: '2.0',
+  id: 1,
+  error: {
+    code: Mcp.paymentRequiredCode,
+    message: 'Payment Required',
+    data: { challenges: [challenge] },
+  },
+}
+
+const request = (overrides: Partial<RequestInit> = {}) =>
+  ({
+    headers: { accept: 'application/json, text/event-stream' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: {} }),
+    ...overrides,
+  }) satisfies RequestInit
+
+const jsonResponse = (body: unknown, contentType = 'application/json') =>
+  new Response(typeof body === 'string' ? body : JSON.stringify(body), {
+    headers: { 'content-type': contentType },
+  })
+
+const sseResponse = (body: string) =>
+  new Response(body, { headers: { 'content-type': 'text/event-stream' } })
+
+const sseEvent = (data: unknown, event = 'message') =>
+  `${event ? `event: ${event}\n` : ''}data: ${
+    typeof data === 'string' ? data : JSON.stringify(data)
+  }\n\n`
+
+async function getChallengeIds(response: Response, requestInit = request()) {
+  return (await mcp().getChallenges(response, requestInit)).map((entry) => entry.id)
+}
+
+describe('mcp HTTP protocol', () => {
+  test('extracts payment challenges from JSON-RPC error JSON', async () => {
+    expect(await getChallengeIds(jsonResponse(paymentRequired))).toEqual([challenge.id])
+  })
+
+  test('extracts all valid payment challenges', async () => {
+    const alternate = { ...challenge, id: 'alternate' }
+    const response = jsonResponse({
+      ...paymentRequired,
+      error: {
+        ...paymentRequired.error,
+        data: { challenges: [challenge, alternate] },
+      },
+    })
+
+    expect(await getChallengeIds(response)).toEqual([challenge.id, alternate.id])
+  })
+
+  test('parses JSON content types case-insensitively', async () => {
+    const response = jsonResponse(paymentRequired, 'Application/JSON; charset=utf-8')
+
+    expect(await getChallengeIds(response)).toEqual([challenge.id])
+  })
+
+  test.each([
+    { body: '[', name: 'invalid JSON' },
+    { body: [paymentRequired], name: 'JSON-RPC batch' },
+    {
+      body: { jsonrpc: '2.0', method: 'notifications/progress', params: {} },
+      name: 'notification',
+    },
+    { body: { jsonrpc: '2.0', id: 1, method: 'tools/call', params: {} }, name: 'request' },
+    { body: { ...paymentRequired, jsonrpc: '2.1' }, name: 'wrong JSON-RPC version' },
+    { body: { ...paymentRequired, id: null }, name: 'null id' },
+    { body: { ...paymentRequired, id: 2 }, name: 'different id' },
+    { body: { ...paymentRequired, result: {} }, name: 'result and error together' },
+    { body: { jsonrpc: '2.0', id: 1, result: {} }, name: 'successful result' },
+    {
+      body: {
+        jsonrpc: '2.0',
+        id: 1,
+        error: { code: -32600, message: 'Invalid Request' },
+      },
+      name: 'non-payment error',
+    },
+    {
+      body: {
+        jsonrpc: '2.0',
+        id: 1,
+        error: { code: `${Mcp.paymentRequiredCode}`, message: 'Payment Required' },
+      },
+      name: 'string error code',
+    },
+    {
+      body: {
+        jsonrpc: '2.0',
+        id: 1,
+        error: { code: Mcp.paymentRequiredCode, message: 402 },
+      },
+      name: 'non-string error message',
+    },
+  ])('ignores $name message shapes', async ({ body }) => {
+    expect(await getChallengeIds(jsonResponse(body))).toEqual([])
+  })
+
+  test.each([
+    { challenges: undefined, name: 'missing challenges' },
+    { challenges: [], name: 'empty challenges' },
+    { challenges: challenge, name: 'non-array challenges' },
+    { challenges: [{ ...challenge, realm: undefined }], name: 'invalid challenge' },
+    {
+      challenges: [challenge, { ...challenge, realm: undefined }],
+      name: 'partially invalid challenges',
+    },
+  ])('ignores $name', async ({ challenges }) => {
+    const response = jsonResponse({
+      ...paymentRequired,
+      error: {
+        ...paymentRequired.error,
+        data: challenges === undefined ? undefined : { challenges },
+      },
+    })
+
+    expect(await getChallengeIds(response)).toEqual([])
+  })
+
+  test('matches string request and response ids without coercion', async () => {
+    const stringRequest = request({
+      body: JSON.stringify({ jsonrpc: '2.0', id: '1', method: 'tools/call', params: {} }),
+    })
+    const response = jsonResponse({ ...paymentRequired, id: '1' })
+
+    expect(await getChallengeIds(response, stringRequest)).toEqual([challenge.id])
+    expect(await getChallengeIds(jsonResponse(paymentRequired), stringRequest)).toEqual([])
+  })
+
+  test.each([
+    {
+      body: '{',
+      headers: { accept: 'application/json, text/event-stream' },
+      name: 'malformed request JSON',
+    },
+    {
+      body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }),
+      headers: { accept: 'application/json, text/event-stream' },
+      name: 'request without id',
+    },
+    {
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, params: {} }),
+      headers: { accept: 'application/json, text/event-stream' },
+      name: 'request without method',
+    },
+    {
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: {} }),
+      headers: { accept: 'application/json' },
+      name: 'request without Streamable HTTP accept',
+    },
+  ])('does not inspect responses for $name', async ({ body, headers }) => {
+    expect(
+      await getChallengeIds(jsonResponse(paymentRequired), request({ body, headers })),
+    ).toEqual([])
+  })
+
+  test('accepts the mcp-method header as MCP request provenance', async () => {
+    const requestInit = request({
+      headers: { 'mcp-method': 'tools/call' },
+    })
+
+    expect(await getChallengeIds(jsonResponse(paymentRequired), requestInit)).toEqual([
+      challenge.id,
+    ])
+  })
+
+  test('does not inspect native HTTP 402 responses', async () => {
+    expect(await getChallengeIds(jsonResponse(paymentRequired), request({}))).toEqual([
+      challenge.id,
+    ])
+    expect(
+      await getChallengeIds(
+        new Response(JSON.stringify(paymentRequired), {
+          status: 402,
+          headers: { 'content-type': 'application/json' },
+        }),
+      ),
+    ).toEqual([])
+  })
+
+  test.each([
+    { body: sseEvent(paymentRequired), name: 'message event' },
+    { body: sseEvent(paymentRequired, ''), name: 'event without explicit type' },
+    { body: `: keepalive\n\n${sseEvent(paymentRequired)}`, name: 'message after SSE comment' },
+  ])('extracts payment challenges from SSE $name', async ({ body }) => {
+    expect(await getChallengeIds(sseResponse(body))).toEqual([challenge.id])
+  })
+
+  test.each([
+    { body: sseEvent('{'), name: 'invalid JSON' },
+    { body: sseEvent({ jsonrpc: '2.0', method: 'notifications/progress' }), name: 'notification' },
+    { body: sseEvent(paymentRequired, 'progress'), name: 'non-message event' },
+    {
+      body:
+        sseEvent({ jsonrpc: '2.0', method: 'notifications/progress' }) + sseEvent(paymentRequired),
+      name: 'payment challenge after first data event',
+    },
+  ])('ignores SSE $name', async ({ body }) => {
+    expect(await getChallengeIds(sseResponse(body))).toEqual([])
+  })
+})

--- a/src/client/internal/protocols/Mcp.ts
+++ b/src/client/internal/protocols/Mcp.ts
@@ -1,0 +1,162 @@
+import { createParser } from 'eventsource-parser'
+
+import * as Challenge from '../../../Challenge.js'
+import * as Credential from '../../../Credential.js'
+import * as Mcp from '../../../Mcp.js'
+import type { Protocol } from './Protocol.js'
+import { paymentRequiredStatus } from './Shared.js'
+
+/** Returns the JSON-RPC request id — only requests can receive a `-32042` response. */
+function jsonRpcRequestId(body: unknown): number | string | undefined {
+  if (typeof body !== 'string') return undefined
+  try {
+    const message = JSON.parse(body)
+    const id = message?.id
+    if (message?.jsonrpc !== '2.0' || typeof message?.method !== 'string') return undefined
+    return typeof id === 'string' || typeof id === 'number' ? id : undefined
+  } catch {
+    return undefined
+  }
+}
+
+const responseCache = new WeakMap<Response, Promise<Mcp.Response | undefined>>()
+
+function mcpHttpRequestId(request?: RequestInit): number | string | undefined {
+  const id = jsonRpcRequestId(request?.body)
+  if (id === undefined) return undefined
+  const headers = new Headers(request?.headers)
+  if (headers.has('mcp-method')) return id
+  const accept = headers.get('accept')?.toLowerCase() ?? ''
+  return accept.includes('application/json') && accept.includes('text/event-stream')
+    ? id
+    : undefined
+}
+
+function parseMessage(value: unknown): Mcp.Response | undefined {
+  if (!value || typeof value !== 'object') return undefined
+  const message = value as {
+    error?: { code?: unknown; message?: unknown }
+    id?: unknown
+    jsonrpc?: unknown
+    result?: unknown
+  }
+  const id = message.id
+  if (message.jsonrpc !== '2.0') return undefined
+  if (id !== undefined && typeof id !== 'string' && typeof id !== 'number') return undefined
+  const hasError = 'error' in message
+  const hasResult = 'result' in message
+  if (hasError === hasResult) return undefined
+  if (hasError)
+    return Number.isInteger(message.error?.code) && typeof message.error?.message === 'string'
+      ? (value as Mcp.Response)
+      : undefined
+  return id !== undefined && typeof message.result === 'object'
+    ? (value as Mcp.Response)
+    : undefined
+}
+
+function paymentRequiredChallenges(
+  message: Mcp.Response | undefined,
+  id: number | string,
+): Challenge.Challenge[] {
+  if (
+    !message ||
+    message.id !== id ||
+    !('error' in message) ||
+    message.error?.code !== Mcp.paymentRequiredCode
+  )
+    return []
+  const challenges = message.error?.data?.challenges
+  if (!Array.isArray(challenges) || challenges.length === 0) return []
+  const parsed: Challenge.Challenge[] = []
+  for (const challenge of challenges) {
+    const result = Challenge.Schema.safeParse(challenge)
+    if (!result.success) return []
+    parsed.push(result.data as Challenge.Challenge)
+  }
+  return parsed
+}
+
+async function parseSseJsonRpcResponse(response: Response): Promise<Mcp.Response | undefined> {
+  const reader = response.clone().body?.getReader()
+  if (!reader) return undefined
+
+  const decoder = new TextDecoder()
+  let dataEventSeen = false
+  let message: Mcp.Response | undefined
+  const parser = createParser({
+    onEvent(event) {
+      if (dataEventSeen || !event.data) return
+      dataEventSeen = true
+      if (event.event && event.event !== 'message') return
+      try {
+        message = parseMessage(JSON.parse(event.data))
+      } catch {}
+    },
+  })
+
+  try {
+    for (;;) {
+      if (dataEventSeen) return message
+      const { done, value } = await reader.read()
+      if (done) {
+        parser.feed(decoder.decode())
+        parser.reset({ consume: true })
+        return message
+      }
+      parser.feed(decoder.decode(value, { stream: true }))
+    }
+  } finally {
+    void reader.cancel().catch(() => {})
+  }
+}
+
+/** Reads a cloned HTTP body into the first JSON-RPC response message, if any. */
+function parseJsonRpcResponse(response: Response): Promise<Mcp.Response | undefined> {
+  const cached = responseCache.get(response)
+  if (cached) return cached
+  const promise = (async (): Promise<Mcp.Response | undefined> => {
+    const contentType = response.headers.get('content-type')?.toLowerCase() ?? ''
+    if (contentType.includes('application/json'))
+      return response
+        .clone()
+        .json()
+        .then(parseMessage)
+        .catch(() => undefined)
+    if (contentType.includes('text/event-stream')) return parseSseJsonRpcResponse(response)
+    return undefined
+  })()
+  responseCache.set(response, promise)
+  return promise
+}
+
+/**
+ * MCP-over-HTTP — remote MCP rides Streamable HTTP, so its challenge is a JSON-RPC `-32042` error
+ * in a normal 200 body (often `text/event-stream`), and the credential rides back in `_meta`.
+ */
+export function mcp(): Protocol {
+  return {
+    getChallenges(response, request) {
+      // The 402 schemes own status 402; MCP challenges arrive in a normal 200 body.
+      const id = mcpHttpRequestId(request)
+      if (response.status === paymentRequiredStatus || id === undefined) return []
+      return parseJsonRpcResponse(response).then((message) =>
+        paymentRequiredChallenges(message, id),
+      )
+    },
+    setCredential(request, credential) {
+      const message = JSON.parse(request.body as string) as Mcp.Request
+      const parsed = Credential.deserialize(credential)
+      return {
+        ...request,
+        body: JSON.stringify({
+          ...message,
+          params: {
+            ...message.params,
+            ['_meta']: { ...message.params?.['_meta'], [Mcp.credentialMetaKey]: parsed },
+          },
+        }),
+      }
+    },
+  }
+}

--- a/src/client/internal/protocols/Mpp.ts
+++ b/src/client/internal/protocols/Mpp.ts
@@ -1,0 +1,21 @@
+import * as Challenge from '../../../Challenge.js'
+import * as Constants from '../../../Constants.js'
+import type { Protocol } from './Protocol.js'
+import { paymentRequiredStatus, setCredentialHeader } from './Shared.js'
+
+/** MPP — the native HTTP scheme: a 402 carrying a `WWW-Authenticate` challenge, paid back in `Authorization`. */
+export function mpp(): Protocol {
+  return {
+    getChallenges(response) {
+      if (
+        response.status !== paymentRequiredStatus ||
+        !response.headers.has(Constants.Headers.wwwAuthenticate)
+      )
+        return []
+      return Challenge.fromResponseList(response)
+    },
+    setCredential(request, credential) {
+      return setCredentialHeader(request, Constants.Headers.authorization, credential)
+    },
+  }
+}

--- a/src/client/internal/protocols/Protocol.ts
+++ b/src/client/internal/protocols/Protocol.ts
@@ -1,0 +1,10 @@
+import type * as Challenge from '../../../Challenge.js'
+import type { MaybePromise } from '../../../internal/types.js'
+
+/** One payment protocol over the `http` transport. */
+export type Protocol = {
+  /** This protocol's challenges from a response; `[]` when the response isn't its concern. */
+  getChallenges: (response: Response, request?: RequestInit) => MaybePromise<Challenge.Challenge[]>
+  /** Attaches this protocol's credential to a retry request. */
+  setCredential: (request: RequestInit, credential: string) => RequestInit
+}

--- a/src/client/internal/protocols/Shared.ts
+++ b/src/client/internal/protocols/Shared.ts
@@ -1,0 +1,25 @@
+import * as Constants from '../../../Constants.js'
+import * as x402_Types from '../../../x402/Types.js'
+
+/** HTTP status that signals a native payment challenge. */
+export const paymentRequiredStatus = 402
+
+/** Credential headers purged before a fresh credential is attached. */
+const credentialHeaders = [
+  Constants.Headers.authorization,
+  x402_Types.paymentRequiredHeader,
+  x402_Types.paymentResponseHeader,
+  x402_Types.paymentSignatureHeader,
+]
+
+/** Attaches `credential` under `header`, clearing any stale credential headers first. */
+export function setCredentialHeader(
+  request: RequestInit,
+  header: string,
+  credential: string,
+): RequestInit {
+  const headers = new Headers(request.headers)
+  for (const stale of credentialHeaders) headers.delete(stale)
+  headers.set(header, credential)
+  return { ...request, headers }
+}

--- a/src/client/internal/protocols/X402.ts
+++ b/src/client/internal/protocols/X402.ts
@@ -1,0 +1,42 @@
+import * as Challenge from '../../../Challenge.js'
+import * as x402_Header from '../../../x402/Header.js'
+import * as x402_ChallengeBrand from '../../../x402/internal/ChallengeBrand.js'
+import * as x402_Types from '../../../x402/Types.js'
+import type { Protocol } from './Protocol.js'
+import { paymentRequiredStatus, setCredentialHeader } from './Shared.js'
+
+/**
+ * x402 — a 402 carrying a `PAYMENT-REQUIRED` header, paid back in `PAYMENT-SIGNATURE`. Synthesized
+ * challenges are branded for `evm/client/Charge.ts`, keeping them distinct from native `evm`
+ * charges with the same method/intent.
+ */
+export function x402(): Protocol {
+  return {
+    getChallenges(response) {
+      if (response.status !== paymentRequiredStatus) return []
+      const header = response.headers.get(x402_Types.paymentRequiredHeader)
+      if (!header) return []
+      const paymentRequired = x402_Header.decodePaymentRequired(header)
+      if (response.url && paymentRequired.resource.url !== response.url)
+        throw new Error('x402 payment-required resource does not match response URL.')
+      return paymentRequired.accepts.map((accepted, index) =>
+        x402_ChallengeBrand.mark(
+          Challenge.from({
+            id: `${x402_Types.syntheticChallengeIdPrefix}${index}`,
+            intent: x402_Types.exactIntent,
+            method: x402_Types.paymentMethod,
+            realm: new URL(paymentRequired.resource.url).host,
+            request: {
+              ...accepted,
+              ...(paymentRequired.extensions ? { extensions: paymentRequired.extensions } : {}),
+              resource: paymentRequired.resource,
+            },
+          }),
+        ),
+      )
+    },
+    setCredential(request, credential) {
+      return setCredentialHeader(request, x402_Types.paymentSignatureHeader, credential)
+    },
+  }
+}


### PR DESCRIPTION
## Summary

- Compose `Transport.http()` from protocol handlers for MPP, x402, and MCP-over-HTTP challenges behind the payment-aware fetch.
- Collect all payment offers from HTTP responses and route retry credentials through the protocol that produced the selected challenge.
- Detect MCP JSON-RPC `-32042` responses at the fetch boundary, including the first SSE event, and retry with credentials in MCP `_meta` while preserving Request-carried bodies.
- Harden MCP-over-HTTP message parsing for invalid JSON-RPC response shapes and case-insensitive content types.

## Validation

- `pnpm check:ci`
- `VITE_TEMPO_NETWORK=none pnpm check:types`
- `VITE_TEMPO_NETWORK=none pnpm vp test --project node src/client/internal/protocols/Mcp.test.ts src/client/Transport.test.ts`
- `VITE_TEMPO_NETWORK=none pnpm vp test --project node src/client/internal/Fetch.test.ts -t "combined MPP|MCP-over-HTTP|Request input|native HTTP 402|JSON-RPC payment|PAYMENT-REQUIRED"`