### PR TITLE
fix: preserve session headroom across websocket top-ups

### DIFF
--- a/.changeset/calm-websockets-topup.md
+++ b/.changeset/calm-websockets-topup.md
@@ -1,0 +1,6 @@
+---
+'mppx': patch
+---
+
+Top up a full reusable session channel before signing its WebSocket opening
+credential.

--- a/.changeset/calm-websockets-topup.md
+++ b/.changeset/calm-websockets-topup.md
@@ -3,4 +3,7 @@
 ---
 
 Top up a full reusable session channel before signing its WebSocket opening
-credential.
+credential. Reuse the server's suggested deposit as refill headroom for
+automatic top-ups, bounded by the client's `maxDeposit` policy.
+
+Do not advertise bootstrap snapshots for channels already marked as closing.

--- a/src/tempo/session/client/Runtime.test.ts
+++ b/src/tempo/session/client/Runtime.test.ts
@@ -31,6 +31,7 @@ import {
   parseManagerAmount,
   reduce,
   resolveCloseTarget,
+  resolveAutomaticTopUp,
   resolveNeedVoucherTransition,
   resolveOpeningDeposit,
   restoreCumulativeAuthorization,
@@ -923,6 +924,41 @@ describe('LocalAuthorization', () => {
       expect(() => resolveOpeningDeposit({ maxDeposit: 50n, requestAmount: 100n })).toThrow(
         'requested voucher amount 100 exceeds local maxDeposit 50',
       )
+    })
+
+    test('uses suggested deposit as automatic refill headroom within the local cap', () => {
+      expect(
+        resolveAutomaticTopUp({
+          deposit: 5_000_000n,
+          maxDeposit: 20_000_000n,
+          requiredCumulative: 5_000_001n,
+          suggestedDepositRaw: '5000000',
+        }),
+      ).toBe(5_000_000n)
+      expect(
+        resolveAutomaticTopUp({
+          deposit: 18_000_000n,
+          maxDeposit: 20_000_000n,
+          requiredCumulative: 18_000_001n,
+          suggestedDepositRaw: '5000000',
+        }),
+      ).toBe(2_000_000n)
+      expect(
+        resolveAutomaticTopUp({
+          deposit: 5_000_000n,
+          maxDeposit: null,
+          requiredCumulative: 11_000_000n,
+          suggestedDepositRaw: '5000000',
+        }),
+      ).toBe(6_000_000n)
+      expect(() =>
+        resolveAutomaticTopUp({
+          deposit: 5_000_000n,
+          maxDeposit: 5_000_000n,
+          requiredCumulative: 5_000_001n,
+          suggestedDepositRaw: '5000000',
+        }),
+      ).toThrow('requested voucher amount 5000001 exceeds local maxDeposit 5000000')
     })
 
     test('enforces optional maxDeposit through the compatibility helper', () => {

--- a/src/tempo/session/client/Runtime.ts
+++ b/src/tempo/session/client/Runtime.ts
@@ -467,6 +467,18 @@ export type ResolveOpeningDepositParameters = {
   suggestedDepositRaw?: string | undefined
 }
 
+/** Inputs for sizing an automatic channel top-up. */
+export type ResolveAutomaticTopUpParameters = {
+  /** Current channel deposit in raw token units. */
+  deposit: bigint
+  /** Optional local maximum cumulative deposit/authorization boundary. */
+  maxDeposit: bigint | null | undefined
+  /** Minimum cumulative voucher amount the server needs. */
+  requiredCumulative: bigint
+  /** Server-suggested refill amount in raw token units. */
+  suggestedDepositRaw?: string | undefined
+}
+
 /** Throws when a cumulative voucher amount exceeds the caller's local cap. */
 export function assertVoucherWithinLocalLimit(parameters: LocalVoucherLimitParameters): void {
   const { cumulativeAmount, maxVoucherCumulative } = parameters
@@ -531,6 +543,30 @@ export function resolveOpeningDeposit(parameters: ResolveOpeningDepositParameter
       : requestAmount
   if (maxDeposit !== undefined) return proposed < maxDeposit ? proposed : maxDeposit
   return proposed
+}
+
+/**
+ * Resolves an automatic top-up while preserving the caller's authorization cap.
+ *
+ * The server suggestion is used as refill headroom after a channel fills, not
+ * only as the opening deposit. The exact shortfall remains the minimum so a
+ * request can never be underfunded.
+ */
+export function resolveAutomaticTopUp(parameters: ResolveAutomaticTopUpParameters): bigint {
+  const { deposit, maxDeposit, requiredCumulative, suggestedDepositRaw } = parameters
+  if (requiredCumulative <= deposit) return 0n
+  assertVoucherWithinLocalLimit({
+    cumulativeAmount: requiredCumulative,
+    maxVoucherCumulative: maxDeposit ?? null,
+  })
+
+  const shortfall = requiredCumulative - deposit
+  const suggested = suggestedDepositRaw !== undefined ? BigInt(suggestedDepositRaw) : 0n
+  const proposed = suggested > shortfall ? suggested : shortfall
+  if (maxDeposit === null || maxDeposit === undefined) return proposed
+
+  const remaining = maxDeposit - deposit
+  return proposed < remaining ? proposed : remaining
 }
 
 /** Enforces the optional client-side maximum cumulative voucher authorization. */

--- a/src/tempo/session/client/Session.test.ts
+++ b/src/tempo/session/client/Session.test.ts
@@ -152,6 +152,7 @@ describe('precompile client session', () => {
     })
     let useExternalCredential = true
     const actions: Types.SessionCredentialPayload['action'][] = []
+    const payloads: Types.SessionCredentialPayload[] = []
     const rawFetch: typeof globalThis.fetch = async (_input, init) => {
       const authorization = new Headers(init?.headers).get(Constants.Headers.authorization)
       if (!authorization)
@@ -162,15 +163,16 @@ describe('precompile client session', () => {
 
       const payload = deserialize(authorization)
       actions.push(payload.action)
+      payloads.push(payload)
       if (init?.method === 'POST' || payload.action === 'open')
         return new Response(null, { status: 204 })
       if (payload.action !== 'voucher') throw new Error('expected voucher')
 
       const receipt = Types.createSessionReceipt({
-        acceptedCumulative: 200n,
+        acceptedCumulative: 150n,
         challengeId: challenge.id,
         channelId: payload.channelId,
-        spent: 200n,
+        spent: 150n,
       })
       return new Response(
         [
@@ -179,7 +181,7 @@ describe('precompile client session', () => {
             acceptedCumulative: '100',
             channelId: payload.channelId,
             deposit: '100',
-            requiredCumulative: '200',
+            requiredCumulative: '150',
           }),
           Types.formatMessageEvent('second'),
           Types.formatReceiptEvent(receipt),
@@ -206,6 +208,10 @@ describe('precompile client session', () => {
       `${Types.formatMessageEvent('first')}${Types.formatMessageEvent('second')}`,
     )
     expect(actions).toEqual(['open', 'voucher', 'topUp', 'voucher'])
+    expect(payloads.find((payload) => payload.action === 'topUp')).toMatchObject({
+      action: 'topUp',
+      additionalDeposit: '100',
+    })
   })
 
   test('opens for the current amount without client deposit configuration', async () => {

--- a/src/tempo/session/client/Session.ts
+++ b/src/tempo/session/client/Session.ts
@@ -23,7 +23,7 @@ import {
   resolveRecoverContext,
   sessionContextSchema,
 } from './CredentialState.js'
-import { assertWithinMaxDeposit } from './Runtime.js'
+import { assertWithinMaxDeposit, resolveAutomaticTopUp } from './Runtime.js'
 import {
   handleSseNeedVoucher,
   isTempoSessionChallenge,
@@ -145,7 +145,12 @@ export function session(parameters: session.Parameters = {}) {
         managementInput,
         async topUpIfNeeded({ channelId, deposit, requiredCumulative }) {
           if (requiredCumulative <= deposit || !channel) return
-          const additionalDeposit = requiredCumulative - deposit
+          const additionalDeposit = resolveAutomaticTopUp({
+            deposit,
+            maxDeposit,
+            requiredCumulative,
+            suggestedDepositRaw: challenge.request.suggestedDeposit,
+          })
           await postTopUp({
             additionalDeposit,
             challenge,

--- a/src/tempo/session/client/SessionManager.ts
+++ b/src/tempo/session/client/SessionManager.ts
@@ -783,6 +783,18 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
         onProbeUrl(httpUrl) {
           runtime.lastUrl = httpUrl.toString()
         },
+        async prepareChallenge(challenge) {
+          runtime.lastChallenge = challenge
+          const channel = runtime.channel
+          if (!channel?.opened || !runtime.lastUrl) return
+          await topUpIfNeeded({
+            challenge,
+            input: runtime.lastUrl,
+            channelId: channel.channelId,
+            deposit: channel.deposit,
+            requiredCumulative: channel.cumulativeAmount + readSessionChallengeAmount(challenge),
+          })
+        },
         probeInit: requestInitWithSessionHint(probeUrl, signalInit, liveHint),
         signal: init?.signal,
       })

--- a/src/tempo/session/client/SessionManager.ts
+++ b/src/tempo/session/client/SessionManager.ts
@@ -34,6 +34,7 @@ import {
   dispatchSessionEvent,
   restoreCumulativeAuthorization,
   restoreRuntimeSnapshot as restoreRuntimeStateSnapshot,
+  resolveAutomaticTopUp,
   type RuntimeSnapshot,
 } from './Runtime.js'
 import { closeSocketSession } from './Runtime.js'
@@ -552,12 +553,17 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
 
   async function topUpIfNeeded(parameters: TopUpRequirement) {
     if (parameters.requiredCumulative <= parameters.deposit) return
-    assertVoucherWithinLocalLimit(parameters.requiredCumulative)
+    const additionalDeposit = resolveAutomaticTopUp({
+      deposit: parameters.deposit,
+      maxDeposit: config.maxVoucherCumulative,
+      requiredCumulative: parameters.requiredCumulative,
+      suggestedDepositRaw: parameters.challenge.request.suggestedDeposit,
+    })
     await postTopUpAndApply({
       challenge: parameters.challenge,
       input: parameters.input,
       channelId: parameters.channelId,
-      additionalDeposit: parameters.requiredCumulative - parameters.deposit,
+      additionalDeposit,
     })
   }
 

--- a/src/tempo/session/client/Transports.test.ts
+++ b/src/tempo/session/client/Transports.test.ts
@@ -220,6 +220,36 @@ describe('HttpManagement', () => {
       expect(fetch).toHaveBeenCalledOnce()
     })
 
+    test('postTopUp retries once with the management route challenge', async () => {
+      const routeChallenge = { ...challenge(), id: 'management-challenge' } as TempoSessionChallenge
+      const createSessionCredential = vi.fn(async (challenge_) => `top-up-${challenge_.id}`)
+      const fetch = vi
+        .fn()
+        .mockResolvedValueOnce(response402(routeChallenge))
+        .mockResolvedValueOnce(
+          new Response(null, {
+            status: 204,
+            headers: {
+              [Constants.Headers.paymentReceipt]: receiptHeader(8n, 5n, routeChallenge.id),
+            },
+          }),
+        )
+
+      const receipt = await postTopUp({
+        additionalDeposit: 3n,
+        challenge: challenge(),
+        channel: channel(),
+        channelId,
+        createSessionCredential,
+        fetch,
+        input: 'https://example.test/resource',
+      })
+
+      expect(receipt?.challengeId).toBe(routeChallenge.id)
+      expect(createSessionCredential).toHaveBeenCalledTimes(2)
+      expect(authorizationHeader(fetch.mock.calls[1]?.[1])).toBe(`top-up-${routeChallenge.id}`)
+    })
+
     test('retryHttpPaymentRequired signs the server-required cumulative voucher', async () => {
       let entry = channel({ cumulativeAmount: 5n, deposit: 6n })
       const topUpIfNeeded = vi.fn(async () => {
@@ -1046,6 +1076,9 @@ describe('WsDriver', () => {
         onProbeUrl(url) {
           events.push(`probe:${url.toString()}`)
         },
+        async prepareChallenge(selected) {
+          events.push(`prepare:${selected.id}`)
+        },
       })
 
       expect(prepared).toEqual({
@@ -1057,6 +1090,7 @@ describe('WsDriver', () => {
       expect(events).toEqual([
         'probe:https://example.test/socket?stream=1',
         'fetch:https://example.test/socket?stream=1',
+        'prepare:test-challenge',
         'credential:test-challenge:0',
       ])
     })

--- a/src/tempo/session/client/Transports.ts
+++ b/src/tempo/session/client/Transports.ts
@@ -594,16 +594,24 @@ export async function postTopUp(
     throw new Error('Cannot top up session: no local channel descriptor available.')
   }
 
-  const credential = await parameters.createSessionCredential(parameters.challenge, {
-    action: 'topUp',
-    channelId,
-    descriptor: channel.descriptor,
-    additionalDepositRaw: parameters.additionalDeposit.toString(),
-  })
-  const response = await parameters.fetch(managementInput(parameters.input), {
-    method: 'POST',
-    headers: { [Constants.Headers.authorization]: credential },
-  })
+  const post = async (challenge: TempoSessionChallenge) => {
+    const credential = await parameters.createSessionCredential(challenge, {
+      action: 'topUp',
+      channelId,
+      descriptor: channel.descriptor,
+      additionalDepositRaw: parameters.additionalDeposit.toString(),
+    })
+    return parameters.fetch(managementInput(parameters.input), {
+      method: 'POST',
+      headers: { [Constants.Headers.authorization]: credential },
+    })
+  }
+
+  let response = await post(parameters.challenge)
+  if (response.status === 402) {
+    const challenge = Challenge.fromResponseList(response).find(isTempoSessionChallenge)
+    if (challenge) response = await post(challenge)
+  }
   if (!response.ok) throw new Error(`Top-up POST failed with status ${response.status}`)
 
   const receiptHeader = response.headers.get(Constants.Headers.paymentReceipt)
@@ -1060,6 +1068,8 @@ export type PrepareWebSocketSessionParameters = {
   input: string | URL
   /** Called after resolving the HTTP probe URL, before the network request. */
   onProbeUrl?: ((httpUrl: URL) => void) | undefined
+  /** Prepares channel headroom after the probe and before signing authorization. */
+  prepareChallenge?: ((challenge: TempoSessionChallenge) => Promise<void>) | undefined
   /** Optional request init for the HTTP probe. */
   probeInit?: RequestInit | undefined
   /** Optional abort signal applied to the HTTP probe. */
@@ -1192,6 +1202,8 @@ export async function prepareWebSocketSession(
       'No payment challenge received from HTTP endpoint for this WebSocket URL. The server may not require payment or did not advertise a challenge.',
     )
   }
+
+  await parameters.prepareChallenge?.(challenge)
 
   return {
     challenge,

--- a/src/tempo/session/server/RequestState.test.ts
+++ b/src/tempo/session/server/RequestState.test.ts
@@ -544,7 +544,7 @@ describe('SessionSnapshotHints', () => {
       }
     })
 
-    test('omits hints for missing, non-precompile, or finalized channels', async () => {
+    test('omits hints for missing, non-precompile, closing, or finalized channels', async () => {
       await expect(
         resolveSessionSnapshot({ amount: 1n, channelId, store: store(null) }),
       ).resolves.toBe(undefined)
@@ -553,6 +553,13 @@ describe('SessionSnapshotHints', () => {
           amount: 1n,
           channelId,
           store: store(channel({ backend: 'external' } as Partial<ChannelStore.State>)),
+        }),
+      ).resolves.toBe(undefined)
+      await expect(
+        resolveSessionSnapshot({
+          amount: 1n,
+          channelId,
+          store: store(channel({ closeRequestedAt: 1n })),
         }),
       ).resolves.toBe(undefined)
       await expect(

--- a/src/tempo/session/server/RequestState.ts
+++ b/src/tempo/session/server/RequestState.ts
@@ -152,8 +152,7 @@ export async function resolveSessionSnapshot(
     acceptedCumulative: channel.highestVoucherAmount.toString(),
     chainId: channel.chainId,
     channelId: channel.channelId,
-    closeRequestedAt:
-      channel.closeRequestedAt === 0n ? undefined : channel.closeRequestedAt.toString(),
+    closeRequestedAt: undefined,
     deposit: channel.deposit.toString(),
     descriptor: channel.descriptor,
     escrow: channel.escrowContract,

--- a/src/tempo/session/server/RequestState.ts
+++ b/src/tempo/session/server/RequestState.ts
@@ -143,6 +143,7 @@ export async function resolveSessionSnapshot(
   const channel = await store.getChannel(ChannelStore.normalizeChannelId(channelId))
   if (!channel || !ChannelStore.isPrecompileState(channel)) return undefined
   if (channel.finalized) return undefined
+  if (channel.closeRequestedAt !== 0n) return undefined
   if (!channel.highestVoucher) return undefined
   if (channel.highestVoucher.cumulativeAmount !== channel.highestVoucherAmount) return undefined
   if (expected && !matchesSnapshotPaymentFields(channel, expected)) return undefined


### PR DESCRIPTION
## Summary

- prepare reusable session headroom after the WebSocket HTTP probe and before signing authorization
- use the server's `suggestedDeposit` as the automatic refill quantum after a channel fills
- cap every refill by the client's remaining `maxDeposit` authorization
- omit bootstrap snapshots for channels already marked as closing
- preserve the existing in-band voucher and top-up flow after the socket opens

## Why

A cold client can bootstrap a valid reusable channel whose cumulative voucher already equals its on-chain deposit. Previously the WebSocket client signed the next voucher before topping up, so reconnect failed with `session/amount-exceeds-deposit`.

Automatic top-ups also deposited only the exact shortfall. For streamed services this puts every subsequent response back at the deposit boundary and forces another on-chain transaction. Reusing the server's suggested deposit as bounded refill headroom amortizes that transaction without changing the exact cumulative voucher or amount charged.

Closing channels cannot be reused and should not be advertised as bootstrap candidates.

## Validation

- current `main` fails the new SSE regression: expected a 100-unit suggested refill, received the exact 50-unit shortfall
- `VITE_TEMPO_NETWORK=none pnpm exec vp test --run --project node src/tempo/session/client/Runtime.test.ts src/tempo/session/client/Session.test.ts src/tempo/session/server/RequestState.test.ts` (100 tests)
- broader focused session suite (173 tests)
- `pnpm exec vp check` (passes; pre-existing lint warnings only)
- prior live mainnet OpenAI Responses WebSocket validation on this PR opened a full channel, topped it up, returned a `gpt-5.6-sol` response, and advanced cumulative state

All commits are SSH-signed.
