### PR TITLE
improve validate agent output and discovery guidance

### DIFF
--- a/.changeset/agent-environment-detection.md
+++ b/.changeset/agent-environment-detection.md
@@ -1,0 +1,7 @@
+---
+'mppx': patch
+---
+
+Improved agent environment detection for automatic JSON validate output.
+
+Added SDK guidance when validate could not find an OpenAPI discovery document.

--- a/src/cli/utils.test.ts
+++ b/src/cli/utils.test.ts
@@ -3,11 +3,34 @@ import { afterEach, describe, expect, test, vi } from 'vp/test'
 
 import {
   fetchTokenInfo,
+  isAgentEnvironment,
   networkRpcUrls,
   resolveChain,
   resolveFundingNetwork,
   resolveRpcUrl,
 } from './utils.js'
+
+describe('isAgentEnvironment', () => {
+  test('detects Claude Code', () => {
+    expect(isAgentEnvironment({ CLAUDECODE: '1' })).toBe(true)
+  })
+
+  test('detects Codex by exact env var', () => {
+    expect(isAgentEnvironment({ CODEX: '1' })).toBe(true)
+  })
+
+  test('detects Codex wrapper env vars', () => {
+    expect(isAgentEnvironment({ CODEX_CI: '1' })).toBe(true)
+    expect(isAgentEnvironment({ CODEX_SANDBOX: 'seatbelt' })).toBe(true)
+    expect(isAgentEnvironment({ CODEX_THREAD_ID: '019f6bc0-b80f-7061-ac1b-7af8ba1ea513' })).toBe(
+      true,
+    )
+  })
+
+  test('ignores empty and unrelated env vars', () => {
+    expect(isAgentEnvironment({ CODEX_CI: '', CI: '1' })).toBe(false)
+  })
+})
 
 describe('resolveRpcUrl', () => {
   afterEach(() => {

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -179,6 +179,16 @@ export function parseMethodOpts(raw: string | string[] | undefined): Record<stri
   return result
 }
 
+/** Returns true when the CLI is running inside an agent wrapper that prefers machine-readable output. */
+export function isAgentEnvironment(env: NodeJS.ProcessEnv = process.env): boolean {
+  if (env.CLAUDECODE) return true
+  for (const [key, value] of Object.entries(env)) {
+    if (!value) continue
+    if (key === 'CODEX' || key.startsWith('CODEX_')) return true
+  }
+  return false
+}
+
 export function isTempoAccount(accountName: string): boolean {
   return accountName.startsWith('tempo:')
 }

--- a/src/cli/validate.test.ts
+++ b/src/cli/validate.test.ts
@@ -6,6 +6,10 @@ import * as Http from '~test/Http.js'
 import * as Challenge from '../Challenge.js'
 import * as Constants from '../Constants.js'
 import * as Receipt from '../Receipt.js'
+import { missingDiscoverySuggestion } from './validate/messages.js'
+
+// Keep validate tests out of JSON mode by default, even when the suite runs inside an agent.
+const isAgentEnvironmentMock = vi.fn(() => false)
 
 // Keep CLI orchestration tests independent of the public Tempo RPC and faucet.
 vi.doMock('viem/tempo', async () => {
@@ -28,11 +32,20 @@ vi.doMock('viem/actions', async () => {
   }
 })
 
+vi.doMock('./utils.js', async () => {
+  const actual = await vi.importActual<typeof import('./utils.js')>('./utils.js')
+  return {
+    ...actual,
+    isAgentEnvironment: isAgentEnvironmentMock,
+  }
+})
+
 // Auto-cleanup for test servers
 const servers: Http.TestServer[] = []
 afterEach(() => {
   servers.forEach((s) => s.close())
   servers.length = 0
+  isAgentEnvironmentMock.mockReturnValue(false)
 })
 
 async function testServer(handler: http.RequestListener) {
@@ -167,11 +180,8 @@ describe('validate: discovery', () => {
     })
     const { output, exitCode } = await serve(['validate', server.url])
     expect(exitCode).toBe(1)
-    expect(output).toContain('No discovery document found.')
-    expect(output).toContain('MPP servers must serve an OpenAPI document at /openapi.json')
-    expect(output).toContain(
-      'To test a specific endpoint: mppx validate <url> --endpoint POST:/your/path',
-    )
+    for (const line of missingDiscoverySuggestion.split('\n').filter(Boolean))
+      expect(output).toContain(line)
   })
 
   test('strips /openapi.json from input URL', { timeout: 15_000 }, async () => {
@@ -774,6 +784,19 @@ describe('validate: JSON mode', () => {
     expect(allPayment.every((r: { severity: string }) => r.severity === 'skip')).toBe(true)
   })
 
+  test(
+    'auto-enables JSON output when an agent environment is detected',
+    { timeout: 15_000 },
+    async () => {
+      const server = await mppServer(mainnetChallenge())
+      isAgentEnvironmentMock.mockReturnValue(true)
+      const { output } = await serve(['validate', server.url])
+      const result = parseJson(output)
+      expect(result.summary.skipped).toBeGreaterThan(0)
+      expect(result.endpoints.length).toBeGreaterThan(0)
+    },
+  )
+
   test('no console leaks before JSON', { timeout: 15_000 }, async () => {
     const server = await mppServer(mainnetChallenge())
     const { output } = await serve(['validate', server.url, '--outputJson', '--yes'])
@@ -790,5 +813,15 @@ describe('validate: JSON mode', () => {
     const { output } = await serve(['validate', server.url, '--outputJson', '--yes'])
     const result = parseJson(output)
     expect(Array.isArray(result.suggestions)).toBe(true)
+  })
+
+  test('includes missing discovery suggestions', { timeout: 15_000 }, async () => {
+    const server = await testServer((_req, res) => {
+      res.writeHead(404)
+      res.end()
+    })
+    const { output } = await serve(['validate', server.url, '--outputJson'])
+    const result = parseJson(output)
+    expect(result.suggestions).toEqual([missingDiscoverySuggestion])
   })
 })

--- a/src/cli/validate/index.ts
+++ b/src/cli/validate/index.ts
@@ -1,9 +1,10 @@
 import { Cli, z } from 'incur'
 
 import { validate as validateCore, validateStream } from '../../validation/core.js'
-import { pc } from '../utils.js'
+import { isAgentEnvironment, pc } from '../utils.js'
 import type { Counts } from './helpers.js'
 import { printResults, printSection } from './helpers.js'
+import { missingDiscoverySuggestion } from './messages.js'
 
 const validate = Cli.create('validate', {
   description: 'Validate an MPP server implementation end-to-end',
@@ -22,7 +23,10 @@ const validate = Cli.create('validate', {
     header: z.array(z.string()).optional().describe('Request header (key:value, repeatable)'),
     verbose: z.number().default(0).meta({ count: true }).describe('Verbosity level'),
     yes: z.boolean().default(false).describe('Auto-approve mainnet payments'),
-    outputJson: z.boolean().default(false).describe('Output results as JSON'),
+    outputJson: z
+      .boolean()
+      .default(false)
+      .describe('Output results as JSON (auto-enabled in known agent environments)'),
   }),
   alias: {
     endpoint: 'e',
@@ -32,8 +36,10 @@ const validate = Cli.create('validate', {
     outputJson: 'j',
   },
   async run(c) {
+    const outputJson = c.options.outputJson || isAgentEnvironment()
+
     // JSON mode: batch everything
-    if (c.options.outputJson) {
+    if (outputJson) {
       const result = await validateCore({
         url: c.args.url,
         endpoint: c.options.endpoint,
@@ -82,17 +88,9 @@ const validate = Cli.create('validate', {
           discoveryFound = event.discovery.found
           if (!discoveryFound && !c.options.endpoint) {
             console.log('')
-            console.log(pc.yellow('  No discovery document found.'))
-            console.log(
-              pc.dim(
-                '  MPP servers must serve an OpenAPI document at /openapi.json with x-payment-info extensions.',
-              ),
-            )
-            console.log(
-              pc.dim(
-                '  To test a specific endpoint: mppx validate <url> --endpoint POST:/your/path',
-              ),
-            )
+            const [headline, ...lines] = missingDiscoverySuggestion.split('\n')
+            console.log(pc.yellow(`  ${headline}`))
+            for (const line of lines) console.log(line ? pc.dim(`  ${line}`) : '')
             console.log('')
             process.exit(1)
           }

--- a/src/cli/validate/messages.ts
+++ b/src/cli/validate/messages.ts
@@ -1,0 +1,7 @@
+export const missingDiscoverySuggestion = [
+  'No discovery document found, endpoints could not be automatically found.',
+  'MPP servers must serve an OpenAPI document at /openapi.json with x-payment-info extensions.',
+  'The MPP SDKs can automatically expose this endpoint. See https://mpp.dev/sdk.',
+  '',
+  'To test a specific endpoint: mppx validate <url> --endpoint POST:/your/path',
+].join('\n')

--- a/src/validation/core.ts
+++ b/src/validation/core.ts
@@ -14,6 +14,7 @@ import {
   parseEndpointArg,
   resolveBodyForEndpoint,
 } from '../cli/validate/helpers.js'
+import { missingDiscoverySuggestion } from '../cli/validate/messages.js'
 import { validatePaymentFlow } from '../cli/validate/payment.js'
 import { validate as validateDiscoveryDoc } from '../discovery/Validate.js'
 
@@ -237,7 +238,7 @@ export async function validate(options: ValidateOptions): Promise<ValidateResult
 
   if (!discovery) throw new Error('Discovery phase did not complete')
 
-  const suggestions = computeSuggestions(endpointResults, { sawTestnet, sawMainnet })
+  const suggestions = computeSuggestions(endpointResults, discovery, { sawTestnet, sawMainnet })
 
   return {
     url: baseUrl,
@@ -250,10 +251,15 @@ export async function validate(options: ValidateOptions): Promise<ValidateResult
 
 function computeSuggestions(
   endpoints: EndpointValidationResult[],
+  discovery: DiscoveryResult,
   flags: { sawTestnet: boolean; sawMainnet: boolean },
 ): string[] {
   const steps: string[] = []
   const allResults = endpoints.flatMap((ep) => [...ep.challenge, ...ep.payment])
+
+  if (!discovery.found) {
+    steps.push(missingDiscoverySuggestion)
+  }
 
   const sawCryptoMainnet = flags.sawMainnet
   const sawCryptoTestnet = flags.sawTestnet


### PR DESCRIPTION
- Auto-enable JSON output mode when an agent is detected (tested with claude and codex).
- Add hint on using SDKs to add OpenAPI discovery.