### PR TITLE
mppx validate: EVM payment support

### DIFF
--- a/.changeset/validate-evm-payments.md
+++ b/.changeset/validate-evm-payments.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+`mppx validate`: EVM payment testing support. Uses the same wallet as Tempo to sign EIP-3009 authorizations, with pre-flight ERC-20 balance checks and chain-aware explorer links.

--- a/src/cli/internal.ts
+++ b/src/cli/internal.ts
@@ -5,10 +5,10 @@ import type * as Challenge from '../Challenge.js'
 import * as AcceptPayment from '../internal/AcceptPayment.js'
 import type * as Method from '../Method.js'
 import type { Config } from './config.js'
-import { stripe as stripePlugin, tempo as tempoPlugin } from './plugins/index.js'
+import { evm as evmPlugin, stripe as stripePlugin, tempo as tempoPlugin } from './plugins/index.js'
 import type { Plugin } from './plugins/plugin.js'
 
-const builtinPlugins: Plugin[] = [tempoPlugin(), stripePlugin()]
+const builtinPlugins: Plugin[] = [tempoPlugin(), stripePlugin(), evmPlugin()]
 
 export function resolvePlugin(
   challenge: Challenge.Challenge,

--- a/src/cli/plugins/evm.ts
+++ b/src/cli/plugins/evm.ts
@@ -1,0 +1,55 @@
+import { type Address, type Chain, createClient, erc20Abi, http } from 'viem'
+import { readContract } from 'viem/actions'
+import * as viemChains from 'viem/chains'
+
+import { evm as evmMethods, assets as evmAssets } from '../../evm/client/index.js'
+import { resolveAccount } from '../account.js'
+import { createPlugin } from './plugin.js'
+
+export function evm() {
+  return createPlugin({
+    method: 'evm',
+
+    async setup({ challenge }) {
+      const request = challenge.request as Record<string, unknown>
+      const methodDetails = request.methodDetails as Record<string, unknown> | undefined
+      const chainId = methodDetails?.chainId as number | undefined
+      const chain = chainId ? resolveChain(chainId) : undefined
+      const currency = request.currency as string | undefined
+
+      const account = await resolveAccount()
+      // Known assets provide EIP-712 domain metadata (token name/version) needed for EIP-3009 signing
+      const knownCurrencies = [
+        ...Object.values(evmAssets.base),
+        ...Object.values(evmAssets.baseSepolia),
+        ...Object.values(evmAssets.celo),
+        ...Object.values(evmAssets.celoSepolia),
+      ]
+
+      let tokenSymbol = currency ?? ''
+      if (chain && currency) {
+        try {
+          const client = createClient({ chain, transport: http() })
+          const symbol = await readContract(client, {
+            address: currency as Address,
+            abi: erc20Abi,
+            functionName: 'symbol',
+          })
+          if (symbol) tokenSymbol = symbol
+        } catch {}
+      }
+
+      return {
+        tokenSymbol,
+        tokenDecimals: (methodDetails?.decimals as number | undefined) ?? 6,
+        explorerUrl: chain?.blockExplorers?.default?.url,
+        methods: [...evmMethods({ account, currencies: knownCurrencies })],
+      }
+    },
+  })
+}
+
+function resolveChain(chainId: number): Chain | undefined {
+  const all = Object.values(viemChains) as Chain[]
+  return all.find((c) => c.id === chainId)
+}

--- a/src/cli/plugins/index.ts
+++ b/src/cli/plugins/index.ts
@@ -1,3 +1,4 @@
+export { evm } from './evm.js'
 export { createPlugin, type Plugin } from './plugin.js'
 export { stripe } from './stripe.js'
 export { tempo } from './tempo.js'

--- a/src/cli/validate/index.ts
+++ b/src/cli/validate/index.ts
@@ -67,6 +67,7 @@ const validate = Cli.create('validate', {
       query: c.options.query,
       verbose: c.options.verbose > 0,
       yes: c.options.yes,
+      onPaymentResults: (results) => printResults(results, counts),
     })) {
       switch (event.phase) {
         case 'discovery':
@@ -115,8 +116,6 @@ const validate = Cli.create('validate', {
           printResults(event.results, counts)
           break
         case 'payment':
-          console.log(pc.dim('  Payment'))
-          printResults(event.results, counts)
           if (event.succeeded) paymentSucceeded = true
           break
       }

--- a/src/cli/validate/payment.ts
+++ b/src/cli/validate/payment.ts
@@ -1,12 +1,14 @@
-import { type Address, createClient, http } from 'viem'
+import { type Address, type Chain, createClient, erc20Abi, http } from 'viem'
 import { privateKeyToAccount, generatePrivateKey } from 'viem/accounts'
-import { waitForTransactionReceipt } from 'viem/actions'
+import { readContract, waitForTransactionReceipt } from 'viem/actions'
+import * as viemChains from 'viem/chains'
 import { Actions } from 'viem/tempo'
 import { tempoModerato, tempo as tempoMainnetChain } from 'viem/tempo/chains'
 
 import * as Challenge from '../../Challenge.js'
 import * as Mppx from '../../client/Mppx.js'
 import * as Constants from '../../Constants.js'
+import { evm as evmMethods } from '../../evm/client/index.js'
 import * as Receipt from '../../Receipt.js'
 import { tempo as tempoMethods } from '../../tempo/client/index.js'
 import { chainId as tempoChainIds } from '../../tempo/internal/defaults.js'
@@ -61,6 +63,44 @@ async function resolveWalletAddress(): Promise<string | undefined> {
   } catch {
     return undefined
   }
+}
+
+async function fetchEvmTokenInfo(
+  chain: Chain,
+  token: Address,
+  account: Address,
+): Promise<{ balance: bigint; symbol: string | undefined }> {
+  const client = createClient({ chain, transport: http() })
+  const [balance, symbol] = await Promise.all([
+    readContract(client, {
+      address: token,
+      abi: erc20Abi,
+      functionName: 'balanceOf',
+      args: [account],
+    }),
+    readContract(client, { address: token, abi: erc20Abi, functionName: 'symbol' }).catch(
+      () => undefined,
+    ),
+  ])
+  return { balance, symbol: symbol ?? undefined }
+}
+
+async function resolveEvmMethods(): Promise<import('../../Method.js').AnyClient[]> {
+  const account = await resolveAccount()
+  // Known assets provide EIP-712 domain metadata (token name/version) needed for EIP-3009 signing
+  const { assets } = await import('../../evm/client/index.js')
+  const knownCurrencies = [
+    ...Object.values(assets.base),
+    ...Object.values(assets.baseSepolia),
+    ...Object.values(assets.celo),
+    ...Object.values(assets.celoSepolia),
+  ]
+  return [...evmMethods({ account, currencies: knownCurrencies })]
+}
+
+function resolveEvmChain(chainId: number): Chain | undefined {
+  const all = Object.values(viemChains) as Chain[]
+  return all.find((c) => c.id === chainId)
 }
 
 function methodSetupHint(challenge: Challenge.Challenge): string {
@@ -171,7 +211,10 @@ export async function validatePaymentFlow(
   // Try each challenge method (skip testnet challenge already handled above)
   const loaded = await loadConfig().catch(() => undefined)
   const isInteractive = process.stdin.isTTY ?? false
-  const supportedPaymentMethods: Set<string> = new Set([Constants.Methods.tempo])
+  const supportedPaymentMethods: Set<string> = new Set([
+    Constants.Methods.tempo,
+    Constants.Methods.evm,
+  ])
 
   for (const challenge of challenges) {
     if (challenge === tempoTestnetChallenge) continue
@@ -207,21 +250,43 @@ export async function validatePaymentFlow(
         continue
       }
 
-      // Pre-flight balance check
+      // Pre-flight balance check and chain resolution
       let insufficientBalance = false
       let tokenSymbol: string | undefined
-      if (requiredAmount && currency) {
+      let paymentChain: Chain | undefined
+      if (challenge.method === Constants.Methods.tempo) {
+        paymentChain = tempoMainnetChain
+      } else if (challenge.method === Constants.Methods.evm) {
+        const chainId = methodDetails?.chainId as number | undefined
+        if (chainId) paymentChain = resolveEvmChain(chainId)
+      }
+
+      if (requiredAmount && currency && paymentChain) {
         try {
-          const client = createClient({ chain: tempoMainnetChain, transport: http() })
-          const info = await fetchTokenInfo(client, currency as Address, walletAddress as Address)
-          tokenSymbol = info.symbol
-          if (info.balance < requiredAmount) {
+          let balance: bigint
+          if (challenge.method === Constants.Methods.tempo) {
+            const client = createClient({ chain: tempoMainnetChain, transport: http() })
+            const info = await fetchTokenInfo(client, currency as Address, walletAddress as Address)
+            balance = info.balance
+            tokenSymbol = info.symbol
+          } else {
+            const info = await fetchEvmTokenInfo(
+              paymentChain,
+              currency as Address,
+              walletAddress as Address,
+            )
+            balance = info.balance
+            tokenSymbol = info.symbol
+          }
+          if (balance < requiredAmount) {
             const requiredDisplay = `$${(Number(requiredAmount) / 10 ** decimals).toFixed(2)}`
-            const balanceDisplay = `$${(Number(info.balance) / 10 ** info.decimals).toFixed(2)}`
+            const balanceDisplay = `$${(Number(balance) / 10 ** decimals).toFixed(2)}`
+            const symbol = tokenSymbol ?? 'tokens'
             results.push(
               skip(
                 tag,
-                `insufficient balance (have ${balanceDisplay}, need ${requiredDisplay} ${info.symbol})`,
+                `insufficient balance (have ${balanceDisplay}, need ${requiredDisplay} ${symbol} on ${paymentChain.name})`,
+                `Fund wallet ${walletAddress} with at least ${requiredDisplay} ${symbol} on ${paymentChain.name}.`,
               ),
             )
             insufficientBalance = true
@@ -237,18 +302,23 @@ export async function validatePaymentFlow(
         ? `$${(Number(requiredAmount) / 10 ** decimals).toFixed(2)}`
         : 'unknown amount'
       const tokenDisplay = tokenSymbol ?? (currency?.length === 3 ? currency.toUpperCase() : '')
-      const chainName = tempoMainnetChain.name
+      const chainName = paymentChain?.name
 
-      if (walletAddress && verbose) console.log(pc.dim(`    Using wallet: ${walletAddress}`))
+      if (walletAddress) console.log(pc.dim(`    Using wallet: ${walletAddress}`))
 
-      if (!options?.yes && !isInteractive) {
+      if (paymentChain?.testnet) {
+        console.log(
+          pc.dim(
+            `    Auto-approved: ${amountDisplay}${tokenDisplay ? ` ${tokenDisplay}` : ''}${chainName ? ` on ${chainName}` : ''} (testnet)`,
+          ),
+        )
+      } else if (!options?.yes && !isInteractive) {
         results.push(skip(tag, 'non-interactive mode, use --yes to approve'))
         continue
-      }
-      if (!options?.yes) {
+      } else if (!options?.yes) {
         console.log('')
         const ok = await confirm(
-          `  ${pc.yellow('Pay')} ${amountDisplay}${tokenDisplay ? ` ${tokenDisplay}` : ''} on ${chainName}. Continue?`,
+          `  ${pc.yellow('Pay')} ${amountDisplay}${tokenDisplay ? ` ${tokenDisplay}` : ''}${chainName ? ` on ${chainName}` : ''}. Continue?`,
           false,
         )
         if (!ok) {
@@ -258,7 +328,7 @@ export async function validatePaymentFlow(
       } else {
         console.log(
           pc.dim(
-            `    Auto-approved: ${amountDisplay}${tokenDisplay ? ` ${tokenDisplay}` : ''} on ${chainName}`,
+            `    Auto-approved: ${amountDisplay}${tokenDisplay ? ` ${tokenDisplay}` : ''}${chainName ? ` on ${chainName}` : ''}`,
           ),
         )
       }
@@ -268,28 +338,37 @@ export async function validatePaymentFlow(
       let createCredentialFn: ((response: Response) => Promise<string>) | undefined
       let plugin: import('../plugins/plugin.js').Plugin | undefined
 
-      const resolved = resolvePlugin(challenge, loaded?.config)
-      plugin = resolved.plugin
-      const directMethod = resolved.method
-      if (!plugin && !directMethod) {
-        results.push(skip(tag, methodSetupHint(challenge)))
-        continue
-      }
-      if (plugin) {
+      if (challenge.method === Constants.Methods.evm) {
         try {
-          const pluginResult = await plugin.setup({
-            challenge,
-            options: { network: 'mainnet' },
-            methodOpts: {},
-          })
-          methods = pluginResult.methods
-          createCredentialFn = pluginResult.createCredential
+          methods = await resolveEvmMethods()
         } catch (error) {
           results.push(skip(tag, (error as Error).message))
           continue
         }
       } else {
-        methods = [directMethod!]
+        const resolved = resolvePlugin(challenge, loaded?.config)
+        plugin = resolved.plugin
+        const directMethod = resolved.method
+        if (!plugin && !directMethod) {
+          results.push(skip(tag, methodSetupHint(challenge)))
+          continue
+        }
+        if (plugin) {
+          try {
+            const pluginResult = await plugin.setup({
+              challenge,
+              options: { network: 'mainnet' },
+              methodOpts: {},
+            })
+            methods = pluginResult.methods
+            createCredentialFn = pluginResult.createCredential
+          } catch (error) {
+            results.push(skip(tag, (error as Error).message))
+            continue
+          }
+        } else {
+          methods = [directMethod!]
+        }
       }
 
       // Create credential and send
@@ -326,7 +405,7 @@ export async function validatePaymentFlow(
         fetchHeaders,
         fetchBody,
         verbose,
-        tempoMainnetChain,
+        paymentChain,
       )
     } finally {
       flush()
@@ -344,7 +423,7 @@ async function sendAndValidateResponse(
   baseHeaders: Record<string, string>,
   fetchBody: string | undefined,
   verbose: boolean,
-  explorerChain?: import('viem').Chain | undefined,
+  explorerChain?: Chain | undefined,
 ): Promise<CheckResult[]> {
   let paymentResponse: Response
   try {

--- a/src/cli/validate/payment.ts
+++ b/src/cli/validate/payment.ts
@@ -8,7 +8,6 @@ import { tempoModerato, tempo as tempoMainnetChain } from 'viem/tempo/chains'
 import * as Challenge from '../../Challenge.js'
 import * as Mppx from '../../client/Mppx.js'
 import * as Constants from '../../Constants.js'
-import { evm as evmMethods } from '../../evm/client/index.js'
 import * as Receipt from '../../Receipt.js'
 import { tempo as tempoMethods } from '../../tempo/client/index.js'
 import { chainId as tempoChainIds } from '../../tempo/internal/defaults.js'
@@ -83,19 +82,6 @@ async function fetchEvmTokenInfo(
     ),
   ])
   return { balance, symbol: symbol ?? undefined }
-}
-
-async function resolveEvmMethods(): Promise<import('../../Method.js').AnyClient[]> {
-  const account = await resolveAccount()
-  // Known assets provide EIP-712 domain metadata (token name/version) needed for EIP-3009 signing
-  const { assets } = await import('../../evm/client/index.js')
-  const knownCurrencies = [
-    ...Object.values(assets.base),
-    ...Object.values(assets.baseSepolia),
-    ...Object.values(assets.celo),
-    ...Object.values(assets.celoSepolia),
-  ]
-  return [...evmMethods({ account, currencies: knownCurrencies })]
 }
 
 function resolveEvmChain(chainId: number): Chain | undefined {
@@ -338,37 +324,28 @@ export async function validatePaymentFlow(
       let createCredentialFn: ((response: Response) => Promise<string>) | undefined
       let plugin: import('../plugins/plugin.js').Plugin | undefined
 
-      if (challenge.method === Constants.Methods.evm) {
+      const resolved = resolvePlugin(challenge, loaded?.config)
+      plugin = resolved.plugin
+      const directMethod = resolved.method
+      if (!plugin && !directMethod) {
+        results.push(skip(tag, methodSetupHint(challenge)))
+        continue
+      }
+      if (plugin) {
         try {
-          methods = await resolveEvmMethods()
+          const pluginResult = await plugin.setup({
+            challenge,
+            options: { network: 'mainnet' },
+            methodOpts: {},
+          })
+          methods = pluginResult.methods
+          createCredentialFn = pluginResult.createCredential
         } catch (error) {
           results.push(skip(tag, (error as Error).message))
           continue
         }
       } else {
-        const resolved = resolvePlugin(challenge, loaded?.config)
-        plugin = resolved.plugin
-        const directMethod = resolved.method
-        if (!plugin && !directMethod) {
-          results.push(skip(tag, methodSetupHint(challenge)))
-          continue
-        }
-        if (plugin) {
-          try {
-            const pluginResult = await plugin.setup({
-              challenge,
-              options: { network: 'mainnet' },
-              methodOpts: {},
-            })
-            methods = pluginResult.methods
-            createCredentialFn = pluginResult.createCredential
-          } catch (error) {
-            results.push(skip(tag, (error as Error).message))
-            continue
-          }
-        } else {
-          methods = [directMethod!]
-        }
+        methods = [directMethod!]
       }
 
       // Create credential and send

--- a/src/validation/core.ts
+++ b/src/validation/core.ts
@@ -26,6 +26,7 @@ export type ValidateOptions = {
   yes?: boolean | undefined
   skipPayment?: boolean | undefined
   discoveryPath?: string | undefined
+  onPaymentResults?: (results: CheckResult[]) => void
 }
 
 export type DiscoveryResult = {
@@ -72,7 +73,13 @@ export type ValidateEvent =
       isMalformedChallenge: boolean
     }
   | { phase: 'errorHandling'; endpoint: EndpointSpec; results: CheckResult[] }
-  | { phase: 'payment'; endpoint: EndpointSpec; results: CheckResult[]; succeeded: boolean }
+  | {
+      phase: 'payment'
+      endpoint: EndpointSpec
+      results: CheckResult[]
+      succeeded: boolean
+      body?: string | undefined
+    }
 
 /** Streams validation results as each phase completes. */
 export async function* validateStream(options: ValidateOptions): AsyncGenerator<ValidateEvent> {
@@ -147,6 +154,7 @@ export async function* validateStream(options: ValidateOptions): AsyncGenerator<
           body: effectiveBody,
           query: options.query,
           yes: options.yes,
+          onResults: options.onPaymentResults,
         })
         const succeeded = paymentResults.some(
           (r) => r.severity === 'pass' && r.label === 'Payment: successful',

--- a/src/validation/core.ts
+++ b/src/validation/core.ts
@@ -150,11 +150,12 @@ export async function* validateStream(options: ValidateOptions): AsyncGenerator<
       yield { phase: 'errorHandling', endpoint, results: errorResults }
 
       if (!options.skipPayment) {
+        const onResults = options.onPaymentResults
         const paymentResults = await validatePaymentFlow(baseUrl, endpoint, verbose, {
           body: effectiveBody,
           query: options.query,
           yes: options.yes,
-          onResults: options.onPaymentResults,
+          ...(onResults && { onResults }),
         })
         const succeeded = paymentResults.some(
           (r) => r.severity === 'pass' && r.label === 'Payment: successful',


### PR DESCRIPTION
- Adds EVM (Base, Celo, etc.) to the payment loop using the same wallet as Tempo
- ERC-20 balance check before attempting payment, with wallet address in the hint for JSON consumers
- Resolves chain from viem/chains by chainId for RPC and block explorer URLs
- Signs EIP-3009 transferWithAuthorization using known asset definitions (USDC on Base, Base Sepolia, Celo, Celo Sepolia)
- Chain name in prompts ("Pay $0.01 USDC on Base")
- Explorer links use correct block explorer per chain (basescan for Base, tempo explorer for Tempo)
- EVM testnets auto-approve without prompting (same as Tempo testnet)
- Streams per-method payment results via onPaymentResults callback so output interleaves with prompts
- Extracted EVM plugin (src/cli/plugins/evm.ts) consistent with tempo.ts and stripe.ts, removing special-case from payment loop

### Examples

#### Live app

```bash
 bensandler@st-bensandler3  ~/stripe/mppx   bensandler-validate-evm-payments  npx tsx src/bin.ts validate https://v0-starlink-payment-api.vercel.app

mppx validate https://v0-starlink-payment-api.vercel.app


Discovery (/openapi.json)
  ✓ Document found and parseable
  ✓ Valid OpenAPI structure
  ✓ Paid endpoints found (2 endpoint(s))

POST /api/flight-starlink
  Challenge
  ✓ Returns 402 without credentials
  ✓ WWW-Authenticate header present (Payment scheme)
  ✓ Challenge parseable (4 methods: tempo/charge, evm/charge, solana/charge, stripe/charge)
  ✓ Challenge has id
  ✓ Challenge has realm
  ✓ Challenge expires in the future (5m from now)
  ⚠ Realm matches server hostname (realm="v0-starlink-payment-gnznzttgq-ben-sandler-s-projects.vercel.app" vs host="v0-starlink-payment-api.vercel.app")
    → Set the realm to your production hostname (or base domain) in the challenge.
  ✓ [tempo] Valid recipient address
  ✓ [tempo] Valid currency address (mainnet)
  ✓ [tempo] Amount is valid integer string
  ✓ [evm] Valid recipient address
  ✓ [evm] Valid currency address
  ✓ [evm] Amount is valid integer string
  ✓ [evm] Has chainId (8453)
  ✓ [stripe] Amount is valid integer string
  ✓ [stripe] Valid currency code (USD)
  ✓ [stripe] Has networkId (profile_61UfVbHEBmn7)
  ✓ [stripe] Has paymentMethodTypes (card, link, crypto)
  Error Handling
  ✓ Malformed credential returns 402 (not 500)
  ✓ Error response includes fresh challenge
    Using wallet: 0x79EBcD74c8e1db9fb78D06Ac53534eE8c92e6f40

▸   Pay $0.01 USDC.e on Tempo Mainnet. Continue? (y/N) y
  ✓ Payment [tempo]: submitted
  ✓ Payment: successful (HTTP 200)
  ✓ Payment-Receipt header present
  ✓ Receipt parseable
  ✓ Receipt status is "success"
  ✓ Receipt reference valid (0x72e3d9560bb2c47491...)
  ✓ Receipt timestamp recent (0s ago)
  ✓ Response body non-empty (application/json, 245B)
  ✓ Content-Type header set (application/json)
  ✓ On-chain transaction (https://explore.tempo.xyz/receipt/0x72e3d9560bb2c47491f348831e5541c5a71e06e76b5be97d9b9127c3c59b5603)
    Using wallet: 0x79EBcD74c8e1db9fb78D06Ac53534eE8c92e6f40

▸   Pay $0.01 USDC on Base. Continue? (y/N) y
  ✓ Payment [evm]: submitted
  ✓ Payment: successful (HTTP 200)
  ✓ Payment-Receipt header present
  ✓ Receipt parseable
  ✓ Receipt status is "success"
  ✓ Receipt reference valid (0xaa618496baeaa4f157...)
  ✓ Receipt timestamp recent (0s ago)
  ✓ Response body non-empty (application/json, 245B)
  ✓ Content-Type header set (application/json)
  ✓ On-chain transaction (https://basescan.org/tx/0xaa618496baeaa4f157f0db90686ca29df90713935a3094060e3be28bbf27b6d8)

GET /api/flight-starlink/{flightNumber}
  Challenge
  ✓ Returns 402 without credentials
  ✓ WWW-Authenticate header present (Payment scheme)
  ✓ Challenge parseable (4 methods: tempo/charge, evm/charge, solana/charge, stripe/charge)
  ✓ Challenge has id
  ✓ Challenge has realm
  ✓ Challenge expires in the future (5m from now)
  ⚠ Realm matches server hostname (realm="v0-starlink-payment-gnznzttgq-ben-sandler-s-projects.vercel.app" vs host="v0-starlink-payment-api.vercel.app")
    → Set the realm to your production hostname (or base domain) in the challenge.
  ✓ [tempo] Valid recipient address
  ✓ [tempo] Valid currency address (mainnet)
  ✓ [tempo] Amount is valid integer string
  ✓ [evm] Valid recipient address
  ✓ [evm] Valid currency address
  ✓ [evm] Amount is valid integer string
  ✓ [evm] Has chainId (8453)
  ✓ [stripe] Amount is valid integer string
  ✓ [stripe] Valid currency code (USD)
  ✓ [stripe] Has networkId (profile_61UfVbHEBmn7)
  ✓ [stripe] Has paymentMethodTypes (card, link, crypto)
  Error Handling
  ✓ Malformed credential returns 402 (not 500)
  ✓ Error response includes fresh challenge
    Using wallet: 0x79EBcD74c8e1db9fb78D06Ac53534eE8c92e6f40

▸   Pay $0.01 USDC.e on Tempo Mainnet. Continue? (y/N) y
  ✓ Payment [tempo]: submitted
  ✓ Payment: successful (HTTP 200)
  ✓ Payment-Receipt header present
  ✓ Receipt parseable
  ✓ Receipt status is "success"
  ✓ Receipt reference valid (0x0538f1fce43dd2b88f...)
  ✓ Receipt timestamp recent (0s ago)
  ✓ Response body non-empty (application/json, 186B)
  ✓ Content-Type header set (application/json)
  ✓ On-chain transaction (https://explore.tempo.xyz/receipt/0x0538f1fce43dd2b88f0af26172290ad9d354b510b41271585e5e1ce6ed74e99c)
    Using wallet: 0x79EBcD74c8e1db9fb78D06Ac53534eE8c92e6f40

▸   Pay $0.01 USDC on Base. Continue? (y/N) y
  ✓ Payment [evm]: submitted
  ✓ Payment: successful (HTTP 200)
  ✓ Payment-Receipt header present
  ✓ Receipt parseable
  ✓ Receipt status is "success"
  ✓ Receipt reference valid (0xaf6ee50f6c6bb4489e...)
  ✓ Receipt timestamp recent (0s ago)
  ✓ Response body non-empty (application/json, 186B)
  ✓ Content-Type header set (application/json)
  ✓ On-chain transaction (https://basescan.org/tx/0xaf6ee50f6c6bb4489ea42361da371fd94969f571639e325aace09e93e7984d9a)

Summary: 81 passed, 2 warning(s)

  Tip: validate a testnet server too for free. This CLI automatically provisions and funds a testnet wallet for testing.
```

#### Test app

```bash
 bensandler@st-bensandler3  ~/stripe/mppx   bensandler-validate-evm-payments  npx tsx src/bin.ts validate https://v0-starlink-payment-api-git-test-ben-sandler-s-projects.vercel.app

mppx validate https://v0-starlink-payment-api-git-test-ben-sandler-s-projects.vercel.app


Discovery (/openapi.json)
  ✓ Document found and parseable
  ✓ Valid OpenAPI structure
  ✓ Paid endpoints found (2 endpoint(s))

POST /api/flight-starlink
  Challenge
  ✓ Returns 402 without credentials
  ✓ WWW-Authenticate header present (Payment scheme)
  ✓ Challenge parseable (2 methods: evm/charge, stripe/charge)
  ✓ Challenge has id
  ✓ Challenge has realm
  ✓ Challenge expires in the future (5m from now)
  ⚠ Realm matches server hostname (realm="v0-starlink-payment-5x67zj7z3-ben-sandler-s-projects.vercel.app" vs host="v0-starlink-payment-api-git-test-ben-sandler-s-projects.vercel.app")
    → Set the realm to your production hostname (or base domain) in the challenge.
  ✓ [evm] Valid recipient address
  ✓ [evm] Valid currency address
  ✓ [evm] Amount is valid integer string
  ✓ [evm] Has chainId (84532)
  ✓ [stripe] Amount is valid integer string
  ✓ [stripe] Valid currency code (USD)
  ✓ [stripe] Has networkId (profile_61UfVbHEBmn7)
  ✓ [stripe] Has paymentMethodTypes (card, link, crypto)
  Error Handling
  ✓ Malformed credential returns 402 (not 500)
  ✓ Error response includes fresh challenge
    Using wallet: 0x79EBcD74c8e1db9fb78D06Ac53534eE8c92e6f40
    Auto-approved: $0.01 USDC on Base Sepolia (testnet)
  ✓ Payment [evm]: submitted
  ✓ Payment: successful (HTTP 200)
  ✓ Payment-Receipt header present
  ✓ Receipt parseable
  ✓ Receipt status is "success"
  ✓ Receipt reference valid (0x31091c62934443f4e7...)
  ✓ Receipt timestamp recent (0s ago)
  ✓ Response body non-empty (application/json, 245B)
  ✓ Content-Type header set (application/json)
  ✓ On-chain transaction (https://sepolia.basescan.org/tx/0x31091c62934443f4e779ec0d7c618dbacd5004cc7b60b2e8c7073b185eb92164)

GET /api/flight-starlink/{flightNumber}
  Challenge
  ✓ Returns 402 without credentials
  ✓ WWW-Authenticate header present (Payment scheme)
  ✓ Challenge parseable (2 methods: evm/charge, stripe/charge)
  ✓ Challenge has id
  ✓ Challenge has realm
  ✓ Challenge expires in the future (5m from now)
  ⚠ Realm matches server hostname (realm="v0-starlink-payment-5x67zj7z3-ben-sandler-s-projects.vercel.app" vs host="v0-starlink-payment-api-git-test-ben-sandler-s-projects.vercel.app")
    → Set the realm to your production hostname (or base domain) in the challenge.
  ✓ [evm] Valid recipient address
  ✓ [evm] Valid currency address
  ✓ [evm] Amount is valid integer string
  ✓ [evm] Has chainId (84532)
  ✓ [stripe] Amount is valid integer string
  ✓ [stripe] Valid currency code (USD)
  ✓ [stripe] Has networkId (profile_61UfVbHEBmn7)
  ✓ [stripe] Has paymentMethodTypes (card, link, crypto)
  Error Handling
  ✓ Malformed credential returns 402 (not 500)
  ✓ Error response includes fresh challenge
    Using wallet: 0x79EBcD74c8e1db9fb78D06Ac53534eE8c92e6f40
    Auto-approved: $0.01 USDC on Base Sepolia (testnet)
  ✓ Payment [evm]: submitted
  ✓ Payment: successful (HTTP 200)
  ✓ Payment-Receipt header present
  ✓ Receipt parseable
  ✓ Receipt status is "success"
  ✓ Receipt reference valid (0x316391d15a76b02c72...)
  ✓ Receipt timestamp recent (0s ago)
  ✓ Response body non-empty (application/json, 186B)
  ✓ Content-Type header set (application/json)
  ✓ On-chain transaction (https://sepolia.basescan.org/tx/0x316391d15a76b02c7232564b464e29eb7ee94aae47b95e15791c2b1b687d415e)

Summary: 55 passed, 2 warning(s)

  Tip: validate a testnet server too for free. This CLI automatically provisions and funds a testnet wallet for testing.
```