### PR TITLE
fix: reject sponsored key authorization

### DIFF
--- a/.changeset/reject-sponsored-key-authorization.md
+++ b/.changeset/reject-sponsored-key-authorization.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Rejected key authorization payloads in fee-sponsored transactions.

--- a/src/tempo/internal/fee-payer.test.ts
+++ b/src/tempo/internal/fee-payer.test.ts
@@ -668,6 +668,30 @@ describe('fillHostedFeePayerTransaction', () => {
       }),
     ).rejects.toThrow('Invalid or revoked API key')
   })
+
+  test('error: rejects keyAuthorization before requesting hosted fill', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      fillHostedFeePayerTransaction({
+        allowedFeeTokens: defaultAllowedFeeTokens(defaults.chainId.mainnet),
+        transaction: {
+          ...hostedTransaction,
+          keyAuthorization: {
+            address: bogus,
+            chainId: defaults.chainId.mainnet,
+            nonce: 1n,
+            r: 1n,
+            s: 2n,
+            yParity: 0,
+          },
+        } as any,
+        url: 'https://sponsor.example/tp_key',
+      }),
+    ).rejects.toThrow('must not include keyAuthorization')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
 })
 
 describe('simulationTransaction', () => {
@@ -843,7 +867,7 @@ describe('prepareSponsoredTransaction', () => {
     ).toThrow('maxPriorityFeePerGas exceeds sponsor policy')
   })
 
-  test('preserves keyAuthorization', () => {
+  test('error: rejects keyAuthorization', () => {
     const keyAuthorization = {
       address: bogus,
       chainId: 42431,
@@ -853,15 +877,15 @@ describe('prepareSponsoredTransaction', () => {
       yParity: 0,
     }
 
-    const sponsored = prepareSponsoredTransaction({
-      account: sponsor,
-      chainId: 42431,
-      details,
-      allowedFeeTokens: [bogus],
-      transaction: { ...baseTransaction, keyAuthorization } as any,
-    }) as { keyAuthorization?: unknown }
-
-    expect(sponsored.keyAuthorization).toEqual(keyAuthorization)
+    expect(() =>
+      prepareSponsoredTransaction({
+        account: sponsor,
+        chainId: 42431,
+        details,
+        allowedFeeTokens: [bogus],
+        transaction: { ...baseTransaction, keyAuthorization } as any,
+      }),
+    ).toThrow('must not include keyAuthorization')
   })
 
   test('error: rejects unknown top-level fields from the sponsored transaction', () => {

--- a/src/tempo/internal/fee-payer.ts
+++ b/src/tempo/internal/fee-payer.ts
@@ -151,9 +151,6 @@ function hostedFeePayerRequest(transaction: SponsoredTransaction) {
     feePayer: true,
     from: transaction.from,
     ...(transaction.gas !== undefined ? { gas: toHex(transaction.gas) } : {}),
-    ...(transaction.keyAuthorization !== undefined
-      ? { keyAuthorization: transaction.keyAuthorization }
-      : {}),
     ...(transaction.maxFeePerGas !== undefined
       ? { maxFeePerGas: toHex(transaction.maxFeePerGas) }
       : {}),
@@ -185,6 +182,7 @@ export async function fillHostedFeePayerTransaction(parameters: {
   url: string
 }) {
   const { allowedFeeTokens, transaction, url } = parameters
+  assertNoKeyAuthorization(transaction)
   const response = await fetch(url, {
     body: JSON.stringify(
       {
@@ -433,6 +431,15 @@ export function validateCalls(
   }
 }
 
+/** Rejects account key authorization payloads on fee-sponsored transactions. */
+export function assertNoKeyAuthorization(transaction: { keyAuthorization?: unknown }) {
+  if (transaction.keyAuthorization !== undefined)
+    throw new FeePayerValidationError(
+      'fee-sponsored transaction must not include keyAuthorization',
+      {},
+    )
+}
+
 export function prepareSponsoredTransaction(parameters: {
   account: Account
   allowedFeeTokens?: readonly TempoAddress.Address[] | undefined
@@ -463,7 +470,6 @@ export function prepareSponsoredTransaction(parameters: {
     feeToken,
     from,
     gas,
-    keyAuthorization,
     maxFeePerGas,
     maxPriorityFeePerGas,
     nonce,
@@ -495,6 +501,8 @@ export function prepareSponsoredTransaction(parameters: {
     fail('fee-sponsored transaction contains rejected fields', {
       rejectedFields: rejectedKeys.join(', '),
     })
+
+  assertNoKeyAuthorization(transaction)
 
   if (transaction.type !== undefined && transaction.type !== 'tempo')
     fail('fee-sponsored transaction type is invalid', {
@@ -589,7 +597,6 @@ export function prepareSponsoredTransaction(parameters: {
     ...(normalizedFeeToken ? { feeToken: normalizedFeeToken } : {}),
     ...(from ? { from } : {}),
     gas: gasLimit,
-    ...(keyAuthorization !== undefined ? { keyAuthorization } : {}),
     ...(nonce !== undefined ? { nonce } : {}),
     maxFeePerGas: maxFeePerGasValue,
     ...(maxPriorityFeePerGas !== undefined ? { maxPriorityFeePerGas } : {}),


### PR DESCRIPTION
## Summary

- Rejected `keyAuthorization` payloads on fee-sponsored transactions.
- Removed hosted fee-payer forwarding of `keyAuthorization` fields.
- Stopped local sponsored transaction preparation from preserving account key authorizations.

## Motivation

Fee sponsorship should only cover payment transactions, not account key-management actions attached to otherwise valid payments.

## Key design considerations

- The guard runs inside both hosted and local fee-payer helpers.
- Rejection is explicit instead of silently omitting a sender-signed field.