### PR TITLE
fix(tempo): normalize sponsored charge signing

### DIFF
--- a/.changeset/quiet-sponsored-charges.md
+++ b/.changeset/quiet-sponsored-charges.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Normalize sponsored Tempo charge transactions before client signing.

--- a/src/tempo/client/Charge.test.ts
+++ b/src/tempo/client/Charge.test.ts
@@ -353,6 +353,67 @@ describe('tempo.charge client', () => {
     }
   })
 
+  test('normalizes sponsored pull transactions before signing', async () => {
+    vi.resetModules()
+    const prepared = {
+      feePayerSignature: { r: '0x1', s: '0x2', yParity: 0 },
+      feeToken: currency,
+      gas: 100n,
+    }
+    const prepareTransactionRequest = vi.fn(async () => prepared)
+    const signTransaction = vi.fn(
+      async (_client: unknown, _transaction: Record<string, unknown>) => '0xdeadbeef',
+    )
+    vi.doMock('viem/actions', () => ({
+      prepareTransactionRequest,
+      sendCallsSync: vi.fn(),
+      signTransaction,
+      signTypedData: vi.fn(),
+    }))
+
+    try {
+      const { charge: chargeWithMockedActions } = await import('./Charge.js')
+      const chainId = 42431
+      const client = createClient({
+        account,
+        chain: tempoLocalnet,
+        transport: http('http://127.0.0.1'),
+      })
+      const method = chargeWithMockedActions({
+        account,
+        getClient: () => client,
+      })
+
+      await method.createCredential({
+        challenge: createChallenge({
+          amount: '1',
+          chainId,
+          feePayer: true,
+          supportedModes: ['pull'],
+        }),
+        context: {},
+      })
+
+      expect(prepareTransactionRequest).toHaveBeenCalledWith(
+        client,
+        expect.not.objectContaining({ feePayer: true }),
+      )
+      expect(signTransaction).toHaveBeenCalledWith(
+        client,
+        expect.objectContaining({
+          feePayer: true,
+          gas: 5_100n,
+        }),
+      )
+      const signed = signTransaction.mock.calls[0]?.[1] as Record<string, unknown>
+      expect(signed).not.toHaveProperty('feePayerSignature')
+      expect(signed).not.toHaveProperty('feeToken')
+    } finally {
+      vi.doUnmock('viem/actions')
+      vi.resetModules()
+    }
+  })
+
   describe('chain pinning', () => {
     const client = createClient({
       account,

--- a/src/tempo/client/Charge.ts
+++ b/src/tempo/client/Charge.ts
@@ -226,7 +226,12 @@ export function charge(parameters: charge.Parameters = {}) {
       // Estimate before enabling fee-payer mode so Tempo includes sender
       // signature and access-key verification costs in the gas budget.
       prepared.gas = (prepared.gas ?? 0n) + 5_000n
-      if (methodDetails?.feePayer) (prepared as Record<string, unknown>).feePayer = true
+      if (methodDetails?.feePayer) {
+        const sponsored = prepared as Record<string, unknown>
+        delete sponsored.feePayerSignature
+        delete sponsored.feeToken
+        sponsored.feePayer = true
+      }
       const signature = await signTransaction(client, prepared as never)
 
       return Credential.serialize({


### PR DESCRIPTION
## Summary

Normalize sponsored Tempo charge transactions before signing by dropping filled fee-payer fields and then setting `feePayer: true`. This keeps client pull-mode charges on the partial fee-payer handoff path expected by servers after viem fee-payer fill behavior changed.

The regression was exposed after [wevm/viem#4773](https://github.com/wevm/viem/pull/4773) landed in `viem@2.54.0`, which tightened transaction signature parsing.

## Testing

- `VITE_TEMPO_NETWORK=none pnpm exec vp test --project node --run src/tempo/client/Charge.test.ts`
- `pnpm exec vp fmt --check src/tempo/client/Charge.ts src/tempo/client/Charge.test.ts`
- `pnpm exec vp lint src/tempo/client/Charge.ts src/tempo/client/Charge.test.ts`
- `pnpm check:types`

Prompted by: @grandizzy