### PR TITLE
fix: bind session vouchers to credential source

### DIFF
--- a/.changeset/fix-session-voucher-replay.md
+++ b/.changeset/fix-session-voucher-replay.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed session voucher replay checks for settled vouchers and mismatched credential sources.

--- a/src/tempo/session/server/ChannelStore.test.ts
+++ b/src/tempo/session/server/ChannelStore.test.ts
@@ -559,6 +559,23 @@ describe('ChannelStore voucher acceptance', () => {
     expect((await store.getChannel(stateUpdateChannelId))?.highestVoucherAmount).toBe(50n)
   })
 
+  test('rejects an already accepted voucher when it has settled on-chain', async () => {
+    vi.spyOn(Voucher, 'verifyVoucher').mockReturnValue(true)
+    const stored = voucherAcceptanceChannel({ highestVoucherAmount: 50n })
+
+    await expect(
+      ChannelStore.verifyAndAcceptVoucher({
+        challenge: voucherAcceptanceChallenge,
+        channel: stored,
+        channelState: { deposit: 100n, settled: 50n, closeRequestedAt: 0 },
+        methodDetails: { chainId: 4217, escrowContract: voucherAcceptanceEscrow },
+        minVoucherDelta: 5n,
+        store: memoryChannelStore(stored),
+        voucher: voucherAcceptanceVoucher(50n),
+      }),
+    ).rejects.toThrow(VerificationFailedError)
+  })
+
   test('rejects vouchers beyond deposit or below minimum delta', async () => {
     vi.spyOn(Voucher, 'verifyVoucher').mockReturnValue(true)
     const stored = voucherAcceptanceChannel({ highestVoucherAmount: 50n })

--- a/src/tempo/session/server/ChannelStore.ts
+++ b/src/tempo/session/server/ChannelStore.ts
@@ -542,6 +542,10 @@ export async function verifyAndAcceptVoucher(
   )
   if (!valid) throw new InvalidSignatureError({ reason: 'invalid voucher signature' })
 
+  if (voucher.cumulativeAmount <= channelState.settled)
+    throw new VerificationFailedError({
+      reason: 'voucher cumulativeAmount is below on-chain settled amount',
+    })
   if (voucher.cumulativeAmount === channel.highestVoucherAmount)
     return createSessionReceipt({
       challengeId: challenge.id,
@@ -549,10 +553,6 @@ export async function verifyAndAcceptVoucher(
       acceptedCumulative: channel.highestVoucherAmount,
       spent: channel.spent,
       units: channel.units,
-    })
-  if (voucher.cumulativeAmount <= channelState.settled)
-    throw new VerificationFailedError({
-      reason: 'voucher cumulativeAmount is below on-chain settled amount',
     })
   const delta = voucher.cumulativeAmount - channel.highestVoucherAmount
   if (delta < minVoucherDelta)

--- a/src/tempo/session/server/CredentialVerification.test.ts
+++ b/src/tempo/session/server/CredentialVerification.test.ts
@@ -1,13 +1,19 @@
 import type { Address, Hex } from 'viem'
-import { describe, expect, test } from 'vp/test'
+import { afterEach, describe, expect, test, vi } from 'vp/test'
 
+import * as Challenge from '../../../Challenge.js'
+import * as Store from '../../../Store.js'
+import { chainId as chainIds } from '../../internal/defaults.js'
 import * as Channel from '../precompile/Channel.js'
+import * as Voucher from '../precompile/Voucher.js'
+import * as ChannelStore from './ChannelStore.js'
 import {
   assertOpenCredentialCoversRequest,
   requireSessionCredentialAction,
   requireSessionCredentialPayload,
   requireSessionCredentialPayloadHeader,
   validateChannelDescriptor,
+  verifyCredentialPayload,
 } from './CredentialVerification.js'
 
 describe('SessionCredentialGuards', () => {
@@ -23,6 +29,10 @@ describe('SessionCredentialGuards', () => {
   } as const
   const signature = `0x${'ab'.repeat(65)}` as Hex
   const transaction = `0x${'cd'.repeat(32)}` as Hex
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
 
   describe('SessionCredentialGuards', () => {
     test('reads valid action discriminators', () => {
@@ -177,6 +187,113 @@ describe('SessionCredentialGuards', () => {
           requestAmount: case_.requestAmount,
         }),
       ).toThrow(case_.expected)
+    })
+  })
+
+  describe('verifyCredentialPayload', () => {
+    const escrow = '0x4D50500000000000000000000000000000000000' as Address
+    const testChainId = chainIds.testnet
+    const computedChannelId = Channel.computeId({ ...descriptor, chainId: testChainId, escrow })
+    const challenge = Challenge.from({
+      id: 'credential-source-test',
+      realm: 'example.test',
+      method: 'tempo',
+      intent: 'session',
+      request: {
+        amount: '1',
+        currency: descriptor.token,
+        recipient: descriptor.payee,
+        unitType: 'request',
+      },
+    })
+
+    function channelStore(): ChannelStore.ChannelStore {
+      return ChannelStore.fromStore(Store.memory())
+    }
+
+    async function seedChannel(store: ChannelStore.ChannelStore) {
+      await store.updateChannel(computedChannelId, () => ({
+        backend: 'precompile',
+        authorizedSigner: descriptor.authorizedSigner,
+        chainId: testChainId,
+        channelId: computedChannelId,
+        closeRequestedAt: 0n,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        deposit: 100n,
+        descriptor,
+        escrowContract: escrow,
+        expiringNonceHash: descriptor.expiringNonceHash,
+        finalized: false,
+        highestVoucher: null,
+        highestVoucherAmount: 50n,
+        operator: descriptor.operator,
+        payee: descriptor.payee,
+        payer: descriptor.payer,
+        salt: descriptor.salt,
+        settledOnChain: 0n,
+        spent: 0n,
+        token: descriptor.token,
+        units: 0,
+      }))
+    }
+
+    test.each([
+      { label: 'payer', sourceAddress: descriptor.payer },
+      { label: 'authorized signer', sourceAddress: descriptor.authorizedSigner },
+    ])('accepts voucher credentials from the channel $label', async ({ sourceAddress }) => {
+      const store = channelStore()
+      await seedChannel(store)
+      const verifyVoucher = vi.spyOn(Voucher, 'verifyVoucher').mockResolvedValue(true)
+
+      await expect(
+        verifyCredentialPayload({
+          challenge,
+          channelStateTtl: 60_000,
+          chainId: testChainId,
+          client: {} as never,
+          credentialSource: `did:pkh:eip155:${testChainId}:${sourceAddress}`,
+          escrow,
+          lastOnChainVerified: new Map([[computedChannelId, Date.now()]]),
+          minVoucherDelta: 1n,
+          payload: {
+            action: 'voucher',
+            channelId: computedChannelId,
+            cumulativeAmount: '60',
+            descriptor,
+            signature,
+          },
+          store,
+        }),
+      ).resolves.toMatchObject({ acceptedCumulative: '60' })
+      expect(verifyVoucher).toHaveBeenCalledOnce()
+    })
+
+    test('rejects voucher credentials from a different source', async () => {
+      const store = channelStore()
+      await seedChannel(store)
+      const verifyVoucher = vi.spyOn(Voucher, 'verifyVoucher').mockResolvedValue(true)
+
+      await expect(
+        verifyCredentialPayload({
+          challenge,
+          channelStateTtl: 60_000,
+          chainId: testChainId,
+          client: {} as never,
+          credentialSource: `did:pkh:eip155:${testChainId}:0x0000000000000000000000000000000000000099`,
+          escrow,
+          lastOnChainVerified: new Map([[computedChannelId, Date.now()]]),
+          minVoucherDelta: 1n,
+          payload: {
+            action: 'voucher',
+            channelId: computedChannelId,
+            cumulativeAmount: '60',
+            descriptor,
+            signature,
+          },
+          store,
+        }),
+      ).rejects.toThrow('credential source does not match channel payer or authorized signer')
+      expect(verifyVoucher).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/tempo/session/server/CredentialVerification.ts
+++ b/src/tempo/session/server/CredentialVerification.ts
@@ -126,6 +126,32 @@ export function assertOpenCredentialCoversRequest(parameters: {
     throw new VerificationFailedError({ reason: 'voucher amount is less than request amount' })
 }
 
+/** Verifies that the credential source is authorized to spend from the channel. */
+export function assertCredentialSourceCanSpend(parameters: {
+  chainId: number
+  channel: Pick<ChannelStore.State, 'authorizedSigner' | 'payer'>
+  source?: string | undefined
+}): void {
+  const sourceAddress = readCredentialSourceAddress(parameters.source, parameters.chainId)
+  if (
+    isAddressEqual(sourceAddress, parameters.channel.payer) ||
+    isAddressEqual(sourceAddress, parameters.channel.authorizedSigner)
+  )
+    return
+  throw new VerificationFailedError({
+    reason: 'credential source does not match channel payer or authorized signer',
+  })
+}
+
+function readCredentialSourceAddress(source: string | undefined, chainId: number): Address {
+  const prefix = `did:pkh:eip155:${chainId}:`
+  if (!source?.startsWith(prefix))
+    throw new VerificationFailedError({ reason: 'credential source does not match channel' })
+  const address = source.slice(prefix.length)
+  if (isAddress(address, { strict: false })) return address
+  throw new VerificationFailedError({ reason: 'invalid credential source' })
+}
+
 const sessionCredentialActions = [
   'open',
   'topUp',
@@ -302,6 +328,8 @@ export type VerifyCredentialPayloadParameters = {
   chainId: number
   /** viem client used for precompile reads and transaction broadcasts. */
   client: Chain.TransactionClient
+  /** Optional payer identifier from the HTTP credential source field. */
+  credentialSource?: string | undefined
   /** TIP20EscrowChannel precompile address for this session method. */
   escrow: Address
   /** Operator address advertised in the HMAC-bound challenge details. */
@@ -531,6 +559,7 @@ async function handleVoucherCredential(
     store,
     client,
     challenge,
+    credentialSource,
     payload,
     chainId,
     escrow,
@@ -564,6 +593,7 @@ async function handleVoucherCredential(
     store,
     validateDescriptor: true,
   })
+  assertCredentialSourceCanSpend({ chainId, channel, source: credentialSource })
   if (channel.finalized) throw new ChannelClosedError({ reason: 'channel is finalized' })
   const isStale = Date.now() - (lastOnChainVerified.get(channelId) ?? 0) > channelStateTtl
   const state = isStale ? await Chain.getChannelState(client, channelId, escrow) : undefined

--- a/src/tempo/session/server/Session.integration.test.ts
+++ b/src/tempo/session/server/Session.integration.test.ts
@@ -84,6 +84,10 @@ function sessionRequest(channelId: Hex.Hex, amount = '100') {
   }
 }
 
+function sourceFor(account = payer): string {
+  return `did:pkh:eip155:${chain.id}:${account.address}`
+}
+
 describe.runIf(isPrecompileTestnet)('precompile server session chain integration', () => {
   test('broadcasts and verifies a real precompile open credential', async () => {
     const rawStore = Store.memory()
@@ -247,6 +251,7 @@ describe.runIf(isPrecompileTestnet)('precompile server session chain integration
           request: sessionRequest(channelId),
         } as never,
         payload,
+        source: sourceFor(),
       },
       request: sessionRequest(channelId) as never,
     })

--- a/src/tempo/session/server/Session.test.ts
+++ b/src/tempo/session/server/Session.test.ts
@@ -235,6 +235,18 @@ function verifyRequestWithFeePayer(channelId: Hex, feePayer: typeof payer): Veri
   } as unknown as VerifyRequest
 }
 
+function sourceFor(account = payer): string {
+  return `did:pkh:eip155:${chainId}:${account.address}`
+}
+
+function voucherCredential(payload: SessionCredentialPayload, channelId: Hex) {
+  return {
+    challenge: makeChallenge(channelId),
+    payload,
+    source: sourceFor(),
+  }
+}
+
 let saltCounter = 0
 
 async function createOpenPayload(
@@ -1434,10 +1446,7 @@ describe('precompile server session unit guardrails', () => {
     )
 
     const receipt = (await method.verify({
-      credential: {
-        challenge: makeChallenge(openPayload.channelId),
-        payload: voucher,
-      },
+      credential: voucherCredential(voucher, openPayload.channelId),
       request: verifyRequest(openPayload.channelId),
     })) as SessionReceipt
 
@@ -1473,10 +1482,7 @@ describe('precompile server session unit guardrails', () => {
     })
 
     const receipt = (await method.verify({
-      credential: {
-        challenge: makeChallenge(openPayload.channelId),
-        payload: voucher,
-      },
+      credential: voucherCredential(voucher, openPayload.channelId),
       request: verifyRequest(openPayload.channelId),
     })) as SessionReceipt
 
@@ -1506,10 +1512,7 @@ describe('precompile server session unit guardrails', () => {
 
     await expect(
       method.verify({
-        credential: {
-          challenge: makeChallenge(openPayload.channelId),
-          payload: voucher,
-        },
+        credential: voucherCredential(voucher, openPayload.channelId),
         request: verifyRequest(openPayload.channelId),
       }),
     ).rejects.toThrow(
@@ -1534,16 +1537,13 @@ describe('precompile server session unit guardrails', () => {
 
     await expect(
       method.verify({
-        credential: {
-          challenge: makeChallenge(openPayload.channelId),
-          payload: voucher,
-        },
+        credential: voucherCredential(voucher, openPayload.channelId),
         request: verifyRequest(openPayload.channelId),
       }),
     ).rejects.toThrow(/voucher delta 150 below minimum 200/)
   })
 
-  test('accepts idempotent precompile voucher replay after on-chain settlement catches up', async () => {
+  test('rejects idempotent precompile voucher replay after on-chain settlement catches up', async () => {
     const rawStore = Store.memory()
     const store = channelStore(rawStore)
     const openPayload = await createOpenPayload({ initialAmount: 100n })
@@ -1572,17 +1572,12 @@ describe('precompile server session unit guardrails', () => {
         createStateClient(payer, { settled: 500n, deposit: 1_000n, closeRequestedAt: 0 }),
     })
 
-    const receipt = (await method.verify({
-      credential: {
-        challenge: makeChallenge(openPayload.channelId),
-        payload: voucher,
-      },
-      request: verifyRequest(openPayload.channelId),
-    })) as SessionReceipt
-
-    expect(receipt.acceptedCumulative).toBe('500')
-    expect(receipt.spent).toBe('500')
-    expect(receipt.units).toBe(10)
+    await expect(
+      method.verify({
+        credential: voucherCredential(voucher, openPayload.channelId),
+        request: verifyRequest(openPayload.channelId),
+      }),
+    ).rejects.toThrow(/below on-chain settled amount/)
   })
 
   test('rejects stale or hijacked precompile voucher signatures', async () => {
@@ -1599,16 +1594,16 @@ describe('precompile server session unit guardrails', () => {
 
     await expect(
       method.verify({
-        credential: {
-          challenge: makeChallenge(openPayload.channelId),
-          payload: {
+        credential: voucherCredential(
+          {
             action: 'voucher',
             channelId: openPayload.channelId,
             cumulativeAmount: '250',
             descriptor: openPayload.descriptor,
             signature,
           },
-        },
+          openPayload.channelId,
+        ),
         request: verifyRequest(openPayload.channelId),
       }),
     ).rejects.toThrow(/invalid voucher signature/)
@@ -1628,10 +1623,7 @@ describe('precompile server session unit guardrails', () => {
 
     await expect(
       method.verify({
-        credential: {
-          challenge: makeChallenge(openPayload.channelId),
-          payload: voucher,
-        },
+        credential: voucherCredential(voucher, openPayload.channelId),
         request: verifyRequest(openPayload.channelId),
       }),
     ).rejects.toThrow(/exceeds.*deposit|insufficient channel deposit/)
@@ -1664,10 +1656,7 @@ describe('precompile server session unit guardrails', () => {
 
     await expect(
       method.verify({
-        credential: {
-          challenge: makeChallenge(openPayload.channelId),
-          payload: voucher,
-        },
+        credential: voucherCredential(voucher, openPayload.channelId),
         request: verifyRequest(openPayload.channelId),
       }),
     ).rejects.toThrow(/pending close request/)
@@ -1699,10 +1688,7 @@ describe('precompile server session unit guardrails', () => {
 
     await expect(
       method.verify({
-        credential: {
-          challenge: makeChallenge(openPayload.channelId),
-          payload: voucher,
-        },
+        credential: voucherCredential(voucher, openPayload.channelId),
         request: verifyRequest(openPayload.channelId),
       }),
     ).rejects.toThrow(/deposit is zero|channel deposit is zero|not found/)
@@ -1853,6 +1839,7 @@ describe('precompile server session unit guardrails', () => {
             Authorization: Credential.serialize({
               challenge: Challenge.fromResponse(first.challenge),
               payload: voucher,
+              source: sourceFor(),
             }),
           },
         }),
@@ -1874,6 +1861,7 @@ describe('precompile server session unit guardrails', () => {
             Authorization: Credential.serialize({
               challenge: Challenge.fromResponse(replayChallenge.challenge),
               payload: voucher,
+              source: sourceFor(),
             }),
           },
         }),
@@ -1915,6 +1903,7 @@ describe('precompile server session unit guardrails', () => {
           Credential.serialize({
             challenge: Challenge.fromResponse(first.challenge),
             payload: voucher,
+            source: sourceFor(),
           }),
         ),
       )
@@ -1933,6 +1922,7 @@ describe('precompile server session unit guardrails', () => {
           Credential.serialize({
             challenge: Challenge.fromResponse(replayChallenge.challenge),
             payload: voucher,
+            source: sourceFor(),
           }),
         ),
       )
@@ -1963,6 +1953,7 @@ describe('precompile server session unit guardrails', () => {
                 descriptor: openPayload.descriptor,
                 signature: (await createOpenPayload({ account: wrongPayer })).signature,
               },
+              source: sourceFor(),
             }),
           },
         }),
@@ -2848,10 +2839,7 @@ describe('precompile server session unit guardrails', () => {
     })
 
     const receipt = await method.verify({
-      credential: {
-        challenge: makeChallenge(openPayload.channelId),
-        payload: lowerVoucher,
-      },
+      credential: voucherCredential(lowerVoucher, openPayload.channelId),
       request: verifyRequest(openPayload.channelId),
     })
 

--- a/src/tempo/session/server/Session.ts
+++ b/src/tempo/session/server/Session.ts
@@ -413,6 +413,7 @@ export function session<const parameters extends session.Parameters>(
         channelStateTtl,
         chainId: context.chainId,
         client: context.client,
+        credentialSource: credential.source,
         escrow: context.escrow,
         expectedOperator: context.methodDetails.operator,
         feePayer: context.feePayer,


### PR DESCRIPTION
## Motivation

Session vouchers could be replayed after settlement or submitted by a different requester, allowing unauthorized channel spend.

## Summary

- Required voucher credential source to match the channel payer or authorized signer.
- Rejected vouchers at or below the on-chain settled amount before idempotent receipt handling.
- Added regression coverage and a patch changeset.

## Key design considerations

- Source binding uses the DID PKH chain/address format emitted by the session client.
- Existing idempotent receipts still work for accepted vouchers that have not settled on-chain.
