### PR TITLE
fix: relay sponsored session transactions

### DIFF
--- a/.changeset/bright-camels-marry.md
+++ b/.changeset/bright-camels-marry.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed hosted fee-payer relays for TIP-1034 session opens and top-ups.

--- a/src/tempo/session/precompile/Chain.test.ts
+++ b/src/tempo/session/precompile/Chain.test.ts
@@ -576,6 +576,48 @@ describe('precompile broadcastOpenTransaction', () => {
     expect(simulationIndex).toBeLessThan(broadcastIndex)
   })
 
+  test('hosted fee-payer relays a sender-signed open without local co-signing', async () => {
+    const rpcMethods: string[] = []
+    const serializedTransaction = await createOpenTransaction({ signed: true })
+    const transaction = Transaction.deserialize(
+      serializedTransaction as Transaction.TransactionSerializedTempo,
+    )
+    const payer = transaction.from!
+    const expiringNonceHash = Channel.computeExpiringNonceHash(
+      Channel.transactionForExpiringNonceHash({ feePayer: true, transaction }),
+      { sender: payer },
+    )
+    const expectedDescriptor = { ...descriptor, payer, expiringNonceHash }
+    const channelId = Channel.computeId({
+      ...expectedDescriptor,
+      chainId,
+      escrow: tip20ChannelEscrow,
+    })
+    const state = { settled: 0n, deposit, closeRequestedAt: 0 }
+
+    await Chain.broadcastOpenTransaction({
+      chainId,
+      client: createMockClient({
+        channel: { descriptor: expectedDescriptor, state },
+        receipt: receipt([openedLog({ channelId, expiringNonceHash })]),
+        rpcMethods,
+      }),
+      escrowContract: tip20ChannelEscrow,
+      expectedAuthorizedSigner: descriptor.authorizedSigner,
+      expectedChannelId: channelId,
+      expectedCurrency: descriptor.token,
+      expectedExpiringNonceHash: expiringNonceHash,
+      expectedOperator: descriptor.operator,
+      expectedPayee: descriptor.payee,
+      expectedPayer: payer,
+      feePayer: true,
+      serializedTransaction,
+    })
+
+    expect(rpcMethods).toContain('eth_sendRawTransaction')
+    expect(rpcMethods).not.toContain('eth_sendRawTransactionSync')
+  })
+
   test('rejects expiring nonce hash mismatches before broadcasting', async () => {
     const serializedTransaction = await createOpenTransaction()
 

--- a/src/tempo/session/precompile/Chain.ts
+++ b/src/tempo/session/precompile/Chain.ts
@@ -361,7 +361,7 @@ type ParsedPrecompileCredentialTransaction = {
 
 function parsePrecompileCredentialTransaction(parameters: {
   escrowContract: Address
-  feePayer?: Account | undefined
+  feePayer?: Account | true | undefined
   label: 'open' | 'topUp'
   serializedTransaction: Hex
 }): ParsedPrecompileCredentialTransaction {
@@ -623,8 +623,8 @@ export type SendCredentialTransactionParameters = {
   allowedFeeTokens?: readonly Address[] | undefined
   /** Human-readable transaction details used by fee-payer policy hooks. */
   details: Record<string, string>
-  /** Fee-payer account used to co-sign Tempo transactions. */
-  feePayer?: Account | undefined
+  /** Fee-payer account, or `true` when the client transport delegates co-signing to a hosted relay. */
+  feePayer?: Account | true | undefined
   /** Optional fee-payer policy enforced before co-signing. */
   feePayerPolicy?: Partial<FeePayer.Policy> | undefined
   /** Management transaction kind, used for validation errors. */
@@ -658,6 +658,11 @@ export async function sendCredentialTransaction(parameters: SendCredentialTransa
   if (!FeePayer.isTempoTransaction(serializedTransaction))
     throw new BadRequestError({ reason: 'Only Tempo (0x76/0x78) transactions are supported' })
   assertSenderSigned(transaction)
+
+  if (feePayer === true) {
+    const txHash = await sendTransaction(client, serializedTransaction)
+    return waitForSuccessfulReceipt(client, txHash)
+  }
 
   await simulateTempoTransaction(client, transaction)
 
@@ -726,8 +731,8 @@ export type BroadcastOpenTransactionParameters = {
   expectedPayee: Address
   /** Payer expected to have signed the open transaction. */
   expectedPayer: Address
-  /** Fee-payer account used to co-sign sponsored open transactions. */
-  feePayer?: Account | undefined
+  /** Fee-payer account, or `true` when the client transport delegates co-signing to a hosted relay. */
+  feePayer?: Account | true | undefined
   /** Optional fee-payer policy enforced before co-signing. */
   feePayerPolicy?: Partial<FeePayer.Policy> | undefined
   /** Client-signed serialized open transaction. */
@@ -848,8 +853,8 @@ export type BroadcastTopUpTransactionParameters = {
   expectedChannelId: Hex
   /** Payment token expected for sponsored transaction fee token checks. */
   expectedCurrency: Address
-  /** Fee-payer account used to co-sign sponsored top-up transactions. */
-  feePayer?: Account | undefined
+  /** Fee-payer account, or `true` when the client transport delegates co-signing to a hosted relay. */
+  feePayer?: Account | true | undefined
   /** Optional fee-payer policy enforced before co-signing. */
   feePayerPolicy?: Partial<FeePayer.Policy> | undefined
   /** Client-signed serialized top-up transaction. */

--- a/src/tempo/session/server/CredentialVerification.ts
+++ b/src/tempo/session/server/CredentialVerification.ts
@@ -306,8 +306,8 @@ export type VerifyCredentialPayloadParameters = {
   escrow: Address
   /** Operator address advertised in the HMAC-bound challenge details. */
   expectedOperator?: Address | undefined
-  /** Optional fee-payer account for fee-sponsored management transactions. */
-  feePayer?: viem_Account | undefined
+  /** Fee-payer account, or `true` when the client transport delegates co-signing to a hosted relay. */
+  feePayer?: viem_Account | true | undefined
   /** Optional policy for fee-sponsored close/open/top-up transactions. */
   feePayerPolicy?: Partial<FeePayer.Policy> | undefined
   /** Optional fee token override for close transactions. */
@@ -684,7 +684,7 @@ async function handleCloseCredential(
       account
         ? {
             account,
-            ...(parameters.feePayer ? { feePayer: parameters.feePayer } : {}),
+            ...(typeof parameters.feePayer === 'object' ? { feePayer: parameters.feePayer } : {}),
             ...(parameters.feePayerPolicy ? { feePayerPolicy: parameters.feePayerPolicy } : {}),
             ...(parameters.feeToken ? { feeToken: parameters.feeToken } : {}),
             candidateFeeTokens: [channel.token],

--- a/src/tempo/session/server/RequestState.ts
+++ b/src/tempo/session/server/RequestState.ts
@@ -27,6 +27,7 @@ import {
   resolveCredentialFeePayer,
   resolveRequestFeePayer,
   type ParameterFeePayer,
+  type ResolvedFeePayer,
 } from './Settlement.js'
 
 /** Inputs used to build server bootstrap hints for a reusable session channel. */
@@ -267,8 +268,8 @@ export type ResolveSessionPaymentRequestParameters = {
 
 /** Inputs used to resolve shared context for credential verification. */
 export type ResolveCredentialVerificationContextParameters = {
-  /** Default configured fee-payer account, when enabled. */
-  feePayer?: viem_Account | undefined
+  /** Configured local fee payer, hosted relay URL, or sponsorship flag. */
+  feePayer?: ParameterFeePayer
   /** Resolves a viem client for the challenge chain ID. */
   getClient(parameters: {
     chainId: number
@@ -294,7 +295,7 @@ export type CredentialVerificationContext = {
   /** Client for precompile reads and transaction broadcasts. */
   client: PrecompileChain.TransactionClient
   /** Fee payer authorized for this credential, when allowed. */
-  feePayer?: viem_Account | undefined
+  feePayer?: ResolvedFeePayer
   /** Minimum allowed voucher delta in raw token units. */
   minVoucherDelta: bigint
 }

--- a/src/tempo/session/server/Session.ts
+++ b/src/tempo/session/server/Session.ts
@@ -315,9 +315,11 @@ export function session<const parameters extends session.Parameters>(
 
   const store = ChannelStore.fromStore(rawStore)
   const lastOnChainVerified = new Map<Hex, number>()
-  const { account, feePayer, recipient } = Account.resolve(parameters)
+  const { account, feePayer, feePayerUrl, recipient } = Account.resolve(parameters)
+  const configuredFeePayer = feePayer ?? feePayerUrl
   const getClient = Client.getResolver({
     chain: tempo_chain,
+    feePayerUrl,
     getClient: parameters.getClient,
     rpcUrl: defaults.rpcUrl,
   })
@@ -326,6 +328,7 @@ export function session<const parameters extends session.Parameters>(
     chainId: parameters.chainId,
     currency,
     decimals,
+    feePayer: parameters.feePayer,
     getClient: parameters.getClient,
     recipient,
     store: rawStore,
@@ -401,7 +404,7 @@ export function session<const parameters extends session.Parameters>(
       const payload = requireSessionCredentialPayload(credential.payload)
       const context = await resolveCredentialVerificationContext({
         decimals,
-        feePayer,
+        feePayer: configuredFeePayer,
         getClient,
         minVoucherDelta: parameters.minVoucherDelta,
         request,
@@ -437,7 +440,7 @@ export function session<const parameters extends session.Parameters>(
           maybeSettleScheduled({
             account,
             client: context.client,
-            feePayer: context.feePayer,
+            ...(typeof context.feePayer === 'object' ? { feePayer: context.feePayer } : {}),
             feePayerPolicy: parameters.feePayerPolicy,
             feeToken: parameters.feeToken,
             schedule: settlementSchedule,

--- a/src/tempo/session/server/Settlement.test.ts
+++ b/src/tempo/session/server/Settlement.test.ts
@@ -23,6 +23,7 @@ describe('FeePayerResolution', () => {
   const requestFeePayer = privateKeyToAccount(
     '0x5de4111a56d1f1ad3c74c8a3be6fba32114d0f9f8e9e4b0d4d4f5a7833f1b6c9',
   )
+  const feePayerUrl = 'https://fee-payer.example/relay'
 
   function credential(): Credential.Credential {
     return {
@@ -58,6 +59,13 @@ describe('FeePayerResolution', () => {
         resolveRequestFeePayer({
           credential: null,
           parameterFeePayer: true,
+        }),
+      ).toBe(true)
+
+      expect(
+        resolveRequestFeePayer({
+          credential: null,
+          parameterFeePayer: feePayerUrl,
         }),
       ).toBe(true)
     })
@@ -105,6 +113,14 @@ describe('FeePayerResolution', () => {
           request: { feePayer: true },
         }),
       ).toBe(defaultFeePayer)
+
+      expect(
+        resolveCredentialFeePayer({
+          feePayer: feePayerUrl,
+          methodDetails: { feePayer: true },
+          request: { feePayer: true },
+        }),
+      ).toBe(true)
 
       expect(
         resolveCredentialFeePayer({

--- a/src/tempo/session/server/Settlement.ts
+++ b/src/tempo/session/server/Settlement.ts
@@ -32,6 +32,9 @@ import * as ChannelStore from './ChannelStore.js'
 /** Fee-payer parameter accepted by the server session method. */
 export type ParameterFeePayer = viem_Account | string | true | undefined
 
+/** Resolved fee-payer mode for credential-time transaction submission. */
+export type ResolvedFeePayer = viem_Account | true | undefined
+
 /** Minimum method details needed to decide credential-time fee sponsorship. */
 export type CredentialFeePayerMethodDetails = {
   /** Whether the challenge advertised fee-payer support. */
@@ -56,8 +59,8 @@ export type ResolveCredentialFeePayerParameters = {
   request: unknown
   /** Challenge method details echoed by the credential. */
   methodDetails: CredentialFeePayerMethodDetails
-  /** Default fee-payer account resolved from server parameters. */
-  feePayer?: viem_Account | undefined
+  /** Configured local fee payer, hosted relay URL, or sponsorship flag. */
+  feePayer?: ParameterFeePayer
 }
 
 /** Fee-payer value read from an untrusted credential challenge request. */
@@ -89,20 +92,28 @@ export function resolveRequestFeePayer(
 
   const account = typeof requestFeePayer === 'object' ? requestFeePayer : defaultFeePayer
   if (credential) return account ?? undefined
-  if (account || defaultFeePayer || parameterFeePayer === true) return true
+  if (
+    account ||
+    defaultFeePayer ||
+    parameterFeePayer === true ||
+    typeof parameterFeePayer === 'string'
+  )
+    return true
   return undefined
 }
 
 /** Resolves the fee-payer account allowed for an incoming credential. */
 export function resolveCredentialFeePayer(
   parameters: ResolveCredentialFeePayerParameters,
-): viem_Account | undefined {
+): ResolvedFeePayer {
   const { feePayer, methodDetails, request } = parameters
   const requestFeePayer = readRequestFeePayer(request)
   const requestAllowsFeePayer =
     requestFeePayer === undefined || requestFeePayer === true || typeof requestFeePayer === 'object'
   if (methodDetails.feePayer !== true || !requestAllowsFeePayer) return undefined
-  return typeof requestFeePayer === 'object' ? requestFeePayer : feePayer
+  if (typeof requestFeePayer === 'object') return requestFeePayer
+  if (typeof feePayer === 'object') return feePayer
+  return typeof feePayer === 'string' ? true : undefined
 }
 
 /** Declarative server-side settlement cadence for automatic session settlement. */


### PR DESCRIPTION
## Motivation

TIP-1034 sessions accepted a hosted fee-payer URL but did not configure the session resolver or retain the hosted sponsorship mode during open and top-up verification.

## Summary

- Configure session clients with hosted fee-payer relay URLs
- Relay sender-signed v2 open and top-up transactions without local co-signing
- Add hosted fee-payer regression coverage and a patch changeset

## Key design considerations

- Hosted relays are represented internally as `feePayer: true`; local accounts retain local policy enforcement.
- Server-driven settlement and close flows continue to require a local fee-payer account.