### PR TITLE
docs: explain session bootstrap recovery flow

### DIFF
--- a/examples/session/multi-fetch/README.md
+++ b/examples/session/multi-fetch/README.md
@@ -4,6 +4,55 @@ Multiple paid requests over a single payment channel, then close and settle. Dem
 
 Each paid HTTP response carries a `Payment-Receipt` header. For session routes, the receipt's `spent` and `units` fields reflect channel state after that request, which is what standalone clients should use for follow-up close flows.
 
+## Reusing a session after client restart
+
+Enable `bootstrap` when a client should recover an existing channel before its
+first paid request:
+
+```ts
+tempo.session({
+  bootstrap: true,
+  resolveChannelId({ source, paymentRequest }) {
+    return db.findChannelId({
+      payer: parseSource(source),
+      payee: paymentRequest.recipient,
+      token: paymentRequest.currency,
+      // Include chain and escrow when the application supports more than one.
+    })
+  },
+})
+```
+
+The bootstrap flow is:
+
+```mermaid
+sequenceDiagram
+  participant Client
+  participant Session as tempo.session
+  participant App as resolveChannelId
+  participant Store as Channel store
+
+  Client->>Session: HEAD protected resource
+  Session-->>Client: 402 zero-amount identity challenge
+  Client->>Session: HEAD with signed proof
+  Session->>Session: Verify proof and recover source
+  Session->>App: source + paymentRequest
+  App-->>Session: channelId
+  Session->>Store: getChannel(channelId)
+  Store-->>Session: channel state
+  Session->>Session: Check chain, token, escrow, payee, and signed voucher
+  Session-->>Client: 204 + Payment-Session + snapshot
+  Client->>Client: Validate snapshot and hydrate session
+```
+
+`resolveChannelId` is the application-owned identity/scope lookup. The channel
+store only loads state for a known `channelId`; MPPx does not scan the store or
+define a secondary-index format. If the request already supplies a channel ID,
+MPPx uses it without calling the hook. Before advertising a recovered channel,
+MPPx checks that it is active, matches the requested chain, token, escrow, and
+payee, and contains the signed highest voucher required for safe client
+rehydration.
+
 ## Setup
 
 ```bash

--- a/src/tempo/session/server/RequestState.ts
+++ b/src/tempo/session/server/RequestState.ts
@@ -80,7 +80,11 @@ export type ResolveSessionChannelIdParameters = {
   store: ChannelStore.ChannelStore
 }
 
-/** Application hook for mapping request identity to an existing session channel. */
+/**
+ * Application-owned lookup from authenticated identity and payment scope to an existing session
+ * channel. MPPx does not derive a storage key or scan the channel store; the returned channel ID is
+ * loaded and independently validated before its snapshot is advertised.
+ */
 export type ResolveSessionChannelId = (
   parameters: ResolveSessionChannelIdParameters,
 ) => Promise<string | null | undefined> | string | null | undefined

--- a/src/tempo/session/server/Session.ts
+++ b/src/tempo/session/server/Session.ts
@@ -492,9 +492,20 @@ export namespace session {
     feePayerPolicy?: FeePayerPolicy | undefined
     /** Minimum voucher delta to accept (numeric string, default: "0"). */
     minVoucherDelta?: string | undefined
-    /** Resolve a reusable channel ID from request identity when no credential/request channel ID is present. */
+    /**
+     * Maps authenticated application identity and payment scope to an existing channel ID.
+     * Called only when the request does not already supply a channel ID. MPPx then loads that
+     * ID from `store` and validates the channel before including its snapshot in a challenge or
+     * bootstrap response. The store is not searched automatically and does not need to implement
+     * a secondary-index format.
+     */
     resolveChannelId?: ResolveSessionChannelId | undefined
-    /** Enables same-route HEAD bootstrap using a zero-amount identity proof. */
+    /**
+     * Enables same-route `HEAD` recovery before a paid request. The server issues a zero-amount
+     * identity challenge, verifies the returned proof, passes its authenticated `source` to
+     * `resolveChannelId`, validates the loaded channel's payment scope, and returns a snapshot
+     * containing the signed highest voucher for client rehydration.
+     */
     bootstrap?: boolean | undefined
     /**
      * Atomic store backend for channel state.


### PR DESCRIPTION
## Summary

- document the zero-amount `HEAD` bootstrap sequence with a Mermaid diagram
- clarify that `resolveChannelId` owns identity/scope lookup
- clarify that the channel store only loads known IDs and MPPx revalidates recovered state
- call out the signed highest voucher required for safe client rehydration

## Validation

- verified the branch is based on current `main`
- reviewed the rendered Mermaid syntax and API comments
- docs-only change; no runtime behavior changed

Prompted by: @gakonst