### PR TITLE
fix: normalize hosted fee payer signatures

### DIFF
--- a/.changeset/fair-payers-normalize.md
+++ b/.changeset/fair-payers-normalize.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Normalize hosted fee-payer JSON-RPC signature parity before recovery.

--- a/src/tempo/internal/fee-payer.test.ts
+++ b/src/tempo/internal/fee-payer.test.ts
@@ -565,7 +565,10 @@ describe('fillHostedFeePayerTransaction', () => {
               },
             },
           },
-          (_key, value) => (typeof value === 'bigint' ? toHex(value) : value),
+          (key, value) => {
+            if (key === 'yParity') return toHex(value)
+            return typeof value === 'bigint' ? toHex(value) : value
+          },
         ),
       )
     })

--- a/src/tempo/internal/fee-payer.ts
+++ b/src/tempo/internal/fee-payer.ts
@@ -224,7 +224,10 @@ export async function fillHostedFeePayerTransaction(parameters: {
 
   assertAllowedFeeToken({ feeToken: filled.feeToken }, allowedFeeTokens)
 
-  const feePayerSignature = filled.feePayerSignature
+  const feePayerSignature = {
+    ...(filled.feePayerSignature as Record<string, unknown>),
+    yParity: Number((filled.feePayerSignature as { yParity?: unknown }).yParity),
+  }
   const feeToken = filled.feeToken
 
   // Recover the concrete sponsor address so the simulation can use a concrete


### PR DESCRIPTION
## Motivation

Hosted fee-payer JSON-RPC responses encode `yParity` as a hex quantity, but signature recovery requires a numeric parity.

## Summary

- Normalize hosted fee-payer signature parity before recovery.
- Cover the JSON-RPC signature encoding in the hosted payer regression test.

## Key design considerations

- Keep the normalization at the RPC boundary while retaining the existing serialized transaction behavior.