### PR TITLE
fix: select payable tempo cli challenges

### DIFF
--- a/.changeset/cli-balance-aware-challenges.md
+++ b/.changeset/cli-balance-aware-challenges.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added CLI selection of payable Tempo charge challenges and a currency override.

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -31,6 +31,7 @@ import cli from './cli.js'
 const testPrivateKey = generatePrivateKey()
 const testAccount = privateKeyToAccount(testPrivateKey)
 const cliTestXdgDataHome = fs.mkdtempSync(path.join(os.tmpdir(), 'mppx-cli-xdg-'))
+const unfundedToken = '0x20c0000000000000000000000000000000000002' as Address
 const cliSessionFeePayerPolicy = {
   maxGas: 2_250_000n,
   maxTotalFee: 60_000_000_000_000_000n,
@@ -463,6 +464,199 @@ describe('basic charge (examples/basic)', () => {
         env: { MPPX_PRIVATE_KEY: testPrivateKey },
       })
       expect(output).toContain('paid')
+    } finally {
+      httpServer.close()
+    }
+  })
+
+  test(
+    'selects a later Tempo charge challenge when wallet has that token balance',
+    { timeout: 120_000 },
+    async () => {
+      const { Actions } = await import('viem/tempo')
+      const payerPrivateKey = generatePrivateKey()
+      const payer = privateKeyToAccount(payerPrivateKey)
+      await Actions.token.transferSync(client, {
+        account: accounts[0],
+        chain: client.chain,
+        token: asset,
+        to: payer.address,
+        amount: parseUnits('100', 6),
+      })
+      await Actions.token.transferSync(client, {
+        account: accounts[0],
+        chain: client.chain,
+        token: Addresses.pathUsd,
+        to: payer.address,
+        amount: parseUnits('100', 6),
+      })
+
+      const tempoMethod = tempo.charge({ getClient: () => client })
+      const server = Mppx_server.create({
+        methods: [tempoMethod],
+        realm: 'cli-test-balance-aware-offers',
+        secretKey: 'cli-test-secret-cli-test-secret-32',
+      })
+      let authorization: string | undefined
+
+      const httpServer = await Http.createServer(async (req, res) => {
+        if (req.headers.authorization) {
+          authorization = req.headers.authorization
+          res.end('paid-from-funded-token')
+          return
+        }
+
+        const result = await toNodeListener(
+          server.compose(
+            [
+              tempoMethod,
+              {
+                amount: '1',
+                currency: unfundedToken,
+                decimals: 6,
+                expires: new Date(Date.now() + 60_000).toISOString(),
+                recipient: accounts[0].address,
+              },
+            ],
+            [
+              tempoMethod,
+              {
+                amount: '1',
+                currency: asset,
+                decimals: 6,
+                expires: new Date(Date.now() + 60_000).toISOString(),
+                recipient: accounts[0].address,
+              },
+            ],
+          ),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('unexpected')
+      })
+
+      try {
+        const { output, exitCode } = await serve([httpServer.url, '--rpc-url', rpcUrl, '-s'], {
+          env: { MPPX_PRIVATE_KEY: payerPrivateKey },
+        })
+
+        expect(exitCode, output).toBeUndefined()
+        expect(output).toContain('paid-from-funded-token')
+        expect(Credential.deserialize(authorization!).challenge.request.currency).toBe(asset)
+      } finally {
+        httpServer.close()
+      }
+    },
+  )
+
+  test('currency option selects a matching offered challenge', { timeout: 120_000 }, async () => {
+    const { Actions } = await import('viem/tempo')
+    const payerPrivateKey = generatePrivateKey()
+    const payer = privateKeyToAccount(payerPrivateKey)
+    await Actions.token.transferSync(client, {
+      account: accounts[0],
+      chain: client.chain,
+      token: asset,
+      to: payer.address,
+      amount: parseUnits('100', 6),
+    })
+    await Actions.token.transferSync(client, {
+      account: accounts[0],
+      chain: client.chain,
+      token: Addresses.pathUsd,
+      to: payer.address,
+      amount: parseUnits('100', 6),
+    })
+
+    const tempoMethod = tempo.charge({ getClient: () => client })
+    const server = Mppx_server.create({
+      methods: [tempoMethod],
+      realm: 'cli-test-currency-option',
+      secretKey: 'cli-test-secret-cli-test-secret-32',
+    })
+    let authorization: string | undefined
+
+    const httpServer = await Http.createServer(async (req, res) => {
+      if (req.headers.authorization) {
+        authorization = req.headers.authorization
+        res.end('paid-from-currency-option')
+        return
+      }
+
+      const result = await toNodeListener(
+        server.compose(
+          [
+            tempoMethod,
+            {
+              amount: '1',
+              currency: unfundedToken,
+              decimals: 6,
+              expires: new Date(Date.now() + 60_000).toISOString(),
+              recipient: accounts[0].address,
+            },
+          ],
+          [
+            tempoMethod,
+            {
+              amount: '1',
+              currency: asset,
+              decimals: 6,
+              expires: new Date(Date.now() + 60_000).toISOString(),
+              recipient: accounts[0].address,
+            },
+          ],
+        ),
+      )(req, res)
+      if (result.status === 402) return
+      res.end('unexpected')
+    })
+
+    try {
+      const { output, exitCode } = await serve(
+        [httpServer.url, '--rpc-url', rpcUrl, '--currency', asset, '-s'],
+        { env: { MPPX_PRIVATE_KEY: payerPrivateKey } },
+      )
+
+      expect(exitCode, output).toBeUndefined()
+      expect(output).toContain('paid-from-currency-option')
+      expect(Credential.deserialize(authorization!).challenge.request.currency).toBe(asset)
+    } finally {
+      httpServer.close()
+    }
+  })
+
+  test('currency option rejects currencies the server did not offer', async () => {
+    const tempoMethod = tempo.charge({ getClient: () => client })
+    const server = Mppx_server.create({
+      methods: [tempoMethod],
+      realm: 'cli-test-currency-unavailable',
+      secretKey: 'cli-test-secret-cli-test-secret-32',
+    })
+
+    const httpServer = await Http.createServer(async (req, res) => {
+      const result = await toNodeListener(
+        server.charge({
+          amount: '1',
+          currency: asset,
+          expires: new Date(Date.now() + 60_000).toISOString(),
+          recipient: accounts[0].address,
+        }),
+      )(req, res)
+      if (result.status === 402) return
+      res.end('unexpected')
+    })
+
+    try {
+      const { output, exitCode } = await serve([
+        httpServer.url,
+        '--currency',
+        Addresses.pathUsd,
+        '-s',
+      ])
+
+      expect(exitCode).toBe(2)
+      expect(output).toContain('UNSUPPORTED_CURRENCY')
+      expect(output).toContain(Addresses.pathUsd)
+      expect(output).toContain(asset)
     } finally {
       httpServer.close()
     }

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -16,7 +16,11 @@ import { validate as validateDiscovery } from '../discovery/Validate.js'
 import { createDefaultStore, createKeychain, resolveAccountName } from './account.js'
 import { loadConfig, resolveAcceptPayment, selectChallenge } from './internal.js'
 import type { Plugin } from './plugins/plugin.js'
-import { readTempoKeystore, resolveTempoAccount } from './plugins/tempo.js'
+import {
+  orderTempoChargeChallengesByBalance,
+  readTempoKeystore,
+  resolveTempoAccount,
+} from './plugins/tempo.js'
 import {
   chainName,
   confirm,
@@ -151,6 +155,18 @@ function formatPayment(payment: unknown): string {
     .join(' ')
 }
 
+function filterChallengesByCurrency(
+  challenges: readonly Challenge.Challenge[],
+  currency: string | undefined,
+): Challenge.Challenge[] {
+  if (!currency) return [...challenges]
+  const normalized = currency.toLowerCase()
+  return challenges.filter((challenge) => {
+    const offered = challenge.request.currency
+    return typeof offered === 'string' && offered.toLowerCase() === normalized
+  })
+}
+
 async function fetchServicesRegistry(): Promise<ServiceRegistryService[]> {
   const url = process.env.MPPX_SERVICES_URL ?? servicesRegistryUrl
   const response = await globalThis.fetch(url)
@@ -198,6 +214,7 @@ const cli = Cli.create('mppx', {
     autoSwap: z.boolean().optional().describe('Auto-swap source tokens into payment currency'),
     config: z.string().optional().describe('Path to config file'),
     confirm: z.boolean().optional().default(false).describe('Show confirmation prompts'),
+    currency: z.string().optional().describe('Payment currency/token address to select'),
     data: z.string().optional().describe('Send request body (implies POST unless -X is set)'),
     fail: z.boolean().optional().describe('Fail silently on HTTP errors (exit 22)'),
     header: z.array(z.string()).optional().describe('Add header (repeatable)'),
@@ -357,12 +374,31 @@ const cli = Cli.create('mppx', {
         return
       }
 
-      const selected = selectChallenge(
-        Challenge.fromResponseList(challengeResponse),
-        loaded?.config,
-      )
+      const methodOpts = parseMethodOpts(c.options.methodOpt)
+      const offeredChallenges = Challenge.fromResponseList(challengeResponse)
+      const currencyChallenges = filterChallengesByCurrency(offeredChallenges, c.options.currency)
+      if (c.options.currency && currencyChallenges.length === 0) {
+        const offers = offeredChallenges
+          .map((challenge) => challenge.request.currency)
+          .filter((currency): currency is string => typeof currency === 'string')
+          .join(', ')
+        return c.error({
+          code: 'UNSUPPORTED_CURRENCY',
+          message: `Server did not offer payment currency ${c.options.currency}.${offers ? ` Offered currencies: ${offers}.` : ''}`,
+          exitCode: 2,
+        })
+      }
+      const challenges = await orderTempoChargeChallengesByBalance(currencyChallenges, {
+        options: {
+          account: c.options.account,
+          network: c.options.network,
+          rpcUrl: c.options.rpcUrl,
+        },
+      })
+
+      const selected = selectChallenge(challenges, loaded?.config)
       if (!selected) {
-        const offers = Challenge.fromResponseList(challengeResponse)
+        const offers = challenges
           .map((challenge) => `${challenge.method}/${challenge.intent}`)
           .join(', ')
         return c.error({
@@ -393,7 +429,7 @@ const cli = Cli.create('mppx', {
             rpcUrl: c.options.rpcUrl,
             slippage: c.options.slippage,
           },
-          methodOpts: parseMethodOpts(c.options.methodOpt),
+          methodOpts,
         })
         tokenSymbol = pluginResult.tokenSymbol
         tokenDecimals = pluginResult.tokenDecimals

--- a/src/cli/plugins/tempo.ts
+++ b/src/cli/plugins/tempo.ts
@@ -9,7 +9,9 @@ import { Base64 } from 'ox'
 import type { Address } from 'viem'
 import { createClient, http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
+import { Actions } from 'viem/tempo'
 
+import type * as Challenge from '../../Challenge.js'
 import { normalizeHeaders } from '../../client/internal/Fetch.js'
 import * as Constants from '../../Constants.js'
 import * as Credential from '../../Credential.js'
@@ -30,10 +32,88 @@ import {
   pc,
   resolveChain,
   resolveRpcUrl,
+  type Network,
 } from '../utils.js'
 import { createPlugin, type Plugin } from './plugin.js'
 
 const packageJson = createRequire(import.meta.url)('../../../package.json') as { name: string }
+const booleanOption = z.union([
+  z.boolean(),
+  z.literal('true').transform(() => true),
+  z.literal('false').transform(() => false),
+])
+const tempoOptionSchema = z.object({
+  autoSwap: z.optional(booleanOption),
+  channel: z.optional(z.coerce.string()),
+  deposit: z.optional(z.union([z.string(), z.number()])),
+  payWith: z.optional(z.string()),
+  slippage: z.optional(z.coerce.number()),
+  tokenIn: z.optional(z.string()),
+})
+const tempoOptionKeys = [
+  'autoSwap',
+  'channel',
+  'deposit',
+  'payWith',
+  'slippage',
+  'tokenIn',
+] as const
+const tempoChargeChallengeScoreOrder = [
+  'payable',
+  'unknownBalance',
+  'insufficientBalance',
+  'unsupported',
+] as const
+
+type TempoChargeChallengeScore = (typeof tempoChargeChallengeScoreOrder)[number]
+
+/**
+ * Orders Tempo charge challenges by whether the configured wallet can satisfy them.
+ *
+ * Direct balances are preferred first. Unsupported or unpayable challenges keep
+ * their original relative order.
+ */
+export async function orderTempoChargeChallengesByBalance(
+  challenges: readonly Challenge.Challenge[],
+  ctx: {
+    options: {
+      account?: string | undefined
+      network?: Network | undefined
+      rpcUrl?: string | undefined
+    }
+  },
+): Promise<Challenge.Challenge[]> {
+  const tempoPositions: number[] = []
+  const tempoChallenges: Challenge.Challenge[] = []
+  for (const [index, challenge] of challenges.entries()) {
+    if (!isTempoChargeChallenge(challenge)) continue
+    tempoPositions.push(index)
+    tempoChallenges.push(challenge)
+  }
+  if (tempoChallenges.length < 2) return [...challenges]
+
+  const probe = await resolveBalanceProbe(ctx).catch(() => undefined)
+  if (!probe) return [...challenges]
+
+  const scored = await Promise.all(
+    tempoChallenges.map(async (challenge, index) => ({
+      challenge,
+      index,
+      score: await scoreTempoChargeChallenge(challenge, probe),
+    })),
+  )
+  scored.sort(
+    (left, right) =>
+      tempoChargeChallengeScoreOrder.indexOf(left.score) -
+        tempoChargeChallengeScoreOrder.indexOf(right.score) || left.index - right.index,
+  )
+
+  const ordered = [...challenges]
+  for (const [index, position] of tempoPositions.entries()) {
+    ordered[position] = scored[index]!.challenge
+  }
+  return ordered
+}
 
 export function tempo() {
   let _session:
@@ -60,23 +140,7 @@ export function tempo() {
       const accountName = resolveAccountName(options.account)
       const challengeRequest = challenge.request as Record<string, unknown>
       const currency = challengeRequest.currency as string | undefined
-      const booleanOption = z.union([
-        z.boolean(),
-        z.literal('true').transform(() => true),
-        z.literal('false').transform(() => false),
-      ])
-      const tempoOpts = parseOptions(
-        z.object({
-          autoSwap: z.optional(booleanOption),
-          channel: z.optional(z.coerce.string()),
-          deposit: z.optional(z.union([z.string(), z.number()])),
-          payWith: z.optional(z.string()),
-          slippage: z.optional(z.coerce.number()),
-          tokenIn: z.optional(z.string()),
-        }),
-        methodOpts,
-        ['autoSwap', 'channel', 'deposit', 'payWith', 'slippage', 'tokenIn'],
-      )
+      const tempoOpts = parseTempoOptions(methodOpts)
       const autoSwap = resolveAutoSwap({
         autoSwap: tempoOpts.autoSwap ?? options.autoSwap,
         payWith: tempoOpts.payWith ?? options.payWith,
@@ -745,6 +809,85 @@ function detectTerminalBg(
 }
 
 // --- Account helpers ---
+
+type BalanceProbe = {
+  account: Address
+  client: ReturnType<typeof createClient>
+}
+
+function parseTempoOptions(rawOptions: Record<string, string>) {
+  return parseOptions(tempoOptionSchema, rawOptions, tempoOptionKeys)
+}
+
+function isTempoChargeChallenge(challenge: Challenge.Challenge): boolean {
+  return challenge.method === 'tempo' && challenge.intent === 'charge'
+}
+
+async function resolveBalanceProbe(ctx: {
+  options: {
+    account?: string | undefined
+    network?: Network | undefined
+    rpcUrl?: string | undefined
+  }
+}): Promise<BalanceProbe | undefined> {
+  const accountName = resolveAccountName(ctx.options.account)
+  const privateKey =
+    process.env.MPPX_PRIVATE_KEY?.trim() ||
+    (isTempoAccount(accountName) ? undefined : await createKeychain(accountName).get())
+
+  let account: Address | undefined
+  if (privateKey) {
+    account = privateKeyToAccount(privateKey as `0x${string}`).address
+  } else if (isTempoAccount(accountName) && hasTempoCliSync()) {
+    account = resolveTempoAccount(accountName)?.wallet_address as Address | undefined
+  } else {
+    const fallback = fallbackFromTempo()
+    if (fallback) {
+      const fallbackKey = await createKeychain(fallback).get()
+      if (fallbackKey) account = privateKeyToAccount(fallbackKey as `0x${string}`).address
+    }
+  }
+  if (!account) return undefined
+
+  const rpcUrl = resolveRpcUrl(ctx.options.rpcUrl, { network: ctx.options.network })
+  const client = createClient({
+    chain: await resolveChain({ network: ctx.options.network, rpcUrl }),
+    transport: http(rpcUrl),
+  })
+
+  return {
+    account,
+    client,
+  }
+}
+
+async function scoreTempoChargeChallenge(
+  challenge: Challenge.Challenge,
+  probe: BalanceProbe,
+): Promise<TempoChargeChallengeScore> {
+  const request = challenge.request as Record<string, unknown>
+  const currency = request.currency
+  const amount = request.amount
+  if (typeof currency !== 'string' || typeof amount !== 'string') return 'unsupported'
+
+  const requiredChainId = (request.methodDetails as { chainId?: number } | undefined)?.chainId
+  if (requiredChainId && probe.client.chain?.id && requiredChainId !== probe.client.chain.id) {
+    return 'unsupported'
+  }
+
+  const amountRaw = BigInt(amount)
+  if (amountRaw === 0n) return 'payable'
+
+  const balance = await Actions.token
+    .getBalance(probe.client as never, {
+      account: probe.account,
+      token: currency as Address,
+    })
+    .catch(() => undefined)
+  if (balance === undefined) return 'unknownBalance'
+  if (balance >= amountRaw) return 'payable'
+  return 'insufficientBalance'
+}
 
 function parseOptions<const schema extends z.ZodType>(
   schema: schema,


### PR DESCRIPTION
## Summary

- Added a CLI `--currency` option to select a specific offered payment currency.
- Ordered multiple Tempo charge challenges by direct wallet balance before selecting a challenge.
- Added CLI coverage and a patch changeset.

## Motivation

When a server offered multiple Tempo charge challenges, the CLI selected the first supported challenge even when the wallet could only pay a later token offer.

## Key design considerations

- Scoped balance probing to the Tempo charge CLI path.
- Preserved existing server order when balance probing is unavailable.
- Kept `--pay-with` as an auto-swap source token and used `--currency` for offered challenge selection.
