### PR TITLE
fix: require explicit cli config

### DIFF
--- a/.changeset/explicit-cli-config.md
+++ b/.changeset/explicit-cli-config.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Disabled automatic CLI configuration discovery from local directories.

--- a/src/cli/config.test.ts
+++ b/src/cli/config.test.ts
@@ -41,35 +41,41 @@ describe('loadConfig', () => {
     expect(result?.path).toBe(configPath)
   })
 
+  test('loads config from explicit config file', async () => {
+    const configPath = path.join(tmpDir, 'custom.mjs')
+    fs.writeFileSync(configPath, 'export default { methods: [] }')
+    const result = await loadConfig(configPath)
+    expect(result?.config).toEqual({ methods: [] })
+    expect(result?.path).toBe(configPath)
+  })
+
   test('returns undefined when MPPX_CONFIG points to nonexistent file', async () => {
     vi.stubEnv('MPPX_CONFIG', path.join(tmpDir, 'nonexistent.ts'))
     const config = await loadConfig()
     expect(config).toBeUndefined()
   })
 
-  test('loads mppx.config.mjs from cwd', async () => {
+  test('ignores mppx.config.mjs from cwd without explicit selection', async () => {
     const configPath = path.join(tmpDir, 'mppx.config.mjs')
     fs.writeFileSync(configPath, 'export default { methods: [] }')
     vi.spyOn(process, 'cwd').mockReturnValue(tmpDir)
     const result = await loadConfig()
-    expect(result?.config).toEqual({ methods: [] })
-    expect(result?.path).toBe(configPath)
+    expect(result).toBeUndefined()
     vi.mocked(process.cwd).mockRestore()
   })
 
-  test('walks up from cwd to find config', async () => {
+  test('does not walk up from cwd to find config', async () => {
     const nested = path.join(tmpDir, 'a', 'b', 'c')
     fs.mkdirSync(nested, { recursive: true })
     const configPath = path.join(tmpDir, 'mppx.config.mjs')
     fs.writeFileSync(configPath, 'export default { methods: [] }')
     vi.spyOn(process, 'cwd').mockReturnValue(nested)
     const result = await loadConfig()
-    expect(result?.config).toEqual({ methods: [] })
-    expect(result?.path).toBe(configPath)
+    expect(result).toBeUndefined()
     vi.mocked(process.cwd).mockRestore()
   })
 
-  test('MPPX_CONFIG takes priority over cwd config', async () => {
+  test('MPPX_CONFIG loads even when cwd config exists', async () => {
     fs.writeFileSync(path.join(tmpDir, 'mppx.config.mjs'), 'export default { methods: ["cwd"] }')
     const envConfig = path.join(tmpDir, 'env.mjs')
     fs.writeFileSync(envConfig, 'export default { methods: ["env"] }')

--- a/src/cli/internal.ts
+++ b/src/cli/internal.ts
@@ -84,8 +84,7 @@ function supportsPlugin(plugin: Plugin, challenge: Challenge.Challenge): boolean
   return plugin.supports ? plugin.supports(challenge) : plugin.method === challenge.method
 }
 
-const CONFIG_NAMES = ['mppx.config.ts', 'mppx.config.js', 'mppx.config.mjs'] as const
-
+/** Loads CLI config only from explicit, user-selected paths. */
 export async function loadConfig(
   configFile?: string | undefined,
 ): Promise<{ config: Config; path: string } | undefined> {
@@ -109,20 +108,6 @@ function resolveConfigPath(configFile?: string | undefined): string | undefined 
     const resolved = path.resolve(envPath)
     if (fs.existsSync(resolved)) return resolved
     return undefined
-  }
-
-  // 2. Walk up from cwd, stopping at project root
-  let dir = process.cwd()
-  while (true) {
-    for (const name of CONFIG_NAMES) {
-      const candidate = path.join(dir, name)
-      if (fs.existsSync(candidate)) return candidate
-    }
-    const isProjectRoot =
-      fs.existsSync(path.join(dir, 'package.json')) || fs.existsSync(path.join(dir, '.git'))
-    const parent = path.dirname(dir)
-    if (isProjectRoot || parent === dir) break
-    dir = parent
   }
 
   return undefined


### PR DESCRIPTION
## Summary

- Removed automatic CLI config discovery from the current directory and parent directories.
- Kept config loading for explicit `--config` paths and `MPPX_CONFIG`.
- Updated config loading coverage for explicit-only behavior.

## Motivation

The CLI should not automatically execute JavaScript config files found in arbitrary local directories.

## Key design considerations

- Explicit user-selected config paths preserve existing advanced configuration support.
- Removing cwd traversal avoids workspace trust prompts or persistent allowlist state.