### PR TITLE
fix: prefer payment auth over x402 challenges

### DIFF
--- a/.changeset/seamless-x402-client.md
+++ b/.changeset/seamless-x402-client.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Updated client negotiation to prefer Payment-auth challenges before x402 challenges.

--- a/src/client/internal/Fetch.test.ts
+++ b/src/client/internal/Fetch.test.ts
@@ -368,8 +368,13 @@ function make402(overrides?: { expires?: string; id?: string; intent?: string; m
   })
 }
 
-function makeCombined402() {
-  const response = make402()
+function makeCombined402(overrides?: {
+  expires?: string
+  id?: string
+  intent?: string
+  method?: string
+}) {
+  const response = make402(overrides)
   const headers = new Headers(response.headers)
   headers.set(
     x402_Types.paymentRequiredHeader,
@@ -727,6 +732,141 @@ describe('Fetch.from: 402 retry path', () => {
     const retryHeaders = new Headers(calls[1]!.init?.headers)
     expect(retryHeaders.get('Authorization')).toBe('credential')
     expect(retryHeaders.get(x402_Types.paymentSignatureHeader)).toBeNull()
+  })
+
+  test('prefers mpp Payment-auth over x402 when both are signable', async () => {
+    let callCount = 0
+    const calls: { init: RequestInit | undefined }[] = []
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      calls.push({ init })
+      callCount++
+      if (callCount === 1) return makeCombined402({ method: 'tempo', intent: 'charge' })
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [
+        {
+          name: 'tempo',
+          intent: 'charge',
+          context: undefined,
+          createCredential: async () => 'tempo-credential',
+        },
+        {
+          name: 'evm',
+          intent: 'charge',
+          context: undefined,
+          createCredential: async () => 'evm-credential',
+        },
+      ] as const,
+    })
+
+    const response = await fetch('https://example.com/api')
+
+    expect(response.status).toBe(200)
+    const retryHeaders = new Headers(calls[1]!.init?.headers)
+    expect(retryHeaders.get('Authorization')).toBe('tempo-credential')
+    expect(retryHeaders.get(x402_Types.paymentSignatureHeader)).toBeNull()
+  })
+
+  test('prefers native EVM Payment-auth over x402 for EVM-only clients', async () => {
+    let callCount = 0
+    const calls: { init: RequestInit | undefined }[] = []
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      calls.push({ init })
+      callCount++
+      if (callCount === 1) return makeCombined402({ method: 'evm', intent: 'charge' })
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [
+        {
+          name: 'evm',
+          intent: 'charge',
+          context: undefined,
+          createCredential: async () => 'evm-credential',
+        },
+      ] as const,
+    })
+
+    const response = await fetch('https://example.com/api')
+
+    expect(response.status).toBe(200)
+    const retryHeaders = new Headers(calls[1]!.init?.headers)
+    expect(retryHeaders.get('Authorization')).toBe('evm-credential')
+    expect(retryHeaders.get(x402_Types.paymentSignatureHeader)).toBeNull()
+  })
+
+  test('uses x402 when no signable Payment-auth challenge is available', async () => {
+    let callCount = 0
+    const calls: { init: RequestInit | undefined }[] = []
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      calls.push({ init })
+      callCount++
+      if (callCount === 1)
+        return new Response(null, {
+          status: 402,
+          headers: {
+            [x402_Types.paymentRequiredHeader]:
+              x402_Header.encodePaymentRequired(x402PaymentRequired),
+          },
+        })
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [
+        {
+          name: 'evm',
+          intent: 'charge',
+          context: undefined,
+          createCredential: async () => 'x402-credential',
+        },
+      ] as const,
+    })
+
+    const response = await fetch('https://example.com/api')
+
+    expect(response.status).toBe(200)
+    const retryHeaders = new Headers(calls[1]!.init?.headers)
+    expect(retryHeaders.get('Authorization')).toBeNull()
+    expect(retryHeaders.get(x402_Types.paymentSignatureHeader)).toBe('x402-credential')
+  })
+
+  test('lets orderChallenges force x402 before native Payment-auth', async () => {
+    let callCount = 0
+    const calls: { init: RequestInit | undefined }[] = []
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      calls.push({ init })
+      callCount++
+      if (callCount === 1) return makeCombined402({ method: 'evm', intent: 'charge' })
+      return new Response('OK', { status: 200 })
+    }
+
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [
+        {
+          name: 'evm',
+          intent: 'charge',
+          context: undefined,
+          createCredential: async () => 'x402-credential',
+        },
+      ] as const,
+      orderChallenges: (candidates) =>
+        [...candidates].sort((left, right) => right.challenge.id.localeCompare(left.challenge.id)),
+    })
+
+    const response = await fetch('https://example.com/api')
+
+    expect(response.status).toBe(200)
+    const retryHeaders = new Headers(calls[1]!.init?.headers)
+    expect(retryHeaders.get('Authorization')).toBeNull()
+    expect(retryHeaders.get(x402_Types.paymentSignatureHeader)).toBe('x402-credential')
   })
 
   test('settles MCP-over-HTTP JSON-RPC payment challenges at the fetch boundary', async () => {

--- a/src/internal/AcceptPayment.test.ts
+++ b/src/internal/AcceptPayment.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vp/test'
 
+import * as x402_ChallengeBrand from '../x402/internal/ChallengeBrand.js'
 import * as AcceptPayment from './AcceptPayment.js'
 
 function stripIndex(entry: AcceptPayment.Entry) {
@@ -176,6 +177,50 @@ describe('AcceptPayment', () => {
       { id: '2', index: 1, key: 'tempo/session' },
       { id: '3', index: 2, key: 'stripe/charge' },
     ])
+  })
+
+  test('selectChallengeCandidates prefers Payment-auth offers before x402 offers', () => {
+    const x402Challenge = x402_ChallengeBrand.mark({
+      id: 'x402:0',
+      intent: 'charge',
+      method: 'evm',
+      realm: 'test',
+      request: { scheme: 'exact' },
+    })
+    const nativeChallenge = {
+      id: 'native',
+      intent: 'charge',
+      method: 'tempo',
+      realm: 'test',
+      request: {},
+    }
+
+    const candidates = AcceptPayment.selectChallengeCandidates(
+      [x402Challenge, nativeChallenge],
+      [
+        { name: 'evm', intent: 'charge' },
+        { name: 'tempo', intent: 'charge' },
+      ] as const,
+      AcceptPayment.parse('evm/charge, tempo/charge;q=0.5'),
+    )
+
+    expect(candidates.map(({ challenge }) => challenge.id)).toEqual(['native', 'x402:0'])
+  })
+
+  test('selectChallengeCandidates preserves preference order within Payment-auth offers', () => {
+    const candidates = AcceptPayment.selectChallengeCandidates(
+      [
+        { id: 'tempo', intent: 'charge', method: 'tempo', realm: 'test', request: {} },
+        { id: 'evm', intent: 'charge', method: 'evm', realm: 'test', request: {} },
+      ],
+      [
+        { name: 'tempo', intent: 'charge' },
+        { name: 'evm', intent: 'charge' },
+      ] as const,
+      AcceptPayment.parse('evm/charge, tempo/charge;q=0.5'),
+    )
+
+    expect(candidates.map(({ challenge }) => challenge.id)).toEqual(['evm', 'tempo'])
   })
 
   test('selectChallengeCandidates supports duplicate method keys with challenge predicates', () => {

--- a/src/internal/AcceptPayment.ts
+++ b/src/internal/AcceptPayment.ts
@@ -1,4 +1,5 @@
 import type * as Challenge from '../Challenge.js'
+import * as x402_ChallengeBrand from '../x402/internal/ChallengeBrand.js'
 import type { MaybePromise } from './types.js'
 
 type MethodLike = {
@@ -208,7 +209,12 @@ export function selectChallengeCandidates<const methods extends readonly MethodL
             }) as ChallengeCandidate<methods[number]> & { match: Match },
         )
     })
-    .sort((left, right) => right.match.q - left.match.q || left.index - right.index)
+    .sort(
+      (left, right) =>
+        protocolRank(left.challenge) - protocolRank(right.challenge) ||
+        right.match.q - left.match.q ||
+        left.index - right.index,
+    )
     .map((candidate) => {
       const { match: _match, ...rest } = candidate
       return rest as unknown as ChallengeCandidate<methods[number]>
@@ -259,6 +265,10 @@ function matches(
 
 function specificity(preference: Pick<Entry, 'intent' | 'method'>): number {
   return Number(preference.method !== '*') + Number(preference.intent !== '*')
+}
+
+function protocolRank(challenge: Challenge.Challenge): number {
+  return x402_ChallengeBrand.is(challenge) ? 1 : 0
 }
 
 function parseEntry(part: string, index: number): Entry {


### PR DESCRIPTION
## Motivation

Client negotiation should mirror server composition by preferring native Payment-auth challenges and treating x402 as a fallback when both are available.

## Summary

- Prefer Payment-auth challenge candidates before branded x402 candidates.
- Preserve q-value and response-order ranking within each protocol group.
- Cover mpp-first, native EVM-first, x402 fallback, and explicit x402 override client flows.

## Key design considerations

- Keeps x402 signing inside `evm.charge()` without adding a public x402 client alias.
- Leaves `orderChallenges` as the explicit escape hatch for callers that want x402 first.
- Adds a patch changeset for the negotiation behavior update.
