### PR TITLE
fix(tempo): select local sponsor fee token

### DIFF
--- a/.changeset/select-local-fee-token.md
+++ b/.changeset/select-local-fee-token.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added local Tempo charge fee-token selection with a pathUSD preference and an explicit override.

--- a/src/tempo/internal/fee-token.test.ts
+++ b/src/tempo/internal/fee-token.test.ts
@@ -77,6 +77,43 @@ describe.runIf(isLocalnet)('resolveFeeToken', () => {
     expectAddress(feeToken, asset)
   })
 
+  test('prioritizes funded allowed candidates', async () => {
+    const account = testAccount()
+    const client = clientFor(account)
+    await fundAccount({ address: account.address, token: asset })
+    await fundAccount({ address: account.address, token: Addresses.pathUsd })
+    await Actions.fee.setUserTokenSync(client, {
+      feeToken: asset,
+      token: asset,
+    } as never)
+
+    const feeToken = await resolveFeeToken({
+      account: account.address,
+      allowedTokens: [Addresses.pathUsd, asset],
+      candidateTokens: [Addresses.pathUsd, asset],
+      client,
+      prioritizeCandidates: true,
+    })
+
+    expectAddress(feeToken, Addresses.pathUsd)
+  })
+
+  test('falls through prioritized candidates when pathUSD is unfunded', async () => {
+    const account = testAccount()
+    const client = clientFor(account)
+    await fundAccount({ address: account.address, token: asset })
+
+    const feeToken = await resolveFeeToken({
+      account: account.address,
+      allowedTokens: [Addresses.pathUsd, asset],
+      candidateTokens: [Addresses.pathUsd, asset],
+      client,
+      prioritizeCandidates: true,
+    })
+
+    expectAddress(feeToken, asset)
+  })
+
   test('uses a funded chain fee token when configured', async () => {
     const account = testAccount()
     const client = createClient({

--- a/src/tempo/internal/fee-token.ts
+++ b/src/tempo/internal/fee-token.ts
@@ -4,8 +4,17 @@ import { Actions, TokenId } from 'viem/tempo'
 import * as TempoAddress from './address.js'
 import * as defaults from './defaults.js'
 
-function pushUnique(tokens: Address[], token: Address | undefined) {
+function pushUnique(
+  tokens: Address[],
+  token: Address | undefined,
+  allowedTokens?: readonly Address[] | undefined,
+) {
   if (!token) return
+  if (
+    allowedTokens &&
+    !allowedTokens.some((allowedToken) => TempoAddress.isEqual(allowedToken, token))
+  )
+    return
   if (tokens.some((t) => TempoAddress.isEqual(t, token))) return
   tokens.push(token)
 }
@@ -27,21 +36,33 @@ function getChainFeeToken(client: Client): Address | undefined {
   return chainId ? defaults.currency[chainId as keyof typeof defaults.currency] : undefined
 }
 
+/**
+ * Resolves a funded fee token from account, chain, and caller-supplied preferences.
+ *
+ * `prioritizeCandidates` checks candidate tokens before account and chain
+ * preferences. `allowedTokens` limits every preference to the caller's policy.
+ */
 export async function resolveFeeToken(parameters: {
   account: Address
+  allowedTokens?: readonly Address[] | undefined
   candidateTokens?: readonly Address[] | undefined
   client: Client
+  prioritizeCandidates?: boolean | undefined
 }): Promise<Address | undefined> {
-  const { account, candidateTokens, client } = parameters
+  const { account, allowedTokens, candidateTokens, client, prioritizeCandidates } = parameters
   const tokens: Address[] = []
+
+  if (prioritizeCandidates)
+    for (const token of candidateTokens ?? []) pushUnique(tokens, token, allowedTokens)
 
   const userToken = await Actions.fee
     .getUserToken(client as never, { account })
     .then((token) => token?.address as Address | undefined)
     .catch(() => undefined)
-  pushUnique(tokens, userToken)
-  pushUnique(tokens, getChainFeeToken(client))
-  for (const token of candidateTokens ?? []) pushUnique(tokens, token)
+  pushUnique(tokens, userToken, allowedTokens)
+  pushUnique(tokens, getChainFeeToken(client), allowedTokens)
+  if (!prioritizeCandidates)
+    for (const token of candidateTokens ?? []) pushUnique(tokens, token, allowedTokens)
 
   for (const token of tokens) {
     if (await hasBalance(client, account, token)) return token

--- a/src/tempo/server/Charge.test.ts
+++ b/src/tempo/server/Charge.test.ts
@@ -1628,7 +1628,8 @@ describe('tempo', () => {
         chain: client.chain,
         transport: custom({
           async request(args: any) {
-            if (args.method === 'eth_call') callRequests.push(args.params?.[0])
+            if (args.method === 'eth_call' && args.params?.[0]?.calls)
+              callRequests.push(args.params[0])
             return client.transport.request(args)
           },
         }),
@@ -1690,6 +1691,7 @@ describe('tempo', () => {
       expect(simRequest.feePayer).not.toBe(true)
       expect(typeof simRequest.feePayer).toBe('string')
       expect((simRequest.feePayer as string).toLowerCase()).toBe(accounts[0].address.toLowerCase())
+      expect(simRequest.feeToken?.toLowerCase()).toBe(defaults.tokens.pathUsd.toLowerCase())
       // Execution runs as the sender, not the sponsor.
       expect((simRequest.from as string).toLowerCase()).toBe(accounts[1].address.toLowerCase())
       expect(simRequest.calls?.length).toBeGreaterThan(0)
@@ -2160,6 +2162,15 @@ describe('tempo', () => {
 
       httpServer.close()
       feePayerServer.close()
+    })
+
+    test('error: rejects a fee token configured for a remote fee payer', () => {
+      expect(() =>
+        tempo_server.charge({
+          feePayer: 'https://fee-payer.example',
+          feeToken: defaults.tokens.pathUsd,
+        }),
+      ).toThrow('`feeToken` can only be configured for a local fee payer.')
     })
 
     test('behavior: access keys', async () => {

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -31,6 +31,7 @@ import * as TempoAddress from '../internal/address.js'
 import * as Charge_internal from '../internal/charge.js'
 import * as defaults from '../internal/defaults.js'
 import * as FeePayer from '../internal/fee-payer.js'
+import { resolveFeeToken } from '../internal/fee-token.js'
 import * as Proof from '../internal/proof.js'
 import * as Selectors from '../internal/selectors.js'
 import type * as types from '../internal/types.js'
@@ -59,6 +60,7 @@ export function charge<const parameters extends charge.Parameters>(
     decimals = defaults.decimals,
     description,
     externalId,
+    feeToken: configuredFeeToken,
     feePayerPolicy,
     html,
     memo,
@@ -79,6 +81,8 @@ export function charge<const parameters extends charge.Parameters>(
     : undefined
 
   const { recipient, feePayer, feePayerUrl } = Account.resolve(parameters)
+  if (configuredFeeToken && feePayerUrl)
+    throw new Error('`feeToken` can only be configured for a local fee payer.')
 
   const getClient = Client.getResolver({
     chain: { ...tempo_chain, experimental_preconfirmationTime: 500 },
@@ -405,6 +409,7 @@ export function charge<const parameters extends charge.Parameters>(
 
             const allowedFeeTokens = FeePayer.defaultAllowedFeeTokens(chainId)
             if (isFeePayerTx) FeePayer.assertAllowedFeeToken(transaction, allowedFeeTokens)
+            const selectableFeeTokens = allowedFeeTokens as readonly `0x${string}`[]
 
             // Request for the pre-broadcast simulation; for sponsored payments
             // this is overwritten below with the co-signed shape.
@@ -415,6 +420,15 @@ export function charge<const parameters extends charge.Parameters>(
 
             const serializedTransaction_final = await (async () => {
               if (feePayerAccount && methodDetails?.feePayer !== false) {
+                const feeToken =
+                  configuredFeeToken ??
+                  (await resolveFeeToken({
+                    account: feePayerAccount.address,
+                    allowedTokens: selectableFeeTokens,
+                    candidateTokens: selectableFeeTokens,
+                    client,
+                    prioritizeCandidates: true,
+                  }))
                 const sponsored = FeePayer.prepareSponsoredTransaction({
                   account: feePayerAccount,
                   allowedFeeTokens,
@@ -424,7 +438,7 @@ export function charge<const parameters extends charge.Parameters>(
                   policy: feePayerPolicy,
                   transaction: {
                     ...transaction,
-                    feeToken: transaction.feeToken ?? defaults.tokens.pathUsd,
+                    ...(feeToken ? { feeToken } : {}),
                   },
                 })
                 // `account` is the sender (eth_call `from`); `feePayer` is the
@@ -563,6 +577,14 @@ export declare namespace charge {
      * `maxTotalFee` so the combined fee budget remains valid.
      */
     feePayerPolicy?: FeePayerPolicy | undefined
+    /**
+     * Token a local fee payer uses to pay gas. If omitted, mppx selects a
+     * funded allowed token, preferring pathUSD.
+     *
+     * This option is not supported with a remote fee-payer URL, which selects
+     * its own token.
+     */
+    feeToken?: `0x${string}` | undefined
     /** Testnet mode. */
     testnet?: boolean | undefined
     /**


### PR DESCRIPTION
## Motivation

Local Tempo charge sponsors always paid gas in pathUSD, even when an allowed mainnet fee token was funded instead.

## Summary

- Selected a funded allowed fee token for local Tempo charge sponsors.
- Added a local-sponsor fee-token override and rejected its use with remote fee-payer URLs.
- Added fee-token selection and sponsorship coverage.

## Key design considerations

- Kept fee-token choice server-side so clients cannot select the sponsor’s spending asset.
- Preserved remote fee-payer token selection and allowlist validation.