### PR TITLE
fix: classify session settlement hook as patch

### DIFF
--- a/.changeset/warm-pandas-climb.md
+++ b/.changeset/warm-pandas-climb.md
@@ -1,5 +1,5 @@
 ---
-'mppx': minor
+'mppx': patch
 ---
 
 Added `onSessionSettlement` hook for visibility into on-chain session settlement transactions, with chain-agnostic context including trigger, txHash, channelId, cumulative amount, and incremental delta.


### PR DESCRIPTION
## Motivation

The release changeset classified an additive hook as a minor release despite the project release policy.

## Summary

- Changed the session-settlement hook changeset from minor to patch

## Key design considerations

- Preserved the existing release notes while correcting the release level