### PR TITLE
feat(client): support standard x402 exact payments

### DIFF
--- a/.changeset/standard-x402-exact-client.md
+++ b/.changeset/standard-x402-exact-client.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added client signing support for standard x402 exact EIP-3009 offers without requiring mppx route-binding extensions.

--- a/src/client/internal/Fetch.test.ts
+++ b/src/client/internal/Fetch.test.ts
@@ -1,5 +1,5 @@
 import { Challenge, Credential, Errors, Mcp, Receipt } from 'mppx'
-import { tempo } from 'mppx/client'
+import { evm, tempo } from 'mppx/client'
 import { Mppx as Mppx_server, tempo as tempo_server } from 'mppx/server'
 import { Header as x402_Header, Types as x402_Types, type PaymentRequired } from 'mppx/x402'
 import { Base64 } from 'ox'
@@ -800,7 +800,20 @@ describe('Fetch.from: 402 retry path', () => {
     expect(retryHeaders.get(x402_Types.paymentSignatureHeader)).toBeNull()
   })
 
-  test('uses x402 when no signable Payment-auth challenge is available', async () => {
+  test('uses x402 exact EIP-3009 when no signable Payment-auth challenge is available', async () => {
+    const paymentRequired = {
+      ...x402PaymentRequired,
+      accepts: [
+        {
+          ...x402PaymentRequired.accepts[0]!,
+          extra: {
+            assetTransferMethod: 'eip3009',
+            name: 'USDC',
+            version: '2',
+          },
+        },
+      ],
+    } satisfies PaymentRequired
     let callCount = 0
     const calls: { init: RequestInit | undefined }[] = []
     const mockFetch: typeof globalThis.fetch = async (_input, init) => {
@@ -810,31 +823,36 @@ describe('Fetch.from: 402 retry path', () => {
         return new Response(null, {
           status: 402,
           headers: {
-            [x402_Types.paymentRequiredHeader]:
-              x402_Header.encodePaymentRequired(x402PaymentRequired),
+            [x402_Types.paymentRequiredHeader]: x402_Header.encodePaymentRequired(paymentRequired),
           },
         })
+
+      const headers = new Headers(init?.headers)
+      expect(headers.get('Authorization')).toBeNull()
+      const paymentSignature = headers.get(x402_Types.paymentSignatureHeader)
+      expect(paymentSignature).toBeTruthy()
+      expect(x402_Header.decodePaymentSignature(paymentSignature!).accepted).toEqual(
+        paymentRequired.accepts[0],
+      )
       return new Response('OK', { status: 200 })
     }
 
     const fetch = Fetch.from({
       fetch: mockFetch,
       methods: [
-        {
-          name: 'evm',
-          intent: 'charge',
-          context: undefined,
-          createCredential: async () => 'x402-credential',
-        },
-      ] as const,
+        evm.charge({
+          account: accounts[0],
+          currencies: [evm.assets.baseSepolia.USDC],
+          maxAmount: '0.01',
+          networks: [84532],
+        }),
+      ],
     })
 
     const response = await fetch('https://example.com/api')
 
     expect(response.status).toBe(200)
-    const retryHeaders = new Headers(calls[1]!.init?.headers)
-    expect(retryHeaders.get('Authorization')).toBeNull()
-    expect(retryHeaders.get(x402_Types.paymentSignatureHeader)).toBe('x402-credential')
+    expect(calls).toHaveLength(2)
   })
 
   test('lets orderChallenges force x402 before native Payment-auth', async () => {

--- a/src/client/internal/Fetch.test.ts
+++ b/src/client/internal/Fetch.test.ts
@@ -820,6 +820,16 @@ describe('Fetch.from: 402 retry path', () => {
             version: '2',
           },
         },
+        {
+          ...eip3009Accept,
+          network: 'eip155:8453',
+        },
+        {
+          ...x402PaymentRequired.accepts[0]!,
+          extra: {
+            assetTransferMethod: 'eip3009',
+          },
+        },
         eip3009Accept,
       ],
     } satisfies PaymentRequired

--- a/src/client/internal/Fetch.test.ts
+++ b/src/client/internal/Fetch.test.ts
@@ -801,17 +801,26 @@ describe('Fetch.from: 402 retry path', () => {
   })
 
   test('uses x402 exact EIP-3009 when no signable Payment-auth challenge is available', async () => {
+    const eip3009Accept = {
+      ...x402PaymentRequired.accepts[0]!,
+      extra: {
+        assetTransferMethod: 'eip3009',
+        name: 'USDC',
+        version: '2',
+      },
+    }
     const paymentRequired = {
       ...x402PaymentRequired,
       accepts: [
         {
           ...x402PaymentRequired.accepts[0]!,
           extra: {
-            assetTransferMethod: 'eip3009',
+            assetTransferMethod: 'permit2',
             name: 'USDC',
             version: '2',
           },
         },
+        eip3009Accept,
       ],
     } satisfies PaymentRequired
     let callCount = 0
@@ -831,9 +840,7 @@ describe('Fetch.from: 402 retry path', () => {
       expect(headers.get('Authorization')).toBeNull()
       const paymentSignature = headers.get(x402_Types.paymentSignatureHeader)
       expect(paymentSignature).toBeTruthy()
-      expect(x402_Header.decodePaymentSignature(paymentSignature!).accepted).toEqual(
-        paymentRequired.accepts[0],
-      )
+      expect(x402_Header.decodePaymentSignature(paymentSignature!).accepted).toEqual(eip3009Accept)
       return new Response('OK', { status: 200 })
     }
 

--- a/src/evm/client/Charge.ts
+++ b/src/evm/client/Charge.ts
@@ -20,7 +20,10 @@ export function charge(parameters: charge.Parameters) {
   return Method.toClient(Methods.charge, {
     canHandleChallenge({ challenge }) {
       if (!isX402Challenge(challenge)) return true
-      return x402TransferMethodOf(challenge) === Types.eip3009
+      return x402_Exact.canHandleChallenge({
+        challenge: challenge as never,
+        config: parameters as x402_Exact.Config,
+      })
     },
     context: z.object({
       account: z.optional(z.custom<Account>()),
@@ -122,12 +125,6 @@ function isX402Challenge(challenge: { request: Record<string, unknown> }) {
     challenge.request.scheme === 'exact' &&
     typeof challenge.request.network === 'string'
   )
-}
-
-function x402TransferMethodOf(challenge: { request: Record<string, unknown> }) {
-  const extra = challenge.request.extra
-  if (!extra || typeof extra !== 'object') return Types.eip3009
-  return (extra as { assetTransferMethod?: unknown }).assetTransferMethod ?? Types.eip3009
 }
 
 function assertPolicy(parameters: charge.Parameters, request: Types.ChargeRequest) {

--- a/src/evm/client/Charge.ts
+++ b/src/evm/client/Charge.ts
@@ -18,6 +18,10 @@ import * as Types from '../Types.js'
  */
 export function charge(parameters: charge.Parameters) {
   return Method.toClient(Methods.charge, {
+    canHandleChallenge({ challenge }) {
+      if (!isX402Challenge(challenge)) return true
+      return x402TransferMethodOf(challenge) === Types.eip3009
+    },
     context: z.object({
       account: z.optional(z.custom<Account>()),
     }),
@@ -118,6 +122,12 @@ function isX402Challenge(challenge: { request: Record<string, unknown> }) {
     challenge.request.scheme === 'exact' &&
     typeof challenge.request.network === 'string'
   )
+}
+
+function x402TransferMethodOf(challenge: { request: Record<string, unknown> }) {
+  const extra = challenge.request.extra
+  if (!extra || typeof extra !== 'object') return Types.eip3009
+  return (extra as { assetTransferMethod?: unknown }).assetTransferMethod ?? Types.eip3009
 }
 
 function assertPolicy(parameters: charge.Parameters, request: Types.ChargeRequest) {

--- a/src/x402/client/Exact.test.ts
+++ b/src/x402/client/Exact.test.ts
@@ -255,32 +255,6 @@ describe('x402 exact credential helper', () => {
       networks: [Chains.baseSepolia],
     } as const
 
-    const credential = await createCredential({
-      challenge: challenge({ extensions: undefined }),
-      config,
-      context: {},
-    })
-    const paymentPayload = Header.decodePaymentSignature(credential)
-
-    expect(signTypedData).toHaveBeenCalledOnce()
-    expect(paymentPayload.x402Version).toBe(2)
-    expect(paymentPayload.accepted.scheme).toBe('exact')
-    expect(paymentPayload.extensions).toBeUndefined()
-    expect(paymentPayload.resource?.url).toBe('https://example.com/paid')
-    expect('authorization' in paymentPayload.payload).toBe(true)
-    if (!('authorization' in paymentPayload.payload)) throw new Error()
-    expect(paymentPayload.payload.authorization.nonce).toMatch(/^0x[0-9a-f]{64}$/)
-    expect(paymentPayload.payload.signature).toBe('0x1234')
-  })
-
-  test('uses a fresh random nonce for repeated standard payments', async () => {
-    const config = {
-      account,
-      currencies: [usdc],
-      maxAmount: '0.01',
-      networks: [Chains.baseSepolia],
-    } as const
-
     const first = Header.decodePaymentSignature(
       await createCredential({
         challenge: challenge({ extensions: undefined }),
@@ -296,9 +270,16 @@ describe('x402 exact credential helper', () => {
       }),
     )
 
+    expect(signTypedData).toHaveBeenCalledTimes(2)
+    expect(first.x402Version).toBe(2)
+    expect(first.accepted.scheme).toBe('exact')
+    expect(first.extensions).toBeUndefined()
+    expect(first.resource?.url).toBe('https://example.com/paid')
     if (!('authorization' in first.payload) || !('authorization' in second.payload))
       throw new Error()
+    expect(first.payload.authorization.nonce).toMatch(/^0x[0-9a-f]{64}$/)
     expect(first.payload.authorization.nonce).not.toBe(second.payload.authorization.nonce)
+    expect(first.payload.signature).toBe('0x1234')
   })
 
   test('uses a fresh route-bound nonce for repeated payments', async () => {

--- a/src/x402/client/Exact.test.ts
+++ b/src/x402/client/Exact.test.ts
@@ -207,7 +207,7 @@ describe('x402 exact credential helper', () => {
     expect(signTypedData).not.toHaveBeenCalled()
   })
 
-  test('signs EIP-3009 exact payment payloads', async () => {
+  test('signs mppx-bound EIP-3009 exact payment payloads', async () => {
     const signTypedData = vi.fn(async () => '0x1234')
     const config = {
       account: {
@@ -243,6 +243,64 @@ describe('x402 exact credential helper', () => {
     expect(paymentPayload.payload.signature).toBe('0x1234')
   })
 
+  test('signs standard EIP-3009 exact payment payloads without mppx route binding', async () => {
+    const signTypedData = vi.fn(async () => '0x1234')
+    const config = {
+      account: {
+        ...account,
+        signTypedData,
+      } as unknown as Account,
+      currencies: [usdc],
+      maxAmount: '0.01',
+      networks: [Chains.baseSepolia],
+    } as const
+
+    const credential = await createCredential({
+      challenge: challenge({ extensions: undefined }),
+      config,
+      context: {},
+    })
+    const paymentPayload = Header.decodePaymentSignature(credential)
+
+    expect(signTypedData).toHaveBeenCalledOnce()
+    expect(paymentPayload.x402Version).toBe(2)
+    expect(paymentPayload.accepted.scheme).toBe('exact')
+    expect(paymentPayload.extensions).toBeUndefined()
+    expect(paymentPayload.resource?.url).toBe('https://example.com/paid')
+    expect('authorization' in paymentPayload.payload).toBe(true)
+    if (!('authorization' in paymentPayload.payload)) throw new Error()
+    expect(paymentPayload.payload.authorization.nonce).toMatch(/^0x[0-9a-f]{64}$/)
+    expect(paymentPayload.payload.signature).toBe('0x1234')
+  })
+
+  test('uses a fresh random nonce for repeated standard payments', async () => {
+    const config = {
+      account,
+      currencies: [usdc],
+      maxAmount: '0.01',
+      networks: [Chains.baseSepolia],
+    } as const
+
+    const first = Header.decodePaymentSignature(
+      await createCredential({
+        challenge: challenge({ extensions: undefined }),
+        config,
+        context: {},
+      }),
+    )
+    const second = Header.decodePaymentSignature(
+      await createCredential({
+        challenge: challenge({ extensions: undefined }),
+        config,
+        context: {},
+      }),
+    )
+
+    if (!('authorization' in first.payload) || !('authorization' in second.payload))
+      throw new Error()
+    expect(first.payload.authorization.nonce).not.toBe(second.payload.authorization.nonce)
+  })
+
   test('uses a fresh route-bound nonce for repeated payments', async () => {
     const config = {
       account,
@@ -273,7 +331,7 @@ describe('x402 exact credential helper', () => {
   })
 })
 
-function challenge(overrides: Partial<Types.PaymentRequirements> = {}): X402Challenge {
+function challenge(overrides: Partial<Types.ExactRequest> = {}): X402Challenge {
   return Challenge.from({
     id: 'x402-test',
     intent: 'charge',

--- a/src/x402/client/Exact.ts
+++ b/src/x402/client/Exact.ts
@@ -17,9 +17,10 @@ export async function createCredential(parameters: createCredential.Parameters):
   const request = parameters.challenge.request as Types.ExactRequest
   const accepted = Types.toPaymentRequirements(request)
   assertPolicy(parameters.config, accepted)
-  if (!request.resource || !request.extensions?.mppx)
-    throw new Error('x402 exact EIP-3009 requires route binding.')
-  const extensions = withNonceSalt(request.extensions)
+  if (!request.resource) throw new Error('x402 exact EIP-3009 requires resource information.')
+  const extensions = request.extensions?.mppx
+    ? withNonceSalt(request.extensions)
+    : request.extensions
   const transferMethod = accepted.extra?.assetTransferMethod ?? 'eip3009'
   if (transferMethod !== 'eip3009')
     throw new Error(`x402 exact ${String(transferMethod)} signing is not implemented yet.`)
@@ -32,11 +33,13 @@ export async function createCredential(parameters: createCredential.Parameters):
   const now = Math.floor(Date.now() / 1000)
   const authorization: Types.ExactEip3009Payload['authorization'] = {
     from: getAddress(account.address),
-    nonce: RouteBinding.nonce({
-      accepted,
-      extensions,
-      resource: request.resource,
-    }),
+    nonce: extensions?.mppx
+      ? RouteBinding.nonce({
+          accepted,
+          extensions,
+          resource: request.resource,
+        })
+      : randomEip3009Nonce(),
     to: getAddress(accepted.payTo),
     validAfter: (now - 600).toString(),
     validBefore: (now + accepted.maxTimeoutSeconds).toString(),
@@ -61,7 +64,7 @@ export async function createCredential(parameters: createCredential.Parameters):
 
   return Header.encodePaymentSignature({
     accepted,
-    extensions,
+    ...(extensions ? { extensions } : {}),
     payload: {
       authorization,
       signature,
@@ -183,4 +186,8 @@ function randomNonceSalt(): string {
   if (!crypto?.getRandomValues) throw new Error('x402 exact requires crypto randomness.')
   const bytes = crypto.getRandomValues(new Uint8Array(32))
   return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')
+}
+
+function randomEip3009Nonce(): `0x${string}` {
+  return `0x${randomNonceSalt()}`
 }

--- a/src/x402/client/Exact.ts
+++ b/src/x402/client/Exact.ts
@@ -74,11 +74,39 @@ export async function createCredential(parameters: createCredential.Parameters):
   })
 }
 
+/** Returns whether this client can sign the given x402 exact challenge. */
+export function canHandleChallenge(parameters: canHandleChallenge.Parameters): boolean {
+  const request = parameters.challenge.request as Types.ExactRequest
+  let accepted: Types.PaymentRequirements
+  try {
+    accepted = Types.toPaymentRequirements(request)
+    assertPolicy(parameters.config, accepted)
+  } catch {
+    return false
+  }
+
+  if (!request.resource) return false
+
+  const transferMethod = accepted.extra?.assetTransferMethod ?? 'eip3009'
+  if (transferMethod !== 'eip3009') return false
+
+  const name = accepted.extra?.name
+  const version = accepted.extra?.version
+  return typeof name === 'string' && typeof version === 'string'
+}
+
 export declare namespace createCredential {
   type Parameters = {
     challenge: Challenge.Challenge<Types.ExactRequest>
     config: Config
     context?: Context | undefined
+  }
+}
+
+export declare namespace canHandleChallenge {
+  type Parameters = {
+    challenge: Challenge.Challenge<Types.ExactRequest>
+    config: Config
   }
 }
 


### PR DESCRIPTION
## Summary
- support standard x402 V2 `exact` EVM EIP-3009 client payments without requiring mppx route binding
- skip x402 exact offers this client cannot pay so a later valid EIP-3009 offer can be selected
- preserve mppx-bound nonce derivation when the route-binding extension is present

## Scope
Support remains limited to x402 V2 `exact` EVM EIP-3009. Permit2, `upto`, batch settlement, and non-EVM schemes remain unsupported.
