### PR TITLE
fix: release validation API as patch

### DIFF
--- a/.changeset/validate-programmatic-api.md
+++ b/.changeset/validate-programmatic-api.md
@@ -1,5 +1,5 @@
 ---
-'mppx': minor
+'mppx': patch
 ---
 
 Added programmatic validation API (`mppx/validation` export), OpenAPI path parameter substitution, x402 protocol detection, multi-path discovery fallback, and `--outputJson` CLI flag.


### PR DESCRIPTION
## Motivation

Release the programmatic validation API in the next patch version.

## Summary

- Change its changeset from minor to patch.

## Key design considerations

- Keeps the release classification aligned with the intended compatibility impact.
