### PR TITLE
fix: precheck session open funding

### DIFF
--- a/.changeset/session-open-economic-precheck.md
+++ b/.changeset/session-open-economic-precheck.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Validated session open deposit and voucher amounts before sponsored broadcast.

--- a/src/tempo/session/server/CredentialVerification.test.ts
+++ b/src/tempo/session/server/CredentialVerification.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'vp/test'
 
 import * as Channel from '../precompile/Channel.js'
 import {
+  assertOpenCredentialCoversRequest,
   requireSessionCredentialAction,
   requireSessionCredentialPayload,
   requireSessionCredentialPayloadHeader,
@@ -141,6 +142,41 @@ describe('SessionCredentialGuards', () => {
           '0x0000000000000000000000000000000000000004',
         ),
       ).toThrow('channel descriptor operator does not match server operator')
+    })
+  })
+
+  describe('assertOpenCredentialCoversRequest', () => {
+    test('accepts deposit and voucher amounts that cover the request', () => {
+      expect(() =>
+        assertOpenCredentialCoversRequest({
+          cumulativeAmount: 100n,
+          openDeposit: 100n,
+          requestAmount: 100n,
+        }),
+      ).not.toThrow()
+    })
+
+    test.each([
+      {
+        cumulativeAmount: 100n,
+        expected: 'open deposit is less than request amount',
+        openDeposit: 99n,
+        requestAmount: 100n,
+      },
+      {
+        cumulativeAmount: 99n,
+        expected: 'voucher amount is less than request amount',
+        openDeposit: 100n,
+        requestAmount: 100n,
+      },
+    ])('rejects insufficient open credential funding: $expected', (case_) => {
+      expect(() =>
+        assertOpenCredentialCoversRequest({
+          cumulativeAmount: case_.cumulativeAmount,
+          openDeposit: case_.openDeposit,
+          requestAmount: case_.requestAmount,
+        }),
+      ).toThrow(case_.expected)
     })
   })
 })

--- a/src/tempo/session/server/CredentialVerification.ts
+++ b/src/tempo/session/server/CredentialVerification.ts
@@ -113,6 +113,19 @@ export function validateChannelState(state: Chain.ChannelState, amount?: bigint)
   }
 }
 
+/** Asserts that an opening channel covers the route's requested payment. */
+export function assertOpenCredentialCoversRequest(parameters: {
+  cumulativeAmount: bigint
+  openDeposit: bigint
+  requestAmount: bigint
+}): void {
+  const { cumulativeAmount, openDeposit, requestAmount } = parameters
+  if (openDeposit < requestAmount)
+    throw new VerificationFailedError({ reason: 'open deposit is less than request amount' })
+  if (cumulativeAmount < requestAmount)
+    throw new VerificationFailedError({ reason: 'voucher amount is less than request amount' })
+}
+
 const sessionCredentialActions = [
   'open',
   'topUp',
@@ -410,6 +423,11 @@ async function handleOpenCredential(
     feePayerPolicy: parameters.feePayerPolicy,
     serializedTransaction: payload.transaction,
     async beforeBroadcast(prepared) {
+      assertOpenCredentialCoversRequest({
+        cumulativeAmount,
+        openDeposit: prepared.openDeposit,
+        requestAmount: request.amount,
+      })
       assertSameDescriptor(prepared.descriptor, payload.descriptor)
       if (cumulativeAmount > prepared.openDeposit)
         throw new AmountExceedsDepositError({ reason: 'voucher amount exceeds open deposit' })


### PR DESCRIPTION
## Summary

- Validated session-open deposits before sponsored broadcast.
- Validated opening voucher amounts before sponsored broadcast.
- Added a shared assertion for session-open economic checks.

## Motivation

Sponsored session-open transactions should only be broadcast after the deposit and voucher satisfy the requested payment amount.

## Key design considerations

- The check runs inside the pre-broadcast hook before fee-payer gas can be spent.
- Existing descriptor and voucher signature validation remain unchanged.