### PR TITLE
fix: allow snapshot preparation lockfile update

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,6 +78,6 @@ jobs:
         run: |
           pnpm changeset version --snapshot main
           pnpm build
-          pnpm exec zile publish:prepare
+          NPM_CONFIG_FROZEN_LOCKFILE=false pnpm exec zile publish:prepare
           pnpm changeset publish --no-git-tag --snapshot main --tag main
           pnpm exec zile publish:post


### PR DESCRIPTION
## Motivation

Snapshot publishing failed when Zile prepared the publish manifest and its nested install inherited CI frozen-lockfile mode.

## Summary

- Allowed the transient lockfile update only during Zile snapshot preparation.

## Key design considerations

- Kept frozen-lockfile protection for all normal CI dependency installs.