### PR TITLE
fix: restore main CI checks

### DIFF
--- a/.changeset/quiet-sessions-design.md
+++ b/.changeset/quiet-sessions-design.md
@@ -1,2 +1,4 @@
 ---
 ---
+
+Added the Tempo session design guide.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ overrides:
   follow-redirects@<=1.15.11: 1.16.0
   fast-uri@<3.1.3: 3.1.4
   hono@<4.12.27: 4.12.27
-  '@hono/node-server@<2.0.5': 2.0.8
+  '@hono/node-server@<2.0.10': 2.0.10
   undici@>=7.0.0 <7.28.0: 7.28.0
   socket.io-parser@>=4.0.0 <4.2.6: '>=4.2.6'
   yaml@<2.8.3: '>=2.8.3'
@@ -68,8 +68,8 @@ importers:
         specifier: ^2.31.0
         version: 2.31.0(@types/node@25.6.0)
       '@hono/node-server':
-        specifier: 2.0.8
-        version: 2.0.8(hono@4.12.27)
+        specifier: 2.0.10
+        version: 2.0.10(hono@4.12.27)
       '@modelcontextprotocol/sdk':
         specifier: 1.29.0
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
@@ -726,8 +726,8 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  '@hono/node-server@2.0.8':
-    resolution: {integrity: sha512-GuCWzLxwg218fy1JaHculFsdcuY12hxit83V+algozTPnwhNjLrRL/Alg9OYjLZLoUZ1rw/S4CdTMsnkSKCmFA==}
+  '@hono/node-server@2.0.10':
+    resolution: {integrity: sha512-ZcnNVhKTmyDJeg0UlnZjvM73JBsTAuhrH/J4fjwGOw59PwOW51r4J+p6CsKZWXdKSme4MFqU62CZMOsdDrU4CA==}
     engines: {node: '>=20'}
     peerDependencies:
       hono: 4.12.27
@@ -4511,7 +4511,7 @@ snapshots:
       protobufjs: 7.6.5
       yargs: 17.7.3
 
-  '@hono/node-server@2.0.8(hono@4.12.27)':
+  '@hono/node-server@2.0.10(hono@4.12.27)':
     dependencies:
       hono: 4.12.27
 
@@ -4715,7 +4715,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 2.0.8(hono@4.12.27)
+      '@hono/node-server': 2.0.10(hono@4.12.27)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -7633,7 +7633,7 @@ snapshots:
 
   wata@0.4.0(react@19.2.7)(typescript@5.9.3):
     dependencies:
-      '@hono/node-server': 2.0.8(hono@4.12.27)
+      '@hono/node-server': 2.0.10(hono@4.12.27)
       '@noble/ciphers': 2.2.0
       '@noble/hashes': 2.2.0
       hono: 4.12.27

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,7 +31,7 @@ overrides:
   follow-redirects@<=1.15.11: '1.16.0'
   fast-uri@<3.1.3: '3.1.4'
   hono@<4.12.27: '4.12.27'
-  '@hono/node-server@<2.0.5': '2.0.8'
+  '@hono/node-server@<2.0.10': '2.0.10'
   undici@>=7.0.0 <7.28.0: '7.28.0'
   socket.io-parser@>=4.0.0 <4.2.6: '>=4.2.6'
   yaml@<2.8.3: '>=2.8.3'


### PR DESCRIPTION
## Motivation

Restored main checks blocked by an empty changeset description and a newly disclosed dependency advisory.

## Summary

- Added the missing description for the Tempo session design changeset.
- Updated the Hono Node server override to the patched release.

## Key design considerations

- Kept the dependency update scoped to the affected transitive package and regenerated the lockfile.