### PR TITLE
feat: add hint field to PaymentError problem details

### DIFF
--- a/src/Errors.test.ts
+++ b/src/Errors.test.ts
@@ -174,6 +174,20 @@ describe('PaymentRequiredError', () => {
         }
       `)
   })
+
+  test('toProblemDetails includes hint', () => {
+    const error = new PaymentRequiredError({ description: 'API access fee' })
+    expect(error.toProblemDetails('ch_abc')).toMatchInlineSnapshot(`
+      {
+        "challengeId": "ch_abc",
+        "detail": "Payment is required (API access fee).",
+        "hint": "Use a supported wallet to pay for this resource using one of the supported payment methods returned in the WWW-Authenticate header. See https://mpp.dev/tools/wallet.md",
+        "status": 402,
+        "title": "Payment Required",
+        "type": "https://paymentauth.org/problems/payment-required",
+      }
+    `)
+  })
 })
 
 describe('InvalidPayloadError', () => {
@@ -273,6 +287,19 @@ describe('PaymentMethodUnsupportedError', () => {
           "type": "https://paymentauth.org/problems/method-unsupported",
         }
       `)
+  })
+
+  test('toProblemDetails includes hint', () => {
+    const error = new PaymentMethodUnsupportedError({ method: 'bitcoin' })
+    expect(error.toProblemDetails()).toMatchInlineSnapshot(`
+      {
+        "detail": "Payment method "bitcoin" is not supported.",
+        "hint": "Use a supported wallet to pay for this resource using one of the supported payment methods returned in the WWW-Authenticate header. See https://mpp.dev/tools/wallet.md",
+        "status": 400,
+        "title": "Method Unsupported",
+        "type": "https://paymentauth.org/problems/method-unsupported",
+      }
+    `)
   })
 })
 
@@ -447,6 +474,7 @@ describe('toProblemDetails', () => {
     expect(error.toProblemDetails()).toMatchInlineSnapshot(`
       {
         "detail": "Credential is malformed: invalid JSON.",
+        "hint": "Use a supported wallet to construct valid credentials for one of the supported payment methods returned in the WWW-Authenticate header. See https://mpp.dev/tools/wallet.md",
         "status": 402,
         "title": "Malformed Credential",
         "type": "https://paymentauth.org/problems/malformed-credential",

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -1,3 +1,13 @@
+/** Default hint messages for payment errors. */
+export const Hints = {
+  paymentRequired:
+    'Use a supported wallet to pay for this resource using one of the supported payment methods returned in the WWW-Authenticate header. See https://mpp.dev/tools/wallet.md',
+  malformedCredential:
+    'Use a supported wallet to construct valid credentials for one of the supported payment methods returned in the WWW-Authenticate header. See https://mpp.dev/tools/wallet.md',
+  methodUnsupported:
+    'Use a supported wallet to pay for this resource using one of the supported payment methods returned in the WWW-Authenticate header. See https://mpp.dev/tools/wallet.md',
+} as const
+
 /**
  * Base class for all payment-related errors.
  */
@@ -11,6 +21,9 @@ export abstract class PaymentError extends Error {
   /** HTTP status code. */
   readonly status: number = 402
 
+  /** Actionable hint for resolving the error (RFC 9457 extension member). */
+  readonly hint: string | undefined
+
   /** Converts the error to RFC 9457 Problem Details format. */
   toProblemDetails(challengeId?: string): PaymentError.ProblemDetails {
     return {
@@ -18,6 +31,7 @@ export abstract class PaymentError extends Error {
       title: this.title,
       status: this.status,
       detail: this.message,
+      ...(this.hint && { hint: this.hint }),
       ...(challengeId && { challengeId }),
     }
   }
@@ -33,6 +47,8 @@ export declare namespace PaymentError {
     status: number
     /** Human-readable explanation. */
     detail: string
+    /** Actionable hint for resolving the error (RFC 9457 extension member). */
+    hint?: string
     /** Associated challenge ID, if applicable. */
     challengeId?: string
   }
@@ -46,6 +62,7 @@ export class MalformedCredentialError extends PaymentError {
   readonly title = 'Malformed Credential'
   override readonly status = 402
   readonly type = 'https://paymentauth.org/problems/malformed-credential'
+  override readonly hint = Hints.malformedCredential
 
   constructor(options: MalformedCredentialError.Options = {}) {
     const { reason } = options
@@ -156,6 +173,7 @@ export class PaymentRequiredError extends PaymentError {
   override readonly name = 'PaymentRequiredError'
   readonly title = 'Payment Required'
   readonly type = 'https://paymentauth.org/problems/payment-required'
+  override readonly hint = Hints.paymentRequired
 
   constructor(options: PaymentRequiredError.Options = {}) {
     const { description } = options
@@ -244,6 +262,7 @@ export class PaymentMethodUnsupportedError extends PaymentError {
   readonly title = 'Method Unsupported'
   override readonly status = 400
   readonly type = 'https://paymentauth.org/problems/method-unsupported'
+  override readonly hint = Hints.methodUnsupported
 
   constructor(options: PaymentMethodUnsupportedError.Options = {}) {
     const { method } = options

--- a/src/server/Mppx.test.ts
+++ b/src/server/Mppx.test.ts
@@ -87,6 +87,7 @@ describe('request handler', () => {
       {
         "challengeId": "[challengeId]",
         "detail": "Payment is required.",
+        "hint": "Use a supported wallet to pay for this resource using one of the supported payment methods returned in the WWW-Authenticate header. See https://mpp.dev/tools/wallet.md",
         "instance": "[instance]",
         "status": 402,
         "title": "Payment Required",
@@ -119,6 +120,7 @@ describe('request handler', () => {
       {
         "challengeId": "[challengeId]",
         "detail": "Credential is malformed: Invalid base64url or JSON..",
+        "hint": "Use a supported wallet to construct valid credentials for one of the supported payment methods returned in the WWW-Authenticate header. See https://mpp.dev/tools/wallet.md",
         "instance": "[instance]",
         "status": 402,
         "title": "Malformed Credential",
@@ -806,6 +808,7 @@ describe('request handler (node)', () => {
       {
         "challengeId": "[challengeId]",
         "detail": "Payment is required.",
+        "hint": "Use a supported wallet to pay for this resource using one of the supported payment methods returned in the WWW-Authenticate header. See https://mpp.dev/tools/wallet.md",
         "instance": "[instance]",
         "status": 402,
         "title": "Payment Required",


### PR DESCRIPTION
Adds an optional `hint` to the problem details response body for `PaymentRequiredError`, `MalformedCredentialError`, and `PaymentMethodUnsupportedError`. We can consider adding hints for other error types in the future. I expect this to significantly help an agent without prior context on MPP too better unblock themself.

Do I need to do anything to make the same change in our other MPP SDKs?