### PR TITLE
ci: enforce changesets on pull requests

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,7 +1,7 @@
 name: Pull Request
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
 
 permissions: {}
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -32,10 +32,15 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          fetch-depth: 2
           persist-credentials: false
 
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies
+
+      - name: Check for changeset
+        if: "${{ github.event_name == 'pull_request' && !(github.event.pull_request.head.ref == 'changeset-release/main' && github.event.pull_request.title == 'chore: version packages') && !contains(github.event.pull_request.labels.*.name, 'skip-changeset') }}"
+        run: pnpm changeset status --since=HEAD^1
 
       - name: Ensure overrides live in pnpm-workspace.yaml
         run: |


### PR DESCRIPTION
## Motivation

Package-impacting pull requests should fail normal CI when they omit a Changeset, while generated release pull requests and intentionally unreleased changes need an explicit escape hatch.

## Summary

- Added a Changesets check to the existing `Verify / Checks` CI job.
- Used the PR merge commit parent (`HEAD^1`) as the comparison point with a shallow depth of 2.
- Skipped the check for generated `changeset-release/main` release pull requests titled `chore: version packages`.
- Added support for a `skip-changeset` label to bypass the check, with PR CI rerunning when labels change.


## Key design considerations

- Kept the existing `main` release workflow unchanged.
- Avoided a full-history checkout and separate PR job by reusing normal CI.
