### PR TITLE
Remove mainnet option from account fund

### DIFF
--- a/.changeset/remove-mainnet-account-fund.md
+++ b/.changeset/remove-mainnet-account-fund.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Removed the mainnet network option from `mppx account fund`.

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -1819,6 +1819,22 @@ test('mppx --help', async () => {
   expect(output).toContain('sign')
 })
 
+describe('account fund help', () => {
+  test('only advertises testnet network funding', async () => {
+    const { output } = await serve(['account', 'fund', '--help'])
+    expect(output).toContain('--network <testnet>')
+    expect(output).not.toContain('mainnet|testnet')
+  })
+
+  test('rejects mainnet network funding', async () => {
+    const { exitCode, output } = await serve(['account', 'fund', '--network', 'mainnet'])
+    expect(exitCode).toBe(1)
+    expect(output).toContain('Invalid input')
+    expect(output).toContain('testnet')
+    expect(output).toContain('mainnet')
+  })
+})
+
 // ---------------------------------------------------------------------------
 // sign
 // ---------------------------------------------------------------------------

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -1831,7 +1831,6 @@ describe('account fund help', () => {
     expect(exitCode).toBe(1)
     expect(output).toContain('Invalid input')
     expect(output).toContain('testnet')
-    expect(output).toContain('mainnet')
   })
 })
 

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -864,7 +864,7 @@ const account = Cli.create('account', {
     description: 'Fund account with testnet tokens',
     options: z.object({
       account: z.string().optional().describe('Account name (env: MPPX_ACCOUNT)'),
-      network: z.enum(['mainnet', 'testnet']).optional().describe('Tempo network'),
+      network: z.enum(['testnet']).optional().describe('Tempo network'),
       rpcUrl: z.string().optional().describe('RPC endpoint (env: MPPX_RPC_URL)'),
     }),
     output: z.object({ account: z.string(), chain: z.string(), transactions: z.array(z.string()) }),


### PR DESCRIPTION
## Summary
- restricted `mppx account fund --network` to `testnet`
- added CLI coverage for help text and rejecting `--network mainnet`
- added a patch changeset

## Validation
- `pnpm check:types`
- `pnpm check:ci`
- `pnpm mppx account fund --help`
- `pnpm mppx account fund --network mainnet --format json`

Note: `pnpm test src/cli/cli.test.ts` and `pnpm exec vp test --project cli src/cli/cli.test.ts --passWithNoTests --dangerouslyIgnoreUnhandledErrors` both hit global localnet setup and failed because `localhost:18545` refused connections before running the focused CLI tests.

Prompted by: @danrobinson