### PR TITLE
fix: avoid self-sponsored session transactions

### DIFF
--- a/.changeset/fix-session-self-sponsorship.md
+++ b/.changeset/fix-session-self-sponsorship.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed server-driven Tempo session close and settlement transactions when the configured account is also the fee payer.

--- a/src/tempo/session/precompile/Chain.test.ts
+++ b/src/tempo/session/precompile/Chain.test.ts
@@ -62,6 +62,7 @@ function createMockClient(
         parameters.rpcMethods?.push(args.method)
         parameters.onRequest?.(args.method, args.params)
         if (args.method === 'eth_chainId') return `0x${chainId.toString(16)}`
+        if (args.method === 'eth_sendTransaction') return txHash
         if (args.method === 'eth_sendRawTransaction') return txHash
         if (args.method === 'eth_sendRawTransactionSync') return parameters.receipt ?? receipt([])
         if (args.method === 'eth_getTransactionReceipt') return parameters.receipt ?? null
@@ -287,6 +288,31 @@ describe('precompile receipt wait', () => {
     expect(result.transactionHash).toBe(requestedHash)
     expect(rpcMethods).not.toContain('eth_getTransactionByHash')
     expect(rpcMethods).not.toContain('eth_getBlockByNumber')
+  })
+})
+
+describe('precompile server transactions', () => {
+  test('does not add a fee-payer signature when the sender and fee payer are the same account', async () => {
+    const rpcMethods: string[] = []
+    const client = createMockClient({ rpcMethods })
+    const sender = { address: feePayer.address, type: 'json-rpc' } as const
+
+    await Chain.closeOnChain(
+      client,
+      descriptor,
+      1n,
+      1n,
+      `0x${'11'.repeat(65)}`,
+      tip20ChannelEscrow,
+      {
+        account: sender,
+        candidateFeeTokens: [descriptor.token],
+        feePayer,
+      },
+    )
+
+    expect(rpcMethods).toContain('eth_sendTransaction')
+    expect(rpcMethods).not.toContain('eth_sendRawTransactionSync')
   })
 })
 

--- a/src/tempo/session/precompile/Chain.ts
+++ b/src/tempo/session/precompile/Chain.ts
@@ -1001,8 +1001,11 @@ async function sendPrecompileTransaction(
   label: string,
   options?: ChannelTransactionOptions,
 ): Promise<Hex> {
-  if (options?.feePayer) {
-    const account = options.account ?? client.account
+  const account = options?.account ?? client.account
+  const selfSponsored =
+    account && options?.feePayer && isAddressEqual(account.address, options.feePayer.address)
+
+  if (options?.feePayer && !selfSponsored) {
     if (!account) throw new Error(`Cannot ${label} precompile channel: no account available.`)
     const feeToken =
       options.feeToken ??
@@ -1033,10 +1036,20 @@ async function sendPrecompileTransaction(
     return receipt.transactionHash
   }
 
+  const feeToken =
+    options?.feeToken ??
+    (selfSponsored
+      ? await resolveFeeToken({
+          account: account.address,
+          candidateTokens: options?.candidateFeeTokens,
+          client,
+        })
+      : undefined)
+
   return sendPrecompileContractCall(client, {
-    account: options?.account,
+    account,
     to,
     data,
-    feeToken: options?.feeToken,
+    feeToken,
   })
 }


### PR DESCRIPTION
## Summary

- send server-driven session transactions normally when the configured sender and fee payer resolve to the same account
- preserve the selected fee token without adding an invalid self-sponsorship signature
- cover the close path with a regression test

## Root cause

With `feePayer: true`, the configured server account sponsors client open/top-up transactions. The same account also sends server-driven close/settle transactions. mppx added that account as its own fee payer, which Tempo rejects as `SelfSponsoredFeePayer` (`fee payer cannot resolve to sender`).

## Validation

- `VITE_TEMPO_NETWORK=none pnpm exec vp test --run src/tempo/session/precompile/Chain.test.ts`
- `pnpm check:ci`
- `pnpm check:types`
- reproduced against the mpp.dev Vercel preview before the fix: open returned 200; close reached the verifier and failed at `eth_sendRawTransactionSync` with `fee payer cannot resolve to sender`