### PR TITLE
fix: reject non-canonical fee-payer transactions

### DIFF
--- a/.changeset/fix-fee-payer-intrinsic-gas.md
+++ b/.changeset/fix-fee-payer-intrinsic-gas.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Rejected non-canonical fee-payer calldata and client-supplied access lists before sponsorship.

--- a/src/tempo/internal/fee-payer.test.ts
+++ b/src/tempo/internal/fee-payer.test.ts
@@ -692,6 +692,47 @@ describe('fillHostedFeePayerTransaction', () => {
     ).rejects.toThrow('gas exceeds sponsor policy')
     expect(fetchMock).not.toHaveBeenCalled()
   })
+
+  test('error: rejects non-empty access lists before requesting hosted fill', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      fillHostedFeePayerTransaction({
+        allowedFeeTokens: defaultAllowedFeeTokens(defaults.chainId.mainnet),
+        ...hostedContext,
+        transaction: {
+          ...hostedTransaction,
+          accessList: [{ address: bogus, storageKeys: [] }],
+        } as any,
+        url: 'https://sponsor.example/tp_key',
+      }),
+    ).rejects.toThrow('accessList is not allowed')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  test('error: rejects padded calldata before requesting hosted fill', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      fillHostedFeePayerTransaction({
+        allowedFeeTokens: defaultAllowedFeeTokens(defaults.chainId.mainnet),
+        ...hostedContext,
+        transaction: {
+          ...hostedTransaction,
+          calls: [
+            {
+              ...hostedTransaction.calls[0],
+              data: `${hostedTransaction.calls[0]!.data}01`,
+            },
+          ],
+        } as any,
+        url: 'https://sponsor.example/tp_key',
+      }),
+    ).rejects.toThrow('calldata is not canonical')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
 })
 
 describe('simulationTransaction', () => {
@@ -971,5 +1012,70 @@ describe('prepareSponsoredTransaction', () => {
         } as any,
       }),
     ).toThrow('validity window exceeds sponsor policy')
+  })
+
+  test('error: rejects non-empty access lists', () => {
+    expect(() =>
+      prepareSponsoredTransaction({
+        account: sponsor,
+        chainId: 42431,
+        details,
+        allowedFeeTokens: [bogus],
+        transaction: {
+          ...baseTransaction,
+          accessList: [{ address: bogus, storageKeys: [] }],
+        } as any,
+      }),
+    ).toThrow('accessList is not allowed')
+  })
+
+  test('error: rejects padded calldata', () => {
+    expect(() =>
+      prepareSponsoredTransaction({
+        account: sponsor,
+        chainId: 42431,
+        details,
+        allowedFeeTokens: [bogus],
+        transaction: {
+          ...baseTransaction,
+          calls: [
+            {
+              ...baseTransaction.calls[0],
+              data: `${baseTransaction.calls[0]!.data}01`,
+            },
+          ],
+        } as any,
+      }),
+    ).toThrow('calldata is not canonical')
+  })
+
+  test('error: rejects missing calls', () => {
+    expect(() =>
+      prepareSponsoredTransaction({
+        account: sponsor,
+        chainId: 42431,
+        details,
+        allowedFeeTokens: [bogus],
+        transaction: {
+          ...baseTransaction,
+          calls: undefined,
+        } as any,
+      }),
+    ).toThrow('must declare calls')
+  })
+
+  test('error: rejects nonzero call value', () => {
+    expect(() =>
+      prepareSponsoredTransaction({
+        account: sponsor,
+        chainId: 42431,
+        details,
+        allowedFeeTokens: [bogus],
+        transaction: {
+          ...baseTransaction,
+          calls: [{ ...baseTransaction.calls[0], value: 1n }],
+        } as any,
+      }),
+    ).toThrow('call value is not allowed')
   })
 })

--- a/src/tempo/internal/fee-payer.ts
+++ b/src/tempo/internal/fee-payer.ts
@@ -3,7 +3,7 @@ import type { TempoAddress } from 'ox/tempo'
 import { TxEnvelopeTempo } from 'ox/tempo'
 import type { Hex } from 'viem'
 import type { Account } from 'viem'
-import { decodeFunctionData, maxUint256, toHex } from 'viem'
+import { decodeFunctionData, encodeFunctionData, maxUint256, toHex } from 'viem'
 import { Abis, Addresses, Transaction } from 'viem/tempo'
 
 import * as TempoAddress_internal from './address.js'
@@ -319,6 +319,74 @@ function isExpiringNonceKey(nonceKey: SponsoredTransaction['nonceKey']): boolean
   return nonceKey === 'expiring' || nonceKey === maxUint256
 }
 
+const sponsoredCallAbi = [...Abis.tip20, ...Abis.stablecoinDex] as const
+const sponsoredCallSelectors = new Set([
+  Selectors.approve,
+  Selectors.transfer,
+  Selectors.transferWithMemo,
+  Selectors.swapExactAmountOut,
+])
+
+function canonicalSponsoredCallData(
+  data: Hex,
+  call: string,
+  fail: (reason: string, extra?: Record<string, string>) => never,
+) {
+  if (!sponsoredCallSelectors.has(data.slice(0, 10) as Hex)) return undefined
+
+  let decoded: ReturnType<typeof decodeFunctionData<typeof sponsoredCallAbi>>
+  try {
+    decoded = decodeFunctionData({ abi: sponsoredCallAbi, data })
+  } catch {
+    fail('fee-sponsored transaction call calldata is invalid', { call })
+  }
+  return encodeFunctionData({
+    abi: sponsoredCallAbi,
+    functionName: decoded.functionName,
+    args: decoded.args,
+  })
+}
+
+/**
+ * Rejects sponsored transaction fields that increase intrinsic gas without
+ * changing the decoded payment intent.
+ */
+function assertCanonicalSponsoredTransaction(
+  transaction: SponsoredTransaction,
+  fail: (reason: string, extra?: Record<string, string>) => never,
+) {
+  if (transaction.accessList !== undefined && transaction.accessList.length > 0)
+    fail('fee-sponsored transaction accessList is not allowed', {
+      accessListEntries: String(transaction.accessList.length),
+    })
+
+  const calls = transaction.calls
+  if (!Array.isArray(calls) || calls.length === 0)
+    fail('fee-sponsored transaction must declare calls')
+
+  for (const [index, call] of calls.entries()) {
+    const callIndex = String(index)
+    const value = call.value
+    if (value !== undefined && value !== 0n)
+      fail('fee-sponsored transaction call value is not allowed', {
+        call: callIndex,
+        value: value.toString(),
+      })
+
+    const data = call.data
+    if (!data)
+      fail('fee-sponsored transaction call is missing calldata', {
+        call: callIndex,
+      })
+
+    const canonical = canonicalSponsoredCallData(data, callIndex, fail)
+    if (canonical && data.toLowerCase() !== canonical.toLowerCase())
+      fail('fee-sponsored transaction call calldata is not canonical', {
+        call: callIndex,
+      })
+  }
+}
+
 /** Validates that a set of transaction calls matches an allowed fee-payer pattern. */
 export function validateCalls(
   calls: readonly { data?: `0x${string}` | undefined; to?: TempoAddress.Address | undefined }[],
@@ -485,6 +553,8 @@ export function assertTransactionPolicy(parameters: {
     fail('fee-sponsored transaction chainId does not match challenge', {
       chainId: String(transactionChainId),
     })
+
+  assertCanonicalSponsoredTransaction(transaction, fail)
 
   if (gas === undefined || gas <= 0n) fail('fee-sponsored transaction must declare gas')
   const gasLimit = gas


### PR DESCRIPTION
## Motivation

Fee-payer sponsorship accepted client-controlled transaction bytes that affect intrinsic gas. This addresses:

- https://github.com/wevm/mppx/security/advisories/GHSA-vc9j-9wph-qghj
- https://github.com/wevm/mppx/security/advisories/GHSA-727h-3vm5-qwq6

## Summary

- Rejected client-supplied access lists on sponsored fee-payer transactions.
- Required sponsored call calldata to round-trip to canonical ABI encoding before sponsorship.
- Rejected missing calls and nonzero call values in sponsored fee-payer transactions.
- Added a patch changeset.

## Key design considerations

- Enforced validation in the shared fee-payer policy gate before local signing or hosted fee-payer requests.
- Kept sponsored calldata scoped to the existing TIP-20 and stablecoin DEX function set.
