### PR TITLE
fix: route custom transports through hosted fee payer

### DIFF
--- a/.changeset/honest-tools-smile.md
+++ b/.changeset/honest-tools-smile.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed hosted fee payer routing for caller-provided custom Viem transports.

--- a/.changeset/quiet-sessions-design.md
+++ b/.changeset/quiet-sessions-design.md
@@ -1,2 +1,4 @@
 ---
 ---
+
+Documented the Tempo session architecture and lifecycle.

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "testcontainers": "^12.0.4",
     "tsx": "^4.22.4",
     "typescript": "~6.0.3",
-    "viem": "^2.54.4",
+    "viem": "https://pkg.pr.new/viem@4880",
     "vite": "^8.1.3",
     "vp": "npm:vite-plus@~0.1.24",
     "ws": "^8.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   vitest: npm:@voidzero-dev/vite-plus-test@~0.1.24
   typescript: ~5.9.3
   ox: 0.14.29
-  viem: ^2.54.1
+  viem: https://pkg.pr.new/viem@4880
   path-to-regexp@<8.4.0: 8.4.0
   tar@<=7.5.18: 7.5.19
   '@modelcontextprotocol/sdk@>=1.10.0 <=1.25.3': 1.26.0
@@ -60,6 +60,9 @@ importers:
       ox:
         specifier: 0.14.29
         version: 0.14.29(typescript@5.9.3)(zod@4.4.3)
+      viem:
+        specifier: https://pkg.pr.new/viem@4880
+        version: https://pkg.pr.new/viem@4880(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -123,7 +126,7 @@ importers:
         version: 1.1.5
       tempo.ts:
         specifier: ^0.14.2
-        version: 0.14.2(typescript@5.9.3)(viem@2.54.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(zod@4.4.3)
+        version: 0.14.2(typescript@5.9.3)(viem@https://pkg.pr.new/viem@4880(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(zod@4.4.3)
       testcontainers:
         specifier: ^12.0.4
         version: 12.0.4
@@ -133,9 +136,6 @@ importers:
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
-      viem:
-        specifier: ^2.54.1
-        version: 2.54.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       vite:
         specifier: ^8.1.3
         version: 8.1.3(@types/node@25.6.0)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
@@ -170,8 +170,8 @@ importers:
         specifier: ~5.9.3
         version: 5.9.3
       viem:
-        specifier: ^2.54.1
-        version: 2.54.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+        specifier: https://pkg.pr.new/viem@4880
+        version: https://pkg.pr.new/viem@4880(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       vite:
         specifier: ^8.1.3
         version: 8.1.3(@types/node@25.6.0)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0)
@@ -200,11 +200,11 @@ importers:
         specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
       viem:
-        specifier: ^2.54.1
-        version: 2.54.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+        specifier: https://pkg.pr.new/viem@4880
+        version: https://pkg.pr.new/viem@4880(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       wagmi:
         specifier: ^3.6.21
-        version: 3.6.21(@tanstack/query-core@5.101.2)(@tanstack/react-query@5.101.2(react@19.2.7))(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@5.9.3)(viem@2.54.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
+        version: 3.6.21(@tanstack/query-core@5.101.2)(@tanstack/react-query@5.101.2(react@19.2.7))(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@5.9.3)(viem@https://pkg.pr.new/viem@4880(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
     devDependencies:
       '@types/react':
         specifier: ^19.2.17
@@ -246,8 +246,8 @@ importers:
         specifier: ~5.9.3
         version: 5.9.3
       viem:
-        specifier: ^2.54.1
-        version: 2.54.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+        specifier: https://pkg.pr.new/viem@4880
+        version: https://pkg.pr.new/viem@4880(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       vite:
         specifier: ^8.1.3
         version: 8.1.3(@types/node@26.1.1)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0)
@@ -273,8 +273,8 @@ importers:
         specifier: ~5.9.3
         version: 5.9.3
       viem:
-        specifier: ^2.54.1
-        version: 2.54.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+        specifier: https://pkg.pr.new/viem@4880
+        version: https://pkg.pr.new/viem@4880(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       vite:
         specifier: ^8.1.3
         version: 8.1.3(@types/node@26.1.1)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0)
@@ -306,8 +306,8 @@ importers:
         specifier: ~5.9.3
         version: 5.9.3
       viem:
-        specifier: ^2.54.1
-        version: 2.54.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+        specifier: https://pkg.pr.new/viem@4880
+        version: https://pkg.pr.new/viem@4880(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       vite:
         specifier: ^8.1.3
         version: 8.1.3(@types/node@25.6.0)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
@@ -363,8 +363,8 @@ importers:
         specifier: ~5.9.3
         version: 5.9.3
       viem:
-        specifier: ^2.54.1
-        version: 2.54.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+        specifier: https://pkg.pr.new/viem@4880
+        version: https://pkg.pr.new/viem@4880(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       vite:
         specifier: ^8.1.3
         version: 8.1.3(@types/node@25.6.2)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.9.0)
@@ -390,8 +390,8 @@ importers:
         specifier: ~5.9.3
         version: 5.9.3
       viem:
-        specifier: ^2.54.1
-        version: 2.54.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+        specifier: https://pkg.pr.new/viem@4880
+        version: https://pkg.pr.new/viem@4880(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
 
   src/stripe/server/internal/html:
     dependencies:
@@ -406,13 +406,13 @@ importers:
     dependencies:
       accounts:
         specifier: 0.14.11
-        version: 0.14.11(@types/react@19.2.17)(@wagmi/core@3.5.5)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.54.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.21)
+        version: 0.14.11(@types/react@19.2.17)(@wagmi/core@3.5.5)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@https://pkg.pr.new/viem@4880(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.21)
       mppx:
         specifier: workspace:*
         version: link:../../../../..
       viem:
-        specifier: ^2.54.1
-        version: 2.54.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+        specifier: https://pkg.pr.new/viem@4880
+        version: https://pkg.pr.new/viem@4880(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
 
 packages:
 
@@ -2005,6 +2005,7 @@ packages:
 
   '@wagmi/connectors@8.0.20':
     resolution: {integrity: sha512-c6BRWBJ2bnYq/Spxpc7H/mdnlZ90CPSEZ4NKCin3gM8yRwqkI4J1BzSXF1jAoHO0QjME1rajGGQKrCli3tV3hw==}
+    version: 8.0.20
     peerDependencies:
       '@base-org/account': ^2.5.1
       '@coinbase/wallet-sdk': ^4.3.6
@@ -2016,7 +2017,7 @@ packages:
       accounts: ~0.14
       porto: ~0.2.35
       typescript: ~5.9.3
-      viem: ^2.54.1
+      viem: 2.x
     peerDependenciesMeta:
       '@base-org/account':
         optional: true
@@ -2039,11 +2040,12 @@ packages:
 
   '@wagmi/core@3.5.5':
     resolution: {integrity: sha512-JEJAwo25p9c52JwQs1WunqANPs4PjJ+eepDLXvQJ390vEXsBexYdCDmsPPcYZaGpk0Umx0w85U1ruRodXusMzg==}
+    version: 3.5.5
     peerDependencies:
       '@tanstack/query-core': '>=5.0.0'
       accounts: ~0.14
       typescript: ~5.9.3
-      viem: ^2.54.1
+      viem: 2.x
     peerDependenciesMeta:
       '@tanstack/query-core':
         optional: true
@@ -2084,6 +2086,7 @@ packages:
 
   accounts@0.14.11:
     resolution: {integrity: sha512-75OHKIbtl0PTrZenrs8WwLf6QI4UZLG3l2CK21OJly4bxzY7m5PbUDYHqk4HGcSjW/NR+fZGPRFIH5ZvKtIqOw==}
+    version: 0.14.11
     peerDependencies:
       '@privy-io/react-auth': '>=3.25.0'
       '@react-native-async-storage/async-storage': ^3.0.2
@@ -2093,7 +2096,7 @@ packages:
       react: '>=18'
       react-native-mmkv: ^4.3.1
       react-native-nitro-modules: ^0.35.9
-      viem: ^2.54.1
+      viem: '>=2.50.4'
       wagmi: '>=0.0.0'
     peerDependenciesMeta:
       '@privy-io/react-auth':
@@ -3796,8 +3799,9 @@ packages:
 
   tempo.ts@0.14.2:
     resolution: {integrity: sha512-N4UkP2X/KDLmYUEIEWUDAk1m/USbKMzTjjUz1m0LwrIEVfoDlcSbBRc9jp14gLZcJVDlnq+fWHFVcH+GdrySgQ==}
+    version: 0.14.2
     peerDependencies:
-      viem: ^2.54.1
+      viem: '>=2.43.3'
     peerDependenciesMeta:
       viem:
         optional: true
@@ -3958,8 +3962,9 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  viem@2.54.4:
-    resolution: {integrity: sha512-ucXzbdRTjPCFo4cKU1n75h/013VTH/Xr+Kq9tV/e+f+GYmTwttgbQZbf9f7gLdKqgSuq80EmImAezwidm4QZtg==}
+  viem@https://pkg.pr.new/viem@4880:
+    resolution: {integrity: sha512-ZC30AIkbk2zdGhVARNvyrnXo9BWbN4T49YhWuIAHmHd/MOjNg+tskVqhiXF72I843x7BtCPRv7/KfROdJ1MpbQ==, tarball: https://pkg.pr.new/viem@4880}
+    version: 2.55.6
     peerDependencies:
       typescript: ~5.9.3
     peerDependenciesMeta:
@@ -4016,11 +4021,12 @@ packages:
 
   wagmi@3.6.21:
     resolution: {integrity: sha512-ao/Zb4Uz1KJvFNpo13DVeWo4eMkNb06RU1uk/xHm+PTGURwP2NHAysZx/CHCV2WS2b1f9MlhYgSCiI5shx5vUA==}
+    version: 3.6.21
     peerDependencies:
       '@tanstack/react-query': '>=5.0.0'
       react: '>=18'
       typescript: ~5.9.3
-      viem: ^2.54.1
+      viem: 2.x
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -5471,23 +5477,23 @@ snapshots:
   '@voidzero-dev/vite-plus-win32-x64-msvc@0.1.24':
     optional: true
 
-  '@wagmi/connectors@8.0.20(@wagmi/core@3.5.5)(accounts@0.14.11)(typescript@5.9.3)(viem@2.54.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))':
+  '@wagmi/connectors@8.0.20(@wagmi/core@3.5.5)(accounts@0.14.11)(typescript@5.9.3)(viem@https://pkg.pr.new/viem@4880(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))':
     dependencies:
-      '@wagmi/core': 3.5.5(@tanstack/query-core@5.101.2)(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.54.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
-      viem: 2.54.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@wagmi/core': 3.5.5(@tanstack/query-core@5.101.2)(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@https://pkg.pr.new/viem@4880(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
+      viem: https://pkg.pr.new/viem@4880(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
     optionalDependencies:
-      accounts: 0.14.11(@types/react@19.2.17)(@wagmi/core@3.5.5)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.54.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.21)
+      accounts: 0.14.11(@types/react@19.2.17)(@wagmi/core@3.5.5)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@https://pkg.pr.new/viem@4880(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.21)
       typescript: 5.9.3
 
-  '@wagmi/core@3.5.5(@tanstack/query-core@5.101.2)(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.54.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))':
+  '@wagmi/core@3.5.5(@tanstack/query-core@5.101.2)(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@https://pkg.pr.new/viem@4880(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.9.3)
-      viem: 2.54.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      viem: https://pkg.pr.new/viem@4880(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
       zustand: 5.0.0(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.4.0(react@19.2.7))
     optionalDependencies:
       '@tanstack/query-core': 5.101.2
-      accounts: 0.14.11(@types/react@19.2.17)(@wagmi/core@3.5.5)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.54.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.21)
+      accounts: 0.14.11(@types/react@19.2.17)(@wagmi/core@3.5.5)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@https://pkg.pr.new/viem@4880(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.21)
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@types/react'
@@ -5514,7 +5520,7 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
-  accounts@0.14.11(@types/react@19.2.17)(@wagmi/core@3.5.5)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.54.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.21):
+  accounts@0.14.11(@types/react@19.2.17)(@wagmi/core@3.5.5)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@https://pkg.pr.new/viem@4880(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.21):
     dependencies:
       hono: 4.12.27
       idb-keyval: 6.2.5
@@ -5527,10 +5533,10 @@ snapshots:
       zod: 4.4.3
       zustand: 5.0.14(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.4.0(react@19.2.7))
     optionalDependencies:
-      '@wagmi/core': 3.5.5(@tanstack/query-core@5.101.2)(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.54.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
+      '@wagmi/core': 3.5.5(@tanstack/query-core@5.101.2)(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@https://pkg.pr.new/viem@4880(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
       react: 19.2.7
-      viem: 2.54.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
-      wagmi: 3.6.21(@tanstack/query-core@5.101.2)(@tanstack/react-query@5.101.2(react@19.2.7))(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@5.9.3)(viem@2.54.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
+      viem: https://pkg.pr.new/viem@4880(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      wagmi: 3.6.21(@tanstack/query-core@5.101.2)(@tanstack/react-query@5.101.2(react@19.2.7))(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@5.9.3)(viem@https://pkg.pr.new/viem@4880(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
     transitivePeerDependencies:
       - '@types/react'
       - expo-crypto
@@ -7327,12 +7333,12 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  tempo.ts@0.14.2(typescript@5.9.3)(viem@2.54.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(zod@4.4.3):
+  tempo.ts@0.14.2(typescript@5.9.3)(viem@https://pkg.pr.new/viem@4880(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))(zod@4.4.3):
     dependencies:
       '@remix-run/fetch-router': 0.17.0
       ox: 0.14.29(typescript@5.9.3)(zod@4.4.3)
     optionalDependencies:
-      viem: 2.54.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      viem: https://pkg.pr.new/viem@4880(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
     transitivePeerDependencies:
       - typescript
       - zod
@@ -7485,7 +7491,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  viem@2.54.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3):
+  viem@https://pkg.pr.new/viem@4880(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
@@ -7608,14 +7614,14 @@ snapshots:
       tsx: 4.23.1
       yaml: 2.9.0
 
-  wagmi@3.6.21(@tanstack/query-core@5.101.2)(@tanstack/react-query@5.101.2(react@19.2.7))(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@5.9.3)(viem@2.54.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)):
+  wagmi@3.6.21(@tanstack/query-core@5.101.2)(@tanstack/react-query@5.101.2(react@19.2.7))(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@5.9.3)(viem@https://pkg.pr.new/viem@4880(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)):
     dependencies:
       '@tanstack/react-query': 5.101.2(react@19.2.7)
-      '@wagmi/connectors': 8.0.20(@wagmi/core@3.5.5)(accounts@0.14.11)(typescript@5.9.3)(viem@2.54.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
-      '@wagmi/core': 3.5.5(@tanstack/query-core@5.101.2)(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@2.54.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
+      '@wagmi/connectors': 8.0.20(@wagmi/core@3.5.5)(accounts@0.14.11)(typescript@5.9.3)(viem@https://pkg.pr.new/viem@4880(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
+      '@wagmi/core': 3.5.5(@tanstack/query-core@5.101.2)(@types/react@19.2.17)(accounts@0.14.11)(react@19.2.7)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.7))(viem@https://pkg.pr.new/viem@4880(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3))
       react: 19.2.7
       use-sync-external-store: 1.4.0(react@19.2.7)
-      viem: 2.54.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+      viem: https://pkg.pr.new/viem@4880(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ overrides:
   follow-redirects@<=1.15.11: 1.16.0
   fast-uri@<3.1.3: 3.1.4
   hono@<4.12.27: 4.12.27
-  '@hono/node-server@<2.0.5': 2.0.8
+  '@hono/node-server@<2.0.10': 2.0.10
   undici@>=7.0.0 <7.28.0: 7.28.0
   socket.io-parser@>=4.0.0 <4.2.6: '>=4.2.6'
   yaml@<2.8.3: '>=2.8.3'
@@ -71,8 +71,8 @@ importers:
         specifier: ^2.31.0
         version: 2.31.0(@types/node@25.6.0)
       '@hono/node-server':
-        specifier: 2.0.8
-        version: 2.0.8(hono@4.12.27)
+        specifier: 2.0.10
+        version: 2.0.10(hono@4.12.27)
       '@modelcontextprotocol/sdk':
         specifier: 1.29.0
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
@@ -726,8 +726,8 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  '@hono/node-server@2.0.8':
-    resolution: {integrity: sha512-GuCWzLxwg218fy1JaHculFsdcuY12hxit83V+algozTPnwhNjLrRL/Alg9OYjLZLoUZ1rw/S4CdTMsnkSKCmFA==}
+  '@hono/node-server@2.0.10':
+    resolution: {integrity: sha512-ZcnNVhKTmyDJeg0UlnZjvM73JBsTAuhrH/J4fjwGOw59PwOW51r4J+p6CsKZWXdKSme4MFqU62CZMOsdDrU4CA==}
     engines: {node: '>=20'}
     peerDependencies:
       hono: 4.12.27
@@ -3963,7 +3963,7 @@ packages:
     engines: {node: '>= 0.8'}
 
   viem@https://pkg.pr.new/viem@4880:
-    resolution: {integrity: sha512-ZC30AIkbk2zdGhVARNvyrnXo9BWbN4T49YhWuIAHmHd/MOjNg+tskVqhiXF72I843x7BtCPRv7/KfROdJ1MpbQ==, tarball: https://pkg.pr.new/viem@4880}
+    resolution: {tarball: https://pkg.pr.new/viem@4880}
     version: 2.55.6
     peerDependencies:
       typescript: ~5.9.3
@@ -4517,7 +4517,7 @@ snapshots:
       protobufjs: 7.6.5
       yargs: 17.7.3
 
-  '@hono/node-server@2.0.8(hono@4.12.27)':
+  '@hono/node-server@2.0.10(hono@4.12.27)':
     dependencies:
       hono: 4.12.27
 
@@ -4721,7 +4721,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 2.0.8(hono@4.12.27)
+      '@hono/node-server': 2.0.10(hono@4.12.27)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -7639,7 +7639,7 @@ snapshots:
 
   wata@0.4.0(react@19.2.7)(typescript@5.9.3):
     dependencies:
-      '@hono/node-server': 2.0.8(hono@4.12.27)
+      '@hono/node-server': 2.0.10(hono@4.12.27)
       '@noble/ciphers': 2.2.0
       '@noble/hashes': 2.2.0
       hono: 4.12.27

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,7 +31,7 @@ overrides:
   follow-redirects@<=1.15.11: '1.16.0'
   fast-uri@<3.1.3: '3.1.4'
   hono@<4.12.27: '4.12.27'
-  '@hono/node-server@<2.0.5': '2.0.8'
+  '@hono/node-server@<2.0.10': '2.0.10'
   undici@>=7.0.0 <7.28.0: '7.28.0'
   socket.io-parser@>=4.0.0 <4.2.6: '>=4.2.6'
   yaml@<2.8.3: '>=2.8.3'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,7 +14,7 @@ overrides:
   vitest: 'npm:@voidzero-dev/vite-plus-test@~0.1.24'
   typescript: '~5.9.3'
   ox: '0.14.29'
-  viem: '^2.54.1'
+  viem: 'https://pkg.pr.new/viem@4880'
   path-to-regexp@<8.4.0: '8.4.0'
   tar@<=7.5.18: '7.5.19'
   '@modelcontextprotocol/sdk@>=1.10.0 <=1.25.3': '1.26.0'

--- a/src/viem/Client.test.ts
+++ b/src/viem/Client.test.ts
@@ -3,11 +3,15 @@ import { privateKeyToAccount } from 'viem/accounts'
 import { signTransaction } from 'viem/actions'
 import { Account as TempoAccount, Transaction } from 'viem/tempo'
 import { tempoLocalnet } from 'viem/tempo/chains'
-import { describe, expect, test } from 'vp/test'
+import { afterEach, describe, expect, test, vi } from 'vp/test'
 
 import * as Client from './Client.js'
 
 const rpcUrl = { 42: 'https://rpc.example.com', 99: 'https://rpc2.example.com' } as const
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
 
 describe('getResolver', () => {
   test('behavior: creates client from rpcUrl for given chainId', async () => {
@@ -60,6 +64,45 @@ describe('getResolver', () => {
     expect(() => getClient({ chainId: 99 })).toThrowErrorMatchingInlineSnapshot(
       `[Error: No \`rpcUrl\` configured for \`chainId\` (99).]`,
     )
+  })
+
+  test('behavior: wraps custom client transports with a hosted fee payer', async () => {
+    const defaultRequests: string[] = []
+    const client = createClient({
+      chain: tempoLocalnet,
+      transport: custom({
+        async request({ method }) {
+          defaultRequests.push(method)
+          return { source: 'default' }
+        },
+      }),
+    })
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const request = JSON.parse(String(init?.body)) as { id: number; jsonrpc: string }
+      return Response.json({
+        id: request.id,
+        jsonrpc: request.jsonrpc,
+        result: { source: 'relay' },
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const getClient = Client.getResolver({
+      chain: tempoLocalnet,
+      feePayerUrl: 'https://sponsor.example',
+      getClient: () => client,
+      rpcUrl: { [tempoLocalnet.id]: 'https://rpc.example.com' },
+    })
+    const resolved = await getClient({ chainId: tempoLocalnet.id })
+    const result = await resolved.request({
+      method: 'eth_fillTransaction',
+      params: [{ feePayer: true }],
+    } as never)
+
+    expect(result).toEqual({ source: 'relay' })
+    expect(fetchMock).toHaveBeenCalledOnce()
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe('https://sponsor.example/')
+    expect(defaultRequests).toEqual([])
   })
 })
 

--- a/src/viem/Client.ts
+++ b/src/viem/Client.ts
@@ -1,4 +1,4 @@
-import { type Chain, type Client, createClient, http } from 'viem'
+import { type Chain, type Client, createClient, custom, http } from 'viem'
 import { withFeePayer } from 'viem/tempo'
 
 import type { MaybePromise } from '../internal/types.js'
@@ -23,31 +23,37 @@ export function getResolver(
     if (!chain?.serializers && !feePayerUrl) return getClient
     return async (params) => {
       const client = await getClient(params)
+      let resolvedClient = client
 
       // Wrap the client's transport with `withFeePayer` when a fee payer URL is provided.
       if (feePayerUrl && client.transport.key !== 'feePayer') {
-        const url = (client.transport as { url?: string }).url
-        if (url) {
-          const wrapped = createClient({
-            chain: client.chain,
-            transport: withFeePayer(http(url), http(feePayerUrl)),
-          })
-          Object.assign(client, { transport: wrapped.transport, request: wrapped.request })
-        }
+        const request = client.request.bind(client)
+        const wrapped = createClient({
+          chain: client.chain,
+          transport: withFeePayer(
+            custom({ request: (args) => request(args as never) }),
+            http(feePayerUrl),
+          ),
+        })
+        resolvedClient = Object.assign({}, client, {
+          request: wrapped.request,
+          transport: wrapped.transport,
+        })
       }
 
-      if (!chain?.serializers || client.chain?.serializers?.transaction) return client
-      return Object.assign({}, client, {
+      if (!chain?.serializers || resolvedClient.chain?.serializers?.transaction)
+        return resolvedClient
+      return Object.assign({}, resolvedClient, {
         chain: {
           ...chain,
-          ...client.chain,
-          formatters: client.chain?.formatters ?? chain.formatters,
+          ...resolvedClient.chain,
+          formatters: resolvedClient.chain?.formatters ?? chain.formatters,
           prepareTransactionRequest:
-            client.chain?.prepareTransactionRequest ?? chain.prepareTransactionRequest,
-          serializers: client.chain?.serializers?.transaction
-            ? client.chain.serializers
+            resolvedClient.chain?.prepareTransactionRequest ?? chain.prepareTransactionRequest,
+          serializers: resolvedClient.chain?.serializers?.transaction
+            ? resolvedClient.chain.serializers
             : chain.serializers,
-        } as typeof client.chain,
+        } as typeof resolvedClient.chain,
       })
     }
   }

--- a/src/viem/Client.ts
+++ b/src/viem/Client.ts
@@ -1,4 +1,4 @@
-import { type Chain, type Client, createClient, custom, http } from 'viem'
+import { type Chain, type Client, createClient, createTransport, custom, http } from 'viem'
 import { withFeePayer } from 'viem/tempo'
 
 import type { MaybePromise } from '../internal/types.js'
@@ -28,16 +28,24 @@ export function getResolver(
       // Wrap the client's transport with `withFeePayer` when a fee payer URL is provided.
       if (feePayerUrl && client.transport.key !== 'feePayer') {
         const request = client.request.bind(client)
-        const wrapped = createClient({
+        // The supplied client already owns retries. Keep the relay middleware retry-free so
+        // failures are not retried once per nested transport layer.
+        const feePayerTransport = withFeePayer(
+          custom({ request: (args) => request(args as never) }, { retryCount: 0 }),
+          http(feePayerUrl, { retryCount: client.transport.retryCount }),
+        )({
+          account: client.account,
           chain: client.chain,
-          transport: withFeePayer(
-            custom({ request: (args) => request(args as never) }),
-            http(feePayerUrl),
-          ),
+          pollingInterval: client.pollingInterval,
+          retryCount: 0,
         })
+        const wrapped = createTransport(
+          { ...feePayerTransport.config, retryCount: 0 },
+          feePayerTransport.value,
+        )
         resolvedClient = Object.assign({}, client, {
           request: wrapped.request,
-          transport: wrapped.transport,
+          transport: { ...wrapped.config, ...wrapped.value },
         })
       }
 


### PR DESCRIPTION
## Summary

- wrap caller-provided Viem clients with the hosted fee-payer transport even when their custom transport has no URL
- preserve the original client request path as the default transport instead of silently bypassing sponsorship
- preserve the supplied client retry ownership instead of multiplying retries across nested transports
- update Viem to the pkg.pr.new build for merged PR #4880, which preserves relay-provided fee-payer signatures
- add a regression test and patch changeset

## Root cause

The resolver only applied withFeePayer when client.transport.url existed. Custom transports such as the retrying transport used by mpp-proxy do not expose that property, so sponsored requests were sent directly through the default RPC transport.

Wrapping the existing request in a normal client also introduced nested retry layers. The relay wrapper now disables middleware-level retries while retaining the supplied client configured retry policy.

## CI follow-up

- updated the existing @hono/node-server security override to 2.0.10 for GHSA-9mqv-5hh9-4cgg
- added the missing description to the empty quiet-sessions-design changeset inherited from main

## Validation

- focused Client tests: 17 passed
- real Tempo localnet hosted fee-payer integration: passed
- Node 1/2 shard sponsorship coverage: passed; 1,110 tests passed before the inherited empty changeset failed
- focused changeset suite after repair: 6 passed
- dependency audit: no known vulnerabilities
- pnpm check:types
- pnpm build
- pnpm check:types:examples
- pnpm check:ci
- frozen lockfile install

The custom-transport regression failed on current main before the implementation and passes with this change.