### PR TITLE
fix: return post-payment `402` with no actionable challenge

### DIFF
--- a/.changeset/fix-post-payment-402.md
+++ b/.changeset/fix-post-payment-402.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed payment-aware fetch to return a post-payment `402` response with no actionable challenge instead of throwing `No method found for challenges`.

--- a/src/client/internal/Fetch.test.ts
+++ b/src/client/internal/Fetch.test.ts
@@ -1742,6 +1742,50 @@ describe('Fetch.from: 402 retry path', () => {
     expect(createCredential).toHaveBeenCalledOnce()
     expect(response.status).toBe(402)
   })
+
+  test('returns a challenge-less 402 after a rejected payment', async () => {
+    let callCount = 0
+    const createCredential = vi.fn(async () => 'credential')
+    const mockFetch: typeof globalThis.fetch = async () => {
+      callCount++
+      if (callCount === 1) return make402()
+      return new Response(JSON.stringify({ title: 'Verification Failed' }), {
+        status: 402,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [{ ...noopMethod, createCredential }],
+    })
+
+    const response = await fetch('https://example.com/api')
+    expect(callCount).toBe(2)
+    expect(createCredential).toHaveBeenCalledOnce()
+    expect(response.status).toBe(402)
+    await expect(response.json()).resolves.toEqual({ title: 'Verification Failed' })
+  })
+
+  test('returns a post-payment 402 with only unsupported challenges', async () => {
+    let callCount = 0
+    const createCredential = vi.fn(async () => 'credential')
+    const mockFetch: typeof globalThis.fetch = async () => {
+      callCount++
+      if (callCount === 1) return make402()
+      return make402({ method: 'stripe', intent: 'charge' })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [{ ...noopMethod, createCredential }],
+    })
+
+    const response = await fetch('https://example.com/api')
+    expect(callCount).toBe(2)
+    expect(createCredential).toHaveBeenCalledOnce()
+    expect(response.status).toBe(402)
+  })
 })
 
 describe('Fetch.from: acceptPaymentPolicy', () => {

--- a/src/client/internal/Fetch.ts
+++ b/src/client/internal/Fetch.ts
@@ -221,10 +221,14 @@ export function from<const methods extends readonly Method.AnyClient[]>(
             orderChallenges,
         )
         const selected = orderedCandidates[0]
-        if (!selected)
+        if (!selected) {
+          // A post-payment 402 with no actionable challenge (e.g. rejected credential)
+          // is the server's final answer, not a new challenge round.
+          if (retry > 0) return response
           throw new Error(
             `No method found for challenges: ${challenges.map((c) => `${c.method}.${c.intent}`).join(', ')}. Available: ${methods.map((m) => `${m.name}.${m.intent}`).join(', ')}`,
           )
+        }
 
         const selectedChallenge = selected.challenge
         challenge = selectedChallenge


### PR DESCRIPTION
Returns a post-payment `402` with no actionable challenge (e.g. rejected credential) to the caller instead of throwing `No method found for challenges`; regressed in `0.8.2` with the incremental payment retry loop. Initial-round selection still throws.
