### PR TITLE
Fix binary-safe CLI response output

### DIFF
--- a/.changeset/binary-safe-cli-output.md
+++ b/.changeset/binary-safe-cli-output.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Preserve raw response bytes when writing CLI response bodies to stdout.

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -43,7 +43,7 @@ afterAll(() => {
 })
 
 async function serve(argv: string[], options?: { env?: Record<string, string | undefined> }) {
-  let output = ''
+  const stdoutChunks: Buffer[] = []
   let stderr = ''
   let exitCode: number | undefined
   const saved: Record<string, string | undefined> = {}
@@ -58,7 +58,9 @@ async function serve(argv: string[], options?: { env?: Record<string, string | u
   const origLog = console.log
   const origError = console.error
   process.stdout.write = ((chunk: unknown) => {
-    output += typeof chunk === 'string' ? chunk : String(chunk)
+    if (typeof chunk === 'string') stdoutChunks.push(Buffer.from(chunk))
+    else if (chunk instanceof Uint8Array) stdoutChunks.push(Buffer.from(chunk))
+    else stdoutChunks.push(Buffer.from(String(chunk)))
     return true
   }) as typeof process.stdout.write
   process.stderr.write = ((chunk: unknown) => {
@@ -66,7 +68,7 @@ async function serve(argv: string[], options?: { env?: Record<string, string | u
     return true
   }) as typeof process.stderr.write
   console.log = (...args: unknown[]) => {
-    output += `${args.map(String).join(' ')}\n`
+    stdoutChunks.push(Buffer.from(`${args.map(String).join(' ')}\n`))
   }
   console.error = (...args: unknown[]) => {
     stderr += `${args.map(String).join(' ')}\n`
@@ -74,7 +76,7 @@ async function serve(argv: string[], options?: { env?: Record<string, string | u
   try {
     await cli.serve(argv, {
       stdout(s: string) {
-        output += s
+        stdoutChunks.push(Buffer.from(s))
       },
       exit(code: number) {
         exitCode = code
@@ -90,7 +92,8 @@ async function serve(argv: string[], options?: { env?: Record<string, string | u
       else process.env[key] = value
     }
   }
-  return { output, stderr, exitCode }
+  const stdoutBytes = Buffer.concat(stdoutChunks)
+  return { output: stdoutBytes.toString(), stderr, exitCode, stdoutBytes }
 }
 
 function createMockChargeMethod(name: string) {
@@ -427,6 +430,24 @@ describe('services', () => {
       expect(output).toContain('3000')
       expect(output).toContain('tempo/charge')
     })
+  })
+})
+
+describe('request output', () => {
+  test('writes non-402 response bodies to stdout without text decoding', async () => {
+    const body = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x0a, 0x0a])
+    const httpServer = await Http.createServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/pdf' })
+      res.end(body)
+    })
+
+    try {
+      const { exitCode, stdoutBytes } = await serve([httpServer.url, '-s'])
+      expect(exitCode).toBeUndefined()
+      expect(stdoutBytes).toEqual(body)
+    } finally {
+      httpServer.close()
+    }
   })
 })
 

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -99,6 +99,10 @@ function outputResult<Data>(
   return undefined as unknown as Data
 }
 
+async function writeResponseBody(response: Response) {
+  process.stdout.write(Buffer.from(await response.arrayBuffer()))
+}
+
 function canReadCommandStdin() {
   if (process.stdin.isTTY !== false) return false
   return process.stdin.listenerCount('data') === 0 && process.stdin.listenerCount('readable') === 0
@@ -371,7 +375,7 @@ const cli = Cli.create('mppx', {
             exitCode: 22,
           })
         printResponseHeaders(challengeResponse, headerOpts)
-        console.log((await challengeResponse.text()).replace(/\n+$/, ''))
+        await writeResponseBody(challengeResponse)
         return
       }
 
@@ -625,8 +629,7 @@ const cli = Cli.create('mppx', {
           } catch {}
         }
 
-        const body = (await credentialResponse.text()).replace(/\n+$/, '')
-        console.log(body)
+        await writeResponseBody(credentialResponse)
       }
     } catch (err) {
       // Re-throw IncurError so incur's error handler formats it properly

--- a/src/cli/plugins/tempo.ts
+++ b/src/cli/plugins/tempo.ts
@@ -42,6 +42,11 @@ const booleanOption = z.union([
   z.literal('true').transform(() => true),
   z.literal('false').transform(() => false),
 ])
+
+async function writeResponseBody(response: Response) {
+  process.stdout.write(Buffer.from(await response.arrayBuffer()))
+}
+
 const tempoOptionSchema = z.object({
   autoSwap: z.optional(booleanOption),
   channel: z.optional(z.coerce.string()),
@@ -425,8 +430,7 @@ export function tempo() {
         })
       } else {
         // Non-SSE: print body, then close channel
-        const body = (await credentialResponse.text()).replace(/\n+$/, '')
-        console.log(body)
+        await writeResponseBody(credentialResponse)
 
         if (channelId && escrowContract && chainId) {
           if (confirmEnabled) info('\n')


### PR DESCRIPTION
## Summary
- write successful CLI response bodies to stdout as raw bytes instead of decoding as text
- preserve binary response bytes and trailing bytes for non-402 and paid response output
- add a regression test that asserts exact stdout bytes for invalid UTF-8/JPEG-style data

## Verification
- pnpm exec vp fmt --write src/cli/cli.ts src/cli/plugins/tempo.ts src/cli/cli.test.ts
- pnpm exec vp lint src/cli/cli.ts src/cli/plugins/tempo.ts src/cli/cli.test.ts
- pnpm build:html && pnpm exec tsgo -b --pretty false
- pnpm test src/cli/cli.test.ts -- --runInBand (blocked: repo global setup requires Tempo localnet at localhost:18545; connection refused before tests were selected)

Prompted by: @danrobinson