### PR TITLE
fix: filter unsupported x402 accepts

### DIFF
--- a/.changeset/filter-x402-accepts.md
+++ b/.changeset/filter-x402-accepts.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Filtered unsupported x402 accepts during HTTP client challenge extraction.

--- a/src/client/Transport.test.ts
+++ b/src/client/Transport.test.ts
@@ -2,6 +2,7 @@ import { Challenge, Credential, Mcp } from 'mppx'
 import { Transport } from 'mppx/client'
 import { Methods } from 'mppx/tempo'
 import { Header as x402_Header, Types as x402_Types, type PaymentRequired } from 'mppx/x402'
+import { Base64 } from 'ox'
 import { describe, expect, test } from 'vp/test'
 
 import * as x402_ChallengeBrand from '../x402/internal/ChallengeBrand.js'
@@ -42,6 +43,25 @@ const x402PaymentRequired = {
   },
   x402Version: 2,
 } satisfies PaymentRequired
+
+const unsupportedSolanaAccept = {
+  amount: '10000',
+  asset: 'USDC',
+  maxTimeoutSeconds: 60,
+  network: 'solana:mainnet',
+  payTo: '9xQeWvG816bUx9EPjHmaT23yvVM2ZWdYqPxfowV5n2kg',
+  scheme: 'exact',
+}
+
+const unsupportedSchemeAccept = {
+  ...x402PaymentRequired.accepts[0]!,
+  scheme: 'upto',
+}
+
+// Strict x402 encoding rejects unsupported accepts before the transport can filter them.
+function encodeRawPaymentRequiredHeader(value: unknown): string {
+  return Base64.fromString(JSON.stringify(value))
+}
 
 describe('http', () => {
   describe('isPaymentRequired', () => {
@@ -140,6 +160,28 @@ describe('http', () => {
         }),
         name: 'Payment auth and x402 challenges when both are present',
       },
+      {
+        expectedIds: [`${x402_Types.syntheticChallengeIdPrefix}0`],
+        expectedMethods: [x402_Types.paymentMethod],
+        headers: () => ({
+          'PAYMENT-REQUIRED': encodeRawPaymentRequiredHeader({
+            ...x402PaymentRequired,
+            accepts: [x402PaymentRequired.accepts[0]!, unsupportedSolanaAccept],
+          }),
+        }),
+        name: 'x402 challenges filtered from mixed EVM and Solana accepts',
+      },
+      {
+        expectedIds: [`${x402_Types.syntheticChallengeIdPrefix}0`],
+        expectedMethods: [x402_Types.paymentMethod],
+        headers: () => ({
+          'PAYMENT-REQUIRED': encodeRawPaymentRequiredHeader({
+            ...x402PaymentRequired,
+            accepts: [x402PaymentRequired.accepts[0]!, unsupportedSchemeAccept],
+          }),
+        }),
+        name: 'x402 challenges filtered from mixed exact and non-exact accepts',
+      },
     ])('returns $name', async ({ expectedIds, expectedMethods, headers }) => {
       const transport = Transport.http()
       const response = new Response(null, {
@@ -150,6 +192,42 @@ describe('http', () => {
 
       expect(challenges.map((entry) => entry.id)).toEqual(expectedIds)
       expect(challenges.map((entry) => entry.method)).toEqual(expectedMethods)
+    })
+
+    test('returns Payment auth challenges when x402 accepts are unsupported', async () => {
+      const transport = Transport.http()
+      const response = new Response(null, {
+        status: 402,
+        headers: {
+          'PAYMENT-REQUIRED': encodeRawPaymentRequiredHeader({
+            ...x402PaymentRequired,
+            accepts: [unsupportedSolanaAccept],
+          }),
+          'WWW-Authenticate': Challenge.serialize(challenge),
+        },
+      })
+
+      const challenges = (await transport.getChallenges?.(response)) ?? []
+
+      expect(challenges.map((entry) => entry.id)).toEqual([challenge.id])
+      expect(challenges.map((entry) => entry.method)).toEqual(['tempo'])
+    })
+
+    test('returns no challenges when only unsupported x402 accepts are present', async () => {
+      const transport = Transport.http()
+      const response = new Response(null, {
+        status: 402,
+        headers: {
+          'PAYMENT-REQUIRED': encodeRawPaymentRequiredHeader({
+            ...x402PaymentRequired,
+            accepts: [unsupportedSolanaAccept],
+          }),
+        },
+      })
+
+      const challenges = (await transport.getChallenges?.(response)) ?? []
+      expect(challenges).toEqual([])
+      expect(() => transport.getChallenge(response)).toThrow('No challenge in response.')
     })
   })
 

--- a/src/client/internal/Fetch.test.ts
+++ b/src/client/internal/Fetch.test.ts
@@ -2,6 +2,7 @@ import { Challenge, Credential, Errors, Mcp, Receipt } from 'mppx'
 import { tempo } from 'mppx/client'
 import { Mppx as Mppx_server, tempo as tempo_server } from 'mppx/server'
 import { Header as x402_Header, Types as x402_Types, type PaymentRequired } from 'mppx/x402'
+import { Base64 } from 'ox'
 import { createClient, defineChain } from 'viem'
 import { describe, expect, test, vi } from 'vp/test'
 import * as Http from '~test/Http.js'
@@ -377,6 +378,11 @@ function makeCombined402() {
     status: 402,
     headers,
   })
+}
+
+// Strict x402 encoding rejects unsupported accepts before the transport can filter them.
+function encodeRawPaymentRequiredHeader(value: unknown): string {
+  return Base64.fromString(JSON.stringify(value))
 }
 
 describe('Fetch.from: init passthrough (non-402)', () => {
@@ -1354,6 +1360,63 @@ describe('Fetch.from: 402 retry path', () => {
 
     const response = await fetch('https://example.com/api')
     expect(response.status).toBe(200)
+  })
+
+  test('ignores unsupported x402 accepts when selecting a Payment auth challenge', async () => {
+    let callCount = 0
+    const createCredential = vi.fn(async () => 'tempo-credential')
+    const tempoChallenge = Challenge.from({
+      id: 'tempo',
+      realm: 'test',
+      method: 'tempo',
+      intent: 'charge',
+      request: { amount: '1' },
+    })
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      callCount++
+      if (callCount === 1) {
+        return new Response(null, {
+          status: 402,
+          headers: {
+            [x402_Types.paymentRequiredHeader]: encodeRawPaymentRequiredHeader({
+              accepts: [
+                {
+                  amount: '10000',
+                  asset: 'USDC',
+                  maxTimeoutSeconds: 60,
+                  network: 'solana:mainnet',
+                  payTo: '9xQeWvG816bUx9EPjHmaT23yvVM2ZWdYqPxfowV5n2kg',
+                  scheme: 'exact',
+                },
+              ],
+              resource: { url: 'https://example.com/api' },
+              x402Version: 2,
+            }),
+            'WWW-Authenticate': Challenge.serialize(tempoChallenge),
+          },
+        })
+      }
+
+      expect(new Headers(init?.headers).get('Authorization')).toBe('tempo-credential')
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [
+        {
+          name: 'tempo',
+          intent: 'charge',
+          context: undefined,
+          createCredential,
+        },
+      ] as const,
+    })
+
+    const response = await fetch('https://example.com/api')
+
+    expect(response.status).toBe(200)
+    expect(createCredential).toHaveBeenCalledOnce()
   })
 
   test('orderChallenges filters and sorts supported challenges before signing', async () => {

--- a/src/client/internal/protocols/X402.ts
+++ b/src/client/internal/protocols/X402.ts
@@ -16,11 +16,15 @@ export function x402(): Protocol {
       if (response.status !== paymentRequiredStatus) return []
       const header = response.headers.get(x402_Types.paymentRequiredHeader)
       if (!header) return []
-      const paymentRequired = x402_Header.decodePaymentRequired(header)
+      const paymentRequired = x402_Header.decodePaymentRequiredEnvelope(header)
       if (response.url && paymentRequired.resource.url !== response.url)
         throw new Error('x402 payment-required resource does not match response URL.')
-      return paymentRequired.accepts.map((accepted, index) =>
-        x402_ChallengeBrand.mark(
+      return paymentRequired.accepts.flatMap((rawAccepted, index) => {
+        const parsed = x402_Types.PaymentRequirementsSchema.safeParse(rawAccepted)
+        if (!parsed.success) return []
+
+        const accepted = parsed.data
+        return x402_ChallengeBrand.mark(
           Challenge.from({
             id: `${x402_Types.syntheticChallengeIdPrefix}${index}`,
             intent: x402_Types.exactIntent,
@@ -32,8 +36,8 @@ export function x402(): Protocol {
               resource: paymentRequired.resource,
             },
           }),
-        ),
-      )
+        )
+      })
     },
     setCredential(request, credential) {
       return setCredentialHeader(request, x402_Types.paymentSignatureHeader, credential)

--- a/src/x402/Header.ts
+++ b/src/x402/Header.ts
@@ -1,11 +1,18 @@
+import { Base64 } from 'ox'
+
 import * as HeaderCodec from '../internal/HeaderCodec.js'
 import {
+  ExtensionsSchema,
   PaymentPayloadSchema,
   PaymentRequiredSchema,
+  ResourceInfoSchema,
   SettleResponseSchema,
+  type Extensions,
   type PaymentPayload,
   type PaymentRequired,
+  type ResourceInfo,
   type SettleResponse,
+  type Version,
 } from './Types.js'
 
 const paymentRequired = HeaderCodec.createJson(PaymentRequiredSchema)
@@ -18,6 +25,24 @@ export const encodePaymentRequired: (paymentRequired: PaymentRequired) => string
 
 /** Decodes an x402 `PAYMENT-REQUIRED` header value. */
 export const decodePaymentRequired: (value: string) => PaymentRequired = paymentRequired.decode
+
+/** Tolerant x402 `PAYMENT-REQUIRED` envelope used before filtering supported accepts. @internal */
+export type PaymentRequiredEnvelope = {
+  accepts: unknown[]
+  extensions?: Extensions | undefined
+  resource: ResourceInfo
+  x402Version: Version
+}
+
+/** Decodes only the x402 `PAYMENT-REQUIRED` envelope, leaving accepts unvalidated. @internal */
+export function decodePaymentRequiredEnvelope(value: string): PaymentRequiredEnvelope {
+  try {
+    const parsed = JSON.parse(Base64.toString(value)) as unknown
+    return parsePaymentRequiredEnvelope(parsed)
+  } catch {
+    throw new HeaderCodec.InvalidJsonHeaderError()
+  }
+}
 
 /** Encodes an x402 payment payload for the `PAYMENT-SIGNATURE` header. */
 export const encodePaymentSignature: (paymentPayload: PaymentPayload) => string =
@@ -32,3 +57,23 @@ export const encodePaymentResponse: (paymentResponse: SettleResponse) => string 
 
 /** Decodes an x402 `PAYMENT-RESPONSE` header value. */
 export const decodePaymentResponse: (value: string) => SettleResponse = paymentResponse.decode
+
+const parsePaymentRequiredEnvelope = (value: unknown): PaymentRequiredEnvelope => {
+  if (!value || typeof value !== 'object' || Array.isArray(value))
+    throw new HeaderCodec.InvalidJsonHeaderError()
+
+  const record = value as Record<string, unknown>
+  if (record.x402Version !== 2 || !Array.isArray(record.accepts))
+    throw new HeaderCodec.InvalidJsonHeaderError()
+
+  const resource = ResourceInfoSchema.parse(record.resource)
+  const extensions =
+    record.extensions === undefined ? undefined : ExtensionsSchema.parse(record.extensions)
+
+  return {
+    accepts: record.accepts,
+    ...(extensions ? { extensions } : {}),
+    resource,
+    x402Version: 2,
+  }
+}


### PR DESCRIPTION
## Summary

- Added tolerant x402 `PAYMENT-REQUIRED` envelope decoding for client-side challenge extraction
- Filtered unsupported x402 accepts before synthesizing EVM exact challenges
- Added regression coverage for mixed EVM/Solana and unsupported x402 offers

## Motivation

Endpoints can advertise mpp, EVM x402, and Solana x402 accepts together. The client should ignore unsupported x402 accepts instead of failing before it can select a supported payment challenge.

## Key design considerations

- Kept strict `decodePaymentRequired` behavior unchanged
- Scoped tolerant parsing to envelope decoding so each accept can be validated independently
- Preserved Payment-auth challenge precedence and existing no-challenge behavior
