### PR TITLE
feat: add Tempo session manager account resolution

### DIFF
--- a/.changeset/tidy-owls-resolve.md
+++ b/.changeset/tidy-owls-resolve.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added account resolution to Tempo session managers.

--- a/src/client/Mppx.test-d.ts
+++ b/src/client/Mppx.test-d.ts
@@ -19,7 +19,9 @@ describe('Mppx', () => {
   test('exports low-level session method and explicit managed session helper', () => {
     expectTypeOf(session({ account: {} as Account })).toMatchTypeOf<Method.AnyClient>()
     expectTypeOf(session.manager({ account: {} as Account })).toHaveProperty('fetch')
-    expectTypeOf(sessionManager({ account: {} as Account })).toHaveProperty('fetch')
+    expectTypeOf(
+      sessionManager({ account: {} as Account, resolveAccount: ({ account }) => account }),
+    ).toHaveProperty('fetch')
     expectTypeOf(sessionMethod({ account: {} as Account })).toMatchTypeOf<Method.AnyClient>()
     expectTypeOf(tempo.session({ account: {} as Account })).toMatchTypeOf<Method.AnyClient>()
     expectTypeOf(tempo.session.manager({ account: {} as Account })).toHaveProperty('fetch')

--- a/src/tempo/session/client/SessionManager.test.ts
+++ b/src/tempo/session/client/SessionManager.test.ts
@@ -329,9 +329,13 @@ describe('Session', () => {
       expect(posted[0]).toMatchObject({ action: 'voucher', channelId: storedChannelId })
     })
 
-    test('seeds a same-route HEAD snapshot into the entry index and resumes it', async () => {
+    test('seeds a same-route HEAD snapshot and resolves the account when resuming it', async () => {
       const { store, set } = makeChannelStore()
       const posted: SessionCredentialPayload[] = []
+      const resolveAccount = vi.fn(
+        (info: Parameters<NonNullable<sessionManager.Parameters['resolveAccount']>>[0]) =>
+          info.account,
+      )
       const mockFetch = vi.fn().mockImplementation((_input, init?: RequestInit) => {
         const headers = new Headers(init?.headers)
         if (init?.method === 'HEAD' && !headers.get(Constants.Headers.authorization)) {
@@ -377,6 +381,7 @@ describe('Session', () => {
         client,
         fetch: mockFetch as typeof globalThis.fetch,
         channelStore: store,
+        resolveAccount,
       })
 
       const response = await s.fetch('https://api.example.com/data')
@@ -384,6 +389,12 @@ describe('Session', () => {
       expect(response.status).toBe(200)
       expect(set).toHaveBeenCalledWith(expect.objectContaining({ channelId: storedChannelId }))
       expect(posted[0]).toMatchObject({ action: 'voucher', channelId: storedChannelId })
+      expect(resolveAccount).toHaveBeenCalledOnce()
+      expect(resolveAccount).toHaveBeenCalledWith({
+        account,
+        chainId: 4217,
+        operation: { authority: account.address, kind: 'authorizePaymentChannel' },
+      })
       const contentCall = mockFetch.mock.calls.find((call) => call[1]?.method !== 'HEAD')
       expect(new Headers(contentCall?.[1]?.headers).get('Payment-Session')).toBeNull()
     })

--- a/src/tempo/session/client/SessionManager.ts
+++ b/src/tempo/session/client/SessionManager.ts
@@ -274,6 +274,7 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
   const method = sessionPlugin({
     account: parameters.account,
     getClient: parameters.client ? () => parameters.client! : parameters.getClient,
+    resolveAccount: parameters.resolveAccount,
     escrow: parameters.escrow,
     decimals: config.decimals,
     maxDeposit: parameters.maxDeposit,
@@ -787,6 +788,8 @@ export namespace sessionManager {
       fetch?: typeof globalThis.fetch | undefined
       /** Maximum deposit in human-readable units (e.g. `'10'` for 10 tokens). Converted to raw units via `decimals`. */
       maxDeposit?: string | undefined
+      /** Selects the account that signs session credentials. */
+      resolveAccount?: sessionPlugin.ResolveAccount | undefined
       /** Store for reusable session channels. Defaults to in-memory. */
       channelStore?: ChannelStore | undefined
       /** Optional websocket constructor for runtimes without a global WebSocket. */


### PR DESCRIPTION
## Summary

- expose `resolveAccount` on Tempo session managers
- forward it to the existing session credential account-selection hook
- cover resumed channels and public typing

## Motivation

The low-level Tempo session client already supports account resolution, but `sessionManager` did not expose the hook. Forwarding it lets hosts choose a delegated account for session actions without coupling mppx to a wallet SDK.

## Validation

- `VITE_TEMPO_NETWORK=none pnpm exec vp test --run src/tempo/session/client/SessionManager.test.ts`
- `pnpm check:types`
- `pnpm check:ci`