### PR TITLE
feat: add configurable payment challenge retries

### DIFF
--- a/.changeset/retry-incremental-402.md
+++ b/.changeset/retry-incremental-402.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added configurable incremental payment challenge retries for client fetch, defaulting to three.

--- a/src/client/Mppx.test-d.ts
+++ b/src/client/Mppx.test-d.ts
@@ -62,6 +62,15 @@ describe('create.Config', () => {
     expectTypeOf<Config>().toHaveProperty('methods')
   })
 
+  test('accepts payment retry cap', () => {
+    const mppx = Mppx.create({
+      maxPaymentRetries: 1,
+      methods: [charge()],
+    })
+
+    expectTypeOf(mppx.fetch).toBeFunction()
+  })
+
   test('paymentPreferences callback exposes typed method keys', () => {
     const mppx = Mppx.create({
       methods: [tempo({ account: {} as Account })],

--- a/src/client/Mppx.test.ts
+++ b/src/client/Mppx.test.ts
@@ -41,6 +41,47 @@ describe('Mppx.create', () => {
     expect(mppx.transport.name).toBe('mcp')
   })
 
+  test('behavior: passes maxPaymentRetries to fetch wrapper', async () => {
+    const testMethod = Method.toClient(
+      Method.from({
+        name: 'test',
+        intent: 'test',
+        schema: Methods.charge.schema,
+      }),
+      {
+        async createCredential() {
+          return 'credential'
+        },
+      },
+    )
+    const challenge = Challenge.from({
+      id: 'retry-cap',
+      realm,
+      method: 'test',
+      intent: 'test',
+      request: { amount: '1' },
+    })
+    let callCount = 0
+    const fetch = vi.fn(async () => {
+      callCount++
+      return new Response(null, {
+        status: 402,
+        headers: { 'WWW-Authenticate': Challenge.serialize(challenge) },
+      })
+    })
+    const mppx = Mppx.create({
+      fetch: fetch as typeof globalThis.fetch,
+      maxPaymentRetries: 1,
+      methods: [testMethod],
+      polyfill: false,
+    })
+
+    const response = await mppx.fetch('https://example.com/api')
+
+    expect(response.status).toBe(402)
+    expect(callCount).toBe(2)
+  })
+
   test('behavior: with multiple methods', () => {
     const stripeCharge = Method.from({
       name: 'stripe',

--- a/src/client/Mppx.ts
+++ b/src/client/Mppx.ts
@@ -100,6 +100,7 @@ export function create<
   >,
 >(config: create.Config<methods, transport>): Mppx<methods, transport> {
   const {
+    maxPaymentRetries,
     onChallenge,
     orderChallenges,
     polyfill = true,
@@ -122,6 +123,7 @@ export function create<
     acceptPaymentPolicy,
     ...(config.fetch && { fetch: config.fetch }),
     eventDispatcher: events,
+    ...(maxPaymentRetries !== undefined && { maxPaymentRetries }),
     ...(resolvedOnChallenge && { onChallenge: resolvedOnChallenge }),
     ...(orderChallenges && { orderChallenges }),
     methods,
@@ -298,6 +300,8 @@ export declare namespace create {
           },
         ) => Promise<string | undefined>)
       | undefined
+    /** Maximum number of payment challenge retries after the initial response. @default 3 */
+    maxPaymentRetries?: Fetch.from.Config['maxPaymentRetries'] | undefined
     /** Filters and sorts supported challenges before credential creation. */
     orderChallenges?: AcceptPayment.OrderChallenges<FlattenMethods<methods>> | undefined
     /** Client-declared supported payment methods, keyed by typed `method/intent` strings. */

--- a/src/client/internal/Fetch.test-d.ts
+++ b/src/client/internal/Fetch.test-d.ts
@@ -57,6 +57,15 @@ describe('Fetch.from', () => {
     })
   })
 
+  test('behavior: accepts payment retry cap', () => {
+    const fetch = Fetch.from({
+      maxPaymentRetries: 1,
+      methods: [charge()],
+    })
+
+    expectTypeOf(fetch).toBeFunction()
+  })
+
   test('behavior: events infer payload types from methods', () => {
     const method = charge()
     const dispatcher = Fetch.createEventDispatcher<[typeof method]>()

--- a/src/client/internal/Fetch.test.ts
+++ b/src/client/internal/Fetch.test.ts
@@ -351,7 +351,8 @@ const x402PaymentRequired = {
 } satisfies PaymentRequired
 
 /** Builds a valid 402 response with a WWW-Authenticate header. */
-function make402(overrides?: { expires?: string; intent?: string; method?: string }) {
+function make402(overrides?: { expires?: string; id?: string; intent?: string; method?: string }) {
+  const id = overrides?.id ?? 'abc'
   const method = overrides?.method ?? 'test'
   const intent = overrides?.intent ?? 'test'
   const expires = overrides?.expires ? `, expires="${overrides.expires}"` : ''
@@ -359,7 +360,7 @@ function make402(overrides?: { expires?: string; intent?: string; method?: strin
     .replace(/\+/g, '-')
     .replace(/\//g, '_')
     .replace(/=+$/, '')
-  const header = `Payment id="abc", realm="test", method="${method}", intent="${intent}", request="${request}"${expires}`
+  const header = `Payment id="${id}", realm="test", method="${method}", intent="${intent}", request="${request}"${expires}`
   return new Response(null, {
     status: 402,
     headers: { 'WWW-Authenticate': header },
@@ -1544,8 +1545,42 @@ describe('Fetch.from: 402 retry path', () => {
     )
   })
 
-  test('retries exactly once — does not loop on repeated 402', async () => {
+  test('creates a fresh credential for each incremental 402 challenge', async () => {
+    const createCredential = vi.fn(
+      async ({ challenge }: { challenge: Challenge.Challenge }) => `credential-${challenge.id}`,
+    )
+    const calls: { init: RequestInit | undefined }[] = []
     let callCount = 0
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      calls.push({ init })
+      callCount++
+      if (callCount === 1) return make402({ id: 'first' })
+      if (callCount === 2) return make402({ id: 'second' })
+      if (callCount === 3) return make402({ id: 'third' })
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [{ ...noopMethod, createCredential }],
+    })
+
+    const response = await fetch('https://example.com/api')
+
+    expect(response.status).toBe(200)
+    expect(createCredential.mock.calls.map((call) => call[0].challenge.id)).toEqual([
+      'first',
+      'second',
+      'third',
+    ])
+    expect(
+      calls.slice(1).map((call) => new Headers(call.init?.headers).get('Authorization')),
+    ).toEqual(['credential-first', 'credential-second', 'credential-third'])
+  })
+
+  test('caps repeated 402 retries at three', async () => {
+    let callCount = 0
+    const createCredential = vi.fn(async () => 'credential')
     const mockFetch: typeof globalThis.fetch = async () => {
       callCount++
       return make402()
@@ -1553,11 +1588,32 @@ describe('Fetch.from: 402 retry path', () => {
 
     const fetch = Fetch.from({
       fetch: mockFetch,
-      methods: [noopMethod],
+      methods: [{ ...noopMethod, createCredential }],
+    })
+
+    const response = await fetch('https://example.com/api')
+    expect(callCount).toBe(4)
+    expect(createCredential).toHaveBeenCalledTimes(3)
+    expect(response.status).toBe(402)
+  })
+
+  test('respects configured retry cap', async () => {
+    let callCount = 0
+    const createCredential = vi.fn(async () => 'credential')
+    const mockFetch: typeof globalThis.fetch = async () => {
+      callCount++
+      return make402()
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      maxPaymentRetries: 1,
+      methods: [{ ...noopMethod, createCredential }],
     })
 
     const response = await fetch('https://example.com/api')
     expect(callCount).toBe(2)
+    expect(createCredential).toHaveBeenCalledOnce()
     expect(response.status).toBe(402)
   })
 })

--- a/src/client/internal/Fetch.ts
+++ b/src/client/internal/Fetch.ts
@@ -11,6 +11,7 @@ import * as Transport from '../Transport.js'
 // even across multiple module instances/bundles. This lets restore() avoid clobbering
 // an unrelated fetch installed by user code or another library.
 const MPPX_FETCH_WRAPPER = Symbol.for('mppx.fetch.wrapper')
+const defaultMaxPaymentRetries = 3
 
 type WrappedFetch = typeof globalThis.fetch & {
   [MPPX_FETCH_WRAPPER]?: typeof globalThis.fetch
@@ -161,6 +162,7 @@ export function from<const methods extends readonly Method.AnyClient[]>(
     acceptPayment,
     acceptPaymentPolicy = 'always',
     fetch = globalThis.fetch,
+    maxPaymentRetries = defaultMaxPaymentRetries,
     methods,
     onChallenge,
     orderChallenges,
@@ -185,7 +187,7 @@ export function from<const methods extends readonly Method.AnyClient[]>(
       hasExplicitAcceptPayment,
       acceptPaymentPolicy,
     )
-    const response = await baseFetch(cloneRequestInput(initialRequest.input), initialRequest.init)
+    let response = await baseFetch(cloneRequestInput(initialRequest.input), initialRequest.init)
     const transportRequest = withCapturedBody(initialRequest.init, await capturedBody)
 
     if (!(await transport.isPaymentRequired(response, transportRequest as never))) return response
@@ -203,91 +205,96 @@ export function from<const methods extends readonly Method.AnyClient[]>(
     let mi: methods[number] | undefined
 
     try {
-      challenges = transport.getChallenges
-        ? await transport.getChallenges(response, transportRequest as never)
-        : [await transport.getChallenge(response, transportRequest as never)]
+      for (let retry = 0; retry < maxPaymentRetries; retry++) {
+        challenges = transport.getChallenges
+          ? await transport.getChallenges(response, transportRequest as never)
+          : [await transport.getChallenge(response, transportRequest as never)]
 
-      const candidates = AcceptPayment.selectChallengeCandidates(
-        challenges,
-        methods,
-        paymentPreferences.entries,
-      )
-      const orderedCandidates = await resolveChallengeOrder(
-        candidates,
-        (requestOrderChallenges as AcceptPayment.OrderChallenges<methods> | undefined) ??
-          orderChallenges,
-      )
-      const selected = orderedCandidates[0]
-      if (!selected)
-        throw new Error(
-          `No method found for challenges: ${challenges.map((c) => `${c.method}.${c.intent}`).join(', ')}. Available: ${methods.map((m) => `${m.name}.${m.intent}`).join(', ')}`,
-        )
-
-      const selectedChallenge = selected.challenge
-      challenge = selectedChallenge
-      mi = selected.method
-      if (challenge.expires) Expires.assert(challenge.expires, challenge.id)
-
-      const createCredential = memoizeCreateCredential((overrideContext?: AnyContextFor<methods>) =>
-        resolveCredential(selectedChallenge, selected.method, overrideContext ?? context),
-      )
-      const eventCredential = await events.emit(
-        'challenge.received',
-        createChallengeReceivedPayload({
-          challenge: selectedChallenge,
+        const candidates = AcceptPayment.selectChallengeCandidates(
           challenges,
-          createCredential,
-          init,
-          input,
-          method: selected.method,
-          response,
-        }),
-      )
-      const onChallengeCredential =
-        eventCredential ??
-        (onChallenge
-          ? await onChallenge(challenge, {
-              createCredential,
-            })
-          : undefined)
-      const credential = onChallengeCredential ?? (await createCredential())
-      validateCredentialHeaderValue(credential)
-      await events.emit(
-        'credential.created',
-        createCredentialCreatedPayload({
-          challenge: selectedChallenge,
-          credential,
-          init,
-          input,
-          method: selected.method,
-          response,
-        }),
-      )
+          methods,
+          paymentPreferences.entries,
+        )
+        const orderedCandidates = await resolveChallengeOrder(
+          candidates,
+          (requestOrderChallenges as AcceptPayment.OrderChallenges<methods> | undefined) ??
+            orderChallenges,
+        )
+        const selected = orderedCandidates[0]
+        if (!selected)
+          throw new Error(
+            `No method found for challenges: ${challenges.map((c) => `${c.method}.${c.intent}`).join(', ')}. Available: ${methods.map((m) => `${m.name}.${m.intent}`).join(', ')}`,
+          )
 
-      const paymentResponse = await baseFetch(
-        resolvePaymentRetryInput(response, initialRequest.input, initialRequest.input),
-        transport.setCredential(
-          {
-            ...fetchInit,
-            headers: initialRequest.headers,
-          },
-          credential,
-          { challenge: selectedChallenge },
-        ),
-      )
-      if (paymentResponse.ok)
+        const selectedChallenge = selected.challenge
+        challenge = selectedChallenge
+        mi = selected.method
+        if (challenge.expires) Expires.assert(challenge.expires, challenge.id)
+
+        const createCredential = memoizeCreateCredential(
+          (overrideContext?: AnyContextFor<methods>) =>
+            resolveCredential(selectedChallenge, selected.method, overrideContext ?? context),
+        )
+        const eventCredential = await events.emit(
+          'challenge.received',
+          createChallengeReceivedPayload({
+            challenge: selectedChallenge,
+            challenges,
+            createCredential,
+            init,
+            input,
+            method: selected.method,
+            response,
+          }),
+        )
+        const onChallengeCredential =
+          eventCredential ??
+          (onChallenge
+            ? await onChallenge(challenge, {
+                createCredential,
+              })
+            : undefined)
+        const credential = onChallengeCredential ?? (await createCredential())
+        validateCredentialHeaderValue(credential)
         await events.emit(
-          'payment.response',
-          createPaymentResponsePayload({
+          'credential.created',
+          createCredentialCreatedPayload({
             challenge: selectedChallenge,
             credential,
             init,
             input,
             method: selected.method,
-            response: paymentResponse,
+            response,
           }),
         )
-      return paymentResponse
+
+        response = await baseFetch(
+          resolvePaymentRetryInput(response, initialRequest.input, initialRequest.input),
+          transport.setCredential(
+            {
+              ...fetchInit,
+              headers: initialRequest.headers,
+            },
+            credential,
+            { challenge: selectedChallenge },
+          ),
+        )
+        if (response.ok)
+          await events.emit(
+            'payment.response',
+            createPaymentResponsePayload({
+              challenge: selectedChallenge,
+              credential,
+              init,
+              input,
+              method: selected.method,
+              response,
+            }),
+          )
+        if (!(await transport.isPaymentRequired(response, transportRequest as never)))
+          return response
+      }
+      return response
     } catch (error) {
       await events.emit(
         'payment.failed',
@@ -335,6 +342,8 @@ export declare namespace from {
     fetch?: typeof globalThis.fetch
     /** Advanced shared event dispatcher. `challenge.received` handlers run before `onChallenge`; the first non-empty credential returned by a handler skips `onChallenge`. */
     eventDispatcher?: ClientEventDispatcher<methods, any> | undefined
+    /** Maximum number of payment challenge retries after the initial response. @default 3 */
+    maxPaymentRetries?: number | undefined
     /** Array of methods to use. */
     methods: methods
     /** Called when a 402 challenge is received and no event handler supplies a credential. */

--- a/src/tempo/session/client/SessionManager.test.ts
+++ b/src/tempo/session/client/SessionManager.test.ts
@@ -466,6 +466,53 @@ describe('Session', () => {
       expect(s.channelId).not.toBe(storedChannelId)
     })
 
+    test('rolls back an optimistic open when a replacement challenge does not reference it', async () => {
+      const { store, delete: remove } = makeChannelStore()
+      const postedPayloads: SessionCredentialPayload[] = []
+      const challenge = (feePayer: boolean) =>
+        makeChallenge({
+          methodDetails: {
+            escrowContract: tip20ChannelEscrow,
+            chainId: 4217,
+            sessionProtocol: Constants.SessionProtocols.v2,
+            feePayer,
+          },
+        })
+      let openCount = 0
+      const mockFetch = vi.fn().mockImplementation((_input, init?: RequestInit) => {
+        const authorization = new Headers(init?.headers).get(Constants.Headers.authorization)
+        const payload = authorization
+          ? Credential.deserialize<SessionCredentialPayload>(authorization).payload
+          : undefined
+        if (payload) postedPayloads.push(payload)
+
+        if (!payload) return Promise.resolve(make402Response(challenge(true)))
+        if (payload.action === 'open') {
+          openCount++
+          if (openCount === 1) return Promise.resolve(make402Response(challenge(false)))
+          return Promise.resolve(makeOkResponse())
+        }
+        return Promise.resolve(new Response('unexpected voucher', { status: 500 }))
+      })
+      const s = sessionManager({
+        account,
+        client,
+        fetch: mockFetch as typeof globalThis.fetch,
+        maxDeposit: '10',
+        channelStore: store,
+      })
+
+      const response = await s.fetch('https://api.example.com/data')
+
+      expect(response.status).toBe(200)
+      // A replacement challenge with no snapshot means the server did not
+      // acknowledge the optimistic open, so the next credential must open again.
+      expect(postedPayloads.map((payload) => payload.action)).toEqual(['open', 'open'])
+      expect(postedPayloads[0]?.channelId).not.toBe(postedPayloads[1]?.channelId)
+      expect(remove).toHaveBeenCalledOnce()
+      expect(s.channelId).toBe(postedPayloads[1]?.channelId)
+    })
+
     test('does not bootstrap when disabled', async () => {
       const mockFetch = vi.fn().mockResolvedValue(makeOkResponse())
       const s = sessionManager({
@@ -686,6 +733,7 @@ describe('Session', () => {
                 methodDetails: {
                   escrowContract: tip20ChannelEscrow,
                   chainId: 4217,
+                  sessionProtocol: Constants.SessionProtocols.v2,
                   sessionSnapshot: {
                     acceptedCumulative: '2000000',
                     chainId: 4217,
@@ -887,8 +935,7 @@ describe('Session', () => {
         }
         if (callCount === 1)
           return Promise.resolve(make402Response(makeChallenge({ suggestedDeposit: '3000000' })))
-        if (callCount === 3) return Promise.resolve(make402Response())
-        if (callCount === 4) return Promise.resolve(make402Response())
+        if (callCount >= 3 && callCount <= 6) return Promise.resolve(make402Response())
         return Promise.resolve(makeOkResponse())
       })
 
@@ -907,8 +954,14 @@ describe('Session', () => {
       expect(s.cumulative).toBe(1000000n)
 
       await s.topUp('1')
-      expect(postedPayloads.map((payload) => payload.action)).toEqual(['open', 'voucher', 'topUp'])
-      const topUpPayload = postedPayloads[2]
+      expect(postedPayloads.map((payload) => payload.action)).toEqual([
+        'open',
+        'voucher',
+        'voucher',
+        'voucher',
+        'topUp',
+      ])
+      const topUpPayload = postedPayloads[4]
       if (topUpPayload?.action !== 'topUp') throw new Error('expected top-up payload')
       expect(topUpPayload.additionalDeposit).toBe('1000000')
     })

--- a/src/tempo/session/client/SessionManager.ts
+++ b/src/tempo/session/client/SessionManager.ts
@@ -201,9 +201,12 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
 
   // Tracks one fetch's channel reuse so stale stored entries can be evicted once.
   type ChannelUse = {
+    challengesReceived: number
+    created: Map<string, ChannelEntry>
     seenExisting: Set<string>
-    createdKeys: Set<string>
+    previous: RuntimeSnapshot
     resumed: ChannelEntry | undefined
+    trackCreates: boolean
   }
   let channelUse: ChannelUse | undefined
 
@@ -219,14 +222,15 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
       const entry = await getReusable(key)
       if (entry && channelUse) {
         channelUse.seenExisting.add(key)
-        if (!channelUse.createdKeys.has(key)) channelUse.resumed ??= entry
+        if (!channelUse.created.has(key)) channelUse.resumed ??= entry
       }
       return entry
     },
     async set(entry) {
       const key = entryKey(entry)
       if (entry.opened) ignoredChannelIds.delete(entry.channelId)
-      if (channelUse && !channelUse.seenExisting.has(key)) channelUse.createdKeys.add(key)
+      if (channelUse?.trackCreates && !channelUse.seenExisting.has(key))
+        channelUse.created.set(key, entry)
       await backing.set(entry)
     },
     delete: (key) => backing.delete(key),
@@ -236,6 +240,31 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
   async function ignoreChannel(entry: ChannelEntry) {
     ignoredChannelIds.add(entry.channelId)
     await Promise.resolve(backing.delete(entryKey(entry))).catch(() => undefined)
+  }
+
+  async function rollbackCreatedChannelsForRetry() {
+    const use = channelUse
+    if (!use?.created.size) return
+    for (const [key, entry] of use.created) {
+      ignoredChannelIds.add(entry.channelId)
+      await Promise.resolve(backing.delete(key)).catch(() => undefined)
+    }
+    use.created.clear()
+    restoreRuntime(use.previous)
+  }
+
+  function referencesCreatedChannel(challenge: Challenge.Challenge): boolean {
+    const snapshot = Constants.getMethodDetail<{ channelId?: unknown }>(
+      challenge.request.methodDetails,
+      Constants.MethodDetailKeys.sessionSnapshot,
+    )
+    if (typeof snapshot?.channelId !== 'string') return false
+    const use = channelUse
+    if (!use?.created.size) return false
+    for (const entry of use.created.values()) {
+      if (entry.channelId.toLowerCase() === snapshot.channelId.toLowerCase()) return true
+    }
+    return false
   }
 
   function dispatch(event: Parameters<typeof dispatchSessionEvent>[1]) {
@@ -273,6 +302,14 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
     methods: [method],
     onChallenge: async (challenge, _helpers) => {
       if (!isTempoSessionChallenge(challenge)) return undefined
+      const use = channelUse
+      const isRepeatedRetryChallenge =
+        use && use.challengesReceived > 0 && challenge.id === runtime.lastChallenge?.id
+      if (!referencesCreatedChannel(challenge)) {
+        if (use?.created.size) await rollbackCreatedChannelsForRetry()
+        else if (isRepeatedRetryChallenge) restoreRuntime(use.previous)
+      }
+      if (use) use.challengesReceived++
       runtime.lastChallenge = challenge
       dispatch({ type: 'challengeReceived', challengeId: challenge.id })
       if (runtime.channel?.opened && runtime.lastUrl) {
@@ -498,9 +535,6 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
       throw new Error(
         'SessionManager: a request is already in flight; concurrent requests on one manager are not supported',
       )
-    const use: ChannelUse = { seenExisting: new Set(), createdKeys: new Set(), resumed: undefined }
-    channelUse = use
-
     runtime.lastUrl = input
 
     const previous = captureRuntimeStateSnapshot({
@@ -508,12 +542,22 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
       spent: runtime.spent,
       state: runtime.state,
     })
+    const use: ChannelUse = {
+      challengesReceived: 0,
+      created: new Map(),
+      previous,
+      seenExisting: new Set(),
+      resumed: undefined,
+      trackCreates: false,
+    }
+    channelUse = use
 
     // Cold starts resume from `channelStore` after the 402 reveals the scope.
     const liveHint = runtime.channel?.opened ? runtime.channel.channelId : undefined
 
     try {
       await bootstrapSession(input, init)
+      use.trackCreates = true
 
       let effectiveInit = requestInitWithSessionHint(input, init, liveHint)
       // Stored channels may be stale, so retry once after evicting the resumed entry.


### PR DESCRIPTION
## Summary

- Added bounded incremental 402 retry handling to client fetch.
- Added `maxPaymentRetries` configuration on `Fetch.from()` and `Mppx.create()`, defaulting to 3.
- Reset session client retry state so failed open/voucher attempts do not poison subsequent challenge handling.
- Added a patch changeset.

## Motivation

Some payment flows can return a second 402 with updated terms after a failed credential attempt. Clients should be able to re-read the latest challenge and sign a fresh credential without unbounded retry loops.

## Key design considerations

- Retries are bounded by `maxPaymentRetries`, preserving the default cap of 3.
- Each retry creates a credential from the latest challenge rather than reusing prior payloads.
- Session manager state is restored between failed retry attempts, while snapshot-backed successful opens are preserved.
