### PR TITLE
fix: close legacy sessions at accepted cumulative

### DIFF
--- a/.changeset/fifty-walls-accept.md
+++ b/.changeset/fifty-walls-accept.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed legacy session manager close amounts when receipts reported per-request spent deltas.

--- a/src/tempo/legacy/client/SessionManager.ts
+++ b/src/tempo/legacy/client/SessionManager.ts
@@ -127,6 +127,7 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
   let channel: ChannelEntry | null = null
   let lastChallenge: Challenge.Challenge | null = null
   let lastUrl: RequestInfo | URL | null = null
+  let acceptedCumulative = 0n
   let spent = 0n
   let activeSocketChallenge: Challenge.Challenge | null = null
   let activeSocketChannelId: Hex.Hex | null = null
@@ -146,7 +147,10 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
     decimals: parameters.decimals,
     maxDeposit: parameters.maxDeposit,
     onChannelUpdate(entry) {
-      if (entry.channelId !== channel?.channelId) spent = 0n
+      if (entry.channelId !== channel?.channelId) {
+        acceptedCumulative = 0n
+        spent = 0n
+      }
       channel = entry
     },
   })
@@ -164,7 +168,10 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
   function updateSpentFromReceipt(receipt: SessionReceipt | null | undefined) {
     if (!receipt || receipt.channelId !== channel?.channelId) return
     assertReceiptWithinLocalState(receipt)
+    const nextAcceptedCumulative = BigInt(receipt.acceptedCumulative)
     const next = BigInt(receipt.spent)
+    acceptedCumulative =
+      acceptedCumulative > nextAcceptedCumulative ? acceptedCumulative : nextAcceptedCumulative
     spent = spent > next ? spent : next
   }
 
@@ -253,8 +260,9 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
       return (bestSpent > cumulative ? cumulative : bestSpent).toString()
     }
 
-    // SSE/HTTP: spent is kept in sync by inline receipts, use it directly.
-    return spent.toString()
+    // Some legacy servers report receipt.spent as a per-request delta while
+    // still requiring close at the highest accepted cumulative voucher.
+    return (spent > acceptedCumulative ? spent : acceptedCumulative).toString()
   }
 
   function assertVoucherWithinLocalLimit(cumulativeAmount: bigint) {

--- a/src/tempo/legacy/server/Session.test.ts
+++ b/src/tempo/legacy/server/Session.test.ts
@@ -3473,6 +3473,71 @@ describe.runIf(isLocalnet)('session', () => {
       expect(persisted?.finalized).toBe(true)
     })
 
+    test('sessionManager closes at accepted cumulative when HTTP receipt spent is per-request delta', async () => {
+      const handler = createHandler()
+      const route = handler.session({
+        amount: '1',
+        decimals: 6,
+        unitType: 'token',
+      })
+
+      let lastAcceptedCumulative = 0n
+      const fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = new Request(input, init)
+        const result = await route(request)
+        if (result.status === 402) return result.challenge
+
+        const response = result.withReceipt(new Response('ok'))
+        const receiptHeader = response.headers.get('Payment-Receipt')
+        if (!receiptHeader) return response
+
+        const receipt = deserializeSessionReceipt(receiptHeader)
+        if (
+          Credential.fromRequest<LegacySessionCredentialPayload>(request).payload?.action ===
+          'close'
+        ) {
+          return response
+        }
+
+        const acceptedCumulative = BigInt(receipt.acceptedCumulative)
+        const delta = acceptedCumulative - lastAcceptedCumulative
+        lastAcceptedCumulative = acceptedCumulative
+        return new Response(response.body, {
+          status: response.status,
+          statusText: response.statusText,
+          headers: {
+            'Payment-Receipt': serializeSessionReceipt({
+              ...receipt,
+              spent: delta.toString(),
+            }),
+          },
+        })
+      }
+
+      const manager = sessionManager({
+        account: payer,
+        client,
+        escrowContract,
+        fetch,
+        maxDeposit: '3',
+      })
+
+      const first = await manager.fetch('https://api.example.com/resource')
+      expect(first.status).toBe(200)
+      expect(first.receipt?.acceptedCumulative).toBe('1000000')
+      expect(first.receipt?.spent).toBe('1000000')
+
+      const second = await manager.fetch('https://api.example.com/resource')
+      expect(second.status).toBe(200)
+      expect(second.receipt?.acceptedCumulative).toBe('2000000')
+      expect(second.receipt?.spent).toBe('1000000')
+
+      const closeReceipt = await manager.close()
+      expect(closeReceipt?.status).toBe('success')
+      expect(closeReceipt?.acceptedCumulative).toBe('2000000')
+      expect(closeReceipt?.spent).toBe('2000000')
+    })
+
     test('sessionManager rejects receipts that exceed the locally signed voucher', async () => {
       const handler = createHandler()
       const route = handler.session({


### PR DESCRIPTION
## Summary

- Tracked accepted cumulative receipt amounts in the legacy session manager.
- Closed HTTP/SSE fallback sessions at the highest accepted cumulative voucher when receipts report spent as a per-request delta.
- Added a regression test for delta spent receipts.

## Motivation

Some legacy session servers report receipt.spent as the per-request delta while receipt.acceptedCumulative carries the running voucher total. Closing at receipt.spent can under-sign the cooperative close and get rejected by the server.

Fixes #575

## Key design considerations

- Preserves the WebSocket close fallback path, which still uses the tighter delivered-chunk estimate when close-ready is unavailable.
- Keeps receipt validation bounded by local voucher state before accepting either spent or accepted cumulative values.
