### PR TITLE
fix: require configured Stripe request fields

### DIFF
--- a/.changeset/bright-items-sleep.md
+++ b/.changeset/bright-items-sleep.md
@@ -2,4 +2,4 @@
 'mppx': patch
 ---
 
-Fixed Stripe charge handlers to require request fields that were not configured as defaults.
+Fixed server method handlers to require request fields that were not configured as defaults, and exposed Tempo's resolved currency and decimals as defaults.

--- a/.changeset/bright-items-sleep.md
+++ b/.changeset/bright-items-sleep.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed Stripe charge handlers to require request fields that were not configured as defaults.

--- a/src/internal/types.test-d.ts
+++ b/src/internal/types.test-d.ts
@@ -1,0 +1,21 @@
+import { expectTypeOf, test } from 'vp/test'
+
+import type { ConfiguredDefaults } from './types.js'
+
+test('ConfiguredDefaults retains only known defined values', () => {
+  type Parameters = {
+    configured: string
+    maybeDefined?: number | undefined
+    explicitlyUndefined: boolean | undefined
+    unrelated: bigint
+  }
+  type Defaults = {
+    configured?: string | undefined
+    maybeDefined?: number | undefined
+    explicitlyUndefined?: boolean | undefined
+  }
+
+  expectTypeOf<ConfiguredDefaults<Parameters, Defaults>>().toEqualTypeOf<{
+    configured: string
+  }>()
+})

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -277,6 +277,24 @@ export type ExactPartial<type> = {
   [key in keyof type]?: type[key] | undefined
 }
 
+/**
+ * Keys whose values are known to be present and defined.
+ *
+ * This is useful when a factory accepts partial configuration and its return
+ * type needs to distinguish values supplied as defaults from fields that
+ * callers must still provide later. Optional and `undefined`-able properties
+ * are excluded because their runtime values cannot be assumed to be defaults.
+ *
+ * @internal
+ */
+export type DefinedKeys<type> = {
+  [key in keyof type]-?: {} extends Pick<type, key>
+    ? never
+    : undefined extends type[key]
+      ? never
+      : key
+}[keyof type]
+
 /** @internal */
 export type ExactRequired<type> = {
   [key in keyof type]-?: Exclude<type[key], undefined>

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -295,6 +295,21 @@ export type DefinedKeys<type> = {
       : key
 }[keyof type]
 
+/**
+ * Request defaults known to have been configured by a factory caller.
+ *
+ * Optional and `undefined`-able parameters are omitted: their runtime values
+ * are not guaranteed to be usable defaults for a subsequently returned
+ * handler. Factories can intersect this type with values they resolve
+ * unconditionally at runtime.
+ *
+ * @internal
+ */
+export type ConfiguredDefaults<parameters, defaults> = Pick<
+  parameters,
+  Extract<DefinedKeys<parameters>, keyof defaults>
+>
+
 /** @internal */
 export type ExactRequired<type> = {
   [key in keyof type]-?: Exclude<type[key], undefined>

--- a/src/server/Mppx.test-d.ts
+++ b/src/server/Mppx.test-d.ts
@@ -313,4 +313,46 @@ describe('Mppx type tests', () => {
       }),
     ).toBeFunction()
   })
+
+  test('tempo factories expose resolved currency and decimals as defaults', () => {
+    const charge = Mppx.create({ methods: [tempo.charge()], realm, secretKey })
+    expectTypeOf(charge.tempo.charge({ amount: '1' })).toBeFunction()
+    // @ts-expect-error amount is not supplied by Tempo's runtime defaults.
+    void charge.tempo.charge({})
+
+    const subscription = Mppx.create({
+      methods: [
+        tempo.subscription({
+          recipient: '0x1234567890abcdef1234567890abcdef12345678',
+          resolve: async () => null,
+        }),
+      ],
+      realm,
+      secretKey,
+    })
+    expectTypeOf(
+      subscription.tempo.subscription({
+        amount: '1',
+        periodCount: 1n,
+        periodUnit: 'day',
+        subscriptionExpires: new Date('2026-01-01T00:00:00Z'),
+      }),
+    ).toBeFunction()
+
+    const session = Mppx.create({ methods: [tempo.session()], realm, secretKey })
+    expectTypeOf(session.tempo.session({ amount: '1', unitType: 'request' })).toBeFunction()
+
+    const common = Mppx.create({
+      methods: [
+        tempo.common({
+          amount: '1',
+          recipient: '0x1234567890abcdef1234567890abcdef12345678',
+        }),
+      ],
+      realm,
+      secretKey,
+    })
+    expectTypeOf(common.tempo.charge({})).toBeFunction()
+    expectTypeOf(common.tempo.session({ unitType: 'request' })).toBeFunction()
+  })
 })

--- a/src/stripe/Methods.test.ts
+++ b/src/stripe/Methods.test.ts
@@ -35,6 +35,16 @@ describe('charge', () => {
     expect(result.success).toBe(false)
   })
 
+  test('schema: requires decimals when no server default supplies it', () => {
+    const result = Methods.charge.schema.request.safeParse({
+      amount: '1',
+      currency: 'usd',
+      networkId: 'profile_123',
+      paymentMethodTypes: ['card'],
+    })
+    expect(result.success).toBe(false)
+  })
+
   test('schema: validates spt payload', () => {
     const result = Methods.charge.schema.credential.payload.safeParse({
       spt: 'spt_test_123',

--- a/src/stripe/server/Charge.test-d.ts
+++ b/src/stripe/server/Charge.test-d.ts
@@ -1,0 +1,66 @@
+import { Mppx, stripe } from 'mppx/server'
+import { test } from 'vp/test'
+
+import type { StripeClient } from '../internal/types.js'
+import type { charge as StripeCharge } from './Charge.js'
+
+const client = {} as StripeClient
+const secretKey = 'test-secret-key-test-secret-key-32'
+
+test('requires request fields not configured as Stripe defaults', () => {
+  const server = Mppx.create({
+    methods: [
+      stripe.charge({
+        client,
+        networkId: 'internal',
+        paymentMethodTypes: ['card'],
+      }),
+    ],
+    realm: 'api.example.com',
+    secretKey,
+  })
+
+  // @ts-expect-error decimals is required unless the factory supplied it.
+  void server.charge({ amount: '1', currency: 'usd' })
+  void server.charge({ amount: '1', currency: 'usd', decimals: 2 })
+})
+
+test('allows request fields configured as Stripe defaults', () => {
+  const server = Mppx.create({
+    methods: [
+      stripe.charge({
+        client,
+        decimals: 2,
+        networkId: 'internal',
+        paymentMethodTypes: ['card'],
+      }),
+    ],
+    realm: 'api.example.com',
+    secretKey,
+  })
+
+  void server.charge({ amount: '1', currency: 'usd' })
+})
+
+test('does not treat optional properties on widened config as defaults', () => {
+  const parameters: StripeCharge.Parameters = {
+    client,
+    networkId: 'internal',
+    paymentMethodTypes: ['card'],
+  }
+  const server = Mppx.create({
+    methods: [stripe.charge(parameters)],
+    realm: 'api.example.com',
+    secretKey,
+  })
+
+  // @ts-expect-error a widened optional decimals property is not a guaranteed default.
+  void server.charge({ amount: '1', currency: 'usd' })
+  void server.charge({
+    amount: '1',
+    currency: 'usd',
+    decimals: 2,
+    networkId: 'internal',
+    paymentMethodTypes: ['card'],
+  })
+})

--- a/src/stripe/server/Charge.ts
+++ b/src/stripe/server/Charge.ts
@@ -6,7 +6,7 @@ import {
   VerificationFailedError,
 } from '../../Errors.js'
 import * as Expires from '../../Expires.js'
-import type { LooseOmit, MaybePromise, OneOf } from '../../internal/types.js'
+import type { DefinedKeys, LooseOmit, MaybePromise, OneOf } from '../../internal/types.js'
 import * as Method from '../../Method.js'
 import type * as Html from '../../server/internal/html/config.ts'
 import type * as z from '../../zod.js'
@@ -207,10 +207,16 @@ export declare namespace charge {
         }
     >
 
+  /**
+   * Captures only configuration values that are known to exist at runtime.
+   *
+   * The returned handler requires any remaining request fields. In particular,
+   * `decimals` remains required when it was not configured on `stripe.charge()`.
+   */
   type DeriveDefaults<parameters extends Parameters> = Pick<
     parameters,
-    Extract<keyof parameters, keyof Defaults>
-  > & { decimals: number }
+    Extract<DefinedKeys<parameters>, keyof Defaults>
+  >
 
   /**
    * Server-side Stripe Connect settlement parameters.

--- a/src/stripe/server/Charge.ts
+++ b/src/stripe/server/Charge.ts
@@ -6,7 +6,7 @@ import {
   VerificationFailedError,
 } from '../../Errors.js'
 import * as Expires from '../../Expires.js'
-import type { DefinedKeys, LooseOmit, MaybePromise, OneOf } from '../../internal/types.js'
+import type { ConfiguredDefaults, LooseOmit, MaybePromise, OneOf } from '../../internal/types.js'
 import * as Method from '../../Method.js'
 import type * as Html from '../../server/internal/html/config.ts'
 import type * as z from '../../zod.js'
@@ -213,10 +213,7 @@ export declare namespace charge {
    * The returned handler requires any remaining request fields. In particular,
    * `decimals` remains required when it was not configured on `stripe.charge()`.
    */
-  type DeriveDefaults<parameters extends Parameters> = Pick<
-    parameters,
-    Extract<DefinedKeys<parameters>, keyof Defaults>
-  >
+  type DeriveDefaults<parameters extends Parameters> = ConfiguredDefaults<parameters, Defaults>
 
   /**
    * Server-side Stripe Connect settlement parameters.

--- a/src/tempo/internal/types.ts
+++ b/src/tempo/internal/types.ts
@@ -1,8 +1,19 @@
 import type { Account } from 'viem'
 
-export type DeriveDefaults<parameters, defaults> = Pick<
+import type { ConfiguredDefaults } from '../../internal/types.js'
+
+/**
+ * Request defaults for a Tempo factory.
+ *
+ * Includes only caller configuration known to be defined, plus `resolved`
+ * values that the factory creates unconditionally before returning its method.
+ * This keeps the returned handler's required request fields aligned with the
+ * values that will actually exist at runtime.
+ */
+export type DeriveDefaults<parameters, defaults, resolved extends object = {}> = ConfiguredDefaults<
   parameters,
-  Extract<keyof parameters, keyof defaults>
+  defaults
 > &
+  resolved &
   (parameters extends { account: Account | string } ? { recipient: string } : {}) &
   (parameters extends { recipient: string } ? { recipient: string } : {})

--- a/src/tempo/legacy/server/Defaults.test-d.ts
+++ b/src/tempo/legacy/server/Defaults.test-d.ts
@@ -1,0 +1,9 @@
+import { expectTypeOf, test } from 'vp/test'
+
+import type { session } from './Session.js'
+
+test('legacy session exposes its resolved currency and decimals as defaults', () => {
+  type Defaults = session.DeriveDefaults<{}>
+  expectTypeOf<Defaults['currency']>().toEqualTypeOf<string>()
+  expectTypeOf<Defaults['decimals']>().toEqualTypeOf<number>()
+})

--- a/src/tempo/legacy/server/Session.ts
+++ b/src/tempo/legacy/server/Session.ts
@@ -399,11 +399,12 @@ export declare namespace session {
 
   type DeriveDefaults<parameters extends Parameters> = types.DeriveDefaults<
     parameters,
-    Defaults
-  > & {
-    decimals: number
-    escrowContract: Address
-  }
+    Defaults,
+    {
+      currency: string
+      decimals: number
+    }
+  >
 }
 
 function assertSettlementSender(parameters: {

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -623,10 +623,12 @@ export declare namespace charge {
 
   type DeriveDefaults<parameters extends Parameters> = types.DeriveDefaults<
     parameters,
-    Defaults
-  > & {
-    decimals: number
-  }
+    Defaults,
+    {
+      currency: string
+      decimals: number
+    }
+  >
 
   type FeePayerPolicy = Partial<FeePayer.Policy>
 }

--- a/src/tempo/server/Methods.ts
+++ b/src/tempo/server/Methods.ts
@@ -1,3 +1,4 @@
+import type { NoExtraKeys } from '../../internal/types.js'
 import { session as sessionLegacy_, settle as settleLegacy_ } from '../legacy/server/index.js'
 import {
   charge as sessionCharge_,
@@ -37,16 +38,16 @@ function createChargeMethod<const parameters extends tempo.Parameters>(
   parameters: parameters | undefined,
 ) {
   // `tempo()` accepts the intersection of charge/session parameters, then
-  // forwards only the fields each method understands. Keep the generic bridge
-  // out of the public control-flow body.
-  return tempo.charge(parameters as charge_.Parameters)
+  // forwards only the fields each method understands. Preserve the inferred
+  // parameter type so configured request defaults remain visible to handlers.
+  return tempo.charge(parameters as NoExtraKeys<parameters, charge_.Parameters> | undefined)
 }
 
 function createSessionMethod<const parameters extends tempo.Parameters>(
   parameters: parameters | undefined,
 ) {
   // See `createChargeMethod()`: session receives the same shared parameter bag.
-  return sessionServer(parameters as session_.Parameters)
+  return sessionServer(parameters as NoExtraKeys<parameters, session_.Parameters> | undefined)
 }
 
 /**

--- a/src/tempo/server/Subscription.ts
+++ b/src/tempo/server/Subscription.ts
@@ -1286,10 +1286,12 @@ export declare namespace subscription {
   /** Derived defaults after account and chain configuration are applied. */
   type DeriveDefaults<parameters extends Parameters> = types.DeriveDefaults<
     parameters,
-    Defaults
-  > & {
-    decimals: number
-  }
+    Defaults,
+    {
+      currency: string
+      decimals: number
+    }
+  >
 }
 
 function createContext<const parameters extends createContext.Parameters>(

--- a/src/tempo/session/server/Session.ts
+++ b/src/tempo/session/server/Session.ts
@@ -522,11 +522,12 @@ export namespace session {
   /** Defaults derived from `session()` parameters for handler type inference. */
   export type DeriveDefaults<parameters extends Parameters> = types.DeriveDefaults<
     parameters,
-    Defaults
-  > & {
-    decimals: number
-    escrowContract: Address
-  }
+    Defaults,
+    {
+      currency: string
+      decimals: number
+    }
+  >
 }
 
 /**


### PR DESCRIPTION
## Motivation

Server method factories accept optional request defaults and return a second-stage handler. Previously, an omitted Stripe `decimals` value was represented as a default in TypeScript even though it remained `undefined` at runtime, so a missing value failed only during Zod validation.

## Summary

- Added `ConfiguredDefaults` to carry only factory values known to be defined.
- Added an explicit resolved-defaults layer for Tempo factories, which always resolve `currency` and `decimals`.
- Preserved caller-provided defaults through `tempo.common()`.
- Added compile-time coverage for configured values, widened optional configuration, Tempo defaults, and legacy session defaults.

```ts
const mppx = Mppx.create({
  methods: [stripe.charge({ client, networkId: "internal", paymentMethodTypes: ["card"] })],
  realm,
  secretKey,
})

mppx.charge({ amount: "1", currency: "usd" })
// TypeScript error: `decimals` is required.

mppx.charge({ amount: "1", currency: "usd", decimals: 2 })
// OK
```

```ts
const mppx = Mppx.create({ methods: [tempo.charge()], realm, secretKey })

mppx.tempo.charge({ amount: "1" })
// OK: Tempo resolves `currency` and `decimals` before returning the handler.
```

## Key design considerations

- A handler treats a field as optional only when its factory configuration is statically known and defined, or when the factory unconditionally resolves it at runtime.
- Stripe has no intrinsic decimal-scale fallback, so callers configure `decimals` either on `stripe.charge()` or on each charge request.
- TypeScript protects typed call sites; existing Zod validation remains the safeguard for JavaScript, `any`, and dynamic values.