### PR TITLE
docs: add validate command changeset

### DIFF
--- a/.changeset/validate-command.md
+++ b/.changeset/validate-command.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added a `mppx validate` CLI command for discovering paid endpoints, validating payment challenges, checking malformed-credential handling, and exercising Tempo payment flows end to end.


### PR DESCRIPTION
## Motivation

The validate CLI command needs a release note entry.

## Summary

- Added a patch Changeset for the `mppx validate` command.


## Key design considerations

- Used a Changeset instead of editing the generated changelog directly.
