### PR TITLE
fix: enforce policy for hosted fee payer

### DIFF
--- a/.changeset/hosted-fee-payer-policy.md
+++ b/.changeset/hosted-fee-payer-policy.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Enforced sponsor fee policies before hosted fee-payer signing.

--- a/src/tempo/internal/fee-payer.test.ts
+++ b/src/tempo/internal/fee-payer.test.ts
@@ -499,6 +499,10 @@ describe('fillHostedFeePayerTransaction', () => {
     signature: { r: 1n, s: 1n, yParity: 0 } as any,
     validBefore: Math.floor(Date.now() / 1_000) + 300,
   } as const
+  const hostedContext = {
+    chainId: defaults.chainId.mainnet,
+    details,
+  } as const
 
   test('uses hosted fillTransaction and preserves sender-committed fields', async () => {
     // Sign over the payload built from the actual RPC request body so this
@@ -569,6 +573,7 @@ describe('fillHostedFeePayerTransaction', () => {
 
     const result = await fillHostedFeePayerTransaction({
       allowedFeeTokens: defaultAllowedFeeTokens(defaults.chainId.mainnet),
+      ...hostedContext,
       transaction: hostedTransaction as any,
       url: 'https://sponsor.example/tp_key',
     })
@@ -621,6 +626,7 @@ describe('fillHostedFeePayerTransaction', () => {
     await expect(
       fillHostedFeePayerTransaction({
         allowedFeeTokens: defaultAllowedFeeTokens(defaults.chainId.mainnet),
+        ...hostedContext,
         transaction: hostedTransaction as any,
         url: 'https://sponsor.example/tp_key',
       }),
@@ -643,6 +649,7 @@ describe('fillHostedFeePayerTransaction', () => {
     await expect(
       fillHostedFeePayerTransaction({
         allowedFeeTokens: defaultAllowedFeeTokens(defaults.chainId.mainnet),
+        ...hostedContext,
         transaction: hostedTransaction as any,
         url: 'https://sponsor.example/tp_key',
       }),
@@ -663,10 +670,27 @@ describe('fillHostedFeePayerTransaction', () => {
     await expect(
       fillHostedFeePayerTransaction({
         allowedFeeTokens: defaultAllowedFeeTokens(defaults.chainId.mainnet),
+        ...hostedContext,
         transaction: hostedTransaction as any,
         url: 'https://sponsor.example/tp_key',
       }),
     ).rejects.toThrow('Invalid or revoked API key')
+  })
+
+  test('error: enforces sponsor policy before requesting hosted fill', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      fillHostedFeePayerTransaction({
+        allowedFeeTokens: defaultAllowedFeeTokens(defaults.chainId.mainnet),
+        ...hostedContext,
+        policy: { maxGas: hostedTransaction.gas - 1n },
+        transaction: hostedTransaction as any,
+        url: 'https://sponsor.example/tp_key',
+      }),
+    ).rejects.toThrow('gas exceeds sponsor policy')
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 })
 

--- a/src/tempo/internal/fee-payer.ts
+++ b/src/tempo/internal/fee-payer.ts
@@ -181,10 +181,22 @@ function hostedFeePayerRequest(transaction: SponsoredTransaction) {
  */
 export async function fillHostedFeePayerTransaction(parameters: {
   allowedFeeTokens: readonly TempoAddress.Address[]
+  challengeExpires?: string | undefined
+  chainId: number
+  details: Record<string, string>
+  policy?: Partial<Policy> | undefined
   transaction: SponsoredTransaction
   url: string
 }) {
-  const { allowedFeeTokens, transaction, url } = parameters
+  const { allowedFeeTokens, challengeExpires, chainId, details, policy, transaction, url } =
+    parameters
+  assertTransactionPolicy({
+    challengeExpires,
+    chainId,
+    details,
+    policy,
+    transaction,
+  })
   const response = await fetch(url, {
     body: JSON.stringify(
       {
@@ -433,9 +445,8 @@ export function validateCalls(
   }
 }
 
-export function prepareSponsoredTransaction(parameters: {
-  account: Account
-  allowedFeeTokens?: readonly TempoAddress.Address[] | undefined
+/** Validates sponsor fee policy limits for a fee-payer transaction. */
+export function assertTransactionPolicy(parameters: {
   challengeExpires?: string | undefined
   chainId: number
   details: Record<string, string>
@@ -444,8 +455,6 @@ export function prepareSponsoredTransaction(parameters: {
   transaction: SponsoredTransaction
 }) {
   const {
-    account,
-    allowedFeeTokens,
     challengeExpires,
     chainId,
     details,
@@ -454,47 +463,18 @@ export function prepareSponsoredTransaction(parameters: {
     transaction,
   } = parameters
   const policy = getPolicy(chainId, policyOverrides)
-  const transactionRecord = transaction as Record<string, unknown>
-
   const {
-    accessList,
-    calls,
     chainId: transactionChainId,
-    feeToken,
-    from,
     gas,
-    keyAuthorization,
     maxFeePerGas,
     maxPriorityFeePerGas,
-    nonce,
     nonceKey,
-    signature,
-    validAfter,
     validBefore,
   } = transaction
 
   const fail = (reason: string, extra: Record<string, string> = {}) => {
     throw new FeePayerValidationError(reason, { ...details, ...extra })
   }
-
-  const unsupportedKeys = Object.entries(transaction).flatMap(([key, value]) => {
-    if (value === undefined) return []
-    if (supportedTransactionKeys.has(key)) return []
-    return [key]
-  })
-  if (unsupportedKeys.length > 0)
-    fail('fee-sponsored transaction contains unsupported fields', {
-      unsupportedFields: unsupportedKeys.join(', '),
-    })
-
-  const rejectedKeys = rejectedTransactionKeys.filter((key) => {
-    const value = transactionRecord[key]
-    return value !== undefined && value !== null
-  })
-  if (rejectedKeys.length > 0)
-    fail('fee-sponsored transaction contains rejected fields', {
-      rejectedFields: rejectedKeys.join(', '),
-    })
 
   if (transaction.type !== undefined && transaction.type !== 'tempo')
     fail('fee-sponsored transaction type is invalid', {
@@ -561,6 +541,77 @@ export function prepareSponsoredTransaction(parameters: {
     fail('fee-sponsored transaction validity window exceeds sponsor policy', {
       validBefore: String(validBeforeValue),
     })
+
+  return { gasLimit, maxFeePerGasValue, validBeforeValue }
+}
+
+export function prepareSponsoredTransaction(parameters: {
+  account: Account
+  allowedFeeTokens?: readonly TempoAddress.Address[] | undefined
+  challengeExpires?: string | undefined
+  chainId: number
+  details: Record<string, string>
+  now?: Date | undefined
+  policy?: Partial<Policy> | undefined
+  transaction: SponsoredTransaction
+}) {
+  const {
+    account,
+    allowedFeeTokens,
+    challengeExpires,
+    chainId,
+    details,
+    now = new Date(),
+    policy: policyOverrides,
+    transaction,
+  } = parameters
+  const transactionRecord = transaction as Record<string, unknown>
+
+  const {
+    accessList,
+    calls,
+    chainId: transactionChainId,
+    feeToken,
+    from,
+    keyAuthorization,
+    maxPriorityFeePerGas,
+    nonce,
+    nonceKey,
+    signature,
+    validAfter,
+  } = transaction
+
+  const fail = (reason: string, extra: Record<string, string> = {}) => {
+    throw new FeePayerValidationError(reason, { ...details, ...extra })
+  }
+
+  const unsupportedKeys = Object.entries(transaction).flatMap(([key, value]) => {
+    if (value === undefined) return []
+    if (supportedTransactionKeys.has(key)) return []
+    return [key]
+  })
+  if (unsupportedKeys.length > 0)
+    fail('fee-sponsored transaction contains unsupported fields', {
+      unsupportedFields: unsupportedKeys.join(', '),
+    })
+
+  const rejectedKeys = rejectedTransactionKeys.filter((key) => {
+    const value = transactionRecord[key]
+    return value !== undefined && value !== null
+  })
+  if (rejectedKeys.length > 0)
+    fail('fee-sponsored transaction contains rejected fields', {
+      rejectedFields: rejectedKeys.join(', '),
+    })
+
+  const { gasLimit, maxFeePerGasValue, validBeforeValue } = assertTransactionPolicy({
+    challengeExpires,
+    chainId,
+    details,
+    now,
+    policy: policyOverrides,
+    transaction,
+  })
 
   const normalizedFeeToken = (() => {
     if (feeToken === undefined) return undefined

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -441,6 +441,10 @@ export function charge<const parameters extends charge.Parameters>(
               if (feePayerUrl && isFeePayerTx) {
                 const hosted = await FeePayer.fillHostedFeePayerTransaction({
                   allowedFeeTokens,
+                  challengeExpires: expires,
+                  chainId: chainId ?? client.chain!.id,
+                  details: { amount, currency, recipient },
+                  policy: feePayerPolicy,
                   transaction,
                   url: feePayerUrl,
                 })


### PR DESCRIPTION
## Summary

- Enforced fee-payer gas and fee policy before hosted fee-payer signing.
- Passed challenge and policy context from charge verification into hosted fee-payer fills.
- Reused the local sponsorship policy checks for hosted fee-payer transactions.

## Motivation

Hosted fee-payer fills should honor the same sponsor budget constraints as locally signed sponsorships before any external signing request is made.

## Key design considerations

- Shared policy validation keeps gas, fee, total budget, nonce, and validity-window checks consistent.
- Hosted validation runs before calling the external fee-payer endpoint.