### PR TITLE
fix: honor snapshot lockfile override

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,6 +78,6 @@ jobs:
         run: |
           pnpm changeset version --snapshot main
           pnpm build
-          NPM_CONFIG_FROZEN_LOCKFILE=false pnpm exec zile publish:prepare
+          npm_config_frozen_lockfile=false pnpm exec zile publish:prepare
           pnpm changeset publish --no-git-tag --snapshot main --tag main
           pnpm exec zile publish:post


### PR DESCRIPTION
## Motivation

The snapshot lockfile override used an environment-variable name pnpm did not apply, so publishing still failed after Zile prepared the manifest.

## Summary

- Used pnpm's recognized lowercase configuration environment variable during snapshot preparation.

## Key design considerations

- Limited the override to the manifest-transforming publish command.