### PR TITLE
feat: add Celo known chains and assets

### DIFF
--- a/.changeset/add-celo-chains-assets.md
+++ b/.changeset/add-celo-chains-assets.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added Celo and Celo Sepolia to known EVM chains and assets: `chains.celo`, `chains.celoSepolia`, `assets.celo.USDC`, `assets.celo.USDT`, and `assets.celoSepolia.USDC`.

--- a/src/evm/Chains.ts
+++ b/src/evm/Chains.ts
@@ -3,3 +3,9 @@ export const base = 8453
 
 /** Base Sepolia testnet EVM chain ID. */
 export const baseSepolia = 84532
+
+/** Celo mainnet EVM chain ID. */
+export const celo = 42220
+
+/** Celo Sepolia testnet EVM chain ID. */
+export const celoSepolia = 11142220

--- a/src/evm/PublicInterface.test-d.ts
+++ b/src/evm/PublicInterface.test-d.ts
@@ -40,8 +40,15 @@ describe('evm public interface', () => {
     expectTypeOf(clientAssets.baseSepolia.USDC).toMatchTypeOf<
       typeof serverAssets.baseSepolia.USDC
     >()
+    expectTypeOf(evmRoot.assets.celo.USDC).toMatchTypeOf<typeof serverAssets.celo.USDC>()
+    expectTypeOf(evmRoot.assets.celo.USDT).toMatchTypeOf<typeof serverAssets.celo.USDT>()
+    expectTypeOf(clientAssets.celoSepolia.USDC).toMatchTypeOf<
+      typeof serverAssets.celoSepolia.USDC
+    >()
     expectTypeOf(evmRoot.chains.base).toMatchTypeOf<number>()
     expectTypeOf(clientChains.baseSepolia).toMatchTypeOf<number>()
+    expectTypeOf(evmRoot.chains.celo).toMatchTypeOf<number>()
+    expectTypeOf(clientChains.celoSepolia).toMatchTypeOf<number>()
   })
 
   test('exports root EVM charge method definition', () => {

--- a/src/x402/Assets.test.ts
+++ b/src/x402/Assets.test.ts
@@ -208,4 +208,46 @@ describe('x402 assets', () => {
       },
     })
   })
+
+  test('exports Celo USDC metadata', () => {
+    expect(Assets.isAsset(Assets.celo.USDC)).toBe(true)
+    expect(Assets.celo.USDC).toMatchObject({
+      address: '0xcebA9300f2b948710d2653dD7B07f33A8B32118C',
+      decimals: 6,
+      network: 'eip155:42220',
+      transfer: {
+        name: 'USDC',
+        type: 'eip3009',
+        version: '2',
+      },
+    })
+  })
+
+  test('exports Celo USDT metadata', () => {
+    expect(Assets.isAsset(Assets.celo.USDT)).toBe(true)
+    expect(Assets.celo.USDT).toMatchObject({
+      address: '0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e',
+      decimals: 6,
+      network: 'eip155:42220',
+      transfer: {
+        name: 'Tether USD',
+        type: 'eip3009',
+        version: '1',
+      },
+    })
+  })
+
+  test('exports Celo Sepolia USDC metadata', () => {
+    expect(Assets.isAsset(Assets.celoSepolia.USDC)).toBe(true)
+    expect(Assets.celoSepolia.USDC).toMatchObject({
+      address: '0x01C5C0122039549AD1493B8220cABEdD739BC44E',
+      decimals: 6,
+      network: 'eip155:11142220',
+      transfer: {
+        name: 'USDC',
+        type: 'eip3009',
+        version: '2',
+      },
+    })
+  })
 })

--- a/src/x402/Assets.ts
+++ b/src/x402/Assets.ts
@@ -91,6 +91,46 @@ export const baseSepolia = {
   }),
 } as const
 
+/** Celo network known assets. */
+export const celo = {
+  USDC: define({
+    address: '0xcebA9300f2b948710d2653dD7B07f33A8B32118C',
+    decimals: 6,
+    network: 'eip155:42220',
+    transfer: {
+      // Celo USDC signs with the shorter EIP-712 domain name.
+      name: 'USDC',
+      type: 'eip3009',
+      version: '2',
+    },
+  }),
+  USDT: define({
+    address: '0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e',
+    decimals: 6,
+    network: 'eip155:42220',
+    transfer: {
+      // Celo USDT signs with domain version "1", unlike Circle's FiatToken "2".
+      name: 'Tether USD',
+      type: 'eip3009',
+      version: '1',
+    },
+  }),
+} as const
+
+/** Celo Sepolia known assets. */
+export const celoSepolia = {
+  USDC: define({
+    address: '0x01C5C0122039549AD1493B8220cABEdD739BC44E',
+    decimals: 6,
+    network: 'eip155:11142220',
+    transfer: {
+      name: 'USDC',
+      type: 'eip3009',
+      version: '2',
+    },
+  }),
+} as const
+
 /** Returns true when a value is known x402 asset metadata. */
 export function isAsset(value: unknown): value is KnownAsset {
   if (typeof value !== 'object' || value === null) return false


### PR DESCRIPTION
## Motivation

Bringing MPP to Celo via the unified `evm` method (following [draft-evm-charge-00](https://paymentauth.org/draft-evm-charge-00.html)'s guidance to avoid fragmenting the registry with chain-specific methods). Nothing on Celo expands beyond the standard EVM for MPP's purposes — fee abstraction and token duality are opt-in and invisible to standard type-2 transactions — so this only adds Celo to the known chains/assets alongside Base.

Everything the `evm` method needs is already live on Celo:

- Permit2 at the canonical address (`0x000000000022D473030F116dDEE9F6B43aC78BA3`) on both Celo mainnet and Celo Sepolia
- Native Circle USDC and native Tether USDT on mainnet, both implementing EIP-3009 (and EIP-2612)
- Circle USDC on the Celo Sepolia testnet

## Summary

- Added `chains.celo` (42220) and `chains.celoSepolia` (11142220) to `mppx/evm`
- Added known assets `assets.celo.USDC`, `assets.celo.USDT`, and `assets.celoSepolia.USDC`
- Added runtime metadata tests and public-interface type coverage mirroring the Base entries
- Added a patch changeset

## Key design considerations

All constants were verified on-chain (via `cast` against `forno.celo.org` / `forno.celo-sepolia.celo-testnet.org`) and cross-checked against [Circle's official contract addresses](https://developers.circle.com/stablecoins/usdc-contract-addresses) and viem's token list:

- **USDC's EIP-712 domain name on Celo is `USDC`, not `USD Coin`** (unlike Base mainnet). Recomputing `keccak256(abi.encode(typehash, keccak("USDC"), keccak("2"), chainId, address))` reproduces the on-chain `DOMAIN_SEPARATOR()` exactly on both Celo mainnet and Celo Sepolia; `USD Coin` does not match. Same class of per-deployment quirk already documented for Base vs Base Sepolia.
- **USDT signs with domain `{name: "Tether USD", version: "1"}`** — verified by the same domain-separator recomputation. Its EIP-3009 support was probed functionally: `transferWithAuthorization` with a dummy signature reverts with `TetherToken: invalid signature` (i.e. it reaches signature validation), `TRANSFER_WITH_AUTHORIZATION_TYPEHASH()` returns the canonical EIP-3009 typehash, and `authorizationState()` is callable. Note `version()` is not implemented on the contract (the domain version is only observable via `DOMAIN_SEPARATOR()`).
- **No testnet USDT**: Tether publishes no Celo Sepolia deployment, so `celoSepolia` only carries USDC (mirroring `baseSepolia`).

| Asset | Address | Domain |
| --- | --- | --- |
| Celo USDC | `0xcebA9300f2b948710d2653dD7B07f33A8B32118C` | `USDC` / `2` |
| Celo USDT | `0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e` | `Tether USD` / `1` |
| Celo Sepolia USDC | `0x01C5C0122039549AD1493B8220cABEdD739BC44E` | `USDC` / `2` |

Follow-ups (separate PRs): an end-to-end demo service accepting Celo payments, and a docs PR listing Celo on the `evm` method page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
