### PR TITLE
fix: top up sessions before signing credentials

### DIFF
--- a/.changeset/calm-websockets-topup.md
+++ b/.changeset/calm-websockets-topup.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed automatic session top-ups before signing HTTP, SSE, and WebSocket credentials.

--- a/src/client/internal/Fetch.ts
+++ b/src/client/internal/Fetch.ts
@@ -6,6 +6,7 @@ import type { MaybePromise } from '../../internal/types.js'
 import type * as Method from '../../Method.js'
 import type * as z from '../../zod.js'
 import * as Transport from '../Transport.js'
+import * as MethodChallenge from './MethodChallenge.js'
 import * as MethodResponse from './MethodResponse.js'
 
 // We tag wrappers with a global symbol so we can recognize wrappers created by mppx,
@@ -241,9 +242,22 @@ export function from<const methods extends readonly Method.AnyClient[]>(
         mi = selected.method
         if (challenge.expires) Expires.assert(challenge.expires, challenge.id)
 
+        const paymentInput = resolvePaymentRetryInput(
+          response,
+          initialRequest.input,
+          initialRequest.input,
+        )
         const createCredential = memoizeCreateCredential(
-          (overrideContext?: AnyContextFor<methods>) =>
-            resolveCredential(selectedChallenge, selected.method, overrideContext ?? context),
+          async (overrideContext?: AnyContextFor<methods>) => {
+            const credentialContext = overrideContext ?? context
+            await MethodChallenge.handle(selected.method, {
+              challenge: selectedChallenge,
+              context: credentialContext,
+              fetch: baseFetch,
+              input: paymentInput,
+            })
+            return resolveCredential(selectedChallenge, selected.method, credentialContext)
+          },
         )
         const eventCredential = await events.emit(
           'challenge.received',
@@ -278,11 +292,6 @@ export function from<const methods extends readonly Method.AnyClient[]>(
           }),
         )
 
-        const paymentInput = resolvePaymentRetryInput(
-          response,
-          initialRequest.input,
-          initialRequest.input,
-        )
         response = await baseFetch(
           paymentInput,
           transport.setCredential(

--- a/src/client/internal/MethodChallenge.ts
+++ b/src/client/internal/MethodChallenge.ts
@@ -1,0 +1,30 @@
+import type * as Challenge from '../../Challenge.js'
+import type { MaybePromise } from '../../internal/types.js'
+import type * as Method from '../../Method.js'
+
+const handlers = new WeakMap<Method.AnyClient, Handler>()
+
+/** Inputs available before a client method creates a challenge credential. */
+export type HandlerParameters = {
+  challenge: Challenge.Challenge
+  context?: unknown
+  fetch: typeof globalThis.fetch
+  input: RequestInfo | URL
+}
+
+/** Internal client-method challenge hook. */
+export type Handler = (parameters: HandlerParameters) => MaybePromise<void>
+
+/** Registers an internal challenge hook without changing the public method shape. */
+export function register<const method extends Method.AnyClient>(
+  method: method,
+  handler: Handler,
+): method {
+  handlers.set(method, handler)
+  return method
+}
+
+/** Runs method-specific work before creating a challenge credential. */
+export function handle(method: Method.AnyClient, parameters: HandlerParameters): Promise<void> {
+  return Promise.resolve(handlers.get(method)?.(parameters))
+}

--- a/src/tempo/session/client/CredentialState.ts
+++ b/src/tempo/session/client/CredentialState.ts
@@ -497,7 +497,7 @@ function assertReusableChannelDescriptor(parameters: {
     throw new Error('context descriptor token does not match challenge')
   if (!isSameAddress(descriptor.payer, payer))
     throw new Error('context descriptor payer does not match account')
-  if (!isSameAddress(descriptor.authorizedSigner, authorizedSigner))
+  if (!isSameAddress(Channel.resolveAuthorizedSigner(descriptor), authorizedSigner))
     throw new Error('context descriptor authorizedSigner does not match account')
 }
 
@@ -558,10 +558,6 @@ export async function hydrateSessionSnapshot(
   if (snapshotSettled > snapshotDeposit)
     throw new Error('session snapshot settled amount exceeds deposit')
 
-  const authorizedSigner =
-    BigInt(snapshot.descriptor.authorizedSigner) === 0n
-      ? snapshot.descriptor.payer
-      : snapshot.descriptor.authorizedSigner
   if (
     !Voucher.verifyVoucher(
       snapshot.escrow,
@@ -571,7 +567,7 @@ export async function hydrateSessionSnapshot(
         cumulativeAmount: voucherCumulative,
         signature: signed.signature,
       },
-      authorizedSigner,
+      Channel.resolveAuthorizedSigner(snapshot.descriptor),
     )
   )
     throw new Error('session snapshot highest voucher signature is invalid')
@@ -618,9 +614,10 @@ export function canSignDescriptor(
 ): boolean {
   // Only the payer can deposit into and voucher against its own channel.
   if (!isSameAddress(account.address, descriptor.payer)) return false
-  const authority = descriptor.authorizedSigner
-  if (BigInt(authority) === 0n || isSameAddress(authority, descriptor.payer)) return true
-  return isSameAddress(resolveAuthorizedSigner(account), authority)
+  return isSameAddress(
+    resolveAuthorizedSigner(account),
+    Channel.resolveAuthorizedSigner(descriptor),
+  )
 }
 
 /** Chooses the next credential plan from local channel cache and optional caller context. */

--- a/src/tempo/session/client/Runtime.test.ts
+++ b/src/tempo/session/client/Runtime.test.ts
@@ -30,6 +30,7 @@ import {
   nextSpentFromReceipt,
   parseManagerAmount,
   reduce,
+  resolveAutomaticTopUp,
   resolveCloseTarget,
   resolveNeedVoucherTransition,
   resolveOpeningDeposit,
@@ -922,6 +923,17 @@ describe('LocalAuthorization', () => {
       expect(resolveOpeningDeposit({ maxDeposit: 1000n, requestAmount: 100n })).toBe(100n)
       expect(() => resolveOpeningDeposit({ maxDeposit: 50n, requestAmount: 100n })).toThrow(
         'requested voucher amount 100 exceeds local maxDeposit 50',
+      )
+    })
+
+    test.each([
+      [{ topUpAmount: 80n, suggestedDeposit: 100n }, 80n],
+      [{ suggestedDeposit: 100n }, 100n],
+      [{}, 50n],
+      [{ maxDeposit: 180n, suggestedDeposit: 100n }, 80n],
+    ])('resolves bounded automatic top-ups %#', (policy, expected) => {
+      expect(resolveAutomaticTopUp({ deposit: 100n, requiredCumulative: 150n, ...policy })).toBe(
+        expected,
       )
     })
 

--- a/src/tempo/session/client/Runtime.ts
+++ b/src/tempo/session/client/Runtime.ts
@@ -533,6 +533,28 @@ export function resolveOpeningDeposit(parameters: ResolveOpeningDepositParameter
   return proposed
 }
 
+/** Resolves a bounded automatic refill, preferring explicit policy over server headroom. */
+export function resolveAutomaticTopUp(parameters: {
+  deposit: bigint
+  maxDeposit?: bigint | null | undefined
+  requiredCumulative: bigint
+  suggestedDeposit?: bigint | undefined
+  topUpAmount?: bigint | null | undefined
+}): bigint {
+  const { deposit, maxDeposit, requiredCumulative, suggestedDeposit, topUpAmount } = parameters
+  if (requiredCumulative <= deposit) return 0n
+  assertVoucherWithinLocalLimit({
+    cumulativeAmount: requiredCumulative,
+    maxVoucherCumulative: maxDeposit ?? null,
+  })
+  const shortfall = requiredCumulative - deposit
+  const preferred = topUpAmount ?? suggestedDeposit ?? shortfall
+  const proposed = preferred > shortfall ? preferred : shortfall
+  if (maxDeposit === null || maxDeposit === undefined) return proposed
+  const remaining = maxDeposit - deposit
+  return proposed < remaining ? proposed : remaining
+}
+
 /** Enforces the optional client-side maximum cumulative voucher authorization. */
 export function assertWithinMaxDeposit(
   cumulativeAmount: bigint,

--- a/src/tempo/session/client/Session.test.ts
+++ b/src/tempo/session/client/Session.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test } from 'vp/test'
 
 import { serialize as serializeChallenge, type Challenge } from '../../../Challenge.js'
 import * as Fetch from '../../../client/internal/Fetch.js'
+import * as MethodChallenge from '../../../client/internal/MethodChallenge.js'
 import * as Constants from '../../../Constants.js'
 import * as Credential from '../../../Credential.js'
 import * as z from '../../../zod.js'
@@ -205,7 +206,164 @@ describe('precompile client session', () => {
     expect(await response.text()).toBe(
       `${Types.formatMessageEvent('first')}${Types.formatMessageEvent('second')}`,
     )
-    expect(actions).toEqual(['open', 'voucher', 'topUp', 'voucher'])
+    expect(actions).toEqual(['open', 'topUp', 'voucher', 'voucher'])
+  })
+
+  test('tops up before signing plain HTTP vouchers through Fetch.from', async () => {
+    const challenge = makeChallenge({
+      suggestedDeposit: '100',
+      methodDetails: {
+        chainId,
+        escrowContract: tip20ChannelEscrow,
+        sessionProtocol: Constants.SessionProtocols.v2,
+      },
+    })
+    const actions: Types.SessionCredentialPayload['action'][] = []
+    const paidRequests: {
+      body: BodyInit | null
+      header: string | null
+      method: string | undefined
+    }[] = []
+    let opened: Extract<Types.SessionCredentialPayload, { action: 'open' }> | undefined
+    const rawFetch: typeof globalThis.fetch = async (_input, init) => {
+      const authorization = new Headers(init?.headers).get(Constants.Headers.authorization)
+      if (!authorization)
+        return new Response(null, {
+          status: 402,
+          headers: { [Constants.Headers.wwwAuthenticate]: serializeChallenge(challenge) },
+        })
+
+      const payload = deserialize(authorization)
+      actions.push(payload.action)
+      if (payload.action === 'open') {
+        opened = payload
+        return new Response('opened')
+      }
+      if (payload.action === 'topUp') return new Response(null, { status: 204 })
+      if (payload.action !== 'voucher' || !opened) throw new Error('expected open voucher')
+
+      paidRequests.push({
+        body: init?.body ?? null,
+        header: new Headers(init?.headers).get('x-test'),
+        method: init?.method,
+      })
+      return new Response('paid')
+    }
+    const fetch = Fetch.from({
+      fetch: rawFetch,
+      methods: [
+        session({
+          account,
+          decimals: 0,
+          getClient: () => client,
+          maxDeposit: '300',
+        }),
+      ],
+    })
+
+    expect(await (await fetch('https://example.com/resource')).text()).toBe('opened')
+    const response = await fetch('https://example.com/resource', {
+      body: 'request-body',
+      headers: { 'x-test': 'preserved' },
+      method: 'POST',
+    })
+
+    expect(await response.text()).toBe('paid')
+    expect(actions).toEqual(['open', 'topUp', 'voucher'])
+    expect(paidRequests).toEqual([{ body: 'request-body', header: 'preserved', method: 'POST' }])
+  })
+
+  test('does not top up a stored channel owned by another account', async () => {
+    const channelStore = createChannelStore()
+    const foreign = '0x0000000000000000000000000000000000000004' as Address
+    await channelStore.set({
+      chainId,
+      channelId: `0x${'44'.repeat(32)}`,
+      cumulativeAmount: 100n,
+      deposit: 100n,
+      descriptor: { ...descriptor, authorizedSigner: foreign, payer: foreign },
+      escrow: tip20ChannelEscrow,
+      opened: true,
+    })
+    const actions: Types.SessionCredentialPayload['action'][] = []
+    const challenge = makeChallenge({
+      methodDetails: {
+        chainId,
+        escrowContract: tip20ChannelEscrow,
+        sessionProtocol: Constants.SessionProtocols.v2,
+      },
+    })
+    const fetch = Fetch.from({
+      fetch: async (_input, init) => {
+        const authorization = new Headers(init?.headers).get(Constants.Headers.authorization)
+        if (!authorization)
+          return new Response(null, {
+            status: 402,
+            headers: { [Constants.Headers.wwwAuthenticate]: serializeChallenge(challenge) },
+          })
+        actions.push(deserialize(authorization).action)
+        return new Response('paid')
+      },
+      methods: [session({ account, channelStore, decimals: 0, getClient: () => client })],
+    })
+
+    expect(await (await fetch('https://example.com/resource')).text()).toBe('paid')
+    expect(actions).toEqual(['open'])
+  })
+
+  test('uses a matching server snapshot deposit when checking headroom', async () => {
+    const channelStore = createChannelStore()
+    const channelId = Channel.computeId({ ...descriptor, chainId, escrow: tip20ChannelEscrow })
+    await channelStore.set({
+      chainId,
+      channelId,
+      cumulativeAmount: 100n,
+      deposit: 100n,
+      descriptor,
+      escrow: tip20ChannelEscrow,
+      opened: true,
+    })
+    const challenge = makeChallenge({
+      methodDetails: {
+        chainId,
+        escrowContract: tip20ChannelEscrow,
+        sessionProtocol: Constants.SessionProtocols.v2,
+        sessionSnapshot: {
+          acceptedCumulative: '100',
+          chainId,
+          channelId,
+          deposit: '200',
+          descriptor,
+          escrow: tip20ChannelEscrow,
+          requiredCumulative: '200',
+          settled: '0',
+          spent: '100',
+          units: 1,
+        },
+      },
+    })
+    let updatedDeposit = 0n
+    const method = session({
+      account,
+      channelStore,
+      decimals: 0,
+      getClient: () => client,
+      onChannelUpdate: (entry) => {
+        updatedDeposit = entry.deposit
+      },
+    })
+
+    await expect(
+      MethodChallenge.handle(method, {
+        challenge,
+        context: {},
+        fetch: async () => {
+          throw new Error('unexpected top-up')
+        },
+        input: 'https://example.com/resource',
+      }),
+    ).resolves.toBeUndefined()
+    expect(updatedDeposit).toBe(200n)
   })
 
   test('opens for the current amount without client deposit configuration', async () => {

--- a/src/tempo/session/client/Session.ts
+++ b/src/tempo/session/client/Session.ts
@@ -1,8 +1,8 @@
 import { type Address, parseUnits } from 'viem'
 import { tempo as tempo_chain } from 'viem/chains'
 
+import * as MethodChallenge from '../../../client/internal/MethodChallenge.js'
 import * as MethodResponse from '../../../client/internal/MethodResponse.js'
-import * as Constants from '../../../Constants.js'
 import * as Credential from '../../../Credential.js'
 import * as Method from '../../../Method.js'
 import * as Account from '../../../viem/Account.js'
@@ -13,24 +13,33 @@ import type {
 } from '../../client/ResolveAccount.js'
 import * as defaults from '../../internal/defaults.js'
 import * as Methods from '../../Methods.js'
-import { isEventStream, requireSessionCredentialContext } from '../precompile/Protocol.js'
+import * as Channel from '../precompile/Channel.js'
+import {
+  isEventStream,
+  readSessionChallengeAmount,
+  requireSessionCredentialContext,
+} from '../precompile/Protocol.js'
 import { serializeCredential, type ChannelEntry } from './ChannelOps.js'
 import { createChannelStore, type ChannelStore } from './ChannelStore.js'
 import {
+  canSignDescriptor,
   executeCredentialPlan,
+  hasSessionAction,
   planCredential,
   resolveChallengeContext,
   resolveRecoverContext,
   sessionContextSchema,
+  type ChallengeContext,
+  type SessionContext as CredentialContext,
 } from './CredentialState.js'
-import { assertWithinMaxDeposit } from './Runtime.js'
+import { assertWithinMaxDeposit, resolveAutomaticTopUp } from './Runtime.js'
 import {
   handleSseNeedVoucher,
-  isTempoSessionChallenge,
-  managementInput,
+  isTip1034SessionChallenge,
   postTopUp,
   wrapSseResponse,
   type SsePaymentDriver,
+  type TempoSessionChallenge,
 } from './Transports.js'
 
 export { sessionContextSchema, type SessionContext } from './CredentialState.js'
@@ -67,15 +76,30 @@ export function session(parameters: session.Parameters = {}) {
   const store = channelStore ?? createChannelStore()
   const sink = { store, notifyUpdate: (entry: ChannelEntry) => onChannelUpdate?.(entry) }
 
+  const resolveCredentialAccount = async (
+    resolved: ChallengeContext,
+    context: CredentialContext | undefined,
+    entry: ChannelEntry | undefined,
+  ) => {
+    const defaultAccount = getAccount(resolved.client, context)
+    const descriptor = context?.action
+      ? context.descriptor
+      : (entry?.descriptor ??
+        resolveRecoverContext({ context, snapshot: resolved.snapshot })?.descriptor)
+    return (
+      (await resolveAccount?.({
+        account: defaultAccount,
+        chainId: resolved.chainId,
+        operation: {
+          kind: 'authorizePaymentChannel',
+          ...(descriptor ? { authority: Channel.resolveAuthorizedSigner(descriptor) } : {}),
+        },
+      })) ?? defaultAccount
+    )
+  }
+
   const method = Method.toClient(Methods.session, {
-    canHandleChallenge({ challenge }) {
-      return (
-        Constants.getMethodDetail(
-          challenge.request.methodDetails,
-          Constants.MethodDetailKeys.sessionProtocol,
-        ) === Constants.SessionProtocols.v2
-      )
-    },
+    canHandleChallenge: ({ challenge }) => isTip1034SessionChallenge(challenge),
     context: sessionContextSchema,
     async createCredential({ challenge, context }) {
       const resolved = await resolveChallengeContext({
@@ -83,22 +107,8 @@ export function session(parameters: session.Parameters = {}) {
         escrowOverride,
         getClient,
       })
-      const defaultAccount = getAccount(resolved.client, context)
       const entry = await store.get(resolved.key)
-      // Resolve recovery hints early so account selection can satisfy an existing channel authority.
-      const recoverContext = resolveRecoverContext({ context, snapshot: resolved.snapshot })
-      const descriptor = context?.action
-        ? context.descriptor
-        : (entry?.descriptor ?? recoverContext?.descriptor)
-      const account =
-        (await resolveAccount?.({
-          account: defaultAccount,
-          chainId: resolved.chainId,
-          operation: {
-            kind: 'authorizePaymentChannel',
-            ...(descriptor ? { authority: descriptor.authorizedSigner } : {}),
-          },
-        })) ?? defaultAccount
+      const account = await resolveCredentialAccount(resolved, context, entry)
       const payload = await executeCredentialPlan(
         planCredential({
           account,
@@ -114,10 +124,83 @@ export function session(parameters: session.Parameters = {}) {
     },
   })
 
+  const topUpChannelIfNeeded = async ({
+    challenge,
+    channel,
+    deposit,
+    fetch,
+    input,
+    requiredCumulative,
+  }: {
+    challenge: TempoSessionChallenge
+    channel: ChannelEntry
+    deposit: bigint
+    fetch: typeof globalThis.fetch
+    input: RequestInfo | URL
+    requiredCumulative: bigint
+  }) => {
+    const knownDeposit = channel.deposit > deposit ? channel.deposit : deposit
+    const additionalDeposit = resolveAutomaticTopUp({
+      deposit: knownDeposit,
+      maxDeposit,
+      requiredCumulative,
+      suggestedDeposit:
+        challenge.request.suggestedDeposit === undefined
+          ? undefined
+          : BigInt(challenge.request.suggestedDeposit),
+      topUpAmount,
+    })
+    if (additionalDeposit > 0n)
+      await postTopUp({
+        additionalDeposit,
+        challenge,
+        channel,
+        channelId: channel.channelId,
+        createSessionCredential: (challenge, context) =>
+          method.createCredential({ challenge, context }),
+        fetch,
+        input,
+      })
+    const nextDeposit = knownDeposit + additionalDeposit
+    if (nextDeposit === channel.deposit) return
+    channel.deposit = nextDeposit
+    await store.set(channel)
+    sink.notifyUpdate(channel)
+  }
+
+  MethodChallenge.register(method, async ({ challenge, context, fetch, input }) => {
+    if (!isTip1034SessionChallenge(challenge)) return
+    const sessionContext = context === undefined ? undefined : sessionContextSchema.parse(context)
+    if (hasSessionAction(sessionContext)) return
+    const resolved = await resolveChallengeContext({ challenge, escrowOverride, getClient })
+    const channel = await store.get(resolved.key)
+    if (!channel?.opened) return
+    const snapshot =
+      resolved.snapshot?.channelId.toLowerCase() === channel.channelId.toLowerCase()
+        ? resolved.snapshot
+        : undefined
+    const nextCumulative = channel.cumulativeAmount + readSessionChallengeAmount(challenge)
+    const snapshotRequired = snapshot ? BigInt(snapshot.requiredCumulative) : nextCumulative
+    const requiredCumulative = snapshotRequired > nextCumulative ? snapshotRequired : nextCumulative
+    const snapshotDeposit = snapshot ? BigInt(snapshot.deposit) : channel.deposit
+    const deposit = snapshotDeposit > channel.deposit ? snapshotDeposit : channel.deposit
+    if (requiredCumulative <= deposit && deposit === channel.deposit) return
+    const account = await resolveCredentialAccount(resolved, sessionContext, channel)
+    if (!canSignDescriptor(account, channel.descriptor)) return
+    await topUpChannelIfNeeded({
+      challenge,
+      channel,
+      deposit,
+      fetch,
+      input,
+      requiredCumulative,
+    })
+  })
+
   return MethodResponse.register(
     method,
     async ({ challenge, credential, fetch, headers, input, refetch, response, signal }) => {
-      if (!isTempoSessionChallenge(challenge)) return response
+      if (!isTip1034SessionChallenge(challenge)) return response
       if (!isEventStream(response)) {
         const credentialContext = requireSessionCredentialContext(
           Credential.deserialize(credential).payload,
@@ -145,27 +228,16 @@ export function session(parameters: session.Parameters = {}) {
           method.createCredential({ challenge, context }),
         fetch,
         getChannel: () => channel ?? null,
-        managementInput,
-        async topUpIfNeeded({ channelId, deposit, requiredCumulative }) {
-          if (requiredCumulative <= deposit || !channel) return
-          const shortfall = requiredCumulative - deposit
-          const preferred = topUpAmount ?? shortfall
-          const proposed = preferred > shortfall ? preferred : shortfall
-          const available = maxDeposit === undefined ? proposed : maxDeposit - deposit
-          const additionalDeposit = proposed < available ? proposed : available
-          await postTopUp({
-            additionalDeposit,
+        async topUpIfNeeded({ deposit, requiredCumulative }) {
+          if (!channel) return
+          await topUpChannelIfNeeded({
             challenge,
             channel,
-            channelId,
-            createSessionCredential: (challenge, context) =>
-              method.createCredential({ challenge, context }),
+            deposit: channel.deposit > deposit ? channel.deposit : deposit,
             fetch,
             input,
+            requiredCumulative,
           })
-          channel.deposit += additionalDeposit
-          await store.set(channel)
-          sink.notifyUpdate(channel)
         },
       } satisfies SsePaymentDriver
 

--- a/src/tempo/session/client/SessionManager.test.ts
+++ b/src/tempo/session/client/SessionManager.test.ts
@@ -753,10 +753,11 @@ describe('Session', () => {
       await restarted.fetch('https://api.example.com/data')
 
       // The first request carries no hint header; after the 402 the restarted
-      // manager resumes the persisted channel from the entry index with a
-      // voucher rather than opening a new one.
+      // manager tops up and resumes the full persisted channel rather than
+      // opening a new one.
       expect(new Headers(resumeFetch.mock.calls[0]?.[1]?.headers).get('Payment-Session')).toBeNull()
-      expect(posted[0]).toMatchObject({ action: 'voucher', channelId })
+      expect(posted.map((payload) => payload.action)).toEqual(['topUp', 'voucher'])
+      expect(posted[1]).toMatchObject({ channelId })
     })
 
     test('persists opened channels and deletes closed channels when supported', async () => {
@@ -1399,6 +1400,51 @@ describe('Session', () => {
       expect(calledHeaders.get('content-type')).toBe('application/json')
       expect(calledHeaders.get('x-custom')).toBe('value')
       expect(calledHeaders.get('accept')).toBe('text/event-stream')
+    })
+  })
+
+  describe('.ws()', () => {
+    test('tops up a full persisted channel before constructing the socket', async () => {
+      const events: string[] = []
+      const { map, set, store } = makeChannelStore([
+        channelEntry({ cumulativeAmount: 1_000_000n, deposit: 1_000_000n }),
+      ])
+      set.mockImplementation((entry) => {
+        map.set(entryKey(entry), entry)
+        events.push(`set:${entry.deposit}:${entry.cumulativeAmount}`)
+      })
+      const fetch = vi.fn(async (_input, init?: RequestInit) => {
+        const authorization = new Headers(init?.headers).get(Constants.Headers.authorization)
+        if (!authorization) {
+          events.push('probe')
+          return make402Response(makeChallenge({ suggestedDeposit: '1000000' }))
+        }
+        const payload = Credential.deserialize<SessionCredentialPayload>(authorization).payload
+        if (payload.action !== 'topUp') throw new Error(`unexpected ${payload.action} fetch`)
+        events.push('topUp')
+        return new Response(null, { status: 204 })
+      })
+      function WebSocket() {
+        events.push('socket')
+        throw new Error('stop after preparation')
+      }
+      const s = sessionManager({
+        account,
+        client,
+        fetch: fetch as typeof globalThis.fetch,
+        maxDeposit: '3',
+        channelStore: store,
+        webSocket: WebSocket as never,
+      })
+
+      await expect(s.ws('wss://api.example.com/socket')).rejects.toThrow('stop after preparation')
+      expect(events).toEqual([
+        'probe',
+        'topUp',
+        'set:2000000:1000000',
+        'set:2000000:2000000',
+        'socket',
+      ])
     })
   })
 

--- a/src/tempo/session/client/SessionManager.ts
+++ b/src/tempo/session/client/SessionManager.ts
@@ -4,6 +4,7 @@ import { tempo as tempo_chain } from 'viem/chains'
 
 import * as Challenge from '../../../Challenge.js'
 import * as Fetch from '../../../client/internal/Fetch.js'
+import * as MethodChallenge from '../../../client/internal/MethodChallenge.js'
 import * as MethodResponse from '../../../client/internal/MethodResponse.js'
 import * as Constants from '../../../Constants.js'
 import * as Account from '../../../viem/Account.js'
@@ -16,7 +17,7 @@ import { hydrateSessionSnapshot, type SessionContext } from '../client/Credentia
 import { session as sessionPlugin } from '../client/Session.js'
 import * as Channel from '../precompile/Channel.js'
 import { deserializeSessionReceipt } from '../precompile/Protocol.js'
-import { readSessionChallengeAmount, type SessionReceipt } from '../precompile/Protocol.js'
+import type { SessionReceipt } from '../precompile/Protocol.js'
 import {
   deserializeSnapshot as deserializeSessionSnapshot,
   serializeSnapshot as serializeSessionSnapshot,
@@ -34,6 +35,7 @@ import {
   dispatchSessionEvent,
   restoreCumulativeAuthorization,
   restoreRuntimeSnapshot as restoreRuntimeStateSnapshot,
+  resolveAutomaticTopUp,
   type RuntimeSnapshot,
 } from './Runtime.js'
 import { closeSocketSession } from './Runtime.js'
@@ -41,7 +43,6 @@ import {
   closeHttpSession,
   getSessionSnapshot,
   isTempoSessionChallenge,
-  managementInput,
   postTopUp,
   retryHttpPaymentRequired,
   type TempoSessionChallenge,
@@ -281,6 +282,7 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
     escrow: parameters.escrow,
     decimals: config.decimals,
     maxDeposit: parameters.maxDeposit,
+    topUpAmount: parameters.topUpAmount,
     channelStore: store,
     onChannelUpdate(entry) {
       if (entry.channelId !== runtime.channel?.channelId) runtime.spent = 0n
@@ -317,17 +319,6 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
       if (use) use.challengesReceived++
       runtime.lastChallenge = challenge
       dispatch({ type: 'challengeReceived', challengeId: challenge.id })
-      if (runtime.channel?.opened && runtime.lastUrl) {
-        const requiredCumulative =
-          runtime.channel.cumulativeAmount + readSessionChallengeAmount(challenge)
-        await topUpIfNeeded({
-          challenge,
-          input: runtime.lastUrl,
-          channelId: runtime.channel.channelId,
-          deposit: runtime.channel.deposit,
-          requiredCumulative,
-        })
-      }
       return undefined
     },
   })
@@ -370,16 +361,12 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
     const snapshot = deserializeSessionSnapshot(header)
     const client = await getClient({ chainId: snapshot.chainId })
     const defaultAccount = getAccount(client)
-    const authority =
-      BigInt(snapshot.descriptor.authorizedSigner) === 0n
-        ? snapshot.descriptor.payer
-        : snapshot.descriptor.authorizedSigner
     const account =
       (await parameters.resolveAccount?.({
         account: defaultAccount,
         chainId: snapshot.chainId,
         operation: {
-          authority,
+          authority: Channel.resolveAuthorizedSigner(snapshot.descriptor),
           kind: 'authorizePaymentChannel',
         },
       })) ?? defaultAccount
@@ -524,9 +511,11 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
     challenge: TempoSessionChallenge
     channelId: Hex.Hex
     input: RequestInfo | URL
+    knownDeposit?: bigint | undefined
   }) {
+    const { knownDeposit, ...topUp } = parameters
     const receipt = await postTopUp({
-      ...parameters,
+      ...topUp,
       channel: runtime.channel,
       createSessionCredential,
       fetch: config.fetch,
@@ -538,6 +527,7 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
       channelId: parameters.channelId,
       challengeId: runtime.lastChallenge?.id,
       currentState: runtime.state,
+      knownDeposit,
       receipt,
       spent: runtime.spent,
     })
@@ -555,20 +545,26 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
   }
 
   async function topUpIfNeeded(parameters: TopUpRequirement) {
-    if (parameters.requiredCumulative <= parameters.deposit) return
-    assertVoucherWithinLocalLimit(parameters.requiredCumulative)
-    const shortfall = parameters.requiredCumulative - parameters.deposit
-    const preferred = config.topUpAmount ?? shortfall
-    const proposed = preferred > shortfall ? preferred : shortfall
-    const available =
-      config.maxVoucherCumulative === null
-        ? proposed
-        : config.maxVoucherCumulative - parameters.deposit
+    const channelDeposit =
+      runtime.channel?.channelId === parameters.channelId ? runtime.channel.deposit : 0n
+    const deposit = channelDeposit > parameters.deposit ? channelDeposit : parameters.deposit
+    const additionalDeposit = resolveAutomaticTopUp({
+      deposit,
+      maxDeposit: config.maxVoucherCumulative,
+      requiredCumulative: parameters.requiredCumulative,
+      suggestedDeposit:
+        parameters.challenge.request.suggestedDeposit === undefined
+          ? undefined
+          : BigInt(parameters.challenge.request.suggestedDeposit),
+      topUpAmount: config.topUpAmount,
+    })
+    if (additionalDeposit === 0n) return
     await postTopUpAndApply({
       challenge: parameters.challenge,
       input: parameters.input,
       channelId: parameters.channelId,
-      additionalDeposit: proposed < available ? proposed : available,
+      additionalDeposit,
+      knownDeposit: deposit,
     })
   }
 
@@ -730,7 +726,6 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
     getChannel: () => runtime.channel,
     getChallenge: () => runtime.lastChallenge,
     assertVoucherWithinLocalLimit,
-    managementInput,
     acceptReceipt(receipt: SessionReceipt) {
       updateSpentFromReceipt(receipt)
     },
@@ -788,7 +783,16 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
       const liveHint = runtime.channel?.opened ? runtime.channel.channelId : undefined
 
       const prepared = await prepareWebSocketSession({
-        createSessionCredential,
+        async createSessionCredential(challenge, context) {
+          runtime.lastChallenge = challenge
+          await MethodChallenge.handle(method, {
+            challenge,
+            context,
+            fetch: config.fetch,
+            input: probeUrl,
+          })
+          return createSessionCredential(challenge, context)
+        },
         fetch: config.fetch,
         input,
         onProbeUrl(httpUrl) {

--- a/src/tempo/session/client/Transports.test.ts
+++ b/src/tempo/session/client/Transports.test.ts
@@ -85,6 +85,7 @@ describe('HttpManagement', () => {
         methodDetails: {
           chainId: 4217,
           escrowContract: undefined,
+          sessionProtocol: Constants.SessionProtocols.v2,
           ...(snapshot && { [Constants.MethodDetailKeys.sessionSnapshot]: snapshot }),
         },
       },
@@ -218,6 +219,36 @@ describe('HttpManagement', () => {
       expect(receipt?.acceptedCumulative).toBe('8')
       expect(createSessionCredential).toHaveBeenCalledOnce()
       expect(fetch).toHaveBeenCalledOnce()
+    })
+
+    test('postTopUp retries once with the management route challenge', async () => {
+      const routeChallenge = { ...challenge(), id: 'management-challenge' } as TempoSessionChallenge
+      const createSessionCredential = vi.fn(async (challenge_) => `top-up-${challenge_.id}`)
+      const fetch = vi
+        .fn()
+        .mockResolvedValueOnce(response402(routeChallenge))
+        .mockResolvedValueOnce(
+          new Response(null, {
+            status: 204,
+            headers: {
+              [Constants.Headers.paymentReceipt]: receiptHeader(8n, 5n, routeChallenge.id),
+            },
+          }),
+        )
+
+      const receipt = await postTopUp({
+        additionalDeposit: 3n,
+        challenge: challenge(),
+        channel: channel(),
+        channelId,
+        createSessionCredential,
+        fetch,
+        input: 'https://example.test/resource',
+      })
+
+      expect(receipt?.challengeId).toBe(routeChallenge.id)
+      expect(createSessionCredential).toHaveBeenCalledTimes(2)
+      expect(authorizationHeader(fetch.mock.calls[1]?.[1])).toBe(`top-up-${routeChallenge.id}`)
     })
 
     test('retryHttpPaymentRequired signs the server-required cumulative voucher', async () => {
@@ -874,7 +905,6 @@ describe('SseDriver', () => {
       fetch: vi.fn(async () => new Response(null, { status: 204 })),
       getChallenge: () => currentChallenge,
       getChannel: () => channel,
-      managementInput: (input) => input,
       async topUpIfNeeded() {},
     })
 
@@ -1011,6 +1041,7 @@ describe('WsDriver', () => {
         methodDetails: {
           chainId: 4217,
           escrowContract: tip20ChannelEscrow,
+          sessionProtocol: Constants.SessionProtocols.v2,
         },
         recipient: '0x742d35cc6634c0532925a3b844bc9e7595f8fe00',
       },

--- a/src/tempo/session/client/Transports.ts
+++ b/src/tempo/session/client/Transports.ts
@@ -268,6 +268,8 @@ export type ApplyTopUpResultParameters = {
   challengeId?: string | undefined
   /** Current active machine state, used to preserve paid unit count when possible. */
   currentState: SessionState
+  /** Highest deposit known before the top-up. */
+  knownDeposit?: bigint | undefined
   /** Receipt returned by the top-up POST, when present. */
   receipt?: SessionReceipt | undefined
   /** Latest locally observed spend in raw units. */
@@ -362,17 +364,27 @@ export function resolveManualTopUp(parameters: ResolveManualTopUpParameters): Ma
 /**
  * Applies local deposit and state bookkeeping for a top-up response.
  *
- * `deposit` is updated from the top-up amount. Receipt cumulative values only
- * update accepted spend authorization; they do not replace deposit.
+ * Deposit advances from the highest known baseline. Receipt cumulative values
+ * only update accepted spend authorization; they do not replace deposit.
  */
 export function applyTopUpResult(
   parameters: ApplyTopUpResultParameters,
 ): AppliedTopUpResult | undefined {
-  const { additionalDeposit, channel, channelId, challengeId, currentState, receipt, spent } =
-    parameters
+  const {
+    additionalDeposit,
+    channel,
+    channelId,
+    challengeId,
+    currentState,
+    knownDeposit,
+    receipt,
+    spent,
+  } = parameters
   if (channel?.channelId !== channelId) return undefined
 
-  channel.deposit += additionalDeposit
+  const baseline =
+    knownDeposit !== undefined && knownDeposit > channel.deposit ? knownDeposit : channel.deposit
+  channel.deposit = baseline + additionalDeposit
 
   if (receipt) return { channel, state: activeStateFromReceipt(receipt, channel) }
   if (!challengeId) return { channel }
@@ -521,6 +533,19 @@ export function isTempoSessionChallenge(
   )
 }
 
+/** Returns true when a challenge selects the TIP-1034 session protocol. */
+export function isTip1034SessionChallenge(
+  challenge: Challenge.Challenge,
+): challenge is TempoSessionChallenge {
+  return (
+    isTempoSessionChallenge(challenge) &&
+    Constants.getMethodDetail(
+      challenge.request.methodDetails,
+      Constants.MethodDetailKeys.sessionProtocol,
+    ) === Constants.SessionProtocols.v2
+  )
+}
+
 /** Reads a server-provided session snapshot from challenge method details. */
 export function getSessionSnapshot(challenge: TempoSessionChallenge): SessionSnapshot | undefined {
   return Constants.getMethodDetail<SessionSnapshot>(
@@ -594,20 +619,46 @@ export async function postTopUp(
     throw new Error('Cannot top up session: no local channel descriptor available.')
   }
 
-  const credential = await parameters.createSessionCredential(parameters.challenge, {
-    action: 'topUp',
-    channelId,
-    descriptor: channel.descriptor,
-    additionalDepositRaw: parameters.additionalDeposit.toString(),
-  })
-  const response = await parameters.fetch(managementInput(parameters.input), {
-    method: 'POST',
-    headers: { [Constants.Headers.authorization]: credential },
+  const response = await postManagementCredential({
+    challenge: parameters.challenge,
+    context: {
+      action: 'topUp',
+      channelId,
+      descriptor: channel.descriptor,
+      additionalDepositRaw: parameters.additionalDeposit.toString(),
+    },
+    createSessionCredential: parameters.createSessionCredential,
+    fetch: parameters.fetch,
+    input: parameters.input,
   })
   if (!response.ok) throw new Error(`Top-up POST failed with status ${response.status}`)
 
   const receiptHeader = response.headers.get(Constants.Headers.paymentReceipt)
   return receiptHeader ? deserializeSessionReceipt(receiptHeader) : undefined
+}
+
+/** Posts a management credential and retries once with a refreshed TIP-1034 challenge. */
+async function postManagementCredential(parameters: {
+  challenge: TempoSessionChallenge
+  context: SessionContext
+  createSessionCredential: CreateSessionCredential
+  fetch: typeof globalThis.fetch
+  input: RequestInfo | URL
+}): Promise<Response> {
+  const post = async (challenge: TempoSessionChallenge) =>
+    parameters.fetch(managementInput(parameters.input), {
+      method: 'POST',
+      headers: {
+        [Constants.Headers.authorization]: await parameters.createSessionCredential(
+          challenge,
+          parameters.context,
+        ),
+      },
+    })
+  const response = await post(parameters.challenge)
+  if (response.status !== 402) return response
+  const challenge = Challenge.fromResponseList(response).find(isTip1034SessionChallenge)
+  return challenge ? post(challenge) : response
 }
 
 /** Retries an HTTP 402 when the server snapshot asks for more voucher headroom. */
@@ -662,7 +713,7 @@ export function resolveRetryHttpPaymentContext(parameters: {
   channel: ChannelEntry | null
   response: Response
 }): RetryHttpPaymentContext | undefined {
-  const challenge = Challenge.fromResponseList(parameters.response).find(isTempoSessionChallenge)
+  const challenge = Challenge.fromResponseList(parameters.response).find(isTip1034SessionChallenge)
   if (!challenge) return undefined
 
   const snapshot = getSessionSnapshot(challenge)
@@ -705,7 +756,7 @@ export async function closeHttpSession(
 
   let response = await postClose(parameters.target.challenge)
   if (response.status === 402) {
-    const challenge = Challenge.fromResponseList(response).find(isTempoSessionChallenge)
+    const challenge = Challenge.fromResponseList(response).find(isTip1034SessionChallenge)
     if (challenge) {
       parameters.setChallenge?.(challenge)
       response = await postClose(challenge, true)
@@ -768,8 +819,6 @@ export type OpenSseSessionParameters = {
   getChallenge(): TempoSessionChallenge | null
   /** Validates a cumulative amount against local client policy. */
   assertVoucherWithinLocalLimit(cumulativeAmount: bigint): void
-  /** Converts a resource URL to the server's session management URL. */
-  managementInput(input: RequestInfo | URL): RequestInfo | URL
   /** Applies an incoming receipt to manager state. */
   acceptReceipt(receipt: SessionReceipt): void
   /** Performs an automatic channel top-up when deposit is insufficient. */
@@ -783,7 +832,6 @@ export type SsePaymentDriver = Pick<
   | 'createSessionCredential'
   | 'fetch'
   | 'getChannel'
-  | 'managementInput'
   | 'topUpIfNeeded'
 >
 
@@ -1018,17 +1066,13 @@ export async function handleSseNeedVoucher(
   })
   if (resolution.status !== 'ready') return
 
-  const credential = await parameters.driver.createSessionCredential(
-    parameters.challenge,
-    resolution.context,
-  )
-  const voucherResponse = await parameters.driver.fetch(
-    parameters.driver.managementInput(parameters.input),
-    {
-      method: 'POST',
-      headers: { [Constants.Headers.authorization]: credential },
-    },
-  )
+  const voucherResponse = await postManagementCredential({
+    challenge: parameters.challenge,
+    context: resolution.context,
+    createSessionCredential: parameters.driver.createSessionCredential,
+    fetch: parameters.driver.fetch,
+    input: parameters.input,
+  })
   if (!voucherResponse.ok) {
     throw new Error(`Voucher POST failed with status ${voucherResponse.status}`)
   }
@@ -1186,7 +1230,7 @@ export async function prepareWebSocketSession(
     )
   }
 
-  const challenge = Challenge.fromResponseList(probe).find(isTempoSessionChallenge)
+  const challenge = Challenge.fromResponseList(probe).find(isTip1034SessionChallenge)
   if (!challenge) {
     throw new Error(
       'No payment challenge received from HTTP endpoint for this WebSocket URL. The server may not require payment or did not advertise a challenge.',

--- a/src/tempo/session/precompile/Channel.test.ts
+++ b/src/tempo/session/precompile/Channel.test.ts
@@ -27,6 +27,15 @@ const transaction = {
 } as const satisfies Channel.ExpiringNonceTransaction
 
 describe('precompile Channel.computeId', () => {
+  test('uses the payer when the descriptor delegates to the zero address', () => {
+    expect(
+      Channel.resolveAuthorizedSigner({
+        ...descriptor,
+        authorizedSigner: '0x0000000000000000000000000000000000000000',
+      }),
+    ).toBe(descriptor.payer)
+  })
+
   test('returns deterministic 32-byte hash for fixed inputs', () => {
     const id = Channel.computeId({ ...descriptor, chainId })
     expect(Channel.computeId({ ...descriptor, chainId })).toBe(id)

--- a/src/tempo/session/precompile/Channel.ts
+++ b/src/tempo/session/precompile/Channel.ts
@@ -9,6 +9,11 @@ import type { ChannelDescriptor } from './Protocol.js'
 /** Re-export of the TIP-1034 channel descriptor shape. */
 export type { ChannelDescriptor } from './Protocol.js'
 
+/** Resolves the descriptor's effective voucher signer; zero delegates to the payer. */
+export function resolveAuthorizedSigner(descriptor: ChannelDescriptor): Address {
+  return BigInt(descriptor.authorizedSigner) === 0n ? descriptor.payer : descriptor.authorizedSigner
+}
+
 /** Tempo transaction shape used to derive the TIP-1034 `expiringNonceHash`. */
 export type ExpiringNonceTransaction = (
   | z_TransactionSerializableTempo

--- a/src/tempo/session/server/RequestState.test.ts
+++ b/src/tempo/session/server/RequestState.test.ts
@@ -544,9 +544,16 @@ describe('SessionSnapshotHints', () => {
       }
     })
 
-    test('omits hints for missing, non-precompile, or finalized channels', async () => {
+    test('omits hints for missing, non-precompile, closing, or finalized channels', async () => {
       await expect(
         resolveSessionSnapshot({ amount: 1n, channelId, store: store(null) }),
+      ).resolves.toBe(undefined)
+      await expect(
+        resolveSessionSnapshot({
+          amount: 1n,
+          channelId,
+          store: store(channel({ closeRequestedAt: 1n })),
+        }),
       ).resolves.toBe(undefined)
       await expect(
         resolveSessionSnapshot({

--- a/src/tempo/session/server/RequestState.ts
+++ b/src/tempo/session/server/RequestState.ts
@@ -143,6 +143,7 @@ export async function resolveSessionSnapshot(
   const channel = await store.getChannel(ChannelStore.normalizeChannelId(channelId))
   if (!channel || !ChannelStore.isPrecompileState(channel)) return undefined
   if (channel.finalized) return undefined
+  if (channel.closeRequestedAt !== 0n) return undefined
   if (!channel.highestVoucher) return undefined
   if (channel.highestVoucher.cumulativeAmount !== channel.highestVoucherAmount) return undefined
   if (expected && !matchesSnapshotPaymentFields(channel, expected)) return undefined
@@ -151,8 +152,7 @@ export async function resolveSessionSnapshot(
     acceptedCumulative: channel.highestVoucherAmount.toString(),
     chainId: channel.chainId,
     channelId: channel.channelId,
-    closeRequestedAt:
-      channel.closeRequestedAt === 0n ? undefined : channel.closeRequestedAt.toString(),
+    closeRequestedAt: undefined,
     deposit: channel.deposit.toString(),
     descriptor: channel.descriptor,
     escrow: channel.escrowContract,


### PR DESCRIPTION
Fixes automatic Tempo session top-ups before credentials are signed.

- uses one shared pre-sign hook for HTTP, SSE, and WebSocket
- applies `topUpAmount`, then bounded `suggestedDeposit`, then the exact shortfall
- retries management credentials against refreshed TIP-1034 challenges
- excludes closing channels from recovery

Supersedes #688.

## Validation

- 231 focused session tests
- 38 focused Fetch 402 retry tests
- `pnpm check:ci`
- `pnpm check:types`
- `pnpm check:types:html`
- `pnpm check:types:examples`
- `pnpm build`
