### PR TITLE
feat(cli): add mppx validate command for end-to-end server validation

### DIFF
--- a/src/cli/account.ts
+++ b/src/cli/account.ts
@@ -203,6 +203,7 @@ export function createKeychain(account = 'main') {
   }
 }
 
+
 /**
  * Resolve a CLI account to a viem `LocalAccount`.
  *

--- a/src/cli/account.ts
+++ b/src/cli/account.ts
@@ -203,7 +203,6 @@ export function createKeychain(account = 'main') {
   }
 }
 
-
 /**
  * Resolve a CLI account to a viem `LocalAccount`.
  *

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -8,6 +8,7 @@ import { type Address, createClient, http } from 'viem'
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
 import { tempo as tempoMainnet } from 'viem/tempo/chains'
 
+import validate from './validate/index.js'
 import * as Challenge from '../Challenge.js'
 import { normalizeHeaders } from '../client/internal/Fetch.js'
 import * as Mppx from '../client/Mppx.js'
@@ -1539,5 +1540,6 @@ cli.command(discover)
 cli.command(init)
 cli.command(services)
 cli.command(sign)
+cli.command(validate)
 
 export default cli

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -8,7 +8,6 @@ import { type Address, createClient, http } from 'viem'
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
 import { tempo as tempoMainnet } from 'viem/tempo/chains'
 
-import validate from './validate/index.js'
 import * as Challenge from '../Challenge.js'
 import { normalizeHeaders } from '../client/internal/Fetch.js'
 import * as Mppx from '../client/Mppx.js'
@@ -37,6 +36,7 @@ import {
   resolveFundingNetwork,
   resolveRpcUrl,
 } from './utils.js'
+import validate from './validate/index.js'
 
 const packageJson = createRequire(import.meta.url)('../../package.json') as {
   name: string

--- a/src/cli/mcp.test.ts
+++ b/src/cli/mcp.test.ts
@@ -194,6 +194,7 @@ test('tools/list exposes mppx commands with input and output schemas', async () 
     'services_list',
     'services_show',
     'sign',
+    'validate',
   ])
   expect(tools.find((tool: { name: string }) => tool.name === 'account_list').outputSchema).toEqual(
     expect.objectContaining({

--- a/src/cli/validate.test.ts
+++ b/src/cli/validate.test.ts
@@ -1,0 +1,399 @@
+import type * as http from 'node:http'
+
+import { afterEach, describe, expect, test } from 'vp/test'
+import * as Http from '~test/Http.js'
+
+import * as Challenge from '../Challenge.js'
+import * as Constants from '../Constants.js'
+import * as Receipt from '../Receipt.js'
+import validate from './validate/index.js'
+
+// Auto-cleanup for test servers
+const servers: Http.TestServer[] = []
+afterEach(() => { servers.forEach((s) => s.close()); servers.length = 0 })
+
+async function testServer(handler: http.RequestListener) {
+  const s = await Http.createServer(handler)
+  servers.push(s)
+  return s
+}
+
+async function serve(argv: string[]) {
+  let output = ''
+  let exitCode: number | undefined
+  const origLog = console.log
+  const origStdout = process.stdout.write
+  const origStderr = process.stderr.write
+  console.log = (...args: unknown[]) => { output += `${args.map(String).join(' ')}\n` }
+  process.stdout.write = ((chunk: unknown) => { output += typeof chunk === 'string' ? chunk : String(chunk); return true }) as typeof process.stdout.write
+  process.stderr.write = ((chunk: unknown) => { output += typeof chunk === 'string' ? chunk : String(chunk); return true }) as typeof process.stderr.write
+  try {
+    const { Cli } = await import('incur')
+    const cli = Cli.create('mppx', {})
+    cli.command(validate)
+    await cli.serve(argv, {
+      stdout(s: string) { output += s },
+      exit(code: number) { exitCode = code },
+    })
+  } finally {
+    console.log = origLog
+    process.stdout.write = origStdout
+    process.stderr.write = origStderr
+  }
+  return { output, exitCode }
+}
+
+function makeChallenge(overrides?: Partial<Challenge.Challenge>) {
+  return {
+    id: 'test-id-123',
+    realm: 'localhost',
+    method: 'tempo',
+    intent: 'charge',
+    request: {
+      amount: '10000',
+      currency: '0x20c0000000000000000000000000000000000000',
+      recipient: '0x1234567890123456789012345678901234567890',
+      methodDetails: { chainId: 42431 },
+    },
+    expires: new Date(Date.now() + 300_000).toISOString(),
+    ...overrides,
+  } as Challenge.Challenge
+}
+
+function makeDiscoveryDoc(endpoints: Record<string, { method?: string; amount?: string; requestBody?: unknown }> = {}) {
+  const paths: Record<string, unknown> = {}
+  for (const [path, opts] of Object.entries(endpoints)) {
+    const op: Record<string, unknown> = {
+      'x-payment-info': { method: 'tempo', intent: 'charge', amount: opts.amount ?? '10000' },
+      responses: { '402': { description: 'Payment required' } },
+    }
+    if (opts.requestBody) op.requestBody = opts.requestBody
+    paths[path] = { [opts.method?.toLowerCase() ?? 'post']: op }
+  }
+  return JSON.stringify({ openapi: '3.1.0', info: { title: 'Test', version: '1.0.0' }, paths })
+}
+
+async function mppServer(challenge: Challenge.Challenge, opts?: { errorStatus?: number; postPaymentStatus?: number }) {
+  return testServer((req, res) => {
+    const url = new URL(req.url!, 'http://localhost')
+    if (url.pathname === '/openapi.json') {
+      res.setHeader('Content-Type', 'application/json')
+      res.end(makeDiscoveryDoc({ '/api/test': {} }))
+      return
+    }
+    const hasAuth = req.headers[Constants.Headers.authorization.toLowerCase()]
+    if (hasAuth && hasAuth !== `${Constants.Schemes.payment} dGhpcyBpcyBnYXJiYWdl`) {
+      const status = opts?.postPaymentStatus ?? 200
+      const receipt = Receipt.serialize({ method: 'tempo', status: 'success', reference: '0x' + 'ab'.repeat(32), timestamp: new Date().toISOString() })
+      res.writeHead(status, { [Constants.Headers.paymentReceipt]: receipt, 'content-type': 'application/json' })
+      res.end(JSON.stringify({ result: 'ok' }))
+    } else if (hasAuth) {
+      const errorStatus = opts?.errorStatus ?? 402
+      if (errorStatus === 402) {
+        res.writeHead(402, { [Constants.Headers.wwwAuthenticate]: Challenge.serialize(challenge) })
+      } else {
+        res.writeHead(errorStatus)
+      }
+      res.end()
+    } else {
+      res.writeHead(402, { [Constants.Headers.wwwAuthenticate]: Challenge.serialize(challenge) })
+      res.end()
+    }
+  })
+}
+
+describe('validate: discovery', () => {
+  test('succeeds with valid discovery doc', { timeout: 15_000 }, async () => {
+    const server = await mppServer(makeChallenge())
+    const { output } = await serve(['validate', server.url])
+    expect(output).toContain('Document found and parseable')
+    expect(output).toContain('Valid OpenAPI structure')
+    expect(output).toContain('Paid endpoints found')
+  })
+
+  test('reports missing discovery doc', { timeout: 15_000 }, async () => {
+    const server = await testServer((_req, res) => { res.writeHead(404); res.end() })
+    const { output, exitCode } = await serve(['validate', server.url])
+    expect(exitCode).toBe(1)
+    expect(output).toContain('No discovery document found.')
+    expect(output).toContain('MPP servers must serve an OpenAPI document at /openapi.json')
+    expect(output).toContain('To test a specific endpoint: mppx validate <url> --endpoint POST:/your/path')
+  })
+
+  test('strips /openapi.json from input URL', { timeout: 15_000 }, async () => {
+    const server = await mppServer(makeChallenge())
+    const { output } = await serve(['validate', `${server.url}/openapi.json`])
+    expect(output).toContain('Document found and parseable')
+  })
+
+  test('reports invalid JSON', { timeout: 15_000 }, async () => {
+    const server = await testServer((req, res) => {
+      if (req.url?.includes('openapi.json')) { res.setHeader('Content-Type', 'application/json'); res.end('not json{{{') }
+      else { res.writeHead(404); res.end() }
+    })
+    const { output, exitCode } = await serve(['validate', server.url])
+    expect(exitCode).toBe(1)
+    expect(output).toContain('Invalid JSON')
+  })
+
+  test('handles no paid endpoints in discovery', { timeout: 15_000 }, async () => {
+    const server = await testServer((req, res) => {
+      if (req.url?.includes('openapi.json')) {
+        res.setHeader('Content-Type', 'application/json')
+        res.end(JSON.stringify({ openapi: '3.1.0', info: { title: 'T', version: '1' }, paths: { '/health': { get: { responses: { '200': {} } } } } }))
+      } else { res.writeHead(200); res.end() }
+    })
+    const { output, exitCode } = await serve(['validate', server.url])
+    expect(exitCode).toBe(1)
+    expect(output).toContain('Paid endpoints found (No endpoints with x-payment-info)')
+    expect(output).toContain('Use --endpoint to specify endpoints manually.')
+  })
+
+  test('falls back to 402 response heuristic', { timeout: 15_000 }, async () => {
+    const challenge = makeChallenge()
+    const server = await testServer((req, res) => {
+      const url = new URL(req.url!, 'http://localhost')
+      if (url.pathname === '/openapi.json') {
+        res.setHeader('Content-Type', 'application/json')
+        res.end(JSON.stringify({
+          openapi: '3.1.0', info: { title: 'T', version: '1' },
+          paths: { '/api/data': { get: { responses: { '402': { description: 'Payment required' } } } } },
+        }))
+      } else {
+        res.writeHead(402, { [Constants.Headers.wwwAuthenticate]: Challenge.serialize(challenge) })
+        res.end()
+      }
+    })
+    const { output } = await serve(['validate', server.url])
+    expect(output).toContain('Paid endpoints found')
+    expect(output).toContain('Challenge parseable')
+  })
+})
+
+describe('validate: challenge', () => {
+  test('validates correct MPP challenge', { timeout: 15_000 }, async () => {
+    const server = await mppServer(makeChallenge())
+    const { output } = await serve(['validate', server.url])
+    expect(output).toContain('Challenge parseable (tempo/charge)')
+    expect(output).toContain('Challenge has id')
+    expect(output).toContain('Challenge has realm')
+    expect(output).toContain('Valid recipient address')
+    expect(output).toContain('Valid currency address (testnet)')
+    expect(output).toContain('Amount is valid integer string')
+  })
+
+  test('fails on expired challenge', { timeout: 15_000 }, async () => {
+    const server = await mppServer(makeChallenge({ expires: '2020-01-01T00:00:00Z' }))
+    const { output } = await serve(['validate', server.url])
+    expect(output).toContain('Challenge expires in the future (Expired at 2020-01-01T00:00:00Z)')
+    expect(output).toContain('The expires timestamp must be in the future')
+  })
+
+  test('warns on realm mismatch', { timeout: 15_000 }, async () => {
+    const server = await mppServer(makeChallenge({ realm: 'other.example.com' }))
+    const { output } = await serve(['validate', server.url])
+    expect(output).toContain('Realm matches server hostname (realm="other.example.com" vs host="localhost")')
+    expect(output).toContain('Set the realm to your production hostname')
+  })
+
+  test('fails on invalid recipient address', { timeout: 15_000 }, async () => {
+    const challenge = makeChallenge()
+    ;(challenge.request as Record<string, unknown>).recipient = 'not-an-address'
+    const server = await mppServer(challenge)
+    const { output } = await serve(['validate', server.url])
+    expect(output).toContain('Valid recipient address (Got: not-an-address)')
+    expect(output).toContain('Set request.recipient to a valid 0x-prefixed 40-hex-char address')
+  })
+
+  test('fails on invalid amount', { timeout: 15_000 }, async () => {
+    const challenge = makeChallenge()
+    ;(challenge.request as Record<string, unknown>).amount = '12.5'
+    const server = await mppServer(challenge)
+    const { output } = await serve(['validate', server.url])
+    expect(output).toContain('Amount is valid integer string (Got: 12.5)')
+    expect(output).toContain('request.amount must be a string of digits')
+  })
+
+  test('detects non-MPP endpoint (x402)', { timeout: 15_000 }, async () => {
+    const server = await testServer((req, res) => {
+      const url = new URL(req.url!, 'http://localhost')
+      if (url.pathname === '/openapi.json') { res.setHeader('Content-Type', 'application/json'); res.end(makeDiscoveryDoc({ '/api/test': {} })) }
+      else { res.writeHead(402, { 'payment-required': 'eyJ0ZXN0IjoxfQ==' }); res.end() }
+    })
+    const { output, exitCode } = await serve(['validate', server.url])
+    expect(output).toContain('Not an MPP endpoint (No WWW-Authenticate header (may be x402 or other protocol))')
+    expect(exitCode).toBe(1)
+  })
+
+  test('skips 200 response', { timeout: 15_000 }, async () => {
+    const server = await testServer((req, res) => {
+      const url = new URL(req.url!, 'http://localhost')
+      if (url.pathname === '/openapi.json') { res.setHeader('Content-Type', 'application/json'); res.end(makeDiscoveryDoc({ '/api/test': { method: 'GET' } })) }
+      else { res.writeHead(200); res.end('ok') }
+    })
+    const { output } = await serve(['validate', server.url])
+    expect(output).toContain('Returns 402 without credentials (Got 200 (endpoint may not require payment in all cases))')
+  })
+
+  test('skips 401 as auth-gated', { timeout: 15_000 }, async () => {
+    const server = await testServer((req, res) => {
+      const url = new URL(req.url!, 'http://localhost')
+      if (url.pathname === '/openapi.json') { res.setHeader('Content-Type', 'application/json'); res.end(makeDiscoveryDoc({ '/api/test': {} })) }
+      else { res.writeHead(401); res.end() }
+    })
+    const { output } = await serve(['validate', server.url])
+    expect(output).toContain('Returns 402 without credentials (Got 401 (endpoint requires auth before payment gate))')
+  })
+
+  test('retries with body on 400', { timeout: 15_000 }, async () => {
+    const challenge = makeChallenge()
+    const doc = JSON.stringify({
+      openapi: '3.1.0', info: { title: 'T', version: '1' },
+      paths: { '/api/test': { post: {
+        'x-payment-info': { method: 'tempo', intent: 'charge', amount: '10000' },
+        responses: { '402': {} },
+        requestBody: { required: true, content: { 'application/json': { schema: { type: 'object', required: ['q'], properties: { q: { type: 'string', example: 'hello' } } } } } },
+      } } },
+    })
+    let requestCount = 0
+    const server = await testServer((req, res) => {
+      const url = new URL(req.url!, 'http://localhost')
+      if (url.pathname === '/openapi.json') { res.setHeader('Content-Type', 'application/json'); res.end(doc) }
+      else {
+        requestCount++
+        const hasAuth = req.headers[Constants.Headers.authorization.toLowerCase()]
+        if (hasAuth) { res.writeHead(402, { [Constants.Headers.wwwAuthenticate]: Challenge.serialize(challenge) }); res.end() }
+        else if (requestCount === 1) { res.writeHead(400); res.end() }
+        else { res.writeHead(402, { [Constants.Headers.wwwAuthenticate]: Challenge.serialize(challenge) }); res.end() }
+      }
+    })
+    const { output } = await serve(['validate', server.url])
+    expect(output).toContain('Challenge parseable')
+    expect(requestCount).toBeGreaterThan(1)
+  })
+})
+
+describe('validate: error handling', () => {
+  test('passes when malformed credential returns 402', { timeout: 15_000 }, async () => {
+    const server = await mppServer(makeChallenge())
+    const { output } = await serve(['validate', server.url])
+    expect(output).toContain('Malformed credential returns 402 (not 500)')
+  })
+
+  test('fails when malformed credential returns 500', { timeout: 15_000 }, async () => {
+    const server = await mppServer(makeChallenge(), { errorStatus: 500 })
+    const { output } = await serve(['validate', server.url])
+    expect(output).toContain('Malformed credential returns 402 (Got 500 (server error))')
+    expect(output).toContain('When the Authorization header contains an invalid credential, respond with 402 (not 500)')
+  })
+
+  test('warns when malformed credential returns other status', { timeout: 15_000 }, async () => {
+    const server = await mppServer(makeChallenge(), { errorStatus: 422 })
+    const { output } = await serve(['validate', server.url])
+    expect(output).toContain('Malformed credential returns 402 (Got 422)')
+    expect(output).toContain('Returning 422 prevents the client from retrying with a valid payment')
+  })
+})
+
+describe('validate: --endpoint flag', () => {
+  test('checks discovery even with --endpoint', { timeout: 15_000 }, async () => {
+    const challenge = makeChallenge()
+    const server = await testServer((_req, res) => {
+      res.writeHead(402, { [Constants.Headers.wwwAuthenticate]: Challenge.serialize(challenge) })
+      res.end()
+    })
+    const { output } = await serve(['validate', server.url, '--endpoint', 'POST:/api/test'])
+    expect(output).toContain('Discovery (/openapi.json)')
+    // Discovery fails (server only returns 402) but doesn't block --endpoint testing
+    expect(output).toContain('Document found')
+    expect(output).toContain('Challenge parseable')
+  })
+
+  test('uses --body directly with --endpoint', { timeout: 15_000 }, async () => {
+    const challenge = makeChallenge()
+    const bodies: string[] = []
+    const server = await testServer((req, res) => {
+      let body = ''
+      req.on('data', (chunk) => { body += chunk })
+      req.on('end', () => {
+        bodies.push(body)
+        res.writeHead(402, { [Constants.Headers.wwwAuthenticate]: Challenge.serialize(challenge) })
+        res.end()
+      })
+    })
+    await serve(['validate', server.url, '--endpoint', 'POST:/api/test', '--body', '{"test":true}'])
+    // Challenge phase: bare request first (no body)
+    expect(bodies[0]).toBe('')
+    // Payment phase: sends body with the credential request
+    const paymentRequest = bodies.find((b) => b === '{"test":true}')
+    expect(paymentRequest).toBe('{"test":true}')
+  })
+})
+
+describe('validate: no MPP endpoints', () => {
+  test('exits non-zero when all endpoints are x402', { timeout: 15_000 }, async () => {
+    const server = await testServer((req, res) => {
+      const url = new URL(req.url!, 'http://localhost')
+      if (url.pathname === '/openapi.json') { res.setHeader('Content-Type', 'application/json'); res.end(makeDiscoveryDoc({ '/api/a': {}, '/api/b': {} })) }
+      else { res.writeHead(402, { 'payment-required': 'eyJ0ZXN0IjoxfQ==' }); res.end() }
+    })
+    const { output, exitCode } = await serve(['validate', server.url])
+    expect(exitCode).toBe(1)
+    expect(output).toContain('No MPP endpoints found.')
+    expect(output).toContain('This server may use x402 or another payment protocol.')
+  })
+
+  test('shows auth-gated message when all return 401', { timeout: 15_000 }, async () => {
+    const server = await testServer((req, res) => {
+      const url = new URL(req.url!, 'http://localhost')
+      if (url.pathname === '/openapi.json') { res.setHeader('Content-Type', 'application/json'); res.end(makeDiscoveryDoc({ '/api/a': {}, '/api/b': {} })) }
+      else { res.writeHead(401); res.end() }
+    })
+    const { output, exitCode } = await serve(['validate', server.url])
+    expect(exitCode).toBe(1)
+    expect(output).toContain('Could not reach payment gate on any endpoint (all returned 401/403/200).')
+    expect(output).toContain('The server may require authentication before payment.')
+  })
+
+  test('mixed: some MPP, some not -- does not show "no MPP" message', { timeout: 15_000 }, async () => {
+    const challenge = makeChallenge()
+    const server = await testServer((req, res) => {
+      const url = new URL(req.url!, 'http://localhost')
+      if (url.pathname === '/openapi.json') { res.setHeader('Content-Type', 'application/json'); res.end(makeDiscoveryDoc({ '/api/paid': {}, '/api/free': {} })) }
+      else if (url.pathname === '/api/paid') { res.writeHead(402, { [Constants.Headers.wwwAuthenticate]: Challenge.serialize(challenge) }); res.end() }
+      else { res.writeHead(402, { 'payment-required': 'eyJ0ZXN0IjoxfQ==' }); res.end() }
+    })
+    const { output } = await serve(['validate', server.url])
+    expect(output).toContain('Challenge parseable')
+    expect(output).toContain('Not an MPP endpoint')
+    expect(output).not.toContain('No MPP endpoints found')
+  })
+})
+
+describe('validate: summary', () => {
+  test('shows pass count in summary', { timeout: 15_000 }, async () => {
+    const server = await mppServer(makeChallenge())
+    const { output } = await serve(['validate', server.url])
+    expect(output).toMatch(/\d+ passed/)
+    expect(output).toContain('Summary:')
+  })
+
+  test('shows skipped count when endpoints are skipped', { timeout: 15_000 }, async () => {
+    const challenge = makeChallenge()
+    const server = await testServer((req, res) => {
+      const url = new URL(req.url!, 'http://localhost')
+      if (url.pathname === '/openapi.json') { res.setHeader('Content-Type', 'application/json'); res.end(makeDiscoveryDoc({ '/api/mpp': {}, '/api/free': { method: 'GET' } })) }
+      else if (url.pathname === '/api/mpp') { res.writeHead(402, { [Constants.Headers.wwwAuthenticate]: Challenge.serialize(challenge) }); res.end() }
+      else { res.writeHead(200); res.end('ok') }
+    })
+    const { output } = await serve(['validate', server.url])
+    expect(output).toContain('skipped')
+  })
+
+  test('exits non-zero when there are failures', { timeout: 15_000 }, async () => {
+    const server = await mppServer(makeChallenge(), { errorStatus: 500 })
+    const { output, exitCode } = await serve(['validate', server.url])
+    expect(exitCode).toBe(1)
+    expect(output).toContain('failed')
+  })
+})

--- a/src/cli/validate.test.ts
+++ b/src/cli/validate.test.ts
@@ -10,7 +10,10 @@ import validate from './validate/index.js'
 
 // Auto-cleanup for test servers
 const servers: Http.TestServer[] = []
-afterEach(() => { servers.forEach((s) => s.close()); servers.length = 0 })
+afterEach(() => {
+  servers.forEach((s) => s.close())
+  servers.length = 0
+})
 
 async function testServer(handler: http.RequestListener) {
   const s = await Http.createServer(handler)
@@ -24,16 +27,28 @@ async function serve(argv: string[]) {
   const origLog = console.log
   const origStdout = process.stdout.write
   const origStderr = process.stderr.write
-  console.log = (...args: unknown[]) => { output += `${args.map(String).join(' ')}\n` }
-  process.stdout.write = ((chunk: unknown) => { output += typeof chunk === 'string' ? chunk : String(chunk); return true }) as typeof process.stdout.write
-  process.stderr.write = ((chunk: unknown) => { output += typeof chunk === 'string' ? chunk : String(chunk); return true }) as typeof process.stderr.write
+  console.log = (...args: unknown[]) => {
+    output += `${args.map(String).join(' ')}\n`
+  }
+  process.stdout.write = ((chunk: unknown) => {
+    output += typeof chunk === 'string' ? chunk : String(chunk)
+    return true
+  }) as typeof process.stdout.write
+  process.stderr.write = ((chunk: unknown) => {
+    output += typeof chunk === 'string' ? chunk : String(chunk)
+    return true
+  }) as typeof process.stderr.write
   try {
     const { Cli } = await import('incur')
     const cli = Cli.create('mppx', {})
     cli.command(validate)
     await cli.serve(argv, {
-      stdout(s: string) { output += s },
-      exit(code: number) { exitCode = code },
+      stdout(s: string) {
+        output += s
+      },
+      exit(code: number) {
+        exitCode = code
+      },
     })
   } finally {
     console.log = origLog
@@ -60,7 +75,9 @@ function makeChallenge(overrides?: Partial<Challenge.Challenge>) {
   } as Challenge.Challenge
 }
 
-function makeDiscoveryDoc(endpoints: Record<string, { method?: string; amount?: string; requestBody?: unknown }> = {}) {
+function makeDiscoveryDoc(
+  endpoints: Record<string, { method?: string; amount?: string; requestBody?: unknown }> = {},
+) {
   const paths: Record<string, unknown> = {}
   for (const [path, opts] of Object.entries(endpoints)) {
     const op: Record<string, unknown> = {
@@ -73,7 +90,10 @@ function makeDiscoveryDoc(endpoints: Record<string, { method?: string; amount?: 
   return JSON.stringify({ openapi: '3.1.0', info: { title: 'Test', version: '1.0.0' }, paths })
 }
 
-async function mppServer(challenge: Challenge.Challenge, opts?: { errorStatus?: number; postPaymentStatus?: number }) {
+async function mppServer(
+  challenge: Challenge.Challenge,
+  opts?: { errorStatus?: number; postPaymentStatus?: number },
+) {
   return testServer((req, res) => {
     const url = new URL(req.url!, 'http://localhost')
     if (url.pathname === '/openapi.json') {
@@ -84,8 +104,16 @@ async function mppServer(challenge: Challenge.Challenge, opts?: { errorStatus?: 
     const hasAuth = req.headers[Constants.Headers.authorization.toLowerCase()]
     if (hasAuth && hasAuth !== `${Constants.Schemes.payment} dGhpcyBpcyBnYXJiYWdl`) {
       const status = opts?.postPaymentStatus ?? 200
-      const receipt = Receipt.serialize({ method: 'tempo', status: 'success', reference: '0x' + 'ab'.repeat(32), timestamp: new Date().toISOString() })
-      res.writeHead(status, { [Constants.Headers.paymentReceipt]: receipt, 'content-type': 'application/json' })
+      const receipt = Receipt.serialize({
+        method: 'tempo',
+        status: 'success',
+        reference: '0x' + 'ab'.repeat(32),
+        timestamp: new Date().toISOString(),
+      })
+      res.writeHead(status, {
+        [Constants.Headers.paymentReceipt]: receipt,
+        'content-type': 'application/json',
+      })
       res.end(JSON.stringify({ result: 'ok' }))
     } else if (hasAuth) {
       const errorStatus = opts?.errorStatus ?? 402
@@ -112,12 +140,17 @@ describe('validate: discovery', () => {
   })
 
   test('reports missing discovery doc', { timeout: 15_000 }, async () => {
-    const server = await testServer((_req, res) => { res.writeHead(404); res.end() })
+    const server = await testServer((_req, res) => {
+      res.writeHead(404)
+      res.end()
+    })
     const { output, exitCode } = await serve(['validate', server.url])
     expect(exitCode).toBe(1)
     expect(output).toContain('No discovery document found.')
     expect(output).toContain('MPP servers must serve an OpenAPI document at /openapi.json')
-    expect(output).toContain('To test a specific endpoint: mppx validate <url> --endpoint POST:/your/path')
+    expect(output).toContain(
+      'To test a specific endpoint: mppx validate <url> --endpoint POST:/your/path',
+    )
   })
 
   test('strips /openapi.json from input URL', { timeout: 15_000 }, async () => {
@@ -128,8 +161,13 @@ describe('validate: discovery', () => {
 
   test('reports invalid JSON', { timeout: 15_000 }, async () => {
     const server = await testServer((req, res) => {
-      if (req.url?.includes('openapi.json')) { res.setHeader('Content-Type', 'application/json'); res.end('not json{{{') }
-      else { res.writeHead(404); res.end() }
+      if (req.url?.includes('openapi.json')) {
+        res.setHeader('Content-Type', 'application/json')
+        res.end('not json{{{')
+      } else {
+        res.writeHead(404)
+        res.end()
+      }
     })
     const { output, exitCode } = await serve(['validate', server.url])
     expect(exitCode).toBe(1)
@@ -140,8 +178,17 @@ describe('validate: discovery', () => {
     const server = await testServer((req, res) => {
       if (req.url?.includes('openapi.json')) {
         res.setHeader('Content-Type', 'application/json')
-        res.end(JSON.stringify({ openapi: '3.1.0', info: { title: 'T', version: '1' }, paths: { '/health': { get: { responses: { '200': {} } } } } }))
-      } else { res.writeHead(200); res.end() }
+        res.end(
+          JSON.stringify({
+            openapi: '3.1.0',
+            info: { title: 'T', version: '1' },
+            paths: { '/health': { get: { responses: { '200': {} } } } },
+          }),
+        )
+      } else {
+        res.writeHead(200)
+        res.end()
+      }
     })
     const { output, exitCode } = await serve(['validate', server.url])
     expect(exitCode).toBe(1)
@@ -155,10 +202,15 @@ describe('validate: discovery', () => {
       const url = new URL(req.url!, 'http://localhost')
       if (url.pathname === '/openapi.json') {
         res.setHeader('Content-Type', 'application/json')
-        res.end(JSON.stringify({
-          openapi: '3.1.0', info: { title: 'T', version: '1' },
-          paths: { '/api/data': { get: { responses: { '402': { description: 'Payment required' } } } } },
-        }))
+        res.end(
+          JSON.stringify({
+            openapi: '3.1.0',
+            info: { title: 'T', version: '1' },
+            paths: {
+              '/api/data': { get: { responses: { '402': { description: 'Payment required' } } } },
+            },
+          }),
+        )
       } else {
         res.writeHead(402, { [Constants.Headers.wwwAuthenticate]: Challenge.serialize(challenge) })
         res.end()
@@ -192,7 +244,9 @@ describe('validate: challenge', () => {
   test('warns on realm mismatch', { timeout: 15_000 }, async () => {
     const server = await mppServer(makeChallenge({ realm: 'other.example.com' }))
     const { output } = await serve(['validate', server.url])
-    expect(output).toContain('Realm matches server hostname (realm="other.example.com" vs host="localhost")')
+    expect(output).toContain(
+      'Realm matches server hostname (realm="other.example.com" vs host="localhost")',
+    )
     expect(output).toContain('Set the realm to your production hostname')
   })
 
@@ -217,54 +271,104 @@ describe('validate: challenge', () => {
   test('detects non-MPP endpoint (x402)', { timeout: 15_000 }, async () => {
     const server = await testServer((req, res) => {
       const url = new URL(req.url!, 'http://localhost')
-      if (url.pathname === '/openapi.json') { res.setHeader('Content-Type', 'application/json'); res.end(makeDiscoveryDoc({ '/api/test': {} })) }
-      else { res.writeHead(402, { 'payment-required': 'eyJ0ZXN0IjoxfQ==' }); res.end() }
+      if (url.pathname === '/openapi.json') {
+        res.setHeader('Content-Type', 'application/json')
+        res.end(makeDiscoveryDoc({ '/api/test': {} }))
+      } else {
+        res.writeHead(402, { 'payment-required': 'eyJ0ZXN0IjoxfQ==' })
+        res.end()
+      }
     })
     const { output, exitCode } = await serve(['validate', server.url])
-    expect(output).toContain('Not an MPP endpoint (No WWW-Authenticate header (may be x402 or other protocol))')
+    expect(output).toContain(
+      'Not an MPP endpoint (No WWW-Authenticate header (may be x402 or other protocol))',
+    )
     expect(exitCode).toBe(1)
   })
 
   test('skips 200 response', { timeout: 15_000 }, async () => {
     const server = await testServer((req, res) => {
       const url = new URL(req.url!, 'http://localhost')
-      if (url.pathname === '/openapi.json') { res.setHeader('Content-Type', 'application/json'); res.end(makeDiscoveryDoc({ '/api/test': { method: 'GET' } })) }
-      else { res.writeHead(200); res.end('ok') }
+      if (url.pathname === '/openapi.json') {
+        res.setHeader('Content-Type', 'application/json')
+        res.end(makeDiscoveryDoc({ '/api/test': { method: 'GET' } }))
+      } else {
+        res.writeHead(200)
+        res.end('ok')
+      }
     })
     const { output } = await serve(['validate', server.url])
-    expect(output).toContain('Returns 402 without credentials (Got 200 (endpoint may not require payment in all cases))')
+    expect(output).toContain(
+      'Returns 402 without credentials (Got 200 (endpoint may not require payment in all cases))',
+    )
   })
 
   test('skips 401 as auth-gated', { timeout: 15_000 }, async () => {
     const server = await testServer((req, res) => {
       const url = new URL(req.url!, 'http://localhost')
-      if (url.pathname === '/openapi.json') { res.setHeader('Content-Type', 'application/json'); res.end(makeDiscoveryDoc({ '/api/test': {} })) }
-      else { res.writeHead(401); res.end() }
+      if (url.pathname === '/openapi.json') {
+        res.setHeader('Content-Type', 'application/json')
+        res.end(makeDiscoveryDoc({ '/api/test': {} }))
+      } else {
+        res.writeHead(401)
+        res.end()
+      }
     })
     const { output } = await serve(['validate', server.url])
-    expect(output).toContain('Returns 402 without credentials (Got 401 (endpoint requires auth before payment gate))')
+    expect(output).toContain(
+      'Returns 402 without credentials (Got 401 (endpoint requires auth before payment gate))',
+    )
   })
 
   test('retries with body on 400', { timeout: 15_000 }, async () => {
     const challenge = makeChallenge()
     const doc = JSON.stringify({
-      openapi: '3.1.0', info: { title: 'T', version: '1' },
-      paths: { '/api/test': { post: {
-        'x-payment-info': { method: 'tempo', intent: 'charge', amount: '10000' },
-        responses: { '402': {} },
-        requestBody: { required: true, content: { 'application/json': { schema: { type: 'object', required: ['q'], properties: { q: { type: 'string', example: 'hello' } } } } } },
-      } } },
+      openapi: '3.1.0',
+      info: { title: 'T', version: '1' },
+      paths: {
+        '/api/test': {
+          post: {
+            'x-payment-info': { method: 'tempo', intent: 'charge', amount: '10000' },
+            responses: { '402': {} },
+            requestBody: {
+              required: true,
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    required: ['q'],
+                    properties: { q: { type: 'string', example: 'hello' } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     })
     let requestCount = 0
     const server = await testServer((req, res) => {
       const url = new URL(req.url!, 'http://localhost')
-      if (url.pathname === '/openapi.json') { res.setHeader('Content-Type', 'application/json'); res.end(doc) }
-      else {
+      if (url.pathname === '/openapi.json') {
+        res.setHeader('Content-Type', 'application/json')
+        res.end(doc)
+      } else {
         requestCount++
         const hasAuth = req.headers[Constants.Headers.authorization.toLowerCase()]
-        if (hasAuth) { res.writeHead(402, { [Constants.Headers.wwwAuthenticate]: Challenge.serialize(challenge) }); res.end() }
-        else if (requestCount === 1) { res.writeHead(400); res.end() }
-        else { res.writeHead(402, { [Constants.Headers.wwwAuthenticate]: Challenge.serialize(challenge) }); res.end() }
+        if (hasAuth) {
+          res.writeHead(402, {
+            [Constants.Headers.wwwAuthenticate]: Challenge.serialize(challenge),
+          })
+          res.end()
+        } else if (requestCount === 1) {
+          res.writeHead(400)
+          res.end()
+        } else {
+          res.writeHead(402, {
+            [Constants.Headers.wwwAuthenticate]: Challenge.serialize(challenge),
+          })
+          res.end()
+        }
       }
     })
     const { output } = await serve(['validate', server.url])
@@ -284,7 +388,9 @@ describe('validate: error handling', () => {
     const server = await mppServer(makeChallenge(), { errorStatus: 500 })
     const { output } = await serve(['validate', server.url])
     expect(output).toContain('Malformed credential returns 402 (Got 500 (server error))')
-    expect(output).toContain('When the Authorization header contains an invalid credential, respond with 402 (not 500)')
+    expect(output).toContain(
+      'When the Authorization header contains an invalid credential, respond with 402 (not 500)',
+    )
   })
 
   test('warns when malformed credential returns other status', { timeout: 15_000 }, async () => {
@@ -314,7 +420,9 @@ describe('validate: --endpoint flag', () => {
     const bodies: string[] = []
     const server = await testServer((req, res) => {
       let body = ''
-      req.on('data', (chunk) => { body += chunk })
+      req.on('data', (chunk) => {
+        body += chunk
+      })
       req.on('end', () => {
         bodies.push(body)
         res.writeHead(402, { [Constants.Headers.wwwAuthenticate]: Challenge.serialize(challenge) })
@@ -334,8 +442,13 @@ describe('validate: no MPP endpoints', () => {
   test('exits non-zero when all endpoints are x402', { timeout: 15_000 }, async () => {
     const server = await testServer((req, res) => {
       const url = new URL(req.url!, 'http://localhost')
-      if (url.pathname === '/openapi.json') { res.setHeader('Content-Type', 'application/json'); res.end(makeDiscoveryDoc({ '/api/a': {}, '/api/b': {} })) }
-      else { res.writeHead(402, { 'payment-required': 'eyJ0ZXN0IjoxfQ==' }); res.end() }
+      if (url.pathname === '/openapi.json') {
+        res.setHeader('Content-Type', 'application/json')
+        res.end(makeDiscoveryDoc({ '/api/a': {}, '/api/b': {} }))
+      } else {
+        res.writeHead(402, { 'payment-required': 'eyJ0ZXN0IjoxfQ==' })
+        res.end()
+      }
     })
     const { output, exitCode } = await serve(['validate', server.url])
     expect(exitCode).toBe(1)
@@ -346,28 +459,48 @@ describe('validate: no MPP endpoints', () => {
   test('shows auth-gated message when all return 401', { timeout: 15_000 }, async () => {
     const server = await testServer((req, res) => {
       const url = new URL(req.url!, 'http://localhost')
-      if (url.pathname === '/openapi.json') { res.setHeader('Content-Type', 'application/json'); res.end(makeDiscoveryDoc({ '/api/a': {}, '/api/b': {} })) }
-      else { res.writeHead(401); res.end() }
+      if (url.pathname === '/openapi.json') {
+        res.setHeader('Content-Type', 'application/json')
+        res.end(makeDiscoveryDoc({ '/api/a': {}, '/api/b': {} }))
+      } else {
+        res.writeHead(401)
+        res.end()
+      }
     })
     const { output, exitCode } = await serve(['validate', server.url])
     expect(exitCode).toBe(1)
-    expect(output).toContain('Could not reach payment gate on any endpoint (all returned 401/403/200).')
+    expect(output).toContain(
+      'Could not reach payment gate on any endpoint (all returned 401/403/200).',
+    )
     expect(output).toContain('The server may require authentication before payment.')
   })
 
-  test('mixed: some MPP, some not -- does not show "no MPP" message', { timeout: 15_000 }, async () => {
-    const challenge = makeChallenge()
-    const server = await testServer((req, res) => {
-      const url = new URL(req.url!, 'http://localhost')
-      if (url.pathname === '/openapi.json') { res.setHeader('Content-Type', 'application/json'); res.end(makeDiscoveryDoc({ '/api/paid': {}, '/api/free': {} })) }
-      else if (url.pathname === '/api/paid') { res.writeHead(402, { [Constants.Headers.wwwAuthenticate]: Challenge.serialize(challenge) }); res.end() }
-      else { res.writeHead(402, { 'payment-required': 'eyJ0ZXN0IjoxfQ==' }); res.end() }
-    })
-    const { output } = await serve(['validate', server.url])
-    expect(output).toContain('Challenge parseable')
-    expect(output).toContain('Not an MPP endpoint')
-    expect(output).not.toContain('No MPP endpoints found')
-  })
+  test(
+    'mixed: some MPP, some not -- does not show "no MPP" message',
+    { timeout: 15_000 },
+    async () => {
+      const challenge = makeChallenge()
+      const server = await testServer((req, res) => {
+        const url = new URL(req.url!, 'http://localhost')
+        if (url.pathname === '/openapi.json') {
+          res.setHeader('Content-Type', 'application/json')
+          res.end(makeDiscoveryDoc({ '/api/paid': {}, '/api/free': {} }))
+        } else if (url.pathname === '/api/paid') {
+          res.writeHead(402, {
+            [Constants.Headers.wwwAuthenticate]: Challenge.serialize(challenge),
+          })
+          res.end()
+        } else {
+          res.writeHead(402, { 'payment-required': 'eyJ0ZXN0IjoxfQ==' })
+          res.end()
+        }
+      })
+      const { output } = await serve(['validate', server.url])
+      expect(output).toContain('Challenge parseable')
+      expect(output).toContain('Not an MPP endpoint')
+      expect(output).not.toContain('No MPP endpoints found')
+    },
+  )
 })
 
 describe('validate: summary', () => {
@@ -382,9 +515,16 @@ describe('validate: summary', () => {
     const challenge = makeChallenge()
     const server = await testServer((req, res) => {
       const url = new URL(req.url!, 'http://localhost')
-      if (url.pathname === '/openapi.json') { res.setHeader('Content-Type', 'application/json'); res.end(makeDiscoveryDoc({ '/api/mpp': {}, '/api/free': { method: 'GET' } })) }
-      else if (url.pathname === '/api/mpp') { res.writeHead(402, { [Constants.Headers.wwwAuthenticate]: Challenge.serialize(challenge) }); res.end() }
-      else { res.writeHead(200); res.end('ok') }
+      if (url.pathname === '/openapi.json') {
+        res.setHeader('Content-Type', 'application/json')
+        res.end(makeDiscoveryDoc({ '/api/mpp': {}, '/api/free': { method: 'GET' } }))
+      } else if (url.pathname === '/api/mpp') {
+        res.writeHead(402, { [Constants.Headers.wwwAuthenticate]: Challenge.serialize(challenge) })
+        res.end()
+      } else {
+        res.writeHead(200)
+        res.end('ok')
+      }
     })
     const { output } = await serve(['validate', server.url])
     expect(output).toContain('skipped')

--- a/src/cli/validate/challenge.ts
+++ b/src/cli/validate/challenge.ts
@@ -1,0 +1,237 @@
+import * as Challenge from '../../Challenge.js'
+import * as Constants from '../../Constants.js'
+import { pc } from '../utils.js'
+import { extractRequestBodyFromDiscovery } from './discovery.js'
+import type { CheckResult, EndpointSpec } from './helpers.js'
+import { buildUrl, check, fail, fetchWithTimeout, isValidAddress, isValidIntegerAmount, MAINNET_CHAIN_ID, skip, warn } from './helpers.js'
+
+function detectTestnet(challenge: Challenge.Challenge): boolean {
+  const request = challenge.request as Record<string, unknown>
+  const methodDetails = request.methodDetails as Record<string, unknown> | undefined
+  if (typeof methodDetails?.chainId === 'number') {
+    return methodDetails.chainId !== MAINNET_CHAIN_ID
+  }
+  return false
+}
+
+export async function validateChallenge(
+  baseUrl: string,
+  endpoint: EndpointSpec,
+  verbose: boolean,
+  options?: { body?: string | undefined; query?: string[] | undefined; discoveryDoc?: Record<string, unknown> | undefined },
+): Promise<{ results: CheckResult[]; resolvedBody?: string | undefined }> {
+  const results: CheckResult[] = []
+  const url = buildUrl(baseUrl, endpoint, options?.query)
+  const fetchHeaders: Record<string, string> = {}
+  let fetchBody: string | undefined
+
+  // Make bare unauthenticated request first (no body)
+  let response: Response
+  try {
+    response = await fetchWithTimeout(url, { method: endpoint.method })
+  } catch (error) {
+    results.push(fail('Request failed', (error as Error).message))
+    return { results }
+  }
+
+  // If we got 400, retry with body (explicit --body or auto-generated from schema)
+  if (response.status === 400) {
+    const bodyToTry = options?.body ?? (options?.discoveryDoc ? extractRequestBodyFromDiscovery(options.discoveryDoc, endpoint) : undefined)
+    if (bodyToTry) {
+      if (verbose) console.log(pc.dim(`  Retrying with body: ${bodyToTry}`))
+      fetchBody = bodyToTry
+      fetchHeaders['content-type'] = 'application/json'
+      try {
+        response = await fetchWithTimeout(url, { method: endpoint.method, headers: fetchHeaders, body: fetchBody })
+      } catch (error) {
+        results.push(fail('Request failed', (error as Error).message))
+        return { results }
+      }
+    }
+  }
+
+  // Check 402
+  if (response.status !== 402) {
+    if (response.status === 200) {
+      results.push(skip('Returns 402 without credentials', 'Got 200 (endpoint may not require payment in all cases)'))
+    } else if (response.status === 401 || response.status === 403) {
+      results.push(skip('Returns 402 without credentials', `Got ${response.status} (endpoint requires auth before payment gate)`))
+    } else {
+      results.push(
+        fail(
+          'Returns 402 without credentials',
+          `Got ${response.status} instead`,
+          response.status === 400
+            ? 'Server requires a valid request body before returning 402. Add a requestBody schema with examples to your OpenAPI doc, or use --body.'
+            : 'Endpoints that require payment must return HTTP 402 with a WWW-Authenticate: Payment header when no valid credential is provided.',
+        ),
+      )
+    }
+    return { results }
+  }
+  results.push(check('Returns 402 without credentials'))
+
+  // Check WWW-Authenticate header
+  const wwwAuth = response.headers.get(Constants.Headers.wwwAuthenticate)
+  if (!wwwAuth) {
+    results.push(skip('Not an MPP endpoint', 'No WWW-Authenticate header (may be x402 or other protocol)'))
+    return { results }
+  }
+  if (!wwwAuth.startsWith(`${Constants.Schemes.payment} `)) {
+    results.push(skip('Not an MPP endpoint', `WWW-Authenticate scheme is not Payment`))
+    return { results }
+  }
+  results.push(check('WWW-Authenticate header present', 'Payment scheme'))
+
+  // Parse challenge
+  let challenge: Challenge.Challenge
+  try {
+    challenge = Challenge.fromResponse(response)
+  } catch (error) {
+    results.push(fail('Challenge parseable', (error as Error).message))
+    return { results }
+  }
+  results.push(check('Challenge parseable', `${challenge.method}/${challenge.intent}`))
+
+  // Validate required fields
+  if (!challenge.id) results.push(fail('Challenge has id', undefined, 'Every challenge must include a unique id field. Generate a random string or hash per challenge.'))
+  else results.push(check('Challenge has id'))
+
+  if (!challenge.realm) results.push(fail('Challenge has realm', undefined, 'Set realm to your server\'s hostname. It tells clients who they are paying.'))
+  else results.push(check('Challenge has realm'))
+
+  if (!challenge.method) results.push(fail('Challenge has method', undefined, 'Set method to the payment method (e.g. "tempo", "stripe").'))
+  if (!challenge.intent) results.push(fail('Challenge has intent', undefined, 'Set intent to the payment type (e.g. "charge", "session").'))
+
+  // Semantic checks
+  if (challenge.expires) {
+    const expiresDate = new Date(challenge.expires)
+    const now = new Date()
+    if (expiresDate <= now) {
+      results.push(fail('Challenge expires in the future', `Expired at ${challenge.expires}`, 'The expires timestamp must be in the future when the challenge is issued. Use a 5-10 minute window from the current time.'))
+    } else {
+      const diffMs = expiresDate.getTime() - now.getTime()
+      const diffMin = Math.round(diffMs / 60000)
+      results.push(check('Challenge expires in the future', `${diffMin}m from now`))
+    }
+  } else {
+    results.push(warn('Challenge has expiration', 'No expires field set', 'Add an expires field (ISO 8601 datetime) to prevent replay attacks. Recommended: 5 minutes from issuance.'))
+  }
+
+  // Realm check (allow subdomain matches)
+  try {
+    const serverHost = new URL(baseUrl).hostname
+    const realm = challenge.realm ?? ''
+    const matches = serverHost === realm || serverHost.endsWith(`.${realm}`)
+    if (matches) {
+      results.push(check('Realm matches server hostname'))
+    } else {
+      results.push(
+        warn(
+          'Realm matches server hostname',
+          `realm="${realm}" vs host="${serverHost}"`,
+          'Set the realm to your production hostname (or base domain) in the challenge. Clients use realm to verify they are paying the right server.',
+        ),
+      )
+    }
+  } catch {}
+
+  // Method-specific validation
+  const request = challenge.request as Record<string, unknown>
+  if (challenge.method === Constants.Methods.tempo) {
+    if (isValidAddress(request.recipient)) {
+      results.push(check('Valid recipient address'))
+    } else {
+      results.push(fail('Valid recipient address', `Got: ${String(request.recipient)}`, 'Set request.recipient to a valid 0x-prefixed 40-hex-char address. This is where payment will be sent.'))
+    }
+
+    if (isValidAddress(request.currency)) {
+      const isTestnet = detectTestnet(challenge)
+      const network = isTestnet ? 'testnet' : 'mainnet'
+      results.push(check('Valid currency address', `${network}`))
+    } else {
+      results.push(fail('Valid currency address', `Got: ${String(request.currency)}`, 'Set request.currency to a valid token address. Common: "0x20c0000000000000000000000000000000000000" (PathUSD).'))
+    }
+
+    if (isValidIntegerAmount(request.amount)) {
+      results.push(check('Amount is valid integer string'))
+    } else if (request.amount === undefined || request.amount === null) {
+      results.push(warn('Amount is valid integer string', 'No amount (dynamic pricing?)', 'Set request.amount to a string of digits in the token\'s smallest unit (e.g. "10000" = $0.01 for 6-decimal tokens).'))
+    } else {
+      results.push(fail('Amount is valid integer string', `Got: ${String(request.amount)}`, 'request.amount must be a string of digits (no decimals, no prefix). Example: "10000" for $0.01 with 6-decimal tokens.'))
+    }
+  } else if (challenge.method === Constants.Methods.stripe) {
+    if (request.amount !== undefined) {
+      results.push(check('Stripe challenge has amount'))
+    } else {
+      results.push(warn('Stripe challenge has amount', 'No amount field'))
+    }
+  }
+
+  if (verbose) {
+    console.log(pc.dim(`    Challenge: ${JSON.stringify(challenge, null, 2)}`))
+  }
+
+  return { results, resolvedBody: fetchBody }
+}
+
+export async function validateErrorHandling(
+  baseUrl: string,
+  endpoint: EndpointSpec,
+  options?: { body?: string | undefined; query?: string[] | undefined },
+): Promise<CheckResult[]> {
+  const results: CheckResult[] = []
+  const url = buildUrl(baseUrl, endpoint, options?.query)
+  const fetchHeaders: Record<string, string> = {
+    [Constants.Headers.authorization]: `${Constants.Schemes.payment} dGhpcyBpcyBnYXJiYWdl`,
+  }
+  let fetchBody: string | undefined
+  if (options?.body) {
+    fetchBody = options.body
+    fetchHeaders['content-type'] = 'application/json'
+  }
+
+  try {
+    const response = await fetchWithTimeout(url, {
+      method: endpoint.method,
+      headers: fetchHeaders,
+      body: fetchBody ?? null,
+    })
+
+    if (response.status === 402) {
+      results.push(check('Malformed credential returns 402', 'not 500'))
+      const wwwAuth = response.headers.get(Constants.Headers.wwwAuthenticate)
+      if (wwwAuth?.startsWith(`${Constants.Schemes.payment} `)) {
+        results.push(check('Error response includes fresh challenge'))
+      } else {
+        results.push(
+          warn(
+            'Error response includes fresh challenge',
+            'No WWW-Authenticate header',
+            'When rejecting an invalid credential, respond with 402 and include a fresh WWW-Authenticate: Payment challenge so the client can retry.',
+          ),
+        )
+      }
+    } else if (response.status >= 500) {
+      results.push(
+        fail(
+          'Malformed credential returns 402',
+          `Got ${response.status} (server error)`,
+          'When the Authorization header contains an invalid credential, respond with 402 (not 500). Catch credential validation errors and return a fresh challenge.',
+        ),
+      )
+    } else {
+      results.push(
+        warn(
+          'Malformed credential returns 402',
+          `Got ${response.status}`,
+          `When the Authorization header contains an invalid Payment credential, respond with 402 and a fresh WWW-Authenticate challenge. Returning ${response.status} prevents the client from retrying with a valid payment.`,
+        ),
+      )
+    }
+  } catch (error) {
+    results.push(fail('Error handling test', (error as Error).message))
+  }
+
+  return results
+}

--- a/src/cli/validate/challenge.ts
+++ b/src/cli/validate/challenge.ts
@@ -3,13 +3,14 @@ import * as Constants from '../../Constants.js'
 import { pc } from '../utils.js'
 import { extractRequestBodyFromDiscovery } from './discovery.js'
 import type { CheckResult, EndpointSpec } from './helpers.js'
-import { buildUrl, check, fail, fetchWithTimeout, isValidAddress, isValidIntegerAmount, MAINNET_CHAIN_ID, skip, warn } from './helpers.js'
+import { chainId as tempoChainIds } from '../../tempo/internal/defaults.js'
+import { buildUrl, check, fail, fetchWithTimeout, isValidAddress, isValidIntegerAmount, skip, warn } from './helpers.js'
 
 function detectTestnet(challenge: Challenge.Challenge): boolean {
   const request = challenge.request as Record<string, unknown>
   const methodDetails = request.methodDetails as Record<string, unknown> | undefined
   if (typeof methodDetails?.chainId === 'number') {
-    return methodDetails.chainId !== MAINNET_CHAIN_ID
+    return methodDetails.chainId !== tempoChainIds.mainnet
   }
   return false
 }

--- a/src/cli/validate/challenge.ts
+++ b/src/cli/validate/challenge.ts
@@ -1,10 +1,19 @@
 import * as Challenge from '../../Challenge.js'
 import * as Constants from '../../Constants.js'
+import { chainId as tempoChainIds } from '../../tempo/internal/defaults.js'
 import { pc } from '../utils.js'
 import { extractRequestBodyFromDiscovery } from './discovery.js'
 import type { CheckResult, EndpointSpec } from './helpers.js'
-import { chainId as tempoChainIds } from '../../tempo/internal/defaults.js'
-import { buildUrl, check, fail, fetchWithTimeout, isValidAddress, isValidIntegerAmount, skip, warn } from './helpers.js'
+import {
+  buildUrl,
+  check,
+  fail,
+  fetchWithTimeout,
+  isValidAddress,
+  isValidIntegerAmount,
+  skip,
+  warn,
+} from './helpers.js'
 
 function detectTestnet(challenge: Challenge.Challenge): boolean {
   const request = challenge.request as Record<string, unknown>
@@ -19,7 +28,11 @@ export async function validateChallenge(
   baseUrl: string,
   endpoint: EndpointSpec,
   verbose: boolean,
-  options?: { body?: string | undefined; query?: string[] | undefined; discoveryDoc?: Record<string, unknown> | undefined },
+  options?: {
+    body?: string | undefined
+    query?: string[] | undefined
+    discoveryDoc?: Record<string, unknown> | undefined
+  },
 ): Promise<{ results: CheckResult[]; resolvedBody?: string | undefined }> {
   const results: CheckResult[] = []
   const url = buildUrl(baseUrl, endpoint, options?.query)
@@ -37,13 +50,21 @@ export async function validateChallenge(
 
   // If we got 400, retry with body (explicit --body or auto-generated from schema)
   if (response.status === 400) {
-    const bodyToTry = options?.body ?? (options?.discoveryDoc ? extractRequestBodyFromDiscovery(options.discoveryDoc, endpoint) : undefined)
+    const bodyToTry =
+      options?.body ??
+      (options?.discoveryDoc
+        ? extractRequestBodyFromDiscovery(options.discoveryDoc, endpoint)
+        : undefined)
     if (bodyToTry) {
       if (verbose) console.log(pc.dim(`  Retrying with body: ${bodyToTry}`))
       fetchBody = bodyToTry
       fetchHeaders['content-type'] = 'application/json'
       try {
-        response = await fetchWithTimeout(url, { method: endpoint.method, headers: fetchHeaders, body: fetchBody })
+        response = await fetchWithTimeout(url, {
+          method: endpoint.method,
+          headers: fetchHeaders,
+          body: fetchBody,
+        })
       } catch (error) {
         results.push(fail('Request failed', (error as Error).message))
         return { results }
@@ -54,9 +75,19 @@ export async function validateChallenge(
   // Check 402
   if (response.status !== 402) {
     if (response.status === 200) {
-      results.push(skip('Returns 402 without credentials', 'Got 200 (endpoint may not require payment in all cases)'))
+      results.push(
+        skip(
+          'Returns 402 without credentials',
+          'Got 200 (endpoint may not require payment in all cases)',
+        ),
+      )
     } else if (response.status === 401 || response.status === 403) {
-      results.push(skip('Returns 402 without credentials', `Got ${response.status} (endpoint requires auth before payment gate)`))
+      results.push(
+        skip(
+          'Returns 402 without credentials',
+          `Got ${response.status} (endpoint requires auth before payment gate)`,
+        ),
+      )
     } else {
       results.push(
         fail(
@@ -75,7 +106,9 @@ export async function validateChallenge(
   // Check WWW-Authenticate header
   const wwwAuth = response.headers.get(Constants.Headers.wwwAuthenticate)
   if (!wwwAuth) {
-    results.push(skip('Not an MPP endpoint', 'No WWW-Authenticate header (may be x402 or other protocol)'))
+    results.push(
+      skip('Not an MPP endpoint', 'No WWW-Authenticate header (may be x402 or other protocol)'),
+    )
     return { results }
   }
   if (!wwwAuth.startsWith(`${Constants.Schemes.payment} `)) {
@@ -95,28 +128,68 @@ export async function validateChallenge(
   results.push(check('Challenge parseable', `${challenge.method}/${challenge.intent}`))
 
   // Validate required fields
-  if (!challenge.id) results.push(fail('Challenge has id', undefined, 'Every challenge must include a unique id field. Generate a random string or hash per challenge.'))
+  if (!challenge.id)
+    results.push(
+      fail(
+        'Challenge has id',
+        undefined,
+        'Every challenge must include a unique id field. Generate a random string or hash per challenge.',
+      ),
+    )
   else results.push(check('Challenge has id'))
 
-  if (!challenge.realm) results.push(fail('Challenge has realm', undefined, 'Set realm to your server\'s hostname. It tells clients who they are paying.'))
+  if (!challenge.realm)
+    results.push(
+      fail(
+        'Challenge has realm',
+        undefined,
+        "Set realm to your server's hostname. It tells clients who they are paying.",
+      ),
+    )
   else results.push(check('Challenge has realm'))
 
-  if (!challenge.method) results.push(fail('Challenge has method', undefined, 'Set method to the payment method (e.g. "tempo", "stripe").'))
-  if (!challenge.intent) results.push(fail('Challenge has intent', undefined, 'Set intent to the payment type (e.g. "charge", "session").'))
+  if (!challenge.method)
+    results.push(
+      fail(
+        'Challenge has method',
+        undefined,
+        'Set method to the payment method (e.g. "tempo", "stripe").',
+      ),
+    )
+  if (!challenge.intent)
+    results.push(
+      fail(
+        'Challenge has intent',
+        undefined,
+        'Set intent to the payment type (e.g. "charge", "session").',
+      ),
+    )
 
   // Semantic checks
   if (challenge.expires) {
     const expiresDate = new Date(challenge.expires)
     const now = new Date()
     if (expiresDate <= now) {
-      results.push(fail('Challenge expires in the future', `Expired at ${challenge.expires}`, 'The expires timestamp must be in the future when the challenge is issued. Use a 5-10 minute window from the current time.'))
+      results.push(
+        fail(
+          'Challenge expires in the future',
+          `Expired at ${challenge.expires}`,
+          'The expires timestamp must be in the future when the challenge is issued. Use a 5-10 minute window from the current time.',
+        ),
+      )
     } else {
       const diffMs = expiresDate.getTime() - now.getTime()
       const diffMin = Math.round(diffMs / 60000)
       results.push(check('Challenge expires in the future', `${diffMin}m from now`))
     }
   } else {
-    results.push(warn('Challenge has expiration', 'No expires field set', 'Add an expires field (ISO 8601 datetime) to prevent replay attacks. Recommended: 5 minutes from issuance.'))
+    results.push(
+      warn(
+        'Challenge has expiration',
+        'No expires field set',
+        'Add an expires field (ISO 8601 datetime) to prevent replay attacks. Recommended: 5 minutes from issuance.',
+      ),
+    )
   }
 
   // Realm check (allow subdomain matches)
@@ -143,7 +216,13 @@ export async function validateChallenge(
     if (isValidAddress(request.recipient)) {
       results.push(check('Valid recipient address'))
     } else {
-      results.push(fail('Valid recipient address', `Got: ${String(request.recipient)}`, 'Set request.recipient to a valid 0x-prefixed 40-hex-char address. This is where payment will be sent.'))
+      results.push(
+        fail(
+          'Valid recipient address',
+          `Got: ${String(request.recipient)}`,
+          'Set request.recipient to a valid 0x-prefixed 40-hex-char address. This is where payment will be sent.',
+        ),
+      )
     }
 
     if (isValidAddress(request.currency)) {
@@ -151,15 +230,33 @@ export async function validateChallenge(
       const network = isTestnet ? 'testnet' : 'mainnet'
       results.push(check('Valid currency address', `${network}`))
     } else {
-      results.push(fail('Valid currency address', `Got: ${String(request.currency)}`, 'Set request.currency to a valid token address. Common: "0x20c0000000000000000000000000000000000000" (PathUSD).'))
+      results.push(
+        fail(
+          'Valid currency address',
+          `Got: ${String(request.currency)}`,
+          'Set request.currency to a valid token address. Common: "0x20c0000000000000000000000000000000000000" (PathUSD).',
+        ),
+      )
     }
 
     if (isValidIntegerAmount(request.amount)) {
       results.push(check('Amount is valid integer string'))
     } else if (request.amount === undefined || request.amount === null) {
-      results.push(warn('Amount is valid integer string', 'No amount (dynamic pricing?)', 'Set request.amount to a string of digits in the token\'s smallest unit (e.g. "10000" = $0.01 for 6-decimal tokens).'))
+      results.push(
+        warn(
+          'Amount is valid integer string',
+          'No amount (dynamic pricing?)',
+          'Set request.amount to a string of digits in the token\'s smallest unit (e.g. "10000" = $0.01 for 6-decimal tokens).',
+        ),
+      )
     } else {
-      results.push(fail('Amount is valid integer string', `Got: ${String(request.amount)}`, 'request.amount must be a string of digits (no decimals, no prefix). Example: "10000" for $0.01 with 6-decimal tokens.'))
+      results.push(
+        fail(
+          'Amount is valid integer string',
+          `Got: ${String(request.amount)}`,
+          'request.amount must be a string of digits (no decimals, no prefix). Example: "10000" for $0.01 with 6-decimal tokens.',
+        ),
+      )
     }
   } else if (challenge.method === Constants.Methods.stripe) {
     if (request.amount !== undefined) {

--- a/src/cli/validate/discovery.ts
+++ b/src/cli/validate/discovery.ts
@@ -1,0 +1,116 @@
+import type { EndpointSpec } from './helpers.js'
+import { fetchWithTimeout, HTTP_METHODS } from './helpers.js'
+
+export async function fetchDiscoveryDoc(
+  baseUrl: string,
+): Promise<{ doc: unknown; raw: string } | { error: string }> {
+  const url = new URL('/openapi.json', baseUrl).href
+  try {
+    const response = await fetchWithTimeout(url, {})
+    if (!response.ok) return { error: `HTTP ${response.status}` }
+    const raw = await response.text()
+    const doc = JSON.parse(raw)
+    return { doc, raw }
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError')
+      return { error: 'Request timed out after 15s' }
+    if (error instanceof SyntaxError) return { error: 'Invalid JSON' }
+    return { error: (error as Error).message }
+  }
+}
+
+// Extracts testable endpoints from an OpenAPI doc. Prefers endpoints with
+// explicit x-payment-info (the server declares them as paid). Falls back to
+// endpoints that list a 402 response (weaker signal, but still worth testing).
+export function extractEndpointsFromDiscovery(doc: Record<string, unknown>): EndpointSpec[] {
+  const withPaymentInfo: EndpointSpec[] = []
+  const with402Response: EndpointSpec[] = []
+  const paths = doc.paths as Record<string, Record<string, unknown>> | undefined
+  if (!paths) return []
+  for (const [pathKey, pathItem] of Object.entries(paths)) {
+    for (const [method, operation] of Object.entries(pathItem)) {
+      if (!HTTP_METHODS.has(method)) continue
+      if (!operation || typeof operation !== 'object' || Array.isArray(operation)) continue
+      const op = operation as Record<string, unknown>
+      if (op['x-payment-info']) {
+        const payInfo = op['x-payment-info'] as Record<string, unknown>
+        withPaymentInfo.push({ method: method.toUpperCase(), path: pathKey, amount: payInfo.amount as string | undefined })
+      } else {
+        const responses = op.responses as Record<string, unknown> | undefined
+        if (responses && '402' in responses) {
+          with402Response.push({ method: method.toUpperCase(), path: pathKey })
+        }
+      }
+    }
+  }
+  return withPaymentInfo.length > 0 ? withPaymentInfo : with402Response
+}
+
+// Recursively generates a minimal valid value from a JSON Schema definition.
+// Fills only required fields, preferring const > example > default > synthetic.
+function generateValueFromSchema(schema: Record<string, unknown>): unknown {
+  if (schema.const !== undefined) return schema.const
+  if (schema.example !== undefined) return schema.example
+  if (schema.default !== undefined) return schema.default
+
+  switch (schema.type) {
+    case 'string': {
+      if (schema.format === 'email') return 'test@example.com'
+      if (schema.format === 'uuid') return '00000000-0000-0000-0000-000000000000'
+      if (schema.format === 'uri' || schema.format === 'url') return 'https://example.com'
+      if (schema.enum && Array.isArray(schema.enum)) return schema.enum[0]
+      return 'test'
+    }
+    case 'number':
+    case 'integer':
+      return schema.minimum ?? 1
+    case 'boolean':
+      return true
+    case 'array':
+      return []
+    case 'object': {
+      const properties = schema.properties as Record<string, Record<string, unknown>> | undefined
+      if (!properties) return {}
+      const required = (schema.required as string[]) || []
+      const obj: Record<string, unknown> = {}
+      for (const key of required) {
+        const prop = properties[key]
+        if (prop) obj[key] = generateValueFromSchema(prop)
+      }
+      return obj
+    }
+    default:
+      return null
+  }
+}
+
+// Looks up the requestBody schema for an endpoint in the OpenAPI doc and
+// returns a JSON string suitable for the request. Uses the doc's example
+// if one exists, otherwise generates a minimal body from the schema.
+export function extractRequestBodyFromDiscovery(
+  doc: Record<string, unknown>,
+  endpoint: EndpointSpec,
+): string | undefined {
+  const paths = doc.paths as Record<string, Record<string, unknown>> | undefined
+  if (!paths) return undefined
+  const pathItem = paths[endpoint.path]
+  if (!pathItem) return undefined
+  const op = pathItem[endpoint.method.toLowerCase()] as Record<string, unknown> | undefined
+  if (!op?.requestBody) return undefined
+
+  const rb = op.requestBody as Record<string, unknown>
+  const content = rb.content as Record<string, unknown> | undefined
+  const jsonContent = content?.['application/json'] as Record<string, unknown> | undefined
+  if (!jsonContent) return undefined
+
+  if (jsonContent.example) return JSON.stringify(jsonContent.example)
+
+  const schema = jsonContent.schema as Record<string, unknown> | undefined
+  if (!schema || schema.type !== 'object') return undefined
+
+  const result = generateValueFromSchema(schema)
+  if (result && typeof result === 'object' && Object.keys(result as object).length > 0) {
+    return JSON.stringify(result)
+  }
+  return undefined
+}

--- a/src/cli/validate/discovery.ts
+++ b/src/cli/validate/discovery.ts
@@ -34,7 +34,11 @@ export function extractEndpointsFromDiscovery(doc: Record<string, unknown>): End
       const op = operation as Record<string, unknown>
       if (op['x-payment-info']) {
         const payInfo = op['x-payment-info'] as Record<string, unknown>
-        withPaymentInfo.push({ method: method.toUpperCase(), path: pathKey, amount: payInfo.amount as string | undefined })
+        withPaymentInfo.push({
+          method: method.toUpperCase(),
+          path: pathKey,
+          amount: payInfo.amount as string | undefined,
+        })
       } else {
         const responses = op.responses as Record<string, unknown> | undefined
         if (responses && '402' in responses) {

--- a/src/cli/validate/helpers.ts
+++ b/src/cli/validate/helpers.ts
@@ -1,0 +1,130 @@
+import { pc } from '../utils.js'
+
+export type CheckResult = {
+  label: string
+  detail?: string | undefined
+  hint?: string | undefined
+  severity: 'pass' | 'fail' | 'warn' | 'skip'
+}
+
+export type EndpointSpec = {
+  method: string
+  path: string
+  amount?: string | undefined
+}
+
+export function check(label: string, detail?: string): CheckResult {
+  return detail ? { label, detail, severity: 'pass' } : { label, severity: 'pass' }
+}
+
+export function fail(label: string, detail?: string, hint?: string): CheckResult {
+  const r: CheckResult = { label, severity: 'fail' }
+  if (detail) r.detail = detail
+  if (hint) r.hint = hint
+  return r
+}
+
+export function warn(label: string, detail?: string, hint?: string): CheckResult {
+  const r: CheckResult = { label, severity: 'warn' }
+  if (detail) r.detail = detail
+  if (hint) r.hint = hint
+  return r
+}
+
+export function skip(label: string, detail?: string, hint?: string): CheckResult {
+  const r: CheckResult = detail ? { label, detail, severity: 'skip' } : { label, severity: 'skip' }
+  if (hint) r.hint = hint
+  return r
+}
+
+const SEVERITY_ICONS = {
+  pass: pc.green('✓'),
+  fail: pc.red('✗'),
+  warn: pc.yellow('⚠'),
+  skip: pc.dim('○'),
+} as const
+
+export function printCheck(result: CheckResult) {
+  const icon = SEVERITY_ICONS[result.severity]
+  const text = result.detail ? `${result.label} (${result.detail})` : result.label
+  console.log(`  ${icon} ${text}`)
+  if (result.hint && result.severity !== 'pass') {
+    console.log(pc.dim(`    → ${result.hint}`))
+  }
+}
+
+export function printSection(title: string) {
+  console.log(`\n${pc.bold(title)}`)
+}
+
+export async function fetchWithTimeout(url: string, init: RequestInit, timeoutMs = 15_000): Promise<Response> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    return await fetch(url, { ...init, signal: controller.signal })
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+export function buildUrl(baseUrl: string, endpoint: EndpointSpec, query?: string[]): string {
+  let url = new URL(endpoint.path, baseUrl).href
+  if (query) {
+    const u = new URL(url)
+    for (const q of query) {
+      const [key, ...rest] = q.split('=')
+      if (key) u.searchParams.set(key, rest.join('='))
+    }
+    url = u.href
+  }
+  return url
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`
+}
+
+export const HTTP_METHODS = new Set(['get', 'post', 'put', 'patch', 'delete', 'head', 'options', 'trace'])
+
+export const MAINNET_CHAIN_ID = 4217
+
+export function isValidAddress(addr: unknown): boolean {
+  return typeof addr === 'string' && /^0x[0-9a-fA-F]{40}$/.test(addr)
+}
+
+export function isValidIntegerAmount(amount: unknown): boolean {
+  return typeof amount === 'string' && /^(0|[1-9][0-9]*)$/.test(amount)
+}
+
+export function parseEndpointArg(input: string): EndpointSpec | null {
+  const sep = input.indexOf(':')
+  if (sep < 1) return null
+  const method = input.slice(0, sep).toLowerCase()
+  if (!HTTP_METHODS.has(method)) return null
+  const path = input.slice(sep + 1)
+  if (!path) return null
+  return { method: method.toUpperCase(), path }
+}
+
+// Resolves --body input: if JSON with all keys starting with /, it's a
+// per-path mapping. Otherwise it's a global body for all endpoints.
+export function resolveBodyForEndpoint(
+  rawBody: string | undefined,
+  endpointPath: string,
+): string | undefined {
+  if (!rawBody) return undefined
+  try {
+    const parsed = JSON.parse(rawBody)
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      const keys = Object.keys(parsed)
+      if (keys.length > 0 && keys.every((k) => k.startsWith('/'))) {
+        const value = parsed[endpointPath]
+        if (value === undefined) return undefined
+        return typeof value === 'string' ? value : JSON.stringify(value)
+      }
+    }
+  } catch {}
+  return rawBody
+}

--- a/src/cli/validate/helpers.ts
+++ b/src/cli/validate/helpers.ts
@@ -57,6 +57,18 @@ export function printSection(title: string) {
   console.log(`\n${pc.bold(title)}`)
 }
 
+export type Counts = { passed: number; failed: number; warnings: number; skipped: number }
+
+export function printResults(results: CheckResult[], counts: Counts) {
+  for (const result of results) {
+    printCheck(result)
+    if (result.severity === 'pass') counts.passed++
+    else if (result.severity === 'fail') counts.failed++
+    else if (result.severity === 'warn') counts.warnings++
+    else if (result.severity === 'skip') counts.skipped++
+  }
+}
+
 export async function fetchWithTimeout(url: string, init: RequestInit, timeoutMs = 15_000): Promise<Response> {
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), timeoutMs)
@@ -88,7 +100,6 @@ export function formatBytes(bytes: number): string {
 
 export const HTTP_METHODS = new Set(['get', 'post', 'put', 'patch', 'delete', 'head', 'options', 'trace'])
 
-export const MAINNET_CHAIN_ID = 4217
 
 export function isValidAddress(addr: unknown): boolean {
   return typeof addr === 'string' && /^0x[0-9a-fA-F]{40}$/.test(addr)
@@ -105,7 +116,8 @@ export function parseEndpointArg(input: string): EndpointSpec | null {
   if (!HTTP_METHODS.has(method)) return null
   const path = input.slice(sep + 1)
   if (!path) return null
-  return { method: method.toUpperCase(), path }
+  const normalizedPath = path.startsWith('/') ? path : '/' + path
+  return { method: method.toUpperCase(), path: normalizedPath }
 }
 
 // Resolves --body input: if JSON with all keys starting with /, it's a

--- a/src/cli/validate/helpers.ts
+++ b/src/cli/validate/helpers.ts
@@ -69,7 +69,11 @@ export function printResults(results: CheckResult[], counts: Counts) {
   }
 }
 
-export async function fetchWithTimeout(url: string, init: RequestInit, timeoutMs = 15_000): Promise<Response> {
+export async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs = 15_000,
+): Promise<Response> {
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), timeoutMs)
   try {
@@ -98,8 +102,16 @@ export function formatBytes(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)}MB`
 }
 
-export const HTTP_METHODS = new Set(['get', 'post', 'put', 'patch', 'delete', 'head', 'options', 'trace'])
-
+export const HTTP_METHODS = new Set([
+  'get',
+  'post',
+  'put',
+  'patch',
+  'delete',
+  'head',
+  'options',
+  'trace',
+])
 
 export function isValidAddress(addr: unknown): boolean {
   return typeof addr === 'string' && /^0x[0-9a-fA-F]{40}$/.test(addr)

--- a/src/cli/validate/index.ts
+++ b/src/cli/validate/index.ts
@@ -4,7 +4,8 @@ import { validate as validateDiscovery } from '../../discovery/Validate.js'
 import { pc } from '../utils.js'
 import { validateChallenge, validateErrorHandling } from './challenge.js'
 import { extractEndpointsFromDiscovery, extractRequestBodyFromDiscovery, fetchDiscoveryDoc } from './discovery.js'
-import { check, fail, parseEndpointArg, printCheck, printSection, resolveBodyForEndpoint, warn } from './helpers.js'
+import { check, fail, parseEndpointArg, printCheck, printResults, printSection, resolveBodyForEndpoint, warn } from './helpers.js'
+import type { Counts, EndpointSpec } from './helpers.js'
 import { validatePaymentFlow } from './payment.js'
 
 const validate = Cli.create('validate', {
@@ -31,214 +32,234 @@ const validate = Cli.create('validate', {
   async run(c) {
     const baseUrl = c.args.url.replace(/\/$/, '').replace(/\/openapi\.json$/i, '')
     const verbose = c.options.verbose > 0
-    let totalPassed = 0
-    let totalFailed = 0
-    let totalWarnings = 0
-    let totalSkipped = 0
+    const counts: Counts = { passed: 0, failed: 0, warnings: 0, skipped: 0 }
 
     console.log(`\n${pc.bold('mppx validate')} ${pc.dim(baseUrl)}\n`)
 
-    // Phase 1: Discovery (always runs)
-    let endpoints: import('./helpers.js').EndpointSpec[] = []
-    let discoveryDoc: Record<string, unknown> | null = null
-
-    printSection('Discovery (/openapi.json)')
-    const discoveryResult = await fetchDiscoveryDoc(baseUrl)
-
-    if ('error' in discoveryResult) {
-      printCheck(fail('Document found', discoveryResult.error, 'MPP servers must serve an OpenAPI document at /openapi.json with x-payment-info extensions.'))
-      totalFailed++
-      if (!c.options.endpoint) {
-        console.log('')
-        console.log(pc.yellow('  No discovery document found.'))
-        console.log(pc.dim('  MPP servers must serve an OpenAPI document at /openapi.json with x-payment-info extensions.'))
-        console.log(pc.dim('  To test a specific endpoint: mppx validate <url> --endpoint POST:/your/path'))
-        console.log('')
-        process.exit(1)
-      }
-    } else {
-      printCheck(check('Document found and parseable'))
-      totalPassed++
-
-      const issues = validateDiscovery(discoveryResult.doc)
-      const errors = issues.filter((i) => i.severity === 'error')
-      const warnings = issues.filter((i) => i.severity === 'warning')
-
-      if (errors.length > 0) {
-        printCheck(fail('Valid OpenAPI structure', `${errors.length} error(s)`))
-        totalFailed++
-        for (const issue of errors) {
-          console.log(pc.dim(`    ${issue.path}: ${issue.message}`))
-        }
-      } else {
-        printCheck(check('Valid OpenAPI structure'))
-        totalPassed++
-      }
-
-      for (const w of warnings) {
-        printCheck(warn(w.message, w.path))
-        totalWarnings++
-      }
-
-      discoveryDoc = discoveryResult.doc as Record<string, unknown>
-    }
-
-    // Resolve endpoints: --endpoint overrides discovery
-    if (c.options.endpoint) {
-      const parsed = parseEndpointArg(c.options.endpoint)
-      if (!parsed) {
-        console.log(pc.red(`Invalid endpoint format: "${c.options.endpoint}". Use METHOD:path (e.g. GET:/api/data)`))
-        process.exit(1)
-      }
-      endpoints.push(parsed)
-    } else if (discoveryDoc) {
-      endpoints = extractEndpointsFromDiscovery(discoveryDoc)
-
-      const NO_AMOUNT = BigInt('999999999999999999')
-      endpoints.sort((a, b) => {
-        const aAmt = a.amount ? BigInt(a.amount) : NO_AMOUNT
-        const bAmt = b.amount ? BigInt(b.amount) : NO_AMOUNT
-        return aAmt < bAmt ? -1 : aAmt > bAmt ? 1 : 0
-      })
-
-      if (endpoints.length === 0) {
-        printCheck(warn('Paid endpoints found', 'No endpoints with x-payment-info'))
-        totalWarnings++
-        console.log(pc.dim('  Use --endpoint to specify endpoints manually.'))
-        process.exit(1)
-      }
-
-      printCheck(check('Paid endpoints found', `${endpoints.length} endpoint(s)`))
-      totalPassed++
-    }
-
-    // Phase 2: Validate each endpoint
-    let sawTestnet = false
-    let sawMainnet = false
-    let paymentSucceeded = false
-    let sawMppEndpoint = false
-    let sawNonMppPaymentEndpoint = false
-
-    for (const endpoint of endpoints) {
-      printSection(`${endpoint.method} ${endpoint.path}`)
-
-      // With --endpoint, --body is used directly. In discovery mode, resolve per-path or auto-generate.
-      let body: string | undefined
-      if (c.options.endpoint) {
-        body = c.options.body
-      } else {
-        body = resolveBodyForEndpoint(c.options.body, endpoint.path)
-        if (!body && discoveryDoc) {
-          body = extractRequestBodyFromDiscovery(discoveryDoc, endpoint)
-          if (body && verbose) {
-            console.log(pc.dim(`  Auto-generated body: ${body}`))
-          }
-        }
-      }
-
-      // Challenge
-      console.log(pc.dim('  Challenge'))
-      const { results: challengeResults, resolvedBody } = await validateChallenge(baseUrl, endpoint, verbose, {
-        body,
-        query: c.options.query,
-        discoveryDoc: discoveryDoc ?? undefined,
-      })
-      const effectiveBody = resolvedBody ?? body
-      for (const result of challengeResults) {
-        printCheck(result)
-        if (result.severity === 'pass') totalPassed++
-        else if (result.severity === 'fail') totalFailed++
-        else if (result.severity === 'warn') totalWarnings++
-        else if (result.severity === 'skip') totalSkipped++
-      }
-
-      const isMppEndpoint = challengeResults.some(
-        (r) => r.severity === 'pass' && r.label === 'Challenge parseable',
-      )
-      if (!isMppEndpoint) {
-        if (challengeResults.some((r) => r.label === 'Not an MPP endpoint')) sawNonMppPaymentEndpoint = true
-        continue
-      }
-      sawMppEndpoint = true
-
-      const isTestnetEndpoint = challengeResults.some(
-        (r) => r.severity === 'pass' && r.label === 'Valid currency address' && r.detail === 'testnet',
-      )
-      if (isTestnetEndpoint) sawTestnet = true
-      else sawMainnet = true
-
-      // Error Handling
-      console.log(pc.dim('  Error Handling'))
-      const errorResults = await validateErrorHandling(baseUrl, endpoint, {
-        body: effectiveBody,
-        query: c.options.query,
-      })
-      for (const result of errorResults) {
-        printCheck(result)
-        if (result.severity === 'pass') totalPassed++
-        else if (result.severity === 'fail') totalFailed++
-        else if (result.severity === 'warn') totalWarnings++
-        else if (result.severity === 'skip') totalSkipped++
-      }
-
-      // Payment
-      console.log(pc.dim('  Payment'))
-      const paymentResults = await validatePaymentFlow(baseUrl, endpoint, verbose, {
-        body: effectiveBody,
-        query: c.options.query,
-        yes: c.options.yes,
-      })
-      for (const result of paymentResults) {
-        printCheck(result)
-        if (result.severity === 'pass') totalPassed++
-        else if (result.severity === 'fail') totalFailed++
-        else if (result.severity === 'warn') totalWarnings++
-        else if (result.severity === 'skip') totalSkipped++
-      }
-      if (paymentResults.some((r) => r.severity === 'pass' && r.label === 'Payment: successful')) {
-        paymentSucceeded = true
-      }
-    }
-
-    // No MPP endpoints found
-    if (!sawMppEndpoint && endpoints.length > 0) {
-      console.log('')
-      if (sawNonMppPaymentEndpoint) {
-        console.log(pc.yellow(`  No MPP endpoints found. Tested ${endpoints.length} endpoint(s) but none use WWW-Authenticate: Payment.`))
-        console.log(pc.dim('  This server may use x402 or another payment protocol.'))
-      } else if (totalSkipped > 0 && totalFailed === 0) {
-        console.log(pc.yellow(`  Could not reach payment gate on any endpoint (all returned 401/403/200).`))
-        console.log(pc.dim('  The server may require authentication before payment. Try providing auth or use --endpoint with a public path.'))
-      } else {
-        console.log(pc.yellow(`  No MPP endpoints found. Tested ${endpoints.length} endpoint(s) but none use WWW-Authenticate: Payment.`))
-        console.log(pc.dim('  This server may use x402 or another payment protocol.'))
-      }
-      console.log('')
-      process.exit(1)
-    }
-
-    // Summary
-    console.log('')
-    const parts: string[] = []
-    if (totalPassed > 0) parts.push(pc.green(`${totalPassed} passed`))
-    if (totalFailed > 0) parts.push(pc.red(`${totalFailed} failed`))
-    if (totalWarnings > 0) parts.push(pc.yellow(`${totalWarnings} warning(s)`))
-    if (totalSkipped > 0) parts.push(pc.yellow(`${totalSkipped} skipped`))
-    console.log(`${pc.bold('Summary:')} ${parts.join(', ')}`)
-
-    // Cross-promotion
-    if (paymentSucceeded && sawTestnet && !sawMainnet) {
-      console.log('')
-      console.log(pc.dim('  Tip: validate your mainnet server too to confirm real payments work end-to-end.'))
-    } else if (sawMainnet && !sawTestnet) {
-      console.log('')
-      console.log(pc.dim('  Tip: validate a testnet server too for free. This CLI automatically provisions and funds a testnet wallet for testing.'))
-    }
-
-    console.log('')
-
-    if (totalFailed > 0) process.exit(1)
+    const { endpoints, discoveryDoc, shouldExit } = await discoverEndpoints(baseUrl, c.options, counts)
+    if (shouldExit) process.exit(1)
+    const flags = await validateEndpoints(baseUrl, endpoints, discoveryDoc, counts, {
+      verbose,
+      endpoint: c.options.endpoint,
+      body: c.options.body,
+      query: c.options.query,
+      yes: c.options.yes,
+    })
+    printSummary(counts, flags, endpoints.length)
   },
 })
 
 export default validate
+
+// Each stage of validation is defined in its own function below.
+
+async function discoverEndpoints(
+  baseUrl: string,
+  options: { endpoint?: string | undefined; body?: string | undefined; query?: string[] | undefined; verbose: number; yes: boolean },
+  counts: Counts,
+): Promise<{ endpoints: EndpointSpec[]; discoveryDoc: Record<string, unknown> | null; shouldExit?: boolean }> {
+  let endpoints: EndpointSpec[] = []
+  let discoveryDoc: Record<string, unknown> | null = null
+
+  printSection('Discovery (/openapi.json)')
+  const discoveryResult = await fetchDiscoveryDoc(baseUrl)
+
+  if ('error' in discoveryResult) {
+    printCheck(fail('Document found', discoveryResult.error, 'MPP servers must serve an OpenAPI document at /openapi.json with x-payment-info extensions.'))
+    counts.failed++
+    if (!options.endpoint) {
+      console.log('')
+      console.log(pc.yellow('  No discovery document found.'))
+      console.log(pc.dim('  MPP servers must serve an OpenAPI document at /openapi.json with x-payment-info extensions.'))
+      console.log(pc.dim('  To test a specific endpoint: mppx validate <url> --endpoint POST:/your/path'))
+      console.log('')
+      return { endpoints, discoveryDoc, shouldExit: true }
+    }
+  } else {
+    printCheck(check('Document found and parseable'))
+    counts.passed++
+
+    const issues = validateDiscovery(discoveryResult.doc)
+    const errors = issues.filter((i) => i.severity === 'error')
+    const warnings = issues.filter((i) => i.severity === 'warning')
+
+    if (errors.length > 0) {
+      printCheck(fail('Valid OpenAPI structure', `${errors.length} error(s)`))
+      counts.failed++
+      for (const issue of errors) {
+        console.log(pc.dim(`    ${issue.path}: ${issue.message}`))
+      }
+    } else {
+      printCheck(check('Valid OpenAPI structure'))
+      counts.passed++
+    }
+
+    for (const w of warnings) {
+      printCheck(warn(w.message, w.path))
+      counts.warnings++
+    }
+
+    discoveryDoc = discoveryResult.doc as Record<string, unknown>
+  }
+
+  // Resolve endpoints: --endpoint overrides discovery
+  if (options.endpoint) {
+    const parsed = parseEndpointArg(options.endpoint)
+    if (!parsed) {
+      console.log(pc.red(`Invalid endpoint format: "${options.endpoint}". Use METHOD:path (e.g. GET:/api/data)`))
+      return { endpoints, discoveryDoc, shouldExit: true }
+    }
+    endpoints.push(parsed)
+  } else if (discoveryDoc) {
+    endpoints = extractEndpointsFromDiscovery(discoveryDoc)
+
+    const NO_AMOUNT = BigInt('999999999999999999')
+    endpoints.sort((a, b) => {
+      const aAmt = a.amount ? BigInt(a.amount) : NO_AMOUNT
+      const bAmt = b.amount ? BigInt(b.amount) : NO_AMOUNT
+      return aAmt < bAmt ? -1 : aAmt > bAmt ? 1 : 0
+    })
+
+    if (endpoints.length === 0) {
+      printCheck(warn('Paid endpoints found', 'No endpoints with x-payment-info'))
+      counts.warnings++
+      console.log(pc.dim('  Use --endpoint to specify endpoints manually.'))
+      return { endpoints, discoveryDoc, shouldExit: true }
+    }
+
+    printCheck(check('Paid endpoints found', `${endpoints.length} endpoint(s)`))
+    counts.passed++
+  }
+
+  return { endpoints, discoveryDoc }
+}
+
+async function validateEndpoints(
+  baseUrl: string,
+  endpoints: EndpointSpec[],
+  discoveryDoc: Record<string, unknown> | null,
+  counts: Counts,
+  options: {
+    verbose: boolean
+    endpoint?: string | undefined
+    body?: string | undefined
+    query?: string[] | undefined
+    yes: boolean
+  },
+): Promise<{ sawMppEndpoint: boolean; sawNonMppPaymentEndpoint: boolean; sawTestnet: boolean; sawMainnet: boolean; paymentSucceeded: boolean }> {
+  let sawTestnet = false
+  let sawMainnet = false
+  let paymentSucceeded = false
+  let sawMppEndpoint = false
+  let sawNonMppPaymentEndpoint = false
+
+  for (const endpoint of endpoints) {
+    printSection(`${endpoint.method} ${endpoint.path}`)
+
+    // With --endpoint, --body is used directly. In discovery mode, resolve per-path or auto-generate.
+    let body: string | undefined
+    if (options.endpoint) {
+      body = options.body
+    } else {
+      body = resolveBodyForEndpoint(options.body, endpoint.path)
+      if (!body && discoveryDoc) {
+        body = extractRequestBodyFromDiscovery(discoveryDoc, endpoint)
+        if (body && options.verbose) {
+          console.log(pc.dim(`  Auto-generated body: ${body}`))
+        }
+      }
+    }
+
+    // Challenge
+    console.log(pc.dim('  Challenge'))
+    const { results: challengeResults, resolvedBody } = await validateChallenge(baseUrl, endpoint, options.verbose, {
+      body,
+      query: options.query,
+      discoveryDoc: discoveryDoc ?? undefined,
+    })
+    const effectiveBody = resolvedBody ?? body
+    printResults(challengeResults, counts)
+
+    const isMppEndpoint = challengeResults.some(
+      (r) => r.severity === 'pass' && r.label === 'Challenge parseable',
+    )
+    if (!isMppEndpoint) {
+      if (challengeResults.some((r) => r.label === 'Not an MPP endpoint')) sawNonMppPaymentEndpoint = true
+      continue
+    }
+    sawMppEndpoint = true
+
+    const isTestnetEndpoint = challengeResults.some(
+      (r) => r.severity === 'pass' && r.label === 'Valid currency address' && r.detail === 'testnet',
+    )
+    if (isTestnetEndpoint) sawTestnet = true
+    else sawMainnet = true
+
+    // Error Handling
+    console.log(pc.dim('  Error Handling'))
+    const errorResults = await validateErrorHandling(baseUrl, endpoint, {
+      body: effectiveBody,
+      query: options.query,
+    })
+    printResults(errorResults, counts)
+
+    // Payment
+    console.log(pc.dim('  Payment'))
+    const paymentResults = await validatePaymentFlow(baseUrl, endpoint, options.verbose, {
+      body: effectiveBody,
+      query: options.query,
+      yes: options.yes,
+    })
+    printResults(paymentResults, counts)
+    if (paymentResults.some((r) => r.severity === 'pass' && r.label === 'Payment: successful')) {
+      paymentSucceeded = true
+    }
+  }
+
+  return { sawMppEndpoint, sawNonMppPaymentEndpoint, sawTestnet, sawMainnet, paymentSucceeded }
+}
+
+function printSummary(
+  counts: Counts,
+  flags: { sawMppEndpoint: boolean; sawNonMppPaymentEndpoint: boolean; sawTestnet: boolean; sawMainnet: boolean; paymentSucceeded: boolean },
+  endpointsLength: number,
+): void {
+  // No MPP endpoints found
+  if (!flags.sawMppEndpoint && endpointsLength > 0) {
+    console.log('')
+    if (flags.sawNonMppPaymentEndpoint) {
+      console.log(pc.yellow(`  No MPP endpoints found. Tested ${endpointsLength} endpoint(s) but none use WWW-Authenticate: Payment.`))
+      console.log(pc.dim('  This server may use x402 or another payment protocol.'))
+    } else if (counts.skipped > 0 && counts.failed === 0) {
+      console.log(pc.yellow(`  Could not reach payment gate on any endpoint (all returned 401/403/200).`))
+      console.log(pc.dim('  The server may require authentication before payment. Try providing auth or use --endpoint with a public path.'))
+    } else {
+      console.log(pc.yellow(`  No MPP endpoints found. Tested ${endpointsLength} endpoint(s) but none use WWW-Authenticate: Payment.`))
+      console.log(pc.dim('  This server may use x402 or another payment protocol.'))
+    }
+    console.log('')
+    process.exit(1)
+  }
+
+  // Summary
+  console.log('')
+  const parts: string[] = []
+  if (counts.passed > 0) parts.push(pc.green(`${counts.passed} passed`))
+  if (counts.failed > 0) parts.push(pc.red(`${counts.failed} failed`))
+  if (counts.warnings > 0) parts.push(pc.yellow(`${counts.warnings} warning(s)`))
+  if (counts.skipped > 0) parts.push(pc.yellow(`${counts.skipped} skipped`))
+  console.log(`${pc.bold('Summary:')} ${parts.join(', ')}`)
+
+  // Cross-promotion
+  if (flags.paymentSucceeded && flags.sawTestnet && !flags.sawMainnet) {
+    console.log('')
+    console.log(pc.dim('  Tip: validate your mainnet server too to confirm real payments work end-to-end.'))
+  } else if (flags.sawMainnet && !flags.sawTestnet) {
+    console.log('')
+    console.log(pc.dim('  Tip: validate a testnet server too for free. This CLI automatically provisions and funds a testnet wallet for testing.'))
+  }
+
+  console.log('')
+
+  if (counts.failed > 0) process.exit(1)
+}

--- a/src/cli/validate/index.ts
+++ b/src/cli/validate/index.ts
@@ -1,0 +1,244 @@
+import { Cli, z } from 'incur'
+
+import { validate as validateDiscovery } from '../../discovery/Validate.js'
+import { pc } from '../utils.js'
+import { validateChallenge, validateErrorHandling } from './challenge.js'
+import { extractEndpointsFromDiscovery, extractRequestBodyFromDiscovery, fetchDiscoveryDoc } from './discovery.js'
+import { check, fail, parseEndpointArg, printCheck, printSection, resolveBodyForEndpoint, warn } from './helpers.js'
+import { validatePaymentFlow } from './payment.js'
+
+const validate = Cli.create('validate', {
+  description: 'Validate an MPP server implementation end-to-end',
+  args: z.object({
+    url: z.string().describe('Base URL of the MPP server to validate'),
+  }),
+  options: z.object({
+    endpoint: z.string().optional().describe('Endpoint to test (METHOD:path). Skips discovery.'),
+    body: z.string().optional().describe('Request body. With --endpoint, used directly. In discovery mode, JSON with / keys is a per-path mapping.'),
+    query: z.array(z.string()).optional().describe('Query parameter (key=value, repeatable)'),
+    verbose: z
+      .number()
+      .default(0)
+      .meta({ count: true })
+      .describe('Verbosity level'),
+    yes: z.boolean().default(false).describe('Auto-approve mainnet payments'),
+  }),
+  alias: {
+    endpoint: 'e',
+    verbose: 'v',
+    yes: 'y',
+  },
+  async run(c) {
+    const baseUrl = c.args.url.replace(/\/$/, '').replace(/\/openapi\.json$/i, '')
+    const verbose = c.options.verbose > 0
+    let totalPassed = 0
+    let totalFailed = 0
+    let totalWarnings = 0
+    let totalSkipped = 0
+
+    console.log(`\n${pc.bold('mppx validate')} ${pc.dim(baseUrl)}\n`)
+
+    // Phase 1: Discovery (always runs)
+    let endpoints: import('./helpers.js').EndpointSpec[] = []
+    let discoveryDoc: Record<string, unknown> | null = null
+
+    printSection('Discovery (/openapi.json)')
+    const discoveryResult = await fetchDiscoveryDoc(baseUrl)
+
+    if ('error' in discoveryResult) {
+      printCheck(fail('Document found', discoveryResult.error, 'MPP servers must serve an OpenAPI document at /openapi.json with x-payment-info extensions.'))
+      totalFailed++
+      if (!c.options.endpoint) {
+        console.log('')
+        console.log(pc.yellow('  No discovery document found.'))
+        console.log(pc.dim('  MPP servers must serve an OpenAPI document at /openapi.json with x-payment-info extensions.'))
+        console.log(pc.dim('  To test a specific endpoint: mppx validate <url> --endpoint POST:/your/path'))
+        console.log('')
+        process.exit(1)
+      }
+    } else {
+      printCheck(check('Document found and parseable'))
+      totalPassed++
+
+      const issues = validateDiscovery(discoveryResult.doc)
+      const errors = issues.filter((i) => i.severity === 'error')
+      const warnings = issues.filter((i) => i.severity === 'warning')
+
+      if (errors.length > 0) {
+        printCheck(fail('Valid OpenAPI structure', `${errors.length} error(s)`))
+        totalFailed++
+        for (const issue of errors) {
+          console.log(pc.dim(`    ${issue.path}: ${issue.message}`))
+        }
+      } else {
+        printCheck(check('Valid OpenAPI structure'))
+        totalPassed++
+      }
+
+      for (const w of warnings) {
+        printCheck(warn(w.message, w.path))
+        totalWarnings++
+      }
+
+      discoveryDoc = discoveryResult.doc as Record<string, unknown>
+    }
+
+    // Resolve endpoints: --endpoint overrides discovery
+    if (c.options.endpoint) {
+      const parsed = parseEndpointArg(c.options.endpoint)
+      if (!parsed) {
+        console.log(pc.red(`Invalid endpoint format: "${c.options.endpoint}". Use METHOD:path (e.g. GET:/api/data)`))
+        process.exit(1)
+      }
+      endpoints.push(parsed)
+    } else if (discoveryDoc) {
+      endpoints = extractEndpointsFromDiscovery(discoveryDoc)
+
+      const NO_AMOUNT = BigInt('999999999999999999')
+      endpoints.sort((a, b) => {
+        const aAmt = a.amount ? BigInt(a.amount) : NO_AMOUNT
+        const bAmt = b.amount ? BigInt(b.amount) : NO_AMOUNT
+        return aAmt < bAmt ? -1 : aAmt > bAmt ? 1 : 0
+      })
+
+      if (endpoints.length === 0) {
+        printCheck(warn('Paid endpoints found', 'No endpoints with x-payment-info'))
+        totalWarnings++
+        console.log(pc.dim('  Use --endpoint to specify endpoints manually.'))
+        process.exit(1)
+      }
+
+      printCheck(check('Paid endpoints found', `${endpoints.length} endpoint(s)`))
+      totalPassed++
+    }
+
+    // Phase 2: Validate each endpoint
+    let sawTestnet = false
+    let sawMainnet = false
+    let paymentSucceeded = false
+    let sawMppEndpoint = false
+    let sawNonMppPaymentEndpoint = false
+
+    for (const endpoint of endpoints) {
+      printSection(`${endpoint.method} ${endpoint.path}`)
+
+      // With --endpoint, --body is used directly. In discovery mode, resolve per-path or auto-generate.
+      let body: string | undefined
+      if (c.options.endpoint) {
+        body = c.options.body
+      } else {
+        body = resolveBodyForEndpoint(c.options.body, endpoint.path)
+        if (!body && discoveryDoc) {
+          body = extractRequestBodyFromDiscovery(discoveryDoc, endpoint)
+          if (body && verbose) {
+            console.log(pc.dim(`  Auto-generated body: ${body}`))
+          }
+        }
+      }
+
+      // Challenge
+      console.log(pc.dim('  Challenge'))
+      const { results: challengeResults, resolvedBody } = await validateChallenge(baseUrl, endpoint, verbose, {
+        body,
+        query: c.options.query,
+        discoveryDoc: discoveryDoc ?? undefined,
+      })
+      const effectiveBody = resolvedBody ?? body
+      for (const result of challengeResults) {
+        printCheck(result)
+        if (result.severity === 'pass') totalPassed++
+        else if (result.severity === 'fail') totalFailed++
+        else if (result.severity === 'warn') totalWarnings++
+        else if (result.severity === 'skip') totalSkipped++
+      }
+
+      const isMppEndpoint = challengeResults.some(
+        (r) => r.severity === 'pass' && r.label === 'Challenge parseable',
+      )
+      if (!isMppEndpoint) {
+        if (challengeResults.some((r) => r.label === 'Not an MPP endpoint')) sawNonMppPaymentEndpoint = true
+        continue
+      }
+      sawMppEndpoint = true
+
+      const isTestnetEndpoint = challengeResults.some(
+        (r) => r.severity === 'pass' && r.label === 'Valid currency address' && r.detail === 'testnet',
+      )
+      if (isTestnetEndpoint) sawTestnet = true
+      else sawMainnet = true
+
+      // Error Handling
+      console.log(pc.dim('  Error Handling'))
+      const errorResults = await validateErrorHandling(baseUrl, endpoint, {
+        body: effectiveBody,
+        query: c.options.query,
+      })
+      for (const result of errorResults) {
+        printCheck(result)
+        if (result.severity === 'pass') totalPassed++
+        else if (result.severity === 'fail') totalFailed++
+        else if (result.severity === 'warn') totalWarnings++
+        else if (result.severity === 'skip') totalSkipped++
+      }
+
+      // Payment
+      console.log(pc.dim('  Payment'))
+      const paymentResults = await validatePaymentFlow(baseUrl, endpoint, verbose, {
+        body: effectiveBody,
+        query: c.options.query,
+        yes: c.options.yes,
+      })
+      for (const result of paymentResults) {
+        printCheck(result)
+        if (result.severity === 'pass') totalPassed++
+        else if (result.severity === 'fail') totalFailed++
+        else if (result.severity === 'warn') totalWarnings++
+        else if (result.severity === 'skip') totalSkipped++
+      }
+      if (paymentResults.some((r) => r.severity === 'pass' && r.label === 'Payment: successful')) {
+        paymentSucceeded = true
+      }
+    }
+
+    // No MPP endpoints found
+    if (!sawMppEndpoint && endpoints.length > 0) {
+      console.log('')
+      if (sawNonMppPaymentEndpoint) {
+        console.log(pc.yellow(`  No MPP endpoints found. Tested ${endpoints.length} endpoint(s) but none use WWW-Authenticate: Payment.`))
+        console.log(pc.dim('  This server may use x402 or another payment protocol.'))
+      } else if (totalSkipped > 0 && totalFailed === 0) {
+        console.log(pc.yellow(`  Could not reach payment gate on any endpoint (all returned 401/403/200).`))
+        console.log(pc.dim('  The server may require authentication before payment. Try providing auth or use --endpoint with a public path.'))
+      } else {
+        console.log(pc.yellow(`  No MPP endpoints found. Tested ${endpoints.length} endpoint(s) but none use WWW-Authenticate: Payment.`))
+        console.log(pc.dim('  This server may use x402 or another payment protocol.'))
+      }
+      console.log('')
+      process.exit(1)
+    }
+
+    // Summary
+    console.log('')
+    const parts: string[] = []
+    if (totalPassed > 0) parts.push(pc.green(`${totalPassed} passed`))
+    if (totalFailed > 0) parts.push(pc.red(`${totalFailed} failed`))
+    if (totalWarnings > 0) parts.push(pc.yellow(`${totalWarnings} warning(s)`))
+    if (totalSkipped > 0) parts.push(pc.yellow(`${totalSkipped} skipped`))
+    console.log(`${pc.bold('Summary:')} ${parts.join(', ')}`)
+
+    // Cross-promotion
+    if (paymentSucceeded && sawTestnet && !sawMainnet) {
+      console.log('')
+      console.log(pc.dim('  Tip: validate your mainnet server too to confirm real payments work end-to-end.'))
+    } else if (sawMainnet && !sawTestnet) {
+      console.log('')
+      console.log(pc.dim('  Tip: validate a testnet server too for free. This CLI automatically provisions and funds a testnet wallet for testing.'))
+    }
+
+    console.log('')
+
+    if (totalFailed > 0) process.exit(1)
+  },
+})
+
+export default validate

--- a/src/cli/validate/index.ts
+++ b/src/cli/validate/index.ts
@@ -3,8 +3,21 @@ import { Cli, z } from 'incur'
 import { validate as validateDiscovery } from '../../discovery/Validate.js'
 import { pc } from '../utils.js'
 import { validateChallenge, validateErrorHandling } from './challenge.js'
-import { extractEndpointsFromDiscovery, extractRequestBodyFromDiscovery, fetchDiscoveryDoc } from './discovery.js'
-import { check, fail, parseEndpointArg, printCheck, printResults, printSection, resolveBodyForEndpoint, warn } from './helpers.js'
+import {
+  extractEndpointsFromDiscovery,
+  extractRequestBodyFromDiscovery,
+  fetchDiscoveryDoc,
+} from './discovery.js'
+import {
+  check,
+  fail,
+  parseEndpointArg,
+  printCheck,
+  printResults,
+  printSection,
+  resolveBodyForEndpoint,
+  warn,
+} from './helpers.js'
 import type { Counts, EndpointSpec } from './helpers.js'
 import { validatePaymentFlow } from './payment.js'
 
@@ -15,13 +28,14 @@ const validate = Cli.create('validate', {
   }),
   options: z.object({
     endpoint: z.string().optional().describe('Endpoint to test (METHOD:path). Skips discovery.'),
-    body: z.string().optional().describe('Request body. With --endpoint, used directly. In discovery mode, JSON with / keys is a per-path mapping.'),
+    body: z
+      .string()
+      .optional()
+      .describe(
+        'Request body. With --endpoint, used directly. In discovery mode, JSON with / keys is a per-path mapping.',
+      ),
     query: z.array(z.string()).optional().describe('Query parameter (key=value, repeatable)'),
-    verbose: z
-      .number()
-      .default(0)
-      .meta({ count: true })
-      .describe('Verbosity level'),
+    verbose: z.number().default(0).meta({ count: true }).describe('Verbosity level'),
     yes: z.boolean().default(false).describe('Auto-approve mainnet payments'),
   }),
   alias: {
@@ -36,7 +50,11 @@ const validate = Cli.create('validate', {
 
     console.log(`\n${pc.bold('mppx validate')} ${pc.dim(baseUrl)}\n`)
 
-    const { endpoints, discoveryDoc, shouldExit } = await discoverEndpoints(baseUrl, c.options, counts)
+    const { endpoints, discoveryDoc, shouldExit } = await discoverEndpoints(
+      baseUrl,
+      c.options,
+      counts,
+    )
     if (shouldExit) process.exit(1)
     const flags = await validateEndpoints(baseUrl, endpoints, discoveryDoc, counts, {
       verbose,
@@ -55,9 +73,19 @@ export default validate
 
 async function discoverEndpoints(
   baseUrl: string,
-  options: { endpoint?: string | undefined; body?: string | undefined; query?: string[] | undefined; verbose: number; yes: boolean },
+  options: {
+    endpoint?: string | undefined
+    body?: string | undefined
+    query?: string[] | undefined
+    verbose: number
+    yes: boolean
+  },
   counts: Counts,
-): Promise<{ endpoints: EndpointSpec[]; discoveryDoc: Record<string, unknown> | null; shouldExit?: boolean }> {
+): Promise<{
+  endpoints: EndpointSpec[]
+  discoveryDoc: Record<string, unknown> | null
+  shouldExit?: boolean
+}> {
   let endpoints: EndpointSpec[] = []
   let discoveryDoc: Record<string, unknown> | null = null
 
@@ -65,13 +93,25 @@ async function discoverEndpoints(
   const discoveryResult = await fetchDiscoveryDoc(baseUrl)
 
   if ('error' in discoveryResult) {
-    printCheck(fail('Document found', discoveryResult.error, 'MPP servers must serve an OpenAPI document at /openapi.json with x-payment-info extensions.'))
+    printCheck(
+      fail(
+        'Document found',
+        discoveryResult.error,
+        'MPP servers must serve an OpenAPI document at /openapi.json with x-payment-info extensions.',
+      ),
+    )
     counts.failed++
     if (!options.endpoint) {
       console.log('')
       console.log(pc.yellow('  No discovery document found.'))
-      console.log(pc.dim('  MPP servers must serve an OpenAPI document at /openapi.json with x-payment-info extensions.'))
-      console.log(pc.dim('  To test a specific endpoint: mppx validate <url> --endpoint POST:/your/path'))
+      console.log(
+        pc.dim(
+          '  MPP servers must serve an OpenAPI document at /openapi.json with x-payment-info extensions.',
+        ),
+      )
+      console.log(
+        pc.dim('  To test a specific endpoint: mppx validate <url> --endpoint POST:/your/path'),
+      )
       console.log('')
       return { endpoints, discoveryDoc, shouldExit: true }
     }
@@ -106,7 +146,11 @@ async function discoverEndpoints(
   if (options.endpoint) {
     const parsed = parseEndpointArg(options.endpoint)
     if (!parsed) {
-      console.log(pc.red(`Invalid endpoint format: "${options.endpoint}". Use METHOD:path (e.g. GET:/api/data)`))
+      console.log(
+        pc.red(
+          `Invalid endpoint format: "${options.endpoint}". Use METHOD:path (e.g. GET:/api/data)`,
+        ),
+      )
       return { endpoints, discoveryDoc, shouldExit: true }
     }
     endpoints.push(parsed)
@@ -146,7 +190,13 @@ async function validateEndpoints(
     query?: string[] | undefined
     yes: boolean
   },
-): Promise<{ sawMppEndpoint: boolean; sawNonMppPaymentEndpoint: boolean; sawTestnet: boolean; sawMainnet: boolean; paymentSucceeded: boolean }> {
+): Promise<{
+  sawMppEndpoint: boolean
+  sawNonMppPaymentEndpoint: boolean
+  sawTestnet: boolean
+  sawMainnet: boolean
+  paymentSucceeded: boolean
+}> {
   let sawTestnet = false
   let sawMainnet = false
   let paymentSucceeded = false
@@ -172,11 +222,16 @@ async function validateEndpoints(
 
     // Challenge
     console.log(pc.dim('  Challenge'))
-    const { results: challengeResults, resolvedBody } = await validateChallenge(baseUrl, endpoint, options.verbose, {
-      body,
-      query: options.query,
-      discoveryDoc: discoveryDoc ?? undefined,
-    })
+    const { results: challengeResults, resolvedBody } = await validateChallenge(
+      baseUrl,
+      endpoint,
+      options.verbose,
+      {
+        body,
+        query: options.query,
+        discoveryDoc: discoveryDoc ?? undefined,
+      },
+    )
     const effectiveBody = resolvedBody ?? body
     printResults(challengeResults, counts)
 
@@ -184,13 +239,15 @@ async function validateEndpoints(
       (r) => r.severity === 'pass' && r.label === 'Challenge parseable',
     )
     if (!isMppEndpoint) {
-      if (challengeResults.some((r) => r.label === 'Not an MPP endpoint')) sawNonMppPaymentEndpoint = true
+      if (challengeResults.some((r) => r.label === 'Not an MPP endpoint'))
+        sawNonMppPaymentEndpoint = true
       continue
     }
     sawMppEndpoint = true
 
     const isTestnetEndpoint = challengeResults.some(
-      (r) => r.severity === 'pass' && r.label === 'Valid currency address' && r.detail === 'testnet',
+      (r) =>
+        r.severity === 'pass' && r.label === 'Valid currency address' && r.detail === 'testnet',
     )
     if (isTestnetEndpoint) sawTestnet = true
     else sawMainnet = true
@@ -221,20 +278,40 @@ async function validateEndpoints(
 
 function printSummary(
   counts: Counts,
-  flags: { sawMppEndpoint: boolean; sawNonMppPaymentEndpoint: boolean; sawTestnet: boolean; sawMainnet: boolean; paymentSucceeded: boolean },
+  flags: {
+    sawMppEndpoint: boolean
+    sawNonMppPaymentEndpoint: boolean
+    sawTestnet: boolean
+    sawMainnet: boolean
+    paymentSucceeded: boolean
+  },
   endpointsLength: number,
 ): void {
   // No MPP endpoints found
   if (!flags.sawMppEndpoint && endpointsLength > 0) {
     console.log('')
     if (flags.sawNonMppPaymentEndpoint) {
-      console.log(pc.yellow(`  No MPP endpoints found. Tested ${endpointsLength} endpoint(s) but none use WWW-Authenticate: Payment.`))
+      console.log(
+        pc.yellow(
+          `  No MPP endpoints found. Tested ${endpointsLength} endpoint(s) but none use WWW-Authenticate: Payment.`,
+        ),
+      )
       console.log(pc.dim('  This server may use x402 or another payment protocol.'))
     } else if (counts.skipped > 0 && counts.failed === 0) {
-      console.log(pc.yellow(`  Could not reach payment gate on any endpoint (all returned 401/403/200).`))
-      console.log(pc.dim('  The server may require authentication before payment. Try providing auth or use --endpoint with a public path.'))
+      console.log(
+        pc.yellow(`  Could not reach payment gate on any endpoint (all returned 401/403/200).`),
+      )
+      console.log(
+        pc.dim(
+          '  The server may require authentication before payment. Try providing auth or use --endpoint with a public path.',
+        ),
+      )
     } else {
-      console.log(pc.yellow(`  No MPP endpoints found. Tested ${endpointsLength} endpoint(s) but none use WWW-Authenticate: Payment.`))
+      console.log(
+        pc.yellow(
+          `  No MPP endpoints found. Tested ${endpointsLength} endpoint(s) but none use WWW-Authenticate: Payment.`,
+        ),
+      )
       console.log(pc.dim('  This server may use x402 or another payment protocol.'))
     }
     console.log('')
@@ -253,10 +330,16 @@ function printSummary(
   // Cross-promotion
   if (flags.paymentSucceeded && flags.sawTestnet && !flags.sawMainnet) {
     console.log('')
-    console.log(pc.dim('  Tip: validate your mainnet server too to confirm real payments work end-to-end.'))
+    console.log(
+      pc.dim('  Tip: validate your mainnet server too to confirm real payments work end-to-end.'),
+    )
   } else if (flags.sawMainnet && !flags.sawTestnet) {
     console.log('')
-    console.log(pc.dim('  Tip: validate a testnet server too for free. This CLI automatically provisions and funds a testnet wallet for testing.'))
+    console.log(
+      pc.dim(
+        '  Tip: validate a testnet server too for free. This CLI automatically provisions and funds a testnet wallet for testing.',
+      ),
+    )
   }
 
   console.log('')

--- a/src/cli/validate/payment.ts
+++ b/src/cli/validate/payment.ts
@@ -1,11 +1,20 @@
+import { createClient, http } from 'viem'
+import { privateKeyToAccount, generatePrivateKey } from 'viem/accounts'
+import { waitForTransactionReceipt } from 'viem/actions'
+import { Actions } from 'viem/tempo'
+import { tempo as tempoMethods } from '../../tempo/client/index.js'
+import { tempoModerato, tempo as tempoMainnetChain } from 'viem/tempo/chains'
+
 import * as Challenge from '../../Challenge.js'
 import * as Constants from '../../Constants.js'
 import * as Mppx from '../../client/Mppx.js'
 import * as Receipt from '../../Receipt.js'
 import { loadConfig, selectChallenge } from '../internal.js'
-import { confirm, pc } from '../utils.js'
+import { resolveAccount, resolveAccountName } from '../account.js'
+import { fetchTokenInfo, confirm, pc } from '../utils.js'
 import type { CheckResult, EndpointSpec } from './helpers.js'
-import { buildUrl, check, fail, fetchWithTimeout, formatBytes, MAINNET_CHAIN_ID, skip, warn } from './helpers.js'
+import { chainId as tempoChainIds } from '../../tempo/internal/defaults.js'
+import { buildUrl, check, fail, fetchWithTimeout, formatBytes, skip, warn } from './helpers.js'
 
 async function provisionAndPayTestnet(
   challenge: Challenge.Challenge,
@@ -13,21 +22,15 @@ async function provisionAndPayTestnet(
 ): Promise<{ methods: import('../../Method.js').AnyClient[] } | undefined> {
   try {
     console.log(pc.dim('    Provisioning testnet wallet and funding via faucet...'))
-    const { privateKeyToAccount, generatePrivateKey } = await import('viem/accounts')
     const key = generatePrivateKey()
     const account = privateKeyToAccount(key)
 
-    const { createClient, http } = await import('viem')
-    const { tempoModerato } = await import('viem/tempo/chains')
     const client = createClient({ chain: tempoModerato, transport: http() })
-    const { Actions } = await import('viem/tempo')
     const hashes = await Actions.faucet.fund(client, { account })
-    const { waitForTransactionReceipt } = await import('viem/actions')
     await Promise.all(hashes.map((hash) => waitForTransactionReceipt(client, { hash })))
     console.log(pc.dim(`    Using wallet: ${account.address}`))
 
-    const { tempo } = await import('../../tempo/client/index.js')
-    const methods = [...tempo({ account })]
+    const methods = [...tempoMethods({ account })]
     return { methods }
   } catch (error) {
     if (verbose) console.log(pc.dim(`    Provisioning failed: ${(error as Error).message}`))
@@ -35,24 +38,20 @@ async function provisionAndPayTestnet(
   }
 }
 
-// Resolves the wallet address using the same priority as the Tempo plugin:
-// MPPX_PRIVATE_KEY env > Tempo CLI keystore > OS keychain.
 async function resolveWalletAddress(): Promise<string | undefined> {
-  const { resolveAccountName, createKeychain } = await import('../account.js')
+  const accountName = resolveAccountName()
   const { isTempoAccount } = await import('../utils.js')
   const { resolveTempoAccount } = await import('../plugins/tempo.js')
-  const { privateKeyToAccount } = await import('viem/accounts')
-
-  const accountName = resolveAccountName()
-  const envKey = process.env.MPPX_PRIVATE_KEY?.trim()
-  if (envKey) return privateKeyToAccount(envKey as `0x${string}`).address
   if (isTempoAccount(accountName)) {
     const entry = resolveTempoAccount(accountName)
     if (entry) return entry.wallet_address
   }
-  const key = await createKeychain(accountName).get()
-  if (key) return privateKeyToAccount(key as `0x${string}`).address
-  return undefined
+  try {
+    const account = await resolveAccount()
+    return account.address
+  } catch {
+    return undefined
+  }
 }
 
 export async function validatePaymentFlow(
@@ -100,7 +99,7 @@ export async function validatePaymentFlow(
   // Detect network
   const request = challenge.request as Record<string, unknown>
   const methodDetails = request.methodDetails as Record<string, unknown> | undefined
-  const isTestnet = typeof methodDetails?.chainId === 'number' && methodDetails.chainId !== MAINNET_CHAIN_ID
+  const isTestnet = typeof methodDetails?.chainId === 'number' && methodDetails.chainId !== tempoChainIds.mainnet
 
   // Testnet Tempo: always use ephemeral wallet (zero-setup, free money)
   if (isTestnet && challenge.method === Constants.Methods.tempo) {
@@ -142,6 +141,7 @@ export async function validatePaymentFlow(
   }
 
   const requiredAmount = request.amount ? BigInt(request.amount as string) : undefined
+  // Display only -- defaults to 6 (standard for USDC/PathUSD tokens)
   const decimals = (request.decimals as number | undefined) ?? 6
   const currency = request.currency as string | undefined
 
@@ -151,9 +151,6 @@ export async function validatePaymentFlow(
     try {
       walletAddress = await resolveWalletAddress()
       if (walletAddress) {
-        const { fetchTokenInfo } = await import('../utils.js')
-        const { createClient, http } = await import('viem')
-        const { tempo: tempoMainnetChain } = await import('viem/tempo/chains')
         const client = createClient({ chain: tempoMainnetChain, transport: http() })
         const tokenInfo = await fetchTokenInfo(client, currency as `0x${string}`, walletAddress as `0x${string}`)
         const requiredDisplay = `$${(Number(requiredAmount) / 10 ** decimals).toFixed(2)}`
@@ -172,9 +169,14 @@ export async function validatePaymentFlow(
     }
   }
 
-  // Prompt before paying on mainnet (unless --yes)
+  // Prompt before paying on mainnet (unless --yes or non-interactive)
   const amountDisplay = requiredAmount ? `$${(Number(requiredAmount) / 10 ** decimals).toFixed(2)}` : 'unknown amount'
   if (walletAddress) console.log(pc.dim(`    Using wallet: ${walletAddress}`))
+  const isInteractive = process.stdin.isTTY ?? false
+  if (!options?.yes && !isInteractive) {
+    results.push(skip('Payment: skipped', 'Non-interactive mode. Use --yes to approve mainnet payments.'))
+    return results
+  }
   if (!options?.yes) {
     console.log('')
     const ok = await confirm(
@@ -377,7 +379,6 @@ async function sendAndValidateResponse(
     try {
       const receipt = Receipt.deserialize(receiptHeader)
       if (receipt.reference && /^0x[0-9a-fA-F]{64}$/.test(receipt.reference)) {
-        const { tempoModerato, tempo: tempoMainnetChain } = await import('viem/tempo/chains')
         const chain = isTestnet ? tempoModerato : tempoMainnetChain
         const explorerUrl = chain.blockExplorers?.default?.url
         if (explorerUrl) {

--- a/src/cli/validate/payment.ts
+++ b/src/cli/validate/payment.ts
@@ -1,0 +1,391 @@
+import * as Challenge from '../../Challenge.js'
+import * as Constants from '../../Constants.js'
+import * as Mppx from '../../client/Mppx.js'
+import * as Receipt from '../../Receipt.js'
+import { loadConfig, selectChallenge } from '../internal.js'
+import { confirm, pc } from '../utils.js'
+import type { CheckResult, EndpointSpec } from './helpers.js'
+import { buildUrl, check, fail, fetchWithTimeout, formatBytes, MAINNET_CHAIN_ID, skip, warn } from './helpers.js'
+
+async function provisionAndPayTestnet(
+  challenge: Challenge.Challenge,
+  verbose: boolean,
+): Promise<{ methods: import('../../Method.js').AnyClient[] } | undefined> {
+  try {
+    console.log(pc.dim('    Provisioning testnet wallet and funding via faucet...'))
+    const { privateKeyToAccount, generatePrivateKey } = await import('viem/accounts')
+    const key = generatePrivateKey()
+    const account = privateKeyToAccount(key)
+
+    const { createClient, http } = await import('viem')
+    const { tempoModerato } = await import('viem/tempo/chains')
+    const client = createClient({ chain: tempoModerato, transport: http() })
+    const { Actions } = await import('viem/tempo')
+    const hashes = await Actions.faucet.fund(client, { account })
+    const { waitForTransactionReceipt } = await import('viem/actions')
+    await Promise.all(hashes.map((hash) => waitForTransactionReceipt(client, { hash })))
+    console.log(pc.dim(`    Using wallet: ${account.address}`))
+
+    const { tempo } = await import('../../tempo/client/index.js')
+    const methods = [...tempo({ account })]
+    return { methods }
+  } catch (error) {
+    if (verbose) console.log(pc.dim(`    Provisioning failed: ${(error as Error).message}`))
+    return undefined
+  }
+}
+
+// Resolves the wallet address using the same priority as the Tempo plugin:
+// MPPX_PRIVATE_KEY env > Tempo CLI keystore > OS keychain.
+async function resolveWalletAddress(): Promise<string | undefined> {
+  const { resolveAccountName, createKeychain } = await import('../account.js')
+  const { isTempoAccount } = await import('../utils.js')
+  const { resolveTempoAccount } = await import('../plugins/tempo.js')
+  const { privateKeyToAccount } = await import('viem/accounts')
+
+  const accountName = resolveAccountName()
+  const envKey = process.env.MPPX_PRIVATE_KEY?.trim()
+  if (envKey) return privateKeyToAccount(envKey as `0x${string}`).address
+  if (isTempoAccount(accountName)) {
+    const entry = resolveTempoAccount(accountName)
+    if (entry) return entry.wallet_address
+  }
+  const key = await createKeychain(accountName).get()
+  if (key) return privateKeyToAccount(key as `0x${string}`).address
+  return undefined
+}
+
+export async function validatePaymentFlow(
+  baseUrl: string,
+  endpoint: EndpointSpec,
+  verbose: boolean,
+  options?: { body?: string | undefined; query?: string[] | undefined; yes?: boolean | undefined },
+): Promise<CheckResult[]> {
+  const results: CheckResult[] = []
+  const url = buildUrl(baseUrl, endpoint, options?.query)
+  const fetchHeaders: Record<string, string> = {}
+  let fetchBody: string | undefined
+  if (options?.body) {
+    fetchBody = options.body
+    fetchHeaders['content-type'] = 'application/json'
+  }
+
+  // Get a fresh challenge
+  let challengeResponse: Response
+  try {
+    challengeResponse = await fetchWithTimeout(url, {
+      method: endpoint.method,
+      headers: fetchHeaders,
+      body: fetchBody ?? null,
+    })
+  } catch (error) {
+    results.push(fail('Payment: fetch challenge', (error as Error).message))
+    return results
+  }
+
+  if (challengeResponse.status !== 402) {
+    results.push(skip('Payment: skipped', `Endpoint returned ${challengeResponse.status}`))
+    return results
+  }
+
+  // Parse challenge
+  let challenge: Challenge.Challenge
+  try {
+    challenge = Challenge.fromResponse(challengeResponse)
+  } catch (error) {
+    results.push(fail('Payment: parse challenge', (error as Error).message))
+    return results
+  }
+
+  // Detect network
+  const request = challenge.request as Record<string, unknown>
+  const methodDetails = request.methodDetails as Record<string, unknown> | undefined
+  const isTestnet = typeof methodDetails?.chainId === 'number' && methodDetails.chainId !== MAINNET_CHAIN_ID
+
+  // Testnet Tempo: always use ephemeral wallet (zero-setup, free money)
+  if (isTestnet && challenge.method === Constants.Methods.tempo) {
+    const provisioned = await provisionAndPayTestnet(challenge, verbose)
+    if (provisioned) {
+      const fakeResp = new Response(null, {
+        status: 402,
+        headers: { [Constants.Headers.wwwAuthenticate]: Challenge.serialize(challenge) },
+      })
+      try {
+        const mppx = Mppx.create({ methods: provisioned.methods, polyfill: false })
+        const cred = await mppx.createCredential(fakeResp)
+        results.push(check('Payment: credential created', 'ephemeral testnet wallet'))
+        return await sendAndValidateResponse(results, url, endpoint, cred, fetchHeaders, fetchBody, verbose, true)
+      } catch (error) {
+        results.push(fail('Payment: create credential', (error as Error).message))
+        return results
+      }
+    } else {
+      results.push(fail('Payment: auto-provision wallet', 'Failed to create and fund testnet wallet'))
+      return results
+    }
+  }
+
+  // Mainnet: use configured wallet
+  const loaded = await loadConfig().catch(() => undefined)
+  const selected = selectChallenge([challenge], loaded?.config)
+
+  if (!selected) {
+    results.push(skip('Payment: no configured method', `Need ${challenge.method}/${challenge.intent}`, 'Run "mppx account create" to create a local wallet for payment testing. The wallet is stored on your machine and only used by mppx.'))
+    return results
+  }
+
+  const { plugin, method: directMethod } = selected
+
+  if (!plugin && !directMethod) {
+    results.push(skip('Payment: no plugin available', `${challenge.method}/${challenge.intent}`))
+    return results
+  }
+
+  const requiredAmount = request.amount ? BigInt(request.amount as string) : undefined
+  const decimals = (request.decimals as number | undefined) ?? 6
+  const currency = request.currency as string | undefined
+
+  // Pre-flight balance check
+  let walletAddress: string | undefined
+  if (challenge.method === Constants.Methods.tempo && requiredAmount && currency) {
+    try {
+      walletAddress = await resolveWalletAddress()
+      if (walletAddress) {
+        const { fetchTokenInfo } = await import('../utils.js')
+        const { createClient, http } = await import('viem')
+        const { tempo: tempoMainnetChain } = await import('viem/tempo/chains')
+        const client = createClient({ chain: tempoMainnetChain, transport: http() })
+        const tokenInfo = await fetchTokenInfo(client, currency as `0x${string}`, walletAddress as `0x${string}`)
+        const requiredDisplay = `$${(Number(requiredAmount) / 10 ** decimals).toFixed(2)}`
+        const balanceDisplay = `$${(Number(tokenInfo.balance) / 10 ** tokenInfo.decimals).toFixed(2)}`
+
+        if (tokenInfo.balance < requiredAmount) {
+          console.log(pc.dim(`    Wallet: ${walletAddress}`))
+          console.log(pc.dim(`    Balance: ${balanceDisplay} ${tokenInfo.symbol}`))
+          const hint = `Wallet ${walletAddress} has ${balanceDisplay} but endpoint requires ${requiredDisplay}. Fund this wallet to run payment tests, or use a testnet server.`
+          results.push(skip('Payment: insufficient balance', `Have ${balanceDisplay}, need ${requiredDisplay}`, hint))
+          return results
+        }
+      }
+    } catch (e) {
+      if (verbose) console.log(pc.dim(`    Balance check skipped: ${(e as Error).message}`))
+    }
+  }
+
+  // Prompt before paying on mainnet (unless --yes)
+  const amountDisplay = requiredAmount ? `$${(Number(requiredAmount) / 10 ** decimals).toFixed(2)}` : 'unknown amount'
+  if (walletAddress) console.log(pc.dim(`    Using wallet: ${walletAddress}`))
+  if (!options?.yes) {
+    console.log('')
+    const ok = await confirm(
+      `  ${pc.yellow('Mainnet payment:')} Will transfer ${amountDisplay} to ${String(request.recipient).slice(0, 10)}... Continue?`,
+      false,
+    )
+    if (!ok) {
+      results.push(skip('Payment: skipped by user', 'mainnet payment declined'))
+      return results
+    }
+  } else {
+    console.log(pc.dim(`    Auto-approved: ${amountDisplay} to ${String(request.recipient).slice(0, 10)}...`))
+  }
+
+  // Setup plugin or use direct method
+  let methods: import('../../Method.js').AnyClient[]
+  let createCredentialFn: ((response: Response) => Promise<string>) | undefined
+
+  if (plugin) {
+    try {
+      const pluginResult = await plugin.setup({
+        challenge,
+        options: { network: 'mainnet' },
+        methodOpts: {},
+      })
+      methods = pluginResult.methods
+      createCredentialFn = pluginResult.createCredential
+    } catch (error) {
+      const msg = (error as Error).message
+      if (msg.includes('No account found') || msg.includes('not found')) {
+        results.push(skip('Payment: no wallet configured', msg))
+      } else {
+        results.push(fail('Payment: wallet setup', msg))
+      }
+      return results
+    }
+  } else {
+    methods = [directMethod!]
+  }
+
+  // Create credential
+  let credential: string
+  const fakeResponse = new Response(null, {
+    status: 402,
+    headers: { [Constants.Headers.wwwAuthenticate]: Challenge.serialize(challenge) },
+  })
+  try {
+    if (createCredentialFn) {
+      credential = await createCredentialFn(fakeResponse)
+    } else {
+      const mppx = Mppx.create({ methods, polyfill: false })
+      credential = await mppx.createCredential(fakeResponse)
+    }
+  } catch (error) {
+    const msg = (error as Error).message
+    const isInsufficientBalance = msg.toLowerCase().includes('insufficientbalance') || msg.toLowerCase().includes('insufficient')
+    if (isInsufficientBalance) {
+      const match = msg.match(/available:\s*(\d+),\s*required:\s*(\d+)/)
+      const available = match ? BigInt(match[1]!) : undefined
+      const required = match ? BigInt(match[2]!) : requiredAmount
+      const fromMatch = msg.match(/from:\s*(0x[0-9a-fA-F]{40})/)
+      const fromAddr = fromMatch?.[1]
+      const requiredDisplay = required ? `$${(Number(required) / 10 ** decimals).toFixed(2)}` : 'unknown'
+      const availableDisplay = available !== undefined ? `$${(Number(available) / 10 ** decimals).toFixed(2)}` : undefined
+      const detail = availableDisplay ? `Have ${availableDisplay}, need ${requiredDisplay}` : `Endpoint requires ${requiredDisplay}`
+      const hint = fromAddr
+        ? `Wallet ${fromAddr} needs at least ${requiredDisplay}. This is a local wallet created by "mppx account create". Fund it to run payment tests, or point at a testnet server for free validation.`
+        : `Fund your mppx wallet with at least ${requiredDisplay} to run payment tests, or use a testnet server.`
+      results.push(skip('Payment: insufficient balance', detail, hint))
+      return results
+    }
+    results.push(fail('Payment: create credential', msg))
+    return results
+  }
+
+  results.push(check('Payment: credential created'))
+
+  // Prepare and send
+  plugin?.prepareCredentialRequest?.({ challenge, credential, headers: fetchHeaders })
+  return await sendAndValidateResponse(results, url, endpoint, credential, fetchHeaders, fetchBody, verbose, isTestnet)
+}
+
+async function sendAndValidateResponse(
+  results: CheckResult[],
+  url: string,
+  endpoint: EndpointSpec,
+  credential: string,
+  baseHeaders: Record<string, string>,
+  fetchBody: string | undefined,
+  verbose: boolean,
+  isTestnet?: boolean,
+): Promise<CheckResult[]> {
+  let paymentResponse: Response
+  try {
+    paymentResponse = await fetchWithTimeout(url, {
+      method: endpoint.method,
+      headers: { ...baseHeaders, [Constants.Headers.authorization]: credential },
+      body: fetchBody ?? null,
+    }, 30_000)
+  } catch (error) {
+    results.push(fail('Payment: send credential', (error as Error).message))
+    return results
+  }
+
+  if (paymentResponse.status === 402) {
+    const body = await paymentResponse.text().catch(() => '')
+    let detail = 'Payment rejected'
+    try {
+      const problem = JSON.parse(body) as Record<string, unknown>
+      detail = (problem.detail as string) ?? (problem.title as string) ?? detail
+    } catch {}
+    results.push(fail('Payment: accepted', detail, 'The server rejected a valid credential. Check that your payment verification logic accepts the credential format and that the payment was processed on-chain.'))
+    return results
+  }
+
+  if (paymentResponse.status >= 400 && paymentResponse.status < 500) {
+    results.push(warn('Payment: post-payment response', `Got ${paymentResponse.status}`, 'Payment succeeded but the endpoint returned a client error. The endpoint likely requires request body parameters. Use --body to provide them.'))
+  } else if (paymentResponse.status >= 500) {
+    results.push(fail('Payment: server response', `Got ${paymentResponse.status}`, 'Payment was accepted but the server errored while generating the response. Check server logs for the underlying error.'))
+    return results
+  } else {
+    results.push(check('Payment: successful', `HTTP ${paymentResponse.status}`))
+  }
+
+  // Validate receipt
+  const receiptHeader = paymentResponse.headers.get(Constants.Headers.paymentReceipt)
+  if (!receiptHeader) {
+    results.push(fail('Payment-Receipt header present', undefined, 'After accepting payment, include a Payment-Receipt header with a base64url-encoded JSON object containing: method, reference, status ("success"), and timestamp (ISO 8601).'))
+  } else {
+    results.push(check('Payment-Receipt header present'))
+    try {
+      const receipt = Receipt.deserialize(receiptHeader)
+      results.push(check('Receipt parseable'))
+
+      if (receipt.status === 'success') {
+        results.push(check('Receipt status is "success"'))
+      } else {
+        results.push(fail('Receipt status is "success"', `Got: ${receipt.status}`))
+      }
+
+      if (receipt.reference) {
+        const validTxHash = /^0x[0-9a-fA-F]{64}$/.test(receipt.reference)
+        const validStripeRef = receipt.reference.startsWith('pi_')
+        if (validTxHash || validStripeRef) {
+          results.push(check('Receipt reference valid', receipt.reference.slice(0, 20) + '...'))
+        } else {
+          results.push(warn('Receipt reference format', receipt.reference.slice(0, 40)))
+        }
+      } else {
+        results.push(warn('Receipt has reference', 'No reference field'))
+      }
+
+      if (receipt.timestamp) {
+        const ts = new Date(receipt.timestamp)
+        const age = Date.now() - ts.getTime()
+        if (age < 60_000) {
+          results.push(check('Receipt timestamp recent', `${Math.round(age / 1000)}s ago`))
+        } else {
+          results.push(warn('Receipt timestamp recent', `${Math.round(age / 60000)}m ago`))
+        }
+      }
+
+      if (verbose) {
+        console.log(pc.dim(`    Receipt: ${JSON.stringify(receipt, null, 2)}`))
+      }
+    } catch (error) {
+      results.push(fail('Receipt parseable', (error as Error).message))
+    }
+  }
+
+  // Validate response body
+  const contentType = paymentResponse.headers.get('content-type') ?? ''
+  const body = await paymentResponse.text().catch(() => '')
+
+  if (body.length > 0) {
+    results.push(check('Response body non-empty', `${contentType.split(';')[0]}, ${formatBytes(body.length)}`))
+  } else {
+    const suspiciousHeaders = [...paymentResponse.headers.entries()].filter(
+      ([key]) =>
+        !key.startsWith('x-') &&
+        !['content-type', 'content-length', 'date', 'server', 'connection', 'keep-alive',
+          'cache-control', 'vary', 'access-control-allow-origin', 'payment-receipt',
+          'payment-session', 'payment-session-snapshot'].includes(key.toLowerCase()),
+    )
+    if (suspiciousHeaders.length > 0) {
+      results.push(warn('Response body empty -- data may be in headers only', suspiciousHeaders.map(([k]) => k).join(', ')))
+    } else {
+      results.push(warn('Response body empty'))
+    }
+  }
+
+  if (!contentType) {
+    results.push(warn('Content-Type header set'))
+  } else {
+    results.push(check('Content-Type header set', contentType.split(';')[0]))
+  }
+
+  // Explorer link for on-chain payments
+  if (receiptHeader) {
+    try {
+      const receipt = Receipt.deserialize(receiptHeader)
+      if (receipt.reference && /^0x[0-9a-fA-F]{64}$/.test(receipt.reference)) {
+        const { tempoModerato, tempo: tempoMainnetChain } = await import('viem/tempo/chains')
+        const chain = isTestnet ? tempoModerato : tempoMainnetChain
+        const explorerUrl = chain.blockExplorers?.default?.url
+        if (explorerUrl) {
+          results.push(check('On-chain transaction', `${explorerUrl}/receipt/${receipt.reference}`))
+        }
+      }
+    } catch {}
+  }
+
+  return results
+}

--- a/src/cli/validate/payment.ts
+++ b/src/cli/validate/payment.ts
@@ -2,18 +2,18 @@ import { createClient, http } from 'viem'
 import { privateKeyToAccount, generatePrivateKey } from 'viem/accounts'
 import { waitForTransactionReceipt } from 'viem/actions'
 import { Actions } from 'viem/tempo'
-import { tempo as tempoMethods } from '../../tempo/client/index.js'
 import { tempoModerato, tempo as tempoMainnetChain } from 'viem/tempo/chains'
 
 import * as Challenge from '../../Challenge.js'
-import * as Constants from '../../Constants.js'
 import * as Mppx from '../../client/Mppx.js'
+import * as Constants from '../../Constants.js'
 import * as Receipt from '../../Receipt.js'
-import { loadConfig, selectChallenge } from '../internal.js'
+import { tempo as tempoMethods } from '../../tempo/client/index.js'
+import { chainId as tempoChainIds } from '../../tempo/internal/defaults.js'
 import { resolveAccount, resolveAccountName } from '../account.js'
+import { loadConfig, selectChallenge } from '../internal.js'
 import { fetchTokenInfo, confirm, pc } from '../utils.js'
 import type { CheckResult, EndpointSpec } from './helpers.js'
-import { chainId as tempoChainIds } from '../../tempo/internal/defaults.js'
 import { buildUrl, check, fail, fetchWithTimeout, formatBytes, skip, warn } from './helpers.js'
 
 async function provisionAndPayTestnet(
@@ -99,7 +99,8 @@ export async function validatePaymentFlow(
   // Detect network
   const request = challenge.request as Record<string, unknown>
   const methodDetails = request.methodDetails as Record<string, unknown> | undefined
-  const isTestnet = typeof methodDetails?.chainId === 'number' && methodDetails.chainId !== tempoChainIds.mainnet
+  const isTestnet =
+    typeof methodDetails?.chainId === 'number' && methodDetails.chainId !== tempoChainIds.mainnet
 
   // Testnet Tempo: always use ephemeral wallet (zero-setup, free money)
   if (isTestnet && challenge.method === Constants.Methods.tempo) {
@@ -113,13 +114,24 @@ export async function validatePaymentFlow(
         const mppx = Mppx.create({ methods: provisioned.methods, polyfill: false })
         const cred = await mppx.createCredential(fakeResp)
         results.push(check('Payment: credential created', 'ephemeral testnet wallet'))
-        return await sendAndValidateResponse(results, url, endpoint, cred, fetchHeaders, fetchBody, verbose, true)
+        return await sendAndValidateResponse(
+          results,
+          url,
+          endpoint,
+          cred,
+          fetchHeaders,
+          fetchBody,
+          verbose,
+          true,
+        )
       } catch (error) {
         results.push(fail('Payment: create credential', (error as Error).message))
         return results
       }
     } else {
-      results.push(fail('Payment: auto-provision wallet', 'Failed to create and fund testnet wallet'))
+      results.push(
+        fail('Payment: auto-provision wallet', 'Failed to create and fund testnet wallet'),
+      )
       return results
     }
   }
@@ -129,7 +141,13 @@ export async function validatePaymentFlow(
   const selected = selectChallenge([challenge], loaded?.config)
 
   if (!selected) {
-    results.push(skip('Payment: no configured method', `Need ${challenge.method}/${challenge.intent}`, 'Run "mppx account create" to create a local wallet for payment testing. The wallet is stored on your machine and only used by mppx.'))
+    results.push(
+      skip(
+        'Payment: no configured method',
+        `Need ${challenge.method}/${challenge.intent}`,
+        'Run "mppx account create" to create a local wallet for payment testing. The wallet is stored on your machine and only used by mppx.',
+      ),
+    )
     return results
   }
 
@@ -152,7 +170,11 @@ export async function validatePaymentFlow(
       walletAddress = await resolveWalletAddress()
       if (walletAddress) {
         const client = createClient({ chain: tempoMainnetChain, transport: http() })
-        const tokenInfo = await fetchTokenInfo(client, currency as `0x${string}`, walletAddress as `0x${string}`)
+        const tokenInfo = await fetchTokenInfo(
+          client,
+          currency as `0x${string}`,
+          walletAddress as `0x${string}`,
+        )
         const requiredDisplay = `$${(Number(requiredAmount) / 10 ** decimals).toFixed(2)}`
         const balanceDisplay = `$${(Number(tokenInfo.balance) / 10 ** tokenInfo.decimals).toFixed(2)}`
 
@@ -160,7 +182,13 @@ export async function validatePaymentFlow(
           console.log(pc.dim(`    Wallet: ${walletAddress}`))
           console.log(pc.dim(`    Balance: ${balanceDisplay} ${tokenInfo.symbol}`))
           const hint = `Wallet ${walletAddress} has ${balanceDisplay} but endpoint requires ${requiredDisplay}. Fund this wallet to run payment tests, or use a testnet server.`
-          results.push(skip('Payment: insufficient balance', `Have ${balanceDisplay}, need ${requiredDisplay}`, hint))
+          results.push(
+            skip(
+              'Payment: insufficient balance',
+              `Have ${balanceDisplay}, need ${requiredDisplay}`,
+              hint,
+            ),
+          )
           return results
         }
       }
@@ -170,11 +198,15 @@ export async function validatePaymentFlow(
   }
 
   // Prompt before paying on mainnet (unless --yes or non-interactive)
-  const amountDisplay = requiredAmount ? `$${(Number(requiredAmount) / 10 ** decimals).toFixed(2)}` : 'unknown amount'
+  const amountDisplay = requiredAmount
+    ? `$${(Number(requiredAmount) / 10 ** decimals).toFixed(2)}`
+    : 'unknown amount'
   if (walletAddress) console.log(pc.dim(`    Using wallet: ${walletAddress}`))
   const isInteractive = process.stdin.isTTY ?? false
   if (!options?.yes && !isInteractive) {
-    results.push(skip('Payment: skipped', 'Non-interactive mode. Use --yes to approve mainnet payments.'))
+    results.push(
+      skip('Payment: skipped', 'Non-interactive mode. Use --yes to approve mainnet payments.'),
+    )
     return results
   }
   if (!options?.yes) {
@@ -188,7 +220,9 @@ export async function validatePaymentFlow(
       return results
     }
   } else {
-    console.log(pc.dim(`    Auto-approved: ${amountDisplay} to ${String(request.recipient).slice(0, 10)}...`))
+    console.log(
+      pc.dim(`    Auto-approved: ${amountDisplay} to ${String(request.recipient).slice(0, 10)}...`),
+    )
   }
 
   // Setup plugin or use direct method
@@ -232,16 +266,23 @@ export async function validatePaymentFlow(
     }
   } catch (error) {
     const msg = (error as Error).message
-    const isInsufficientBalance = msg.toLowerCase().includes('insufficientbalance') || msg.toLowerCase().includes('insufficient')
+    const isInsufficientBalance =
+      msg.toLowerCase().includes('insufficientbalance') ||
+      msg.toLowerCase().includes('insufficient')
     if (isInsufficientBalance) {
       const match = msg.match(/available:\s*(\d+),\s*required:\s*(\d+)/)
       const available = match ? BigInt(match[1]!) : undefined
       const required = match ? BigInt(match[2]!) : requiredAmount
       const fromMatch = msg.match(/from:\s*(0x[0-9a-fA-F]{40})/)
       const fromAddr = fromMatch?.[1]
-      const requiredDisplay = required ? `$${(Number(required) / 10 ** decimals).toFixed(2)}` : 'unknown'
-      const availableDisplay = available !== undefined ? `$${(Number(available) / 10 ** decimals).toFixed(2)}` : undefined
-      const detail = availableDisplay ? `Have ${availableDisplay}, need ${requiredDisplay}` : `Endpoint requires ${requiredDisplay}`
+      const requiredDisplay = required
+        ? `$${(Number(required) / 10 ** decimals).toFixed(2)}`
+        : 'unknown'
+      const availableDisplay =
+        available !== undefined ? `$${(Number(available) / 10 ** decimals).toFixed(2)}` : undefined
+      const detail = availableDisplay
+        ? `Have ${availableDisplay}, need ${requiredDisplay}`
+        : `Endpoint requires ${requiredDisplay}`
       const hint = fromAddr
         ? `Wallet ${fromAddr} needs at least ${requiredDisplay}. This is a local wallet created by "mppx account create". Fund it to run payment tests, or point at a testnet server for free validation.`
         : `Fund your mppx wallet with at least ${requiredDisplay} to run payment tests, or use a testnet server.`
@@ -256,7 +297,16 @@ export async function validatePaymentFlow(
 
   // Prepare and send
   plugin?.prepareCredentialRequest?.({ challenge, credential, headers: fetchHeaders })
-  return await sendAndValidateResponse(results, url, endpoint, credential, fetchHeaders, fetchBody, verbose, isTestnet)
+  return await sendAndValidateResponse(
+    results,
+    url,
+    endpoint,
+    credential,
+    fetchHeaders,
+    fetchBody,
+    verbose,
+    isTestnet,
+  )
 }
 
 async function sendAndValidateResponse(
@@ -271,11 +321,15 @@ async function sendAndValidateResponse(
 ): Promise<CheckResult[]> {
   let paymentResponse: Response
   try {
-    paymentResponse = await fetchWithTimeout(url, {
-      method: endpoint.method,
-      headers: { ...baseHeaders, [Constants.Headers.authorization]: credential },
-      body: fetchBody ?? null,
-    }, 30_000)
+    paymentResponse = await fetchWithTimeout(
+      url,
+      {
+        method: endpoint.method,
+        headers: { ...baseHeaders, [Constants.Headers.authorization]: credential },
+        body: fetchBody ?? null,
+      },
+      30_000,
+    )
   } catch (error) {
     results.push(fail('Payment: send credential', (error as Error).message))
     return results
@@ -288,14 +342,32 @@ async function sendAndValidateResponse(
       const problem = JSON.parse(body) as Record<string, unknown>
       detail = (problem.detail as string) ?? (problem.title as string) ?? detail
     } catch {}
-    results.push(fail('Payment: accepted', detail, 'The server rejected a valid credential. Check that your payment verification logic accepts the credential format and that the payment was processed on-chain.'))
+    results.push(
+      fail(
+        'Payment: accepted',
+        detail,
+        'The server rejected a valid credential. Check that your payment verification logic accepts the credential format and that the payment was processed on-chain.',
+      ),
+    )
     return results
   }
 
   if (paymentResponse.status >= 400 && paymentResponse.status < 500) {
-    results.push(warn('Payment: post-payment response', `Got ${paymentResponse.status}`, 'Payment succeeded but the endpoint returned a client error. The endpoint likely requires request body parameters. Use --body to provide them.'))
+    results.push(
+      warn(
+        'Payment: post-payment response',
+        `Got ${paymentResponse.status}`,
+        'Payment succeeded but the endpoint returned a client error. The endpoint likely requires request body parameters. Use --body to provide them.',
+      ),
+    )
   } else if (paymentResponse.status >= 500) {
-    results.push(fail('Payment: server response', `Got ${paymentResponse.status}`, 'Payment was accepted but the server errored while generating the response. Check server logs for the underlying error.'))
+    results.push(
+      fail(
+        'Payment: server response',
+        `Got ${paymentResponse.status}`,
+        'Payment was accepted but the server errored while generating the response. Check server logs for the underlying error.',
+      ),
+    )
     return results
   } else {
     results.push(check('Payment: successful', `HTTP ${paymentResponse.status}`))
@@ -304,7 +376,13 @@ async function sendAndValidateResponse(
   // Validate receipt
   const receiptHeader = paymentResponse.headers.get(Constants.Headers.paymentReceipt)
   if (!receiptHeader) {
-    results.push(fail('Payment-Receipt header present', undefined, 'After accepting payment, include a Payment-Receipt header with a base64url-encoded JSON object containing: method, reference, status ("success"), and timestamp (ISO 8601).'))
+    results.push(
+      fail(
+        'Payment-Receipt header present',
+        undefined,
+        'After accepting payment, include a Payment-Receipt header with a base64url-encoded JSON object containing: method, reference, status ("success"), and timestamp (ISO 8601).',
+      ),
+    )
   } else {
     results.push(check('Payment-Receipt header present'))
     try {
@@ -352,17 +430,35 @@ async function sendAndValidateResponse(
   const body = await paymentResponse.text().catch(() => '')
 
   if (body.length > 0) {
-    results.push(check('Response body non-empty', `${contentType.split(';')[0]}, ${formatBytes(body.length)}`))
+    results.push(
+      check('Response body non-empty', `${contentType.split(';')[0]}, ${formatBytes(body.length)}`),
+    )
   } else {
     const suspiciousHeaders = [...paymentResponse.headers.entries()].filter(
       ([key]) =>
         !key.startsWith('x-') &&
-        !['content-type', 'content-length', 'date', 'server', 'connection', 'keep-alive',
-          'cache-control', 'vary', 'access-control-allow-origin', 'payment-receipt',
-          'payment-session', 'payment-session-snapshot'].includes(key.toLowerCase()),
+        ![
+          'content-type',
+          'content-length',
+          'date',
+          'server',
+          'connection',
+          'keep-alive',
+          'cache-control',
+          'vary',
+          'access-control-allow-origin',
+          'payment-receipt',
+          'payment-session',
+          'payment-session-snapshot',
+        ].includes(key.toLowerCase()),
     )
     if (suspiciousHeaders.length > 0) {
-      results.push(warn('Response body empty -- data may be in headers only', suspiciousHeaders.map(([k]) => k).join(', ')))
+      results.push(
+        warn(
+          'Response body empty -- data may be in headers only',
+          suspiciousHeaders.map(([k]) => k).join(', '),
+        ),
+      )
     } else {
       results.push(warn('Response body empty'))
     }


### PR DESCRIPTION
### Overview

Validates MPP server implementations by testing discovery, challenges, error handling, and end-to-end payment flows.

Right now, this only does end-to-end livenet/testnet payments with tempo, but I plan to add support for stripe payments in a follow-up.

When a server defines a `openapi.json`, the validate command automatically discovers and hits machine-payable endpoints, validating their behavior and error handling. The tool constructs request bodies for these endpoints in the following priority order (1) one provided explicitly with `--body`, (2) an example body documented in the `openapi.json`, (3) an auto-generated body using the API schema.

CLI subcommand structure:
```
  src/cli/validate/
    index.ts      - command definition and orchestration
    challenge.ts  - challenge parsing and error handling checks
    payment.ts    - payment flow, wallet provisioning, receipt validation
    discovery.ts  - OpenAPI fetching, endpoint extraction, body generation
    helpers.ts    - shared types, utilities, output formatting
```

### Demonstration

livenet server with `openapi.json`:

```
$ mppx validate https://parallelmpp.dev

Discovery (/openapi.json)
  ✓ Document found and parseable
  ✗ Valid OpenAPI structure (2 error(s))
    paths./api/task/{runId}.get.responses: Operation with x-payment-info MUST have a 402 response
    paths./api/wallet/balance/{address}.get.responses: Operation with x-payment-info MUST have a 402 response
  ✓ Paid endpoints found (5 endpoint(s))

POST /api/search
  Challenge
  ✓ Returns 402 without credentials
  ✓ WWW-Authenticate header present (Payment scheme)
  ✓ Challenge parseable (tempo/charge)
  ✓ Challenge has id
  ✓ Challenge has realm
  ✓ Challenge expires in the future (5m from now)
  ✓ Realm matches server hostname
  ✓ Valid recipient address
  ✓ Valid currency address (mainnet)
  ✓ Amount is valid integer string
  Error Handling
  ✗ Malformed credential returns 402 (Got 500 (server error))
    → When the Authorization header contains an invalid credential, respond with 402 (not 500). Catch credential validation errors and return a fresh challenge.
  Payment
    Using wallet: 0x37138facb18b3Da341004646D29E3c75F7a3beAF

▸   Mainnet payment: Will transfer $0.01 to 0x4021a678... Continue? (y/N) y
  ✓ Payment: credential created
  ⚠ Payment: post-payment response (Got 400)
    → Payment succeeded but the endpoint returned a client error. The endpoint likely requires request body parameters. Use --body to provide them.
  ✓ Payment-Receipt header present
  ✓ Receipt parseable
  ✓ Receipt status is "success"
  ✓ Receipt reference valid (0xd613f9f045e76527a2...)
  ✓ Receipt timestamp recent (0s ago)
  ✓ Response body non-empty (application/json, 164B)
  ✓ Content-Type header set (application/json)
  ✓ On-chain transaction (https://explore.tempo.xyz/receipt/0xd613f9f045e76527a26659aa5d9910f846d4e98f660fadf33be5b0c3a086889b)
```

Without an `openapi.json`, the CLI prints
```
$ mppx validate https://mpp.browserbase.com

Discovery (/openapi.json)
  ✗ Document found (HTTP 404)

  No discovery document found.
  MPP servers must serve an OpenAPI document at /openapi.json with x-payment-info extensions.
  In the meantime, to test a specific endpoint, you can use mppx validate <url> --endpoint POST:/your/path
```

The user can then pass a `--endpoint` override to test

```
$ mppx validate https://mpp.browserbase.com --endpoint POST:browser/session/create

Discovery (/openapi.json)
  ✗ Document found (HTTP 404)
    → MPP servers must serve an OpenAPI document at /openapi.json with x-payment-info extensions.

POST browser/session/create
  Challenge
  ✓ Returns 402 without credentials
  ✓ WWW-Authenticate header present (Payment scheme)
  ✓ Challenge parseable (tempo/charge)
  ✓ Challenge has id
  ✓ Challenge has realm
  ✓ Challenge expires in the future (5m from now)
  ⚠ Realm matches server hostname (realm="ip-172-31-3-82.ec2.internal" vs host="mpp.browserbase.com")
    → Set the realm to your production hostname (or base domain) in the challenge. Clients use realm to verify they are paying the right server.
  ✓ Valid recipient address
  ✓ Valid currency address (mainnet)
  ✓ Amount is valid integer string
  Error Handling
  ✓ Malformed credential returns 402 (not 500)
  ✓ Error response includes fresh challenge
  Payment
    Using wallet: 0x37138facb18b3Da341004646D29E3c75F7a3beAF

▸   Mainnet payment: Will transfer $0.01 to 0x3e4bb7be... Continue? (y/N) y
  ✓ Payment: credential created
  ✓ Payment: successful (HTTP 200)
  ✓ Payment-Receipt header present
  ✓ Receipt parseable
  ✓ Receipt status is "success"
  ✓ Receipt reference valid (0x4702cfa7c4104ef0e0...)
  ✓ Receipt timestamp recent (1s ago)
  ✓ Response body non-empty (application/json, 1.0KB)
  ✓ Content-Type header set (application/json)
  ✓ On-chain transaction (https://explore.tempo.xyz/receipt/0x4702cfa7c4104ef0e09575b0a790fa3aec09f2cce197e9fbe2d6f1ad3333a473)

Summary: 21 passed, 1 failed, 1 warning(s)

  Tip: validate a testnet server too for free. This CLI automatically provisions and funds a testnet wallet for testing.
```

If a server supporting the testnet is provided, the CLI will automatically provision and fund a testnet wallet for testing.

```
$ mppx validate https://starlink-payment-test.vercel.app


Discovery (/openapi.json)
  ✓ Document found and parseable
  ✓ Valid OpenAPI structure
  ✓ Paid endpoints found (1 endpoint(s))

POST /api/flight-starlink
  Challenge
  ✓ Returns 402 without credentials
  ✓ WWW-Authenticate header present (Payment scheme)
  ✓ Challenge parseable (tempo/charge)
  ✓ Challenge has id
  ✓ Challenge has realm
  ✓ Challenge expires in the future (5m from now)
  ✓ Realm matches server hostname
  ✓ Valid recipient address
  ✓ Valid currency address (testnet)
  ✓ Amount is valid integer string
  Error Handling
  ✓ Malformed credential returns 402 (not 500)
  ✓ Error response includes fresh challenge
  Payment
    Provisioning testnet wallet and funding via faucet...
    Using wallet: 0xacEEF24d1138992822AFb50b78642E8E024871B0
  ✓ Payment: credential created (ephemeral testnet wallet)
  ✓ Payment: successful (HTTP 200)
  ✓ Payment-Receipt header present
  ✓ Receipt parseable
  ✓ Receipt status is "success"
  ✓ Receipt reference valid (0x616d4a3d4485bb753a...)
  ✓ Receipt timestamp recent (1s ago)
  ✓ Response body non-empty (application/json, 373B)
  ✓ Content-Type header set (application/json)
  ✓ On-chain transaction (https://explore.testnet.tempo.xyz/receipt/0x616d4a3d4485bb753a2d7eeee176868f706f3f8144426a1e8c368e23e0c22c08)

Summary: 25 passed

  Tip: validate your mainnet server too to confirm real payments work end-to-end.
```