### PR TITLE
fix: resolve dependency audit failures

### DIFF
--- a/.changeset/fix-dependency-audit.md
+++ b/.changeset/fix-dependency-audit.md
@@ -1,0 +1,4 @@
+---
+---
+
+Updated dependency audit overrides.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,9 @@ overrides:
   file-type: 21.3.2
   flatted@<=3.4.1: '>=3.4.2'
   follow-redirects@<=1.15.11: 1.16.0
-  fast-uri@<=3.1.0: 3.1.1
-  hono@<4.12.25: 4.12.25
+  fast-uri@<3.1.3: 3.1.4
+  hono@<4.12.27: 4.12.27
+  '@hono/node-server@<2.0.5': 2.0.8
   undici@>=7.0.0 <7.28.0: 7.28.0
   socket.io-parser@>=4.0.0 <4.2.6: '>=4.2.6'
   yaml@<2.8.3: '>=2.8.3'
@@ -34,7 +35,6 @@ overrides:
   lodash@<=4.17.23: '>=4.18.0'
   protobufjs@<=7.6.4: 7.6.5
   uuid@<14.0.0: 14.0.0
-  fast-uri@<=3.1.1: ^3.1.2
   tmp@>=0.2.6 <0.2.7: 0.2.7
   vite@>=8.0.0 <=8.0.15: 8.0.16
   vite-plus@<=0.1.23: 0.1.24
@@ -726,17 +726,11 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
-    engines: {node: '>=18.14.1'}
-    peerDependencies:
-      hono: 4.12.25
-
   '@hono/node-server@2.0.8':
     resolution: {integrity: sha512-GuCWzLxwg218fy1JaHculFsdcuY12hxit83V+algozTPnwhNjLrRL/Alg9OYjLZLoUZ1rw/S4CdTMsnkSKCmFA==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: 4.12.25
+      hono: 4.12.27
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -2725,8 +2719,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -2897,10 +2891,6 @@ packages:
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
-
-  hono@4.12.25:
-    resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
-    engines: {node: '>=16.9.0'}
 
   hono@4.12.27:
     resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
@@ -4521,10 +4511,6 @@ snapshots:
       protobufjs: 7.6.5
       yargs: 17.7.3
 
-  '@hono/node-server@1.19.14(hono@4.12.25)':
-    dependencies:
-      hono: 4.12.25
-
   '@hono/node-server@2.0.8(hono@4.12.27)':
     dependencies:
       hono: 4.12.27
@@ -4729,7 +4715,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.25)
+      '@hono/node-server': 2.0.8(hono@4.12.27)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -4739,7 +4725,7 @@ snapshots:
       eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.25
+      hono: 4.12.27
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -5572,7 +5558,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6227,7 +6213,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.4: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -6403,8 +6389,6 @@ snapshots:
   hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
-
-  hono@4.12.25: {}
 
   hono@4.12.27: {}
 
@@ -7649,10 +7633,10 @@ snapshots:
 
   wata@0.4.0(react@19.2.7)(typescript@5.9.3):
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.25)
+      '@hono/node-server': 2.0.8(hono@4.12.27)
       '@noble/ciphers': 2.2.0
       '@noble/hashes': 2.2.0
-      hono: 4.12.25
+      hono: 4.12.27
       ox: 0.14.29(typescript@5.9.3)(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,8 +29,9 @@ overrides:
   file-type: '21.3.2'
   flatted@<=3.4.1: '>=3.4.2'
   follow-redirects@<=1.15.11: '1.16.0'
-  fast-uri@<=3.1.0: '3.1.1'
-  hono@<4.12.25: '4.12.25'
+  fast-uri@<3.1.3: '3.1.4'
+  hono@<4.12.27: '4.12.27'
+  '@hono/node-server@<2.0.5': '2.0.8'
   undici@>=7.0.0 <7.28.0: '7.28.0'
   socket.io-parser@>=4.0.0 <4.2.6: '>=4.2.6'
   yaml@<2.8.3: '>=2.8.3'
@@ -39,7 +40,6 @@ overrides:
   lodash@<=4.17.23: '>=4.18.0'
   protobufjs@<=7.6.4: '7.6.5'
   uuid@<14.0.0: '14.0.0'
-  fast-uri@<=3.1.1: ^3.1.2
   tmp@>=0.2.6 <0.2.7: '0.2.7'
   vite@>=8.0.0 <=8.0.15: '8.0.16'
   vite-plus@<=0.1.23: '0.1.24'
@@ -64,8 +64,8 @@ minimumReleaseAgeExclude:
   - esbuild@0.28.1
   - body-parser@2.3.0
   - brace-expansion@5.0.7
-  - fast-uri@3.1.2
-  - hono@4.12.25
+  - fast-uri@3.1.4
+  - hono@4.12.27
   - js-yaml@4.3.0
   - ox@0.14.29
   - protobufjs@7.6.5


### PR DESCRIPTION
## Summary

- update the stale `fast-uri` audit override to a patched 3.x release
- align transitive Hono and Hono Node adapter dependencies with the already-installed patched versions
- regenerate the lockfile so MCP SDK and Accounts dependency paths no longer resolve vulnerable releases

## Root cause

New advisories cover versions held in the lockfile by older security overrides. This is unrelated to the changes in #679, but it causes the shared `Verify / Checks` dependency audit to fail for that PR and other branches based on `main`.

## Validation

- `pnpm audit --ignore-registry-errors`
- `pnpm check:ci`
- `pnpm check:types`
- `VITE_TEMPO_NETWORK=none pnpm exec vp test --run src/mcp/server/Transport.test.ts src/mcp/client/McpClient.test.ts --testNamePattern='behavior|error|in-place|isPaymentRequiredError'`
- `pnpm changeset status --since=HEAD^1`
