### PR TITLE
feat(tempo): rehydrate client sessions from server snapshots

### DIFF
--- a/.changeset/session-client-rehydration.md
+++ b/.changeset/session-client-rehydration.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Rehydrate Tempo client sessions from server snapshots, reconciling the last accepted voucher with on-chain channel state before continuing cumulative payments.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
   ox: 0.14.29
   viem: ^2.54.1
   path-to-regexp@<8.4.0: 8.4.0
-  tar@<=7.5.15: 7.5.16
+  tar@<=7.5.18: 7.5.19
   '@modelcontextprotocol/sdk@>=1.10.0 <=1.25.3': 1.26.0
   '@modelcontextprotocol/server': 2.0.0-alpha.2
   qs@>=6.7.0 <=6.15.1: 6.15.2
@@ -29,10 +29,10 @@ overrides:
   undici@>=7.0.0 <7.28.0: 7.28.0
   socket.io-parser@>=4.0.0 <4.2.6: '>=4.2.6'
   yaml@<2.8.3: '>=2.8.3'
-  brace-expansion@>=5.0.0 <5.0.6: 5.0.6
+  brace-expansion@>=5.0.0 <5.0.7: 5.0.7
   ws@>=8.0.0 <8.21.0: 8.21.0
   lodash@<=4.17.23: '>=4.18.0'
-  protobufjs@<=7.6.2: 7.6.3
+  protobufjs@<=7.6.4: 7.6.5
   uuid@<14.0.0: 14.0.0
   fast-uri@<=3.1.1: ^3.1.2
   tmp@>=0.2.6 <0.2.7: 0.2.7
@@ -41,7 +41,8 @@ overrides:
   '@voidzero-dev/vite-plus-test@<=0.1.23': 0.1.24
   esbuild@>=0.17.0 <0.28.1: 0.28.1
   read-yaml-file@^1.1.0: 2.1.0
-  js-yaml@>=4.0.0 <=4.1.1: 4.2.0
+  js-yaml@>=4.0.0 <4.3.0: 4.3.0
+  body-parser@>=2.0.0 <2.3.0: 2.3.0
 
 importers:
 
@@ -1445,9 +1446,6 @@ packages:
   '@protobufjs/float@1.0.2':
     resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
 
-  '@protobufjs/inquire@1.1.2':
-    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
-
   '@protobufjs/path@1.1.2':
     resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
 
@@ -2274,8 +2272,8 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
-  body-parser@2.2.2:
-    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
   bowser@2.14.1:
@@ -2284,8 +2282,8 @@ packages:
   brace-expansion@2.1.2:
     resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -2383,6 +2381,10 @@ packages:
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
 
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
@@ -3037,8 +3039,8 @@ packages:
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -3528,8 +3530,8 @@ packages:
     resolution: {integrity: sha512-WPn+h9RGEExOKdu4bsF4HksG/uzd3cFq3MFtq8PsFeExPse5Ha/VOjQNyHhjboBFwGXGev6muJYTSPAOkROq2g==}
     engines: {node: '>=18'}
 
-  protobufjs@7.6.3:
-    resolution: {integrity: sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw==}
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -3795,8 +3797,8 @@ packages:
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
 
-  tar@7.5.16:
-    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
+  tar@7.5.19:
+    resolution: {integrity: sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==}
     engines: {node: '>=18'}
 
   teex@1.0.1:
@@ -3895,6 +3897,10 @@ packages:
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -4301,7 +4307,7 @@ snapshots:
   '@changesets/parse@0.4.3':
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
 
   '@changesets/pre@2.0.2':
     dependencies:
@@ -4505,14 +4511,14 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.6.3
+      protobufjs: 7.6.5
       yargs: 17.7.3
 
   '@grpc/proto-loader@0.8.1':
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.6.3
+      protobufjs: 7.6.5
       yargs: 17.7.3
 
   '@hono/node-server@1.19.14(hono@4.12.25)':
@@ -5061,8 +5067,6 @@ snapshots:
       '@protobufjs/aspromise': 1.1.2
 
   '@protobufjs/float@1.0.2': {}
-
-  '@protobufjs/inquire@1.1.2': {}
 
   '@protobufjs/path@1.1.2': {}
 
@@ -5683,17 +5687,17 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  body-parser@2.2.2:
+  body-parser@2.3.0:
     dependencies:
       bytes: 3.1.2
-      content-type: 1.0.5
+      content-type: 2.0.0
       debug: 4.4.3
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
       qs: 6.15.2
       raw-body: 3.0.2
-      type-is: 2.0.1
+      type-is: 2.1.0
     transitivePeerDependencies:
       - supports-color
 
@@ -5703,7 +5707,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -5814,6 +5818,8 @@ snapshots:
 
   content-type@1.0.5: {}
 
+  content-type@2.0.0: {}
+
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
@@ -5905,7 +5911,7 @@ snapshots:
       '@grpc/grpc-js': 1.14.4
       '@grpc/proto-loader': 0.7.15
       docker-modem: 5.0.7
-      protobufjs: 7.6.3
+      protobufjs: 7.6.5
       tar-fs: 2.1.5
     transitivePeerDependencies:
       - supports-color
@@ -6154,7 +6160,7 @@ snapshots:
   express@5.2.1:
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.2
+      body-parser: 2.3.0
       content-disposition: 1.0.1
       content-type: 1.0.5
       cookie: 0.7.2
@@ -6520,7 +6526,7 @@ snapshots:
 
   jose@6.2.3: {}
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -6645,7 +6651,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@5.1.8:
     dependencies:
@@ -6653,7 +6659,7 @@ snapshots:
 
   minimatch@9.0.7:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minipass@7.1.3: {}
 
@@ -6937,7 +6943,7 @@ snapshots:
       execa: 9.6.1
       get-port: 7.2.0
       http-proxy: 1.18.1
-      tar: 7.5.16
+      tar: 7.5.19
     optionalDependencies:
       testcontainers: 12.0.4
     transitivePeerDependencies:
@@ -6956,7 +6962,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  protobufjs@7.6.3:
+  protobufjs@7.6.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
@@ -6964,7 +6970,6 @@ snapshots:
       '@protobufjs/eventemitter': 1.1.1
       '@protobufjs/fetch': 1.1.1
       '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.2
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.2
@@ -7011,7 +7016,7 @@ snapshots:
 
   read-yaml-file@2.1.0:
     dependencies:
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       strip-bom: 4.0.0
 
   readable-stream@2.3.8:
@@ -7323,7 +7328,7 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
-  tar@7.5.16:
+  tar@7.5.19:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
@@ -7437,6 +7442,12 @@ snapshots:
   type-is@2.0.1:
     dependencies:
       content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
       media-typer: 1.1.0
       mime-types: 3.0.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,7 +16,7 @@ overrides:
   ox: '0.14.29'
   viem: '^2.54.1'
   path-to-regexp@<8.4.0: '8.4.0'
-  tar@<=7.5.15: '7.5.16'
+  tar@<=7.5.18: '7.5.19'
   '@modelcontextprotocol/sdk@>=1.10.0 <=1.25.3': '1.26.0'
   '@modelcontextprotocol/server': '2.0.0-alpha.2'
   qs@>=6.7.0 <=6.15.1: '6.15.2'
@@ -34,10 +34,10 @@ overrides:
   undici@>=7.0.0 <7.28.0: '7.28.0'
   socket.io-parser@>=4.0.0 <4.2.6: '>=4.2.6'
   yaml@<2.8.3: '>=2.8.3'
-  brace-expansion@>=5.0.0 <5.0.6: '5.0.6'
+  brace-expansion@>=5.0.0 <5.0.7: '5.0.7'
   ws@>=8.0.0 <8.21.0: '8.21.0'
   lodash@<=4.17.23: '>=4.18.0'
-  protobufjs@<=7.6.2: '7.6.3'
+  protobufjs@<=7.6.4: '7.6.5'
   uuid@<14.0.0: '14.0.0'
   fast-uri@<=3.1.1: ^3.1.2
   tmp@>=0.2.6 <0.2.7: '0.2.7'
@@ -46,7 +46,8 @@ overrides:
   '@voidzero-dev/vite-plus-test@<=0.1.23': '0.1.24'
   esbuild@>=0.17.0 <0.28.1: '0.28.1'
   read-yaml-file@^1.1.0: '2.1.0'
-  js-yaml@>=4.0.0 <=4.1.1: '4.2.0'
+  js-yaml@>=4.0.0 <4.3.0: '4.3.0'
+  body-parser@>=2.0.0 <2.3.0: '2.3.0'
 
 nodeOptions: '--disable-warning=ExperimentalWarning --disable-warning=DeprecationWarning'
 
@@ -61,12 +62,14 @@ allowBuilds:
 
 minimumReleaseAgeExclude:
   - esbuild@0.28.1
+  - body-parser@2.3.0
+  - brace-expansion@5.0.7
   - fast-uri@3.1.2
   - hono@4.12.25
-  - js-yaml@4.2.0
+  - js-yaml@4.3.0
   - ox@0.14.29
-  - protobufjs@7.6.3
-  - tar@7.5.16
+  - protobufjs@7.6.5
+  - tar@7.5.19
   - tmp@0.2.7
   - viem@2.54.1
   - vite@8.0.16

--- a/src/tempo/session/Snapshot.ts
+++ b/src/tempo/session/Snapshot.ts
@@ -22,6 +22,17 @@ export type SessionSnapshot = {
   escrow: Address
   /** Minimum cumulative authorization needed for the challenged request or stream continuation. */
   requiredCumulative: RawAmountString
+  /** Highest client-signed voucher accepted by the server. */
+  highestVoucher?:
+    | {
+        /** Channel identifier bound into the voucher signature. */
+        channelId: Hex
+        /** Cumulative authorization bound into the voucher signature. */
+        cumulativeAmount: RawAmountString
+        /** Original client signature proving the accepted cumulative authorization. */
+        signature: Hex
+      }
+    | undefined
   /** Amount already settled on-chain. */
   settled: RawAmountString
   /** Amount consumed by delivered content according to server accounting. */
@@ -35,6 +46,9 @@ const addressSchema = z.custom<Address>(
 )
 const hashSchema = z.custom<Hex>(
   (value) => typeof value === 'string' && /^0x[0-9a-fA-F]{64}$/.test(value),
+)
+const hexSchema = z.custom<Hex>(
+  (value) => typeof value === 'string' && /^0x[0-9a-fA-F]+$/.test(value),
 )
 
 const channelDescriptorSchema = z.object({
@@ -55,6 +69,13 @@ const sessionSnapshotSchema = z.object({
   deposit: z.string(),
   descriptor: channelDescriptorSchema,
   escrow: addressSchema,
+  highestVoucher: z.optional(
+    z.object({
+      channelId: hashSchema,
+      cumulativeAmount: z.string(),
+      signature: hexSchema,
+    }),
+  ),
   requiredCumulative: z.string(),
   settled: z.string(),
   spent: z.string(),

--- a/src/tempo/session/client/CredentialState.test.ts
+++ b/src/tempo/session/client/CredentialState.test.ts
@@ -443,7 +443,7 @@ describe('CredentialPlan', () => {
       })
     })
 
-    test('recovery cumulative ignores server-advertised unused voucher headroom', () => {
+    test('recovery cumulative never decreases below the server-accepted voucher', () => {
       expect(
         resolveRecoveredCumulative({
           context: { descriptor, channelId },
@@ -456,7 +456,7 @@ describe('CredentialPlan', () => {
             spent: '10',
           }),
         }),
-      ).toBe(15n)
+      ).toBe(1_000_000n)
     })
 
     test('plans manual credentials only when an explicit action includes descriptor', () => {

--- a/src/tempo/session/client/CredentialState.ts
+++ b/src/tempo/session/client/CredentialState.ts
@@ -14,6 +14,7 @@ import * as z from '../../../zod.js'
 import * as Chain from '../precompile/Chain.js'
 import * as Channel from '../precompile/Channel.js'
 import type { SessionCredentialPayload } from '../precompile/Protocol.js'
+import * as Voucher from '../precompile/Voucher.js'
 import type { SessionSnapshot } from '../Snapshot.js'
 import {
   createClosePayload,
@@ -309,6 +310,26 @@ export type ResolveRecoveredCumulativeParameters = {
   settled: bigint
 }
 
+/** Inputs used to validate and hydrate a server-provided session snapshot. */
+export type HydrateSessionSnapshotParameters = {
+  /** Account expected to own the channel and its voucher authority. */
+  account: ViemAccount
+  /** Viem client used to read authoritative TIP-1034 channel state. */
+  client: Client
+  /** Snapshot returned by an MPP server bootstrap. */
+  snapshot: SessionSnapshot
+  /** Optional state reader for deterministic tests. */
+  readChannelState?: ReadReusableChannelState | undefined
+}
+
+/** Validated client channel state reconstructed without local persistence. */
+export type HydratedSessionSnapshot = {
+  /** Reusable channel entry safe to cache locally. */
+  entry: ChannelEntry
+  /** Server-accounted delivered spend at bootstrap time. */
+  spent: bigint
+}
+
 /** Data-first description of the next credential operation the client should execute. */
 export type CredentialPlan =
   /** No reusable channel is available, so create an open transaction and initial voucher. */
@@ -501,12 +522,93 @@ export function resolveRecoveredCumulative(
   const { context, decimals, requestAmount, snapshot, settled } = parameters
 
   if (snapshot) {
-    return BigInt(snapshot.spent) + requestAmount
+    return [
+      BigInt(snapshot.acceptedCumulative),
+      BigInt(snapshot.requiredCumulative),
+      BigInt(snapshot.spent) + requestAmount,
+      settled,
+    ].reduce((highest, value) => (value > highest ? value : highest), 0n)
   }
 
   const contextCumulative = parseOptionalContextAmount(context, decimals, 'cumulativeAmount')
   if (contextCumulative !== undefined) return contextCumulative + requestAmount
   return settled + requestAmount
+}
+
+/** Checks a server snapshot against its signed voucher and current TIP-1034 state. */
+export async function hydrateSessionSnapshot(
+  parameters: HydrateSessionSnapshotParameters,
+): Promise<HydratedSessionSnapshot> {
+  const { account, client, readChannelState, snapshot } = parameters
+  const signed = snapshot.highestVoucher
+  if (!signed) throw new Error('session snapshot is missing its highest signed voucher')
+  if (signed.channelId.toLowerCase() !== snapshot.channelId.toLowerCase())
+    throw new Error('session snapshot voucher channelId does not match snapshot channelId')
+
+  const acceptedCumulative = BigInt(snapshot.acceptedCumulative)
+  const voucherCumulative = BigInt(signed.cumulativeAmount)
+  const requiredCumulative = BigInt(snapshot.requiredCumulative)
+  const snapshotDeposit = BigInt(snapshot.deposit)
+  const snapshotSettled = BigInt(snapshot.settled)
+  const spent = BigInt(snapshot.spent)
+  if (voucherCumulative !== acceptedCumulative)
+    throw new Error('session snapshot voucher amount does not match acceptedCumulative')
+  if (spent > acceptedCumulative)
+    throw new Error('session snapshot spent exceeds acceptedCumulative')
+  if (snapshotSettled > snapshotDeposit)
+    throw new Error('session snapshot settled amount exceeds deposit')
+
+  const authorizedSigner =
+    BigInt(snapshot.descriptor.authorizedSigner) === 0n
+      ? snapshot.descriptor.payer
+      : snapshot.descriptor.authorizedSigner
+  if (
+    !Voucher.verifyVoucher(
+      snapshot.escrow,
+      snapshot.chainId,
+      {
+        channelId: signed.channelId,
+        cumulativeAmount: voucherCumulative,
+        signature: signed.signature,
+      },
+      authorizedSigner,
+    )
+  )
+    throw new Error('session snapshot highest voucher signature is invalid')
+
+  const reusable = await resolveReusableChannel({
+    channelId: snapshot.channelId,
+    client,
+    descriptor: snapshot.descriptor,
+    expected: {
+      chainId: snapshot.chainId,
+      escrow: snapshot.escrow,
+      payee: snapshot.descriptor.payee,
+      payer: account.address,
+      authorizedSigner: resolveAuthorizedSigner(account),
+      token: snapshot.descriptor.token,
+    },
+    readChannelState,
+  })
+  const cumulativeAmount = [acceptedCumulative, requiredCumulative, reusable.state.settled].reduce(
+    (highest, value) => (value > highest ? value : highest),
+    0n,
+  )
+  if (cumulativeAmount > reusable.state.deposit)
+    throw new Error('recovered session cumulative amount exceeds on-chain channel deposit')
+
+  return {
+    entry: {
+      channelId: reusable.channelId,
+      cumulativeAmount,
+      deposit: reusable.state.deposit,
+      descriptor: snapshot.descriptor,
+      escrow: snapshot.escrow,
+      chainId: snapshot.chainId,
+      opened: true,
+    },
+    spent,
+  }
 }
 
 /** Returns whether `account` can satisfy the descriptor's voucher authority. */

--- a/src/tempo/session/client/Session.test.ts
+++ b/src/tempo/session/client/Session.test.ts
@@ -506,7 +506,7 @@ describe('precompile client session', () => {
     expect(payload.cumulativeAmount).toBe('400')
   })
 
-  test('ignores accepted snapshot headroom above current request spend', async () => {
+  test('does not decrease recovered authorization below accepted snapshot headroom', async () => {
     const method = session({ account, decimals: 0, maxDeposit: '1000', getClient: () => client })
     const channelId = Channel.computeId({ ...descriptor, chainId, escrow: tip20ChannelEscrow })
     const payload = deserialize(
@@ -535,7 +535,7 @@ describe('precompile client session', () => {
 
     expect(payload.action).toBe('voucher')
     if (payload.action !== 'voucher') throw new Error('expected voucher')
-    expect(payload.cumulativeAmount).toBe('400')
+    expect(payload.cumulativeAmount).toBe('500')
   })
 
   test('caps recovered voucher authorization by maxDeposit', async () => {
@@ -593,7 +593,7 @@ describe('precompile client session', () => {
         }),
         context: {},
       }),
-    ).rejects.toThrow('requested voucher amount 700 exceeds local maxDeposit 300')
+    ).rejects.toThrow('requested voucher amount 1000 exceeds local maxDeposit 300')
   })
 
   test('rejects descriptor recovery for closed or missing channels', async () => {

--- a/src/tempo/session/client/SessionManager.test.ts
+++ b/src/tempo/session/client/SessionManager.test.ts
@@ -403,7 +403,11 @@ describe('Session', () => {
           ? Credential.deserialize<SessionCredentialPayload>(authorization).payload
           : undefined
         if (payload) posted.push(payload)
-        if (!payload) return Promise.resolve(make402Response())
+        if (!payload) {
+          expect(s.channelId).toBe(storedChannelId)
+          expect(s.cumulative).toBe(1_000_000n)
+          return Promise.resolve(make402Response())
+        }
         return Promise.resolve(makeOkResponse())
       })
       const s = sessionManager({

--- a/src/tempo/session/client/SessionManager.test.ts
+++ b/src/tempo/session/client/SessionManager.test.ts
@@ -14,6 +14,7 @@ import { createSessionReceipt, serializeSessionReceipt } from '../precompile/Pro
 import type { NeedVoucherEvent, SessionReceipt } from '../precompile/Protocol.js'
 import { formatNeedVoucherEvent, parseEvent } from '../precompile/Protocol.js'
 import type { SessionCredentialPayload } from '../precompile/Protocol.js'
+import * as Voucher from '../precompile/Voucher.js'
 import { computeFallbackCloseAmount, sessionManager } from './SessionManager.js'
 
 const channelId = '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex
@@ -43,6 +44,24 @@ const client = createClient({
     },
   }),
 })
+
+function channelStateClient(state: { closeRequestedAt: number; deposit: bigint; settled: bigint }) {
+  return createClient({
+    account,
+    chain: { id: 4217 } as never,
+    transport: custom({
+      async request(args) {
+        if (args.method === 'eth_call')
+          return encodeFunctionResult({
+            abi: escrowAbi,
+            functionName: 'getChannelState',
+            result: state,
+          })
+        throw new Error(`unexpected rpc request: ${args.method}`)
+      },
+    }),
+  })
+}
 
 const storedDescriptor = {
   authorizedSigner: account.address,
@@ -332,6 +351,17 @@ describe('Session', () => {
     test('seeds a same-route HEAD snapshot and resolves the account when resuming it', async () => {
       const { store, set } = makeChannelStore()
       const posted: SessionCredentialPayload[] = []
+      const highestVoucher = {
+        channelId: storedChannelId,
+        cumulativeAmount: '1000000',
+        signature: await Voucher.signVoucher(
+          client,
+          account,
+          { channelId: storedChannelId, cumulativeAmount: 1_000_000n },
+          tip20ChannelEscrow,
+          4217,
+        ),
+      }
       const resolveAccount = vi.fn(
         (info: Parameters<NonNullable<sessionManager.Parameters['resolveAccount']>>[0]) =>
           info.account,
@@ -356,6 +386,7 @@ describe('Session', () => {
                   deposit: '10000000',
                   descriptor: storedDescriptor,
                   escrow: tip20ChannelEscrow,
+                  highestVoucher,
                   requiredCumulative: '1000000',
                   settled: '0',
                   spent: '0',
@@ -389,14 +420,111 @@ describe('Session', () => {
       expect(response.status).toBe(200)
       expect(set).toHaveBeenCalledWith(expect.objectContaining({ channelId: storedChannelId }))
       expect(posted[0]).toMatchObject({ action: 'voucher', channelId: storedChannelId })
-      expect(resolveAccount).toHaveBeenCalledOnce()
-      expect(resolveAccount).toHaveBeenCalledWith({
+      expect(resolveAccount).toHaveBeenCalledTimes(2)
+      expect(resolveAccount).toHaveBeenNthCalledWith(1, {
         account,
         chainId: 4217,
         operation: { authority: account.address, kind: 'authorizePaymentChannel' },
       })
       const contentCall = mockFetch.mock.calls.find((call) => call[1]?.method !== 'HEAD')
       expect(new Headers(contentCall?.[1]?.headers).get('Payment-Session')).toBeNull()
+    })
+
+    test('does not cache a server snapshot for a channel that is closed on-chain', async () => {
+      const { store, set } = makeChannelStore()
+      const highestVoucher = {
+        channelId: storedChannelId,
+        cumulativeAmount: '1000000',
+        signature: await Voucher.signVoucher(
+          client,
+          account,
+          { channelId: storedChannelId, cumulativeAmount: 1_000_000n },
+          tip20ChannelEscrow,
+          4217,
+        ),
+      }
+      const mockFetch = vi.fn().mockImplementation((_input, init?: RequestInit) => {
+        const headers = new Headers(init?.headers)
+        if (init?.method === 'HEAD' && !headers.get(Constants.Headers.authorization))
+          return Promise.resolve(make402Response(makeChargeChallenge()))
+        if (init?.method === 'HEAD')
+          return Promise.resolve(
+            new Response(null, {
+              status: 204,
+              headers: {
+                [Constants.Headers.paymentSessionSnapshot]: sessionManager.serializeSnapshot({
+                  acceptedCumulative: '1000000',
+                  chainId: 4217,
+                  channelId: storedChannelId,
+                  deposit: '10000000',
+                  descriptor: storedDescriptor,
+                  escrow: tip20ChannelEscrow,
+                  highestVoucher,
+                  requiredCumulative: '1000000',
+                  settled: '0',
+                  spent: '0',
+                  units: 0,
+                }),
+              },
+            }),
+          )
+        return Promise.resolve(makeOkResponse())
+      })
+      const s = sessionManager({
+        account,
+        bootstrap: true,
+        client: channelStateClient({ closeRequestedAt: 0, deposit: 0n, settled: 0n }),
+        fetch: mockFetch as typeof globalThis.fetch,
+        channelStore: store,
+      })
+
+      expect((await s.fetch('https://api.example.com/data')).status).toBe(200)
+      expect(set).not.toHaveBeenCalled()
+    })
+
+    test('does not cache a server snapshot with an invalid highest voucher signature', async () => {
+      const { store, set } = makeChannelStore()
+      const mockFetch = vi.fn().mockImplementation((_input, init?: RequestInit) => {
+        const headers = new Headers(init?.headers)
+        if (init?.method === 'HEAD' && !headers.get(Constants.Headers.authorization))
+          return Promise.resolve(make402Response(makeChargeChallenge()))
+        if (init?.method === 'HEAD')
+          return Promise.resolve(
+            new Response(null, {
+              status: 204,
+              headers: {
+                [Constants.Headers.paymentSessionSnapshot]: sessionManager.serializeSnapshot({
+                  acceptedCumulative: '1000000',
+                  chainId: 4217,
+                  channelId: storedChannelId,
+                  deposit: '10000000',
+                  descriptor: storedDescriptor,
+                  escrow: tip20ChannelEscrow,
+                  highestVoucher: {
+                    channelId: storedChannelId,
+                    cumulativeAmount: '1000000',
+                    signature: `0x${'00'.repeat(64)}`,
+                  },
+                  requiredCumulative: '1000000',
+                  settled: '0',
+                  spent: '0',
+                  units: 0,
+                }),
+              },
+            }),
+          )
+        return Promise.resolve(makeOkResponse())
+      })
+      const s = sessionManager({
+        account,
+        bootstrap: true,
+        client,
+        fetch: mockFetch as typeof globalThis.fetch,
+        channelStore: store,
+      })
+
+      expect((await s.fetch('https://api.example.com/data')).status).toBe(200)
+      expect(set).not.toHaveBeenCalled()
     })
 
     test('does not answer non-zero bootstrap charge challenges', async () => {

--- a/src/tempo/session/client/SessionManager.ts
+++ b/src/tempo/session/client/SessionManager.ts
@@ -376,9 +376,11 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
           kind: 'authorizePaymentChannel',
         },
       })) ?? defaultAccount
-    const { entry } = await hydrateSessionSnapshot({ account, client, snapshot })
+    const { entry, spent } = await hydrateSessionSnapshot({ account, client, snapshot })
     assertVoucherWithinLocalLimit(entry.cumulativeAmount)
     await Promise.resolve(store.set(entry)).catch(() => undefined)
+    runtime.channel = entry
+    runtime.spent = spent
     return entry
   }
 

--- a/src/tempo/session/client/SessionManager.ts
+++ b/src/tempo/session/client/SessionManager.ts
@@ -1,16 +1,18 @@
 import type { Hex } from 'ox'
 import { parseUnits, type Address } from 'viem'
+import { tempo as tempo_chain } from 'viem/chains'
 
 import * as Challenge from '../../../Challenge.js'
 import * as Fetch from '../../../client/internal/Fetch.js'
 import * as MethodResponse from '../../../client/internal/MethodResponse.js'
 import * as Constants from '../../../Constants.js'
-import type * as Account from '../../../viem/Account.js'
-import type * as Client from '../../../viem/Client.js'
+import * as Account from '../../../viem/Account.js'
+import * as Client from '../../../viem/Client.js'
 import { charge as chargePlugin } from '../../client/Charge.js'
+import * as defaults from '../../internal/defaults.js'
 import type { ChannelEntry } from '../client/ChannelOps.js'
 import { createChannelStore, entryKey, type ChannelStore } from '../client/ChannelStore.js'
-import type { SessionContext } from '../client/CredentialState.js'
+import { hydrateSessionSnapshot, type SessionContext } from '../client/CredentialState.js'
 import { session as sessionPlugin } from '../client/Session.js'
 import { deserializeSessionReceipt } from '../precompile/Protocol.js'
 import { readSessionChallengeAmount, type SessionReceipt } from '../precompile/Protocol.js'
@@ -126,19 +128,6 @@ function isZeroAmountChargeChallenge(challenge: Challenge.Challenge) {
   }
 }
 
-/** Builds a reusable channel entry from a server session snapshot header. */
-function entryFromSnapshot(snapshot: ReturnType<typeof deserializeSessionSnapshot>): ChannelEntry {
-  return {
-    channelId: snapshot.channelId,
-    cumulativeAmount: BigInt(snapshot.acceptedCumulative),
-    deposit: BigInt(snapshot.deposit),
-    descriptor: snapshot.descriptor,
-    escrow: snapshot.escrow,
-    chainId: snapshot.chainId,
-    opened: true,
-  }
-}
-
 function requestInitWithSessionHint(
   input: RequestInfo | URL,
   init: RequestInit | undefined,
@@ -192,6 +181,12 @@ function resolveSessionManagerConfig(parameters: sessionManager.Parameters): Ses
  */
 export function sessionManager(parameters: sessionManager.Parameters): SessionManager {
   const config = resolveSessionManagerConfig(parameters)
+  const getClient = Client.getResolver({
+    chain: tempo_chain,
+    getClient: parameters.client ? () => parameters.client! : parameters.getClient,
+    rpcUrl: defaults.rpcUrl,
+  })
+  const getAccount = Account.getResolver({ account: parameters.account })
   const runtime = createSessionManagerRuntime()
   const receipts = createSessionReceiptCoordinator({
     getSocketSession: () => runtime.socketSession,
@@ -365,7 +360,24 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
   async function storeSnapshotHeader(response: Response): Promise<ChannelEntry | undefined> {
     const header = response.headers.get(Constants.Headers.paymentSessionSnapshot)
     if (!header) return undefined
-    const entry = entryFromSnapshot(deserializeSessionSnapshot(header))
+    const snapshot = deserializeSessionSnapshot(header)
+    const client = await getClient({ chainId: snapshot.chainId })
+    const defaultAccount = getAccount(client)
+    const authority =
+      BigInt(snapshot.descriptor.authorizedSigner) === 0n
+        ? snapshot.descriptor.payer
+        : snapshot.descriptor.authorizedSigner
+    const account =
+      (await parameters.resolveAccount?.({
+        account: defaultAccount,
+        chainId: snapshot.chainId,
+        operation: {
+          authority,
+          kind: 'authorizePaymentChannel',
+        },
+      })) ?? defaultAccount
+    const { entry } = await hydrateSessionSnapshot({ account, client, snapshot })
+    assertVoucherWithinLocalLimit(entry.cumulativeAmount)
     await Promise.resolve(store.set(entry)).catch(() => undefined)
     return entry
   }


### PR DESCRIPTION
## Summary

This PR adds the client-side half of session rehydration. It lets a client that starts without a hydrated local channel store resume a server-known Tempo session instead of abandoning the channel or restarting its cumulative vouchers from zero.

- hydrate client session state from a server-provided snapshot
- restore the server's highest accepted voucher and current required cumulative boundary
- reconcile the snapshot with the current on-chain channel state
- preserve monotonic cumulative vouchers after restart
- include resumed spend when enforcing the channel's maximum-deposit policy
- reject snapshots for the wrong account/channel or with malformed voucher state

The voucher check confirms that the snapshot's `acceptedCumulative` value corresponds to a voucher signed by the client account. The snapshot's `requiredCumulative` may be higher and is treated as the server's current payment requirement, subject to the configured maximum-deposit policy.

This does **not** establish that the server's pricing is fair, and it does not prevent the server from requesting a higher new payment. Independent pricing policy is outside this PR.

This PR deliberately does not add server-side channel discovery/snapshot emission (#676) or the Node SQLite channel store (#677).

## Why this is needed

The latest client can only resume an off-chain session when its local store already contains the channel state. With no hydrated `channels.db`, it does not know the server's highest unredeemed cumulative voucher. On-chain state alone is insufficient because the server may hold a newer accepted voucher that has not been settled.

The snapshot supplies that missing off-chain baseline so a fresh client can continue the session.

## Exact current-main red proof

Tested against exact `origin/main` commit `bd9b05c` before applying this branch:

- a direct recovered session generated cumulative `15` below the server's accepted `1,000,000`; this branch resumes from `1,000,000`
- the manager recovery path generated `400` below accepted `500`; this branch resumes from `500`
- maximum-deposit accounting used `700` instead of the resumed `1,000`; this branch includes resumed spend
- main cached closed-channel and invalid/wrong-voucher snapshots; this branch rejects those inconsistent recovery inputs

These tests use synthetic snapshots and mocked Tempo chain reads, so the client behavior is independently reviewable before the server starts emitting snapshots.

## Validation

- `pnpm check:ci`: pass (existing underscore warnings only)
- `pnpm check:types`: pass
- focused client rehydration regressions: pass
- prior full runtime matrix for these changes: pass
