### PR TITLE
fix(tempo): include signed voucher in session snapshots

### DIFF
--- a/.changeset/session-server-bootstrap.md
+++ b/.changeset/session-server-bootstrap.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Include the highest signed voucher in Tempo session bootstrap snapshots so cold clients can safely validate and resume an existing channel.

--- a/src/tempo/session/server/RequestState.test.ts
+++ b/src/tempo/session/server/RequestState.test.ts
@@ -316,7 +316,11 @@ describe('SessionSnapshotHints', () => {
       escrowContract,
       expiringNonceHash: descriptor.expiringNonceHash,
       finalized: false,
-      highestVoucher: null,
+      highestVoucher: {
+        channelId,
+        cumulativeAmount: 500n,
+        signature: `0x${'44'.repeat(64)}`,
+      },
       highestVoucherAmount: 500n,
       operator: descriptor.operator,
       payee: descriptor.payee,
@@ -451,6 +455,11 @@ describe('SessionSnapshotHints', () => {
         deposit: '1000',
         descriptor,
         escrow: escrowContract,
+        highestVoucher: {
+          channelId,
+          cumulativeAmount: '500',
+          signature: `0x${'44'.repeat(64)}`,
+        },
         requiredCumulative: '350',
         settled: '100',
         spent: '300',
@@ -458,7 +467,7 @@ describe('SessionSnapshotHints', () => {
       })
     })
 
-    test('raises accepted cumulative when next request exceeds current authorization', async () => {
+    test('keeps accepted cumulative at the signed voucher when the next request needs more', async () => {
       const snapshot = await resolveSessionSnapshot({
         amount: 300n,
         channelId,
@@ -466,7 +475,34 @@ describe('SessionSnapshotHints', () => {
       })
 
       expect(snapshot?.requiredCumulative).toBe('600')
-      expect(snapshot?.acceptedCumulative).toBe('600')
+      expect(snapshot?.acceptedCumulative).toBe('500')
+      expect(snapshot?.highestVoucher?.cumulativeAmount).toBe('500')
+    })
+
+    test('omits reusable channel hints without a matching signed highest voucher', async () => {
+      await expect(
+        resolveSessionSnapshot({
+          amount: 50n,
+          channelId,
+          store: store(channel({ highestVoucher: null })),
+        }),
+      ).resolves.toBeUndefined()
+
+      await expect(
+        resolveSessionSnapshot({
+          amount: 50n,
+          channelId,
+          store: store(
+            channel({
+              highestVoucher: {
+                channelId,
+                cumulativeAmount: 499n,
+                signature: `0x${'44'.repeat(64)}`,
+              },
+            }),
+          ),
+        }),
+      ).resolves.toBeUndefined()
     })
 
     test('omits reusable channel hints when payment fields do not match', async () => {

--- a/src/tempo/session/server/RequestState.ts
+++ b/src/tempo/session/server/RequestState.ts
@@ -139,14 +139,12 @@ export async function resolveSessionSnapshot(
   const channel = await store.getChannel(ChannelStore.normalizeChannelId(channelId))
   if (!channel || !ChannelStore.isPrecompileState(channel)) return undefined
   if (channel.finalized) return undefined
+  if (!channel.highestVoucher) return undefined
+  if (channel.highestVoucher.cumulativeAmount !== channel.highestVoucherAmount) return undefined
   if (expected && !matchesSnapshotPaymentFields(channel, expected)) return undefined
   const requiredCumulative = channel.spent + amount
-  const acceptedCumulative =
-    channel.highestVoucherAmount > requiredCumulative
-      ? channel.highestVoucherAmount
-      : requiredCumulative
   return {
-    acceptedCumulative: acceptedCumulative.toString(),
+    acceptedCumulative: channel.highestVoucherAmount.toString(),
     chainId: channel.chainId,
     channelId: channel.channelId,
     closeRequestedAt:
@@ -154,6 +152,11 @@ export async function resolveSessionSnapshot(
     deposit: channel.deposit.toString(),
     descriptor: channel.descriptor,
     escrow: channel.escrowContract,
+    highestVoucher: {
+      channelId: channel.highestVoucher.channelId,
+      cumulativeAmount: channel.highestVoucher.cumulativeAmount.toString(),
+      signature: channel.highestVoucher.signature,
+    },
     requiredCumulative: requiredCumulative.toString(),
     settled: channel.settledOnChain.toString(),
     spent: channel.spent.toString(),

--- a/src/tempo/session/server/Session.test.ts
+++ b/src/tempo/session/server/Session.test.ts
@@ -556,8 +556,21 @@ describe('precompile server session unit guardrails', () => {
   test('request returns a server session snapshot for a known precompile channel', async () => {
     const { method, store } = createServer()
     const openPayload = await createOpenPayload({ initialAmount: 100n })
+    const highestVoucher = await ClientOps.createVoucherPayload(
+      createSigningClient(),
+      payer,
+      openPayload.descriptor,
+      Types.uint96(250n),
+      chainId,
+    )
+    if (highestVoucher.action !== 'voucher') throw new Error('expected voucher payload')
     await persistPrecompileChannel(store, openPayload, {
       highestVoucherAmount: 250n,
+      highestVoucher: {
+        channelId: openPayload.channelId,
+        cumulativeAmount: 250n,
+        signature: highestVoucher.signature,
+      },
       spent: 200n,
       units: 2,
     })
@@ -585,6 +598,11 @@ describe('precompile server session unit guardrails', () => {
       deposit: '1000',
       descriptor: openPayload.descriptor,
       escrow: tip20ChannelEscrow,
+      highestVoucher: {
+        channelId: openPayload.channelId,
+        cumulativeAmount: '250',
+        signature: highestVoucher.signature,
+      },
       requiredCumulative: '201',
       settled: '0',
       spent: '200',
@@ -594,6 +612,14 @@ describe('precompile server session unit guardrails', () => {
 
   test('request can resolve a server session snapshot from request identity', async () => {
     const openPayload = await createOpenPayload({ initialAmount: 100n })
+    const highestVoucher = await ClientOps.createVoucherPayload(
+      createSigningClient(),
+      payer,
+      openPayload.descriptor,
+      Types.uint96(250n),
+      chainId,
+    )
+    if (highestVoucher.action !== 'voucher') throw new Error('expected voucher payload')
     const { method, store } = createServer({
       resolveChannelId({ request, credential, paymentRequest, store: hookStore }) {
         expect(request?.headers.get('cookie')).toBe('sid=session-1')
@@ -605,6 +631,11 @@ describe('precompile server session unit guardrails', () => {
     })
     await persistPrecompileChannel(store, openPayload, {
       highestVoucherAmount: 250n,
+      highestVoucher: {
+        channelId: openPayload.channelId,
+        cumulativeAmount: 250n,
+        signature: highestVoucher.signature,
+      },
       spent: 200n,
       units: 2,
     })
@@ -661,8 +692,21 @@ describe('precompile server session unit guardrails', () => {
   test('request uses zero effective amount for non-content snapshot hints', async () => {
     const { method, store } = createServer()
     const openPayload = await createOpenPayload({ initialAmount: 100n })
+    const highestVoucher = await ClientOps.createVoucherPayload(
+      createSigningClient(),
+      payer,
+      openPayload.descriptor,
+      Types.uint96(250n),
+      chainId,
+    )
+    if (highestVoucher.action !== 'voucher') throw new Error('expected voucher payload')
     await persistPrecompileChannel(store, openPayload, {
       highestVoucherAmount: 250n,
+      highestVoucher: {
+        channelId: openPayload.channelId,
+        cumulativeAmount: 250n,
+        signature: highestVoucher.signature,
+      },
       spent: 250n,
       units: 2,
     })
@@ -2032,8 +2076,21 @@ describe('precompile server session unit guardrails', () => {
       const rawStore = Store.memory()
       const store = channelStore(rawStore)
       const openPayload = await createOpenPayload({ initialAmount: 1n })
+      const highestVoucher = await ClientOps.createVoucherPayload(
+        createSigningClient(),
+        payer,
+        openPayload.descriptor,
+        Types.uint96(5n),
+        chainId,
+      )
+      if (highestVoucher.action !== 'voucher') throw new Error('expected voucher payload')
       await persistPrecompileChannel(store, openPayload, {
         highestVoucherAmount: 5n,
+        highestVoucher: {
+          channelId: openPayload.channelId,
+          cumulativeAmount: 5n,
+          signature: highestVoucher.signature,
+        },
         spent: 3n,
         units: 3,
       })
@@ -2056,6 +2113,10 @@ describe('precompile server session unit guardrails', () => {
       expect(snapshot).toMatchObject({
         channelId: openPayload.channelId,
         acceptedCumulative: '5',
+        highestVoucher: {
+          channelId: openPayload.channelId,
+          cumulativeAmount: '5',
+        },
         requiredCumulative: '3',
         spent: '3',
       })


### PR DESCRIPTION
## Summary

- keep the existing `resolveChannelId` hook as the only application-defined durable session lookup boundary
- include the stored highest signed voucher in reusable Tempo session snapshots
- omit snapshots when the stored voucher is missing or does not match `highestVoucherAmount`
- keep `acceptedCumulative` bound to the signed voucher while `requiredCumulative` carries the next request boundary

## Why

#675 safely rehydrates cold clients by verifying the server snapshot against the client-signed highest voucher. The server snapshot did not include that voucher, so a cold client could discover a channel but could not validate or resume it.

No new store API is needed. Applications that need durable discovery can already implement `resolveChannelId({ source, paymentRequest })`, after which MPPx loads the channel through the existing primary-key store lookup and returns the signed snapshot.

## Validation

- `pnpm check:types`
- `pnpm check:ci`
- `VITE_TEMPO_NETWORK=none pnpm exec vp test --run --project node src/tempo/session/server/RequestState.test.ts src/tempo/session/server/Session.test.ts --reporter=verbose --bail=1` — 108 passed
