### PR TITLE
feat: export SSE session controller

### DIFF
--- a/.changeset/export-sse-session-controller.md
+++ b/.changeset/export-sse-session-controller.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Exported SSE session controller helpers through Tempo server namespaces.

--- a/src/tempo/PublicExports.test-d.ts
+++ b/src/tempo/PublicExports.test-d.ts
@@ -1,3 +1,4 @@
+import { tempo as serverTempo } from 'mppx/server'
 import { expectTypeOf, test } from 'vp/test'
 
 import type {
@@ -22,6 +23,7 @@ import type { SessionTransition as MachineSessionTransition } from './session/cl
 import type { ChannelTransactionOptions } from './session/precompile/Chain.js'
 import type { RawAmountString } from './session/precompile/index.js'
 import type { SettlementSchedule as SessionSettlementSchedule } from './session/server/index.js'
+import type { SessionController } from './session/server/Sse.js'
 
 test('tempo session public barrels expose manager and schedule interfaces', () => {
   expectTypeOf(Tempo.Session).toBeObject()
@@ -43,6 +45,8 @@ test('tempo session public barrels expose manager and schedule interfaces', () =
     units?: number | undefined
   }>()
   expectTypeOf<RawAmountString>().toEqualTypeOf<string>()
+  expectTypeOf<serverTempo.Sse.SessionController>().toEqualTypeOf<SessionController>()
+  expectTypeOf<Tempo.Session.Server.Sse.SessionController>().toEqualTypeOf<SessionController>()
   expectTypeOf<ActiveSessionState['status']>().toEqualTypeOf<'active'>()
   expectTypeOf<VoucherNeededSessionState['status']>().toEqualTypeOf<'voucherNeeded'>()
   expectTypeOf<ClosedSessionState['status']>().toEqualTypeOf<'closed'>()

--- a/src/tempo/server/Methods.ts
+++ b/src/tempo/server/Methods.ts
@@ -5,6 +5,7 @@ import {
   settle as settle_,
   settleBatch as settleBatch_,
 } from '../session/server/Session.js'
+import * as Sse_ from '../session/server/Sse.js'
 import * as Ws_ from '../session/server/Ws.js'
 import { charge as charge_ } from './Charge.js'
 import { renew as renewSubscription_, subscription as subscription_ } from './Subscription.js'
@@ -83,6 +84,8 @@ export namespace tempo {
   export const settle = settle_
   /** Batch-settle precompile-backed session channels. */
   export const settleBatch = settleBatch_
+  /** SSE helpers and types for Tempo session streams. */
+  export import Sse = Sse_
   /** Experimental websocket helpers for Tempo sessions. */
   export const Ws = Ws_
 }

--- a/src/tempo/server/Methods.ts
+++ b/src/tempo/server/Methods.ts
@@ -5,7 +5,7 @@ import {
   settle as settle_,
   settleBatch as settleBatch_,
 } from '../session/server/Session.js'
-import * as Sse_ from '../session/server/Sse.js'
+import type { SessionController as SessionController_ } from '../session/server/Sse.js'
 import * as Ws_ from '../session/server/Ws.js'
 import { charge as charge_ } from './Charge.js'
 import { renew as renewSubscription_, subscription as subscription_ } from './Subscription.js'
@@ -84,8 +84,11 @@ export namespace tempo {
   export const settle = settle_
   /** Batch-settle precompile-backed session channels. */
   export const settleBatch = settleBatch_
-  /** SSE helpers and types for Tempo session streams. */
-  export import Sse = Sse_
+  /** Types for Tempo session streams. */
+  export namespace Sse {
+    /** Controller passed to manual-charge SSE generators. */
+    export type SessionController = SessionController_
+  }
   /** Experimental websocket helpers for Tempo sessions. */
   export const Ws = Ws_
 }

--- a/src/tempo/session/server/index.ts
+++ b/src/tempo/session/server/index.ts
@@ -1,4 +1,6 @@
 export { charge, session, settle, settleBatch } from './Session.js'
+/** SSE helpers and types for Tempo session streams. */
+export * as Sse from './Sse.js'
 /** Server-side automatic settlement schedule. */
 export type {
   ResolveSessionChannelId,


### PR DESCRIPTION
## Motivation

Middleware authors need a public type for manually charging Tempo SSE session streams.

## Summary

- Exported SSE helpers through Tempo server namespaces.
- Added public-interface type coverage for both server entrypoints.

## Key design considerations

- Used a namespace alias so `SessionController` remains available as a TypeScript type as well as SSE runtime helpers.