### PR TITLE
fix: emit MCP SDK payment metadata

### DIFF
--- a/.changeset/mcp-sdk-payment-metadata.md
+++ b/.changeset/mcp-sdk-payment-metadata.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed MCP SDK server challenges to return payment-required metadata.

--- a/src/Mcp.ts
+++ b/src/Mcp.ts
@@ -44,11 +44,21 @@ export type JsonRpcRequest = Request & {
 }
 
 /**
+ * Payment-required metadata carried by MCP errors or tool results.
+ */
+export type PaymentRequiredData = {
+  httpStatus: number
+  challenges: Challenge.Challenge[]
+  /** RFC 9457 Problem Details for rich error context. */
+  problem?: Errors.PaymentError.ProblemDetails
+}
+
+/**
  * MCP result with optional receipt metadata.
  */
 export type Result = {
   _meta?: {
-    [paymentRequiredMetaKey]?: ErrorObject['data']
+    [paymentRequiredMetaKey]?: PaymentRequiredData
     [receiptMetaKey]?: Receipt
     [key: string]: unknown
   }
@@ -61,12 +71,7 @@ export type Result = {
 export type ErrorObject = {
   code: number
   message: string
-  data?: {
-    httpStatus: number
-    challenges: Challenge.Challenge[]
-    /** RFC 9457 Problem Details for rich error context. */
-    problem?: Errors.PaymentError.ProblemDetails
-  }
+  data?: PaymentRequiredData
 }
 
 /**

--- a/src/client/internal/protocols/Mcp.ts
+++ b/src/client/internal/protocols/Mcp.ts
@@ -21,10 +21,8 @@ function jsonRpcRequestId(body: unknown): number | string | undefined {
 
 const responseCache = new WeakMap<Response, Promise<Mcp.Response | undefined>>()
 
-type CorePaymentRequiredData = NonNullable<Mcp.ErrorObject['data']>
-
-export type PaymentRequiredData = Pick<CorePaymentRequiredData, 'challenges'> &
-  Partial<Pick<CorePaymentRequiredData, 'httpStatus' | 'problem'>>
+export type PaymentRequiredData = Pick<Mcp.PaymentRequiredData, 'challenges'> &
+  Partial<Pick<Mcp.PaymentRequiredData, 'httpStatus' | 'problem'>>
 
 function mcpHttpRequestId(request?: RequestInit): number | string | undefined {
   const id = jsonRpcRequestId(request?.body)

--- a/src/mcp/client/McpClient.integration.test.ts
+++ b/src/mcp/client/McpClient.integration.test.ts
@@ -486,7 +486,7 @@ async function createHarness(options?: {
     const result = await (payment.charge({ amount: '1' }) as (input: unknown) => Promise<any>)(
       extra,
     )
-    if (result.status === 402) throw result.challenge
+    if (result.status === 402) return result.challenge
 
     return result.withReceipt({
       content: [{ type: 'text' as const, text: 'charge tool executed' }],
@@ -499,7 +499,7 @@ async function createHarness(options?: {
         input: unknown,
       ) => Promise<any>
     )(extra)
-    if (result.status === 402) throw result.challenge
+    if (result.status === 402) return result.challenge
 
     return (result as { withReceipt: (response: unknown) => unknown }).withReceipt({
       content: [{ type: 'text' as const, text: 'session tool executed' }],
@@ -515,7 +515,7 @@ async function createHarness(options?: {
           input: unknown,
         ) => Promise<any>
       )(extra)
-      if (result.status === 402) throw result.challenge
+      if (result.status === 402) return result.challenge
 
       return (result as { withReceipt: (response: unknown) => unknown }).withReceipt({
         content: [{ type: 'text' as const, text: 'session double tool executed' }],

--- a/src/mcp/client/McpClient.test.ts
+++ b/src/mcp/client/McpClient.test.ts
@@ -74,7 +74,7 @@ describe('McpClient.wrap', () => {
           recipient: accounts[0].address,
         })(extra)
 
-        if (result.status === 402) throw result.challenge
+        if (result.status === 402) return result.challenge
 
         return result.withReceipt({
           content: [{ type: 'text' as const, text: 'Premium tool executed' }],

--- a/src/mcp/client/McpClient.ts
+++ b/src/mcp/client/McpClient.ts
@@ -15,7 +15,7 @@ type DefaultMethods = readonly [Method.AnyClient | readonly Method.AnyClient[]]
 type CallToolParams = Parameters<Client['callTool']>[0]
 type CallToolResultSchema = Parameters<Client['callTool']>[1]
 type CallToolRequestOptions = Parameters<Client['callTool']>[2]
-type PaymentRequiredData = NonNullable<core_Mcp.ErrorObject['data']>
+type PaymentRequiredData = core_Mcp.PaymentRequiredData
 
 const MPPX_MCP_CLIENT_WRAPPER = Symbol.for('mppx.mcp.client.wrapper')
 

--- a/src/mcp/server/Transport.test.ts
+++ b/src/mcp/server/Transport.test.ts
@@ -67,19 +67,19 @@ describe('mcpSdk', () => {
   })
 
   describe('respondChallenge', () => {
-    test('creates McpError with correct code and challenge data', async () => {
+    test('creates payment-required metadata with challenge data', async () => {
       const transport = mcpSdk()
       const result = await transport.respondChallenge({
         challenge,
         input: {} as Extra,
       })
 
-      expect(result).toBeInstanceOf(Error)
-      const err = result as any
-      expect(err.code).toBe(Mcp.paymentRequiredCode)
-      expect(err.message).toContain('Payment Required')
-      expect(err.data?.httpStatus).toBe(402)
-      expect(err.data?.challenges).toEqual([challenge])
+      const data = result._meta?.[Mcp.paymentRequiredMetaKey] as
+        | Mcp.PaymentRequiredData
+        | undefined
+      expect(result.isError).toBe(true)
+      expect(data?.httpStatus).toBe(402)
+      expect(data?.challenges).toEqual([challenge])
     })
 
     test('includes problem details when error is provided', async () => {
@@ -91,22 +91,25 @@ describe('mcpSdk', () => {
         input: {} as Extra,
       })
 
-      const err = result as any
-      expect(err.code).toBe(Mcp.paymentRequiredCode)
-      expect(err.message).toContain('verification failed')
-      expect(err.data?.problem).toBeDefined()
-      expect(err.data?.problem?.type).toBe(error.type)
-      expect(err.data?.problem?.challengeId).toBe(challenge.id)
+      const data = result._meta?.[Mcp.paymentRequiredMetaKey] as
+        | Mcp.PaymentRequiredData
+        | undefined
+      expect(data?.problem).toBeDefined()
+      expect(data?.problem?.type).toBe(error.type)
+      expect(data?.problem?.challengeId).toBe(challenge.id)
     })
 
-    test('uses default message when no error provided', async () => {
+    test('marks the result as a tool error', async () => {
       const transport = mcpSdk()
       const result = await transport.respondChallenge({
         challenge,
         input: {} as Extra,
       })
-      const err = result as any
-      expect(err.message).toContain('Payment Required')
+
+      expect(result).toMatchObject({
+        content: [],
+        isError: true,
+      })
     })
   })
 

--- a/src/mcp/server/Transport.ts
+++ b/src/mcp/server/Transport.ts
@@ -1,4 +1,4 @@
-import type { CallToolResult, McpError } from '@modelcontextprotocol/sdk/types.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 
 import type * as Credential from '../../Credential.js'
 import * as core_Mcp from '../../Mcp.js'
@@ -18,13 +18,13 @@ export type Extra = {
   [key: string]: unknown
 }
 
-export type McpSdk = Transport.Transport<Extra, McpError, CallToolResult>
+export type McpSdk = Transport.Transport<Extra, CallToolResult, CallToolResult>
 
 /**
  * MCP SDK transport for server-side payment handling with `@modelcontextprotocol/sdk`.
  *
  * - Reads credentials from `_meta["org.paymentauth/credential"]`
- * - Issues challenges as `McpError` with code `-32042` and challenge in `error.data`
+ * - Issues challenges as tool error results with `_meta["org.paymentauth/payment-required"]`
  * - Attaches receipts via `_meta["org.paymentauth/receipt"]` on tool results
  *
  * @example
@@ -40,15 +40,13 @@ export type McpSdk = Transport.Transport<Extra, McpError, CallToolResult>
  *
  * server.registerTool('premium', { description: '...' }, async (extra) => {
  *   const result = await payment.charge({ request: { ... } })(extra)
- *   if (result.status === 402) throw result.challenge
+ *   if (result.status === 402) return result.challenge
  *   return result.withReceipt({ content: [...] })
  * })
  * ```
  */
 export function mcpSdk(): McpSdk {
-  let McpErrorClass: typeof McpError | undefined
-
-  return Transport.from<Extra, McpError, CallToolResult>({
+  return Transport.from<Extra, CallToolResult, CallToolResult>({
     name: 'mcp-sdk',
 
     captureRequest() {
@@ -68,24 +66,18 @@ export function mcpSdk(): McpSdk {
       return credential
     },
 
-    async respondChallenge({ challenge, error }) {
-      if (!McpErrorClass) {
-        try {
-          const mod = await import('@modelcontextprotocol/sdk/types.js')
-          McpErrorClass = mod.McpError
-        } catch (error) {
-          const err = new Error(
-            'Missing optional dependency "@modelcontextprotocol/sdk". Install it to use mppx MCP SDK transports.',
-          )
-          ;(err as Error & { cause?: unknown }).cause = error
-          throw err
-        }
+    respondChallenge({ challenge, error }) {
+      return {
+        content: [],
+        isError: true,
+        _meta: {
+          [core_Mcp.paymentRequiredMetaKey]: {
+            httpStatus: 402,
+            challenges: [challenge],
+            ...(error && { problem: error.toProblemDetails(challenge.id) }),
+          },
+        },
       }
-      return new McpErrorClass(core_Mcp.paymentRequiredCode, error?.message ?? 'Payment Required', {
-        httpStatus: 402,
-        challenges: [challenge],
-        ...(error && { problem: error.toProblemDetails(challenge.id) }),
-      })
     },
 
     respondReceipt({ receipt, response, challengeId }) {


### PR DESCRIPTION
## Summary

- Returned MCP SDK payment challenges as tool error results with payment-required metadata.
- Shared the MCP payment-required data type across MCP transports.
- Updated MCP SDK tests to use the returned challenge result.

## Why

The payment-aware fetch already handles MCP payment challenges in JSON-RPC errors and tool result metadata. The official MCP SDK tool path does not preserve ordinary thrown tool errors as JSON-RPC payment errors, so the server adapter should emit the metadata result shape directly.

## Validation

- `VITE_TEMPO_NETWORK=none pnpm exec vp test --run src/mcp/server/Transport.test.ts src/mcp/client/McpClient.test.ts src/client/internal/Fetch.test.ts src/client/Transport.test.ts`
- `pnpm check:types`
