### PR TITLE
Stream validate output as each phase completes

### DIFF
--- a/.changeset/validate-stream-refactor.md
+++ b/.changeset/validate-stream-refactor.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+`mppx validate`: Stream results as each phase completes instead of batching until the end. Discovery and challenge checks now appear before the payment prompt.

--- a/src/cli/validate/index.ts
+++ b/src/cli/validate/index.ts
@@ -1,6 +1,6 @@
 import { Cli, z } from 'incur'
 
-import { validate as validateCore } from '../../validation/core.js'
+import { validate as validateCore, validateStream } from '../../validation/core.js'
 import { pc } from '../utils.js'
 import type { Counts } from './helpers.js'
 import { printResults, printSection } from './helpers.js'
@@ -30,73 +30,108 @@ const validate = Cli.create('validate', {
     outputJson: 'j',
   },
   async run(c) {
-    const result = await validateCore({
-      url: c.args.url,
-      endpoint: c.options.endpoint,
-      body: c.options.body,
-      query: c.options.query,
-      verbose: c.options.verbose > 0,
-      yes: c.options.yes,
-    })
-
+    // JSON mode: batch everything
     if (c.options.outputJson) {
+      const result = await validateCore({
+        url: c.args.url,
+        endpoint: c.options.endpoint,
+        body: c.options.body,
+        query: c.options.query,
+        verbose: c.options.verbose > 0,
+        yes: c.options.yes,
+      })
       console.log(JSON.stringify(result, null, 2))
       const noEndpoints = result.endpoints.length === 0 && !c.options.endpoint
       if (result.summary.failed > 0 || !result.discovery.found || noEndpoints) process.exit(1)
       return
     }
 
-    // Human-readable output
-    console.log(`\n${pc.bold('mppx validate')} ${pc.dim(result.url)}\n`)
+    // Streaming human-readable output
+    const baseUrl = c.args.url.replace(/\/$/, '').replace(/\/openapi\.json$/i, '')
+    console.log(`\n${pc.bold('mppx validate')} ${pc.dim(baseUrl)}\n`)
 
-    // Discovery
-    printSection('Discovery (/openapi.json)')
     const counts: Counts = { passed: 0, failed: 0, warnings: 0, skipped: 0 }
-    printResults(result.discovery.checks, counts)
+    let sawMppEndpoint = false
+    let sawNonMppPaymentEndpoint = false
+    let sawTestnet = false
+    let sawMainnet = false
+    let paymentSucceeded = false
+    let discoveryFound = false
+    let endpointCount = 0
 
-    if (!result.discovery.found && !c.options.endpoint) {
-      console.log('')
-      console.log(pc.yellow('  No discovery document found.'))
-      console.log(
-        pc.dim(
-          '  MPP servers must serve an OpenAPI document at /openapi.json with x-payment-info extensions.',
-        ),
-      )
-      console.log(
-        pc.dim('  To test a specific endpoint: mppx validate <url> --endpoint POST:/your/path'),
-      )
-      console.log('')
-      process.exit(1)
-    }
-
-    if (result.discovery.endpoints.length === 0 && !c.options.endpoint && result.discovery.found) {
-      console.log(pc.dim('  Use --endpoint to specify endpoints manually.'))
-      console.log('')
-      process.exit(1)
-    }
-
-    // Endpoints
-    for (const ep of result.endpoints) {
-      printSection(`${ep.method} ${ep.path}`)
-
-      if (ep.challenge.length > 0) {
-        console.log(pc.dim('  Challenge'))
-        printResults(ep.challenge, counts)
-      }
-
-      if (ep.errorHandling.length > 0) {
-        console.log(pc.dim('  Error Handling'))
-        printResults(ep.errorHandling, counts)
-      }
-
-      if (ep.payment.length > 0) {
-        console.log(pc.dim('  Payment'))
-        printResults(ep.payment, counts)
+    for await (const event of validateStream({
+      url: c.args.url,
+      endpoint: c.options.endpoint,
+      body: c.options.body,
+      query: c.options.query,
+      verbose: c.options.verbose > 0,
+      yes: c.options.yes,
+    })) {
+      switch (event.phase) {
+        case 'discovery':
+          printSection('Discovery (/openapi.json)')
+          printResults(event.results, counts)
+          discoveryFound = event.discovery.found
+          if (!discoveryFound && !c.options.endpoint) {
+            console.log('')
+            console.log(pc.yellow('  No discovery document found.'))
+            console.log(
+              pc.dim(
+                '  MPP servers must serve an OpenAPI document at /openapi.json with x-payment-info extensions.',
+              ),
+            )
+            console.log(
+              pc.dim(
+                '  To test a specific endpoint: mppx validate <url> --endpoint POST:/your/path',
+              ),
+            )
+            console.log('')
+            process.exit(1)
+          }
+          if (event.discovery.endpoints.length === 0 && !c.options.endpoint && discoveryFound) {
+            console.log(pc.dim('  Use --endpoint to specify endpoints manually.'))
+            console.log('')
+            process.exit(1)
+          }
+          break
+        case 'endpoint':
+          endpointCount++
+          printSection(`${event.endpoint.method} ${event.endpoint.path}`)
+          break
+        case 'challenge':
+          console.log(pc.dim('  Challenge'))
+          printResults(event.results, counts)
+          if (event.isMpp) {
+            sawMppEndpoint = true
+            if (event.isTestnet) sawTestnet = true
+            else sawMainnet = true
+          }
+          if (event.isNonMppPayment) sawNonMppPaymentEndpoint = true
+          break
+        case 'errorHandling':
+          console.log(pc.dim('  Error Handling'))
+          printResults(event.results, counts)
+          break
+        case 'payment':
+          console.log(pc.dim('  Payment'))
+          printResults(event.results, counts)
+          if (event.succeeded) paymentSucceeded = true
+          break
       }
     }
 
     // Summary
-    printSummary(counts, result.flags, result.endpoints.length)
+    printSummary(
+      counts,
+      {
+        sawMppEndpoint,
+        sawNonMppPaymentEndpoint,
+        sawTestnet,
+        sawMainnet,
+        paymentSucceeded,
+      },
+      endpointCount,
+    )
   },
 })
 

--- a/src/validation/core.ts
+++ b/src/validation/core.ts
@@ -54,21 +54,31 @@ export type ValidateResult = {
   }
 }
 
-/** Runs the full MPP validation suite against a server: discovery, challenge parsing, error handling, and (optionally) payment flow. */
-export async function validate(options: ValidateOptions): Promise<ValidateResult> {
+export type ValidateEvent =
+  | { phase: 'discovery'; discovery: DiscoveryResult; results: CheckResult[] }
+  | { phase: 'endpoint'; endpoint: EndpointSpec }
+  | {
+      phase: 'challenge'
+      endpoint: EndpointSpec
+      results: CheckResult[]
+      isMpp: boolean
+      isTestnet: boolean
+      isNonMppPayment: boolean
+    }
+  | { phase: 'errorHandling'; endpoint: EndpointSpec; results: CheckResult[] }
+  | { phase: 'payment'; endpoint: EndpointSpec; results: CheckResult[]; succeeded: boolean }
+
+/** Streams validation results as each phase completes. */
+export async function* validateStream(options: ValidateOptions): AsyncGenerator<ValidateEvent> {
   const baseUrl = options.url.replace(/\/$/, '').replace(/\/openapi\.json$/i, '')
   const verbose = options.verbose ?? false
 
   const discovery = await runDiscovery(baseUrl, options)
-  const endpointResults: EndpointValidationResult[] = []
-
-  let sawTestnet = false
-  let sawMainnet = false
-  let paymentSucceeded = false
-  let sawMppEndpoint = false
-  let sawNonMppPaymentEndpoint = false
+  yield { phase: 'discovery', discovery, results: discovery.checks }
 
   for (const endpoint of discovery.endpoints) {
+    yield { phase: 'endpoint', endpoint }
+
     let body: string | undefined
     if (options.endpoint) {
       body = options.body
@@ -90,56 +100,103 @@ export async function validate(options: ValidateOptions): Promise<ValidateResult
       },
     )
     const effectiveBody = resolvedBody ?? body
-
-    const isMppEndpoint = challengeResults.some(
+    const isMpp = challengeResults.some(
       (r) => r.severity === 'pass' && r.label === 'Challenge parseable',
     )
+    const isTestnet = challengeResults.some(
+      (r) =>
+        r.severity === 'pass' && r.label === 'Valid currency address' && r.detail === 'testnet',
+    )
+    const isNonMppPayment =
+      !isMpp && challengeResults.some((r) => r.label === 'Not an MPP endpoint')
 
-    let errorResults: CheckResult[] = []
-    let paymentResults: CheckResult[] = []
+    yield {
+      phase: 'challenge',
+      endpoint,
+      results: challengeResults,
+      isMpp,
+      isTestnet,
+      isNonMppPayment,
+    }
 
-    if (isMppEndpoint) {
-      sawMppEndpoint = true
-
-      const isTestnetEndpoint = challengeResults.some(
-        (r) =>
-          r.severity === 'pass' && r.label === 'Valid currency address' && r.detail === 'testnet',
-      )
-      if (isTestnetEndpoint) sawTestnet = true
-      else sawMainnet = true
-
-      errorResults = await validateErrorHandling(baseUrl, endpoint, {
+    if (isMpp) {
+      const errorResults = await validateErrorHandling(baseUrl, endpoint, {
         body: effectiveBody,
         query: options.query,
       })
+      yield { phase: 'errorHandling', endpoint, results: errorResults }
 
       if (!options.skipPayment) {
-        paymentResults = await validatePaymentFlow(baseUrl, endpoint, verbose, {
+        const paymentResults = await validatePaymentFlow(baseUrl, endpoint, verbose, {
           body: effectiveBody,
           query: options.query,
           yes: options.yes,
         })
-        if (
-          paymentResults.some((r) => r.severity === 'pass' && r.label === 'Payment: successful')
-        ) {
-          paymentSucceeded = true
-        }
+        const succeeded = paymentResults.some(
+          (r) => r.severity === 'pass' && r.label === 'Payment: successful',
+        )
+        yield { phase: 'payment', endpoint, results: paymentResults, succeeded }
       }
-    } else {
-      if (challengeResults.some((r) => r.label === 'Not an MPP endpoint'))
-        sawNonMppPaymentEndpoint = true
     }
+  }
+}
 
-    endpointResults.push({
-      method: endpoint.method,
-      path: endpoint.path,
-      challenge: challengeResults,
-      errorHandling: errorResults,
-      payment: paymentResults,
-    })
+/** Runs the full validation suite and returns all results as a batch. */
+export async function validate(options: ValidateOptions): Promise<ValidateResult> {
+  const baseUrl = options.url.replace(/\/$/, '').replace(/\/openapi\.json$/i, '')
+  let discovery: DiscoveryResult | undefined
+  const endpointResults: EndpointValidationResult[] = []
+  let current: EndpointValidationResult | undefined
+
+  let sawTestnet = false
+  let sawMainnet = false
+  let paymentSucceeded = false
+  let sawMppEndpoint = false
+  let sawNonMppPaymentEndpoint = false
+
+  for await (const event of validateStream(options)) {
+    switch (event.phase) {
+      case 'discovery':
+        discovery = event.discovery
+        break
+      case 'endpoint':
+        current = {
+          method: event.endpoint.method,
+          path: event.endpoint.path,
+          challenge: [],
+          errorHandling: [],
+          payment: [],
+        }
+        endpointResults.push(current)
+        break
+      case 'challenge':
+        if (current) current.challenge = event.results
+        if (event.isMpp) {
+          sawMppEndpoint = true
+          if (event.isTestnet) sawTestnet = true
+          else sawMainnet = true
+        }
+        if (event.isNonMppPayment) sawNonMppPaymentEndpoint = true
+        break
+      case 'errorHandling':
+        if (current) current.errorHandling = event.results
+        break
+      case 'payment':
+        if (current) current.payment = event.results
+        if (event.succeeded) paymentSucceeded = true
+        break
+    }
   }
 
   const summary = { passed: 0, failed: 0, warnings: 0, skipped: 0 }
+  if (discovery) {
+    for (const r of discovery.checks) {
+      if (r.severity === 'pass') summary.passed++
+      else if (r.severity === 'fail') summary.failed++
+      else if (r.severity === 'warn') summary.warnings++
+      else if (r.severity === 'skip') summary.skipped++
+    }
+  }
   for (const ep of endpointResults) {
     for (const r of [...ep.challenge, ...ep.errorHandling, ...ep.payment]) {
       if (r.severity === 'pass') summary.passed++
@@ -148,12 +205,8 @@ export async function validate(options: ValidateOptions): Promise<ValidateResult
       else if (r.severity === 'skip') summary.skipped++
     }
   }
-  for (const r of discovery.checks) {
-    if (r.severity === 'pass') summary.passed++
-    else if (r.severity === 'fail') summary.failed++
-    else if (r.severity === 'warn') summary.warnings++
-    else if (r.severity === 'skip') summary.skipped++
-  }
+
+  if (!discovery) throw new Error('Discovery phase did not complete')
 
   return {
     url: baseUrl,

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -1,10 +1,11 @@
-export { buildUrl, validate } from './core.js'
+export { buildUrl, validate, validateStream } from './core.js'
 export type {
   CheckResult,
   DiscoveryResult,
   EndpointSpec,
   EndpointValidationResult,
   PathParameter,
+  ValidateEvent,
   ValidateOptions,
   ValidateResult,
 } from './core.js'


### PR DESCRIPTION
A recent PR (https://github.com/wevm/mppx/pull/622), which exposes our validation logic to non-CLI callers, accidentally regressed `mppx validate` causing it to batch all results and only print them after the entire run finished. This means the payment prompt (which blocks on user input) appeared before any discovery or challenge output was visible.

Example before:
https://github.com/user-attachments/assets/729ce9c2-61c5-45ef-a1fc-a24ebf5ff08c

This PR adds `validateStream()`, an async generator that yields results per-phase. The CLI now uses `for await` so discovery and challenge checks print immediately, and the payment prompt appears in context. `validate()` remains as a batch wrapper for JSON mode and the programmatic API.

Example after:
https://github.com/user-attachments/assets/28fcd9a4-7d9f-49c2-a84a-f5057df5b98d