### PR TITLE
fix: recover abandoned sponsored sender locks

### DIFF
--- a/.changeset/fuzzy-spoons-recover.md
+++ b/.changeset/fuzzy-spoons-recover.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed abandoned Tempo sponsored-sender locks with bounded leases, transaction reconciliation, owner-fenced cleanup, diagnostics, observability, and manual recovery.

--- a/src/tempo/server/AtomicStore.test-d.ts
+++ b/src/tempo/server/AtomicStore.test-d.ts
@@ -1,3 +1,4 @@
+import { createClient, custom } from 'viem'
 import { expectTypeOf, test } from 'vp/test'
 
 import { tempo } from '../../server/index.js'
@@ -17,6 +18,15 @@ test('tempo.charge store parameter requires AtomicStore', () => {
   // @ts-expect-error — charge replay protection requires AtomicStore
   tempo.charge({ store: nonAtomic })
   tempo.charge({ store: Store.memory() })
+})
+
+test('tempo exposes sponsored sender lock recovery', () => {
+  tempo.recoverSponsoredSenderLock({
+    chainId: 4217,
+    client: createClient({ transport: custom({ request: async () => null }) }),
+    sender: '0x0000000000000000000000000000000000000001',
+    store: Store.memory(),
+  })
 })
 
 test('tempo.session store parameter requires AtomicStore', () => {

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -37,6 +37,7 @@ import * as Selectors from '../internal/selectors.js'
 import type * as types from '../internal/types.js'
 import * as Methods from '../Methods.js'
 import { html as htmlContent } from './internal/html.gen.js'
+import * as SponsoredSenderLock from './SponsoredSenderLock.js'
 
 /**
  * Creates a Tempo charge method intent for usage on the server.
@@ -66,6 +67,8 @@ export function charge<const parameters extends charge.Parameters>(
     memo,
     splits,
     supportedModes,
+    onSponsorshipEvent,
+    sponsorshipLockTimeoutMs,
     validateSender,
     waitForConfirmation = true,
   } = parameters
@@ -344,14 +347,11 @@ export function charge<const parameters extends charge.Parameters>(
 
           const serializedTransaction = payload.signature as Transaction.TransactionSerializedTempo
 
-          // Pre-broadcast dedup: catch exact byte-for-byte replays early.
           const hash = keccak256(serializedTransaction)
-          if (!(await markHashUsed(store, hash))) {
-            throw new VerificationFailedError({ reason: 'Transaction hash has already been used' })
-          }
-
           let releaseReservation = true
-          let sponsoredSenderReservation: { chainId: number; sender: `0x${string}` } | undefined
+          let hashReserved = false
+          let sponsoredSenderReservation: SponsoredSenderLock.SponsoredSenderLockRecord | undefined
+          let sponsoredSenderTarget: { chainId: number; sender: `0x${string}` } | undefined
 
           try {
             if (!FeePayer.isTempoTransaction(serializedTransaction))
@@ -386,25 +386,53 @@ export function charge<const parameters extends charge.Parameters>(
 
             if (isFeePayerTx) {
               const reservationChainId = chainId ?? client.chain!.id
-              if (
-                !(await markSponsoredSenderInFlight(store, {
-                  chainId: reservationChainId,
-                  sender: transaction.from as `0x${string}`,
-                }))
-              ) {
+              const sender = transaction.from as `0x${string}`
+              sponsoredSenderTarget = { chainId: reservationChainId, sender }
+              await SponsoredSenderLock.reconcile({
+                ...sponsoredSenderTarget,
+                client,
+                leaseTimeoutMs: sponsorshipLockTimeoutMs,
+                onEvent: onSponsorshipEvent,
+                store,
+              })
+              const reservation = await SponsoredSenderLock.acquire({
+                ...sponsoredSenderTarget,
+                inputHash: hash,
+                leaseTimeoutMs: sponsorshipLockTimeoutMs,
+                nonce: String(transaction.nonce),
+                nonceKey: String(transaction.nonceKey),
+                onEvent: onSponsorshipEvent,
+                store,
+                validBefore: resolveSponsoredLockExpiry(
+                  transaction.validBefore,
+                  sponsorshipLockTimeoutMs,
+                ),
+              })
+              if (reservation.status === 'contended') {
+                const ageSeconds = Math.max(0, Math.floor(reservation.ageMs / 1_000))
                 throw new VerificationFailedError({
-                  reason: 'Sponsored transaction from this sender is already in flight',
+                  reason: `Sponsored transaction from this sender is already in flight (lock age: ${ageSeconds}s). Retry after the transaction confirms or expires; operators can call recoverSponsoredSenderLock for safe manual recovery.`,
                 })
               }
-              sponsoredSenderReservation = {
-                chainId: reservationChainId,
-                sender: transaction.from as `0x${string}`,
-              }
+              sponsoredSenderReservation = reservation.lock
+              // Reconciliation may have discovered this exact transaction and
+              // finalized its replay marker before releasing the previous lock.
+              if ((await store.get(getHashStoreKey(hash))) !== null)
+                throw new VerificationFailedError({
+                  reason: 'Transaction hash has already been used',
+                })
               FeePayer.validateCalls(
                 transaction.calls,
                 { amount, currency, recipient },
                 { currency, expectedTransfers: transfers },
               )
+            } else {
+              // Pre-broadcast dedup for transactions without a sponsored-sender lock.
+              if (!(await markHashUsed(store, hash)))
+                throw new VerificationFailedError({
+                  reason: 'Transaction hash has already been used',
+                })
+              hashReserved = true
             }
 
             const allowedFeeTokens = FeePayer.defaultAllowedFeeTokens(chainId)
@@ -472,10 +500,46 @@ export function charge<const parameters extends charge.Parameters>(
                 FeePayer.simulationTransaction(transaction, { feePayer: false }) as never,
               )
 
+            const transactionHash = keccak256(serializedTransaction_final)
+            if (sponsoredSenderReservation?.phase === 'preparing' && sponsoredSenderTarget) {
+              const prepared = await SponsoredSenderLock.prepare({
+                ...sponsoredSenderTarget,
+                lock: sponsoredSenderReservation,
+                onEvent: onSponsorshipEvent,
+                store,
+                transactionHash,
+              })
+              if (!prepared)
+                throw new VerificationFailedError({
+                  reason:
+                    'Sponsored transaction lock expired while preparing. Retry with a fresh credential.',
+                })
+              sponsoredSenderReservation = prepared
+            }
+
             if (waitForConfirmation) {
               const receipt = await sendRawTransactionSync(client, {
                 serializedTransaction: serializedTransaction_final,
               })
+              if (receipt.transactionHash.toLowerCase() !== transactionHash.toLowerCase())
+                throw new Error(
+                  'Sponsored transaction hash returned by RPC does not match payload.',
+                )
+              if (isFeePayerTx) {
+                await markHashUsed(store, hash)
+                if (transactionHash.toLowerCase() !== hash.toLowerCase())
+                  await markHashUsed(store, transactionHash)
+                releaseReservation = false
+                if (sponsoredSenderReservation && sponsoredSenderTarget)
+                  await SponsoredSenderLock.clear({
+                    ...sponsoredSenderTarget,
+                    lock: sponsoredSenderReservation,
+                    onEvent: onSponsorshipEvent,
+                    reason: 'terminal',
+                    store,
+                  })
+                sponsoredSenderReservation = undefined
+              }
               const matchedLogs = await assertTransferLogs(receipt, {
                 currency,
                 sender: transaction.from! as `0x${string}`,
@@ -491,6 +555,7 @@ export function charge<const parameters extends charge.Parameters>(
               // bypass the pre-broadcast check. Skip if the broadcast
               // hash matches the input hash (already stored above).
               if (
+                !isFeePayerTx &&
                 receipt.transactionHash.toLowerCase() !== hash.toLowerCase() &&
                 !(await markHashUsed(store, receipt.transactionHash))
               ) {
@@ -508,8 +573,26 @@ export function charge<const parameters extends charge.Parameters>(
             const reference = await sendRawTransaction(client, {
               serializedTransaction: serializedTransaction_final,
             })
+            if (reference.toLowerCase() !== transactionHash.toLowerCase())
+              throw new Error('Sponsored transaction hash returned by RPC does not match payload.')
+            if (isFeePayerTx) {
+              await markHashUsed(store, hash)
+              if (transactionHash.toLowerCase() !== hash.toLowerCase())
+                await markHashUsed(store, transactionHash)
+              releaseReservation = false
+              if (sponsoredSenderReservation && sponsoredSenderTarget)
+                await SponsoredSenderLock.clear({
+                  ...sponsoredSenderTarget,
+                  lock: sponsoredSenderReservation,
+                  onEvent: onSponsorshipEvent,
+                  reason: 'submitted',
+                  store,
+                })
+              sponsoredSenderReservation = undefined
+            }
             // Post-broadcast dedup: same
             if (
+              !isFeePayerTx &&
               reference.toLowerCase() !== hash.toLowerCase() &&
               !(await markHashUsed(store, reference))
             ) {
@@ -525,11 +608,17 @@ export function charge<const parameters extends charge.Parameters>(
               reference,
             } as const
           } catch (error) {
-            if (releaseReservation) await releaseHashUse(store, hash)
+            if (hashReserved && releaseReservation) await releaseHashUse(store, hash)
             throw error
           } finally {
-            if (sponsoredSenderReservation)
-              await releaseSponsoredSenderInFlight(store, sponsoredSenderReservation)
+            if (sponsoredSenderReservation?.phase === 'preparing' && sponsoredSenderTarget)
+              await SponsoredSenderLock.clear({
+                ...sponsoredSenderTarget,
+                lock: sponsoredSenderReservation,
+                onEvent: onSponsorshipEvent,
+                reason: 'pre-broadcast-failure',
+                store,
+              })
           }
         }
 
@@ -541,7 +630,9 @@ export function charge<const parameters extends charge.Parameters>(
 }
 
 export declare namespace charge {
-  type StoreItemMap = { [key: `mppx:charge:${string}`]: number }
+  type StoreItemMap = {
+    [key: `mppx:charge:${string}`]: number | SponsoredSenderLock.SponsoredSenderLockRecord
+  }
 
   type Defaults = LooseOmit<Method.RequestDefaults<typeof Methods.charge>, 'feePayer' | 'recipient'>
 
@@ -576,6 +667,16 @@ export declare namespace charge {
      * its own token.
      */
     feeToken?: `0x${string}` | undefined
+    /** Receives best-effort sponsored transaction lock lifecycle events. */
+    onSponsorshipEvent?:
+      | ((event: SponsoredSenderLock.SponsorshipEvent) => void | Promise<void>)
+      | undefined
+    /**
+     * Maximum time spent preparing a sponsored transaction before its sender
+     * lock can be recovered. The lock is also capped by the transaction's
+     * `validBefore` timestamp. @default 60000
+     */
+    sponsorshipLockTimeoutMs?: number | undefined
     /** Testnet mode. */
     testnet?: boolean | undefined
     /**
@@ -971,14 +1072,6 @@ function getProofStoreKey(challengeId: string): `mppx:charge:${string}` {
   return `mppx:charge:proof:${challengeId}`
 }
 
-/** @internal */
-function getSponsoredSenderStoreKey(parameters: {
-  chainId: number
-  sender: `0x${string}`
-}): `mppx:charge:${string}` {
-  return `mppx:charge:sponsor:${parameters.chainId}:${parameters.sender.toLowerCase()}`
-}
-
 async function markHashUsed(
   store: Store.AtomicStore<charge.StoreItemMap>,
   hash: `0x${string}`,
@@ -1013,25 +1106,6 @@ function parseHashCredentialSource(parameters: {
 }
 
 /** @internal */
-async function markSponsoredSenderInFlight(
-  store: Store.AtomicStore<charge.StoreItemMap>,
-  parameters: { chainId: number; sender: `0x${string}` },
-): Promise<boolean> {
-  return store.update(getSponsoredSenderStoreKey(parameters), (current) => {
-    if (current !== null) return { op: 'noop', result: false }
-    return { op: 'set', value: Date.now(), result: true }
-  })
-}
-
-/** @internal */
-async function releaseSponsoredSenderInFlight(
-  store: Store.AtomicStore<charge.StoreItemMap>,
-  parameters: { chainId: number; sender: `0x${string}` },
-): Promise<void> {
-  await store.delete(getSponsoredSenderStoreKey(parameters))
-}
-
-/** @internal */
 async function markProofUsed(
   store: Store.AtomicStore<charge.StoreItemMap>,
   challengeId: string,
@@ -1040,6 +1114,13 @@ async function markProofUsed(
     if (current !== null) return { op: 'noop', result: false }
     return { op: 'set', value: Date.now(), result: true }
   })
+}
+
+function resolveSponsoredLockExpiry(validBefore: number | undefined, lockTimeoutMs = 60_000) {
+  const fallback = Date.now() + lockTimeoutMs
+  if (validBefore === undefined) return fallback
+  const expiry = Number(validBefore) * 1_000
+  return Number.isFinite(expiry) ? expiry : fallback
 }
 
 function recoverAuthorizedProofSigner(parameters: {

--- a/src/tempo/server/Methods.ts
+++ b/src/tempo/server/Methods.ts
@@ -9,6 +9,7 @@ import {
 import type { SessionController as SessionController_ } from '../session/server/Sse.js'
 import * as Ws_ from '../session/server/Ws.js'
 import { charge as charge_ } from './Charge.js'
+import { recoverSponsoredSenderLock as recoverSponsoredSenderLock_ } from './SponsoredSenderLock.js'
 import { renew as renewSubscription_, subscription as subscription_ } from './Subscription.js'
 
 const sessionServer = Object.assign(session_, {
@@ -81,6 +82,8 @@ export namespace tempo {
   export const subscription = subscription_
   /** Renews an overdue Tempo subscription outside of the HTTP request path. */
   export const renewSubscription = renewSubscription_
+  /** Safely reconciles an abandoned sponsored transaction sender lock. */
+  export const recoverSponsoredSenderLock = recoverSponsoredSenderLock_
   /** One-shot settle: reads highest voucher from storage and submits on-chain. */
   export const settle = settle_
   /** Batch-settle precompile-backed session channels. */

--- a/src/tempo/server/SponsoredSenderLock.test.ts
+++ b/src/tempo/server/SponsoredSenderLock.test.ts
@@ -1,0 +1,211 @@
+import type { Client } from 'viem'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vp/test'
+
+import * as Store from '../../Store.js'
+import {
+  acquire,
+  clear,
+  prepare,
+  reconcile,
+  recoverSponsoredSenderLock,
+  type SponsoredSenderLockRecord,
+  type SponsorshipEvent,
+} from './SponsoredSenderLock.js'
+
+const now = 1_800_000_000_000
+const chainId = 4217
+const sender = `0x${'1'.repeat(40)}` as const
+const inputHash = `0x${'2'.repeat(64)}` as const
+const transactionHash = `0x${'3'.repeat(64)}` as const
+const key = `mppx:charge:sponsor:${chainId}:${sender}` as const
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(now)
+})
+
+afterEach(() => vi.useRealTimers())
+
+describe('sponsored sender lock', () => {
+  test('owner-fences concurrent acquisition and stale cleanup', async () => {
+    const store = Store.memory()
+    const first = await acquire(parameters(store))
+    const second = await acquire(parameters(store))
+
+    expect(first.status).toBe('acquired')
+    expect(second).toMatchObject({ ageMs: 0, status: 'contended' })
+    if (first.status !== 'acquired' || second.status !== 'contended') return
+    if (typeof second.lock === 'number') return
+
+    expect(
+      await clear({
+        ...target(store),
+        lock: { ...second.lock, owner: 'stale-owner' },
+        reason: 'manual',
+      }),
+    ).toBe(false)
+    expect(await store.get(key)).toEqual(first.lock)
+  })
+
+  test('recovers an abandoned preparing lock after its bounded lease', async () => {
+    const store = Store.memory()
+    const first = await acquire(parameters(store, { leaseTimeoutMs: 1_000 }))
+    expect(first.status).toBe('acquired')
+
+    vi.setSystemTime(now + 1_000)
+    const recovered = await acquire(parameters(store, { leaseTimeoutMs: 1_000 }))
+
+    expect(recovered.status).toBe('acquired')
+    if (first.status === 'acquired' && recovered.status === 'acquired')
+      expect(recovered.lock.owner).not.toBe(first.lock.owner)
+  })
+
+  test('reconciles confirmed success and revert after restart', async () => {
+    for (const status of ['0x1', '0x0'] as const) {
+      const store = Store.memory()
+      await putPrepared(store)
+      const result = await recoverSponsoredSenderLock({
+        ...target(store),
+        client: rpcClient({ receiptStatus: status }),
+      })
+
+      expect(result).toEqual({
+        reason: status === '0x1' ? 'success' : 'reverted',
+        status: 'cleared',
+      })
+      expect(await store.get(key)).toBeNull()
+      expect(await store.get(`mppx:charge:${inputHash}`)).toBe(now)
+      expect(await store.get(`mppx:charge:${transactionHash}`)).toBe(now)
+    }
+  })
+
+  test('clears a positively visible mempool transaction', async () => {
+    const store = Store.memory()
+    await putPrepared(store)
+
+    await expect(
+      reconcile({ ...target(store), client: rpcClient({ pending: true }) }),
+    ).resolves.toEqual({ reason: 'pending', status: 'cleared' })
+    expect(await store.get(key)).toBeNull()
+  })
+
+  test('does not misclassify an RPC miss as a drop or replacement', async () => {
+    const store = Store.memory()
+    await putPrepared(store)
+
+    await expect(reconcile({ ...target(store), client: rpcClient({}) })).resolves.toMatchObject({
+      status: 'unknown',
+      transactionHash,
+    })
+    expect(await store.get(key)).not.toBeNull()
+  })
+
+  test('clears a dropped or unknown transaction only after nonce expiry', async () => {
+    const store = Store.memory()
+    await putPrepared(store, now + 1_000)
+    vi.setSystemTime(now + 1_000)
+
+    await expect(
+      recoverSponsoredSenderLock({ ...target(store), client: rpcClient({}) }),
+    ).resolves.toEqual({ reason: 'expired', status: 'cleared' })
+    await expect(
+      recoverSponsoredSenderLock({ ...target(store), client: rpcClient({}) }),
+    ).resolves.toEqual({ status: 'absent' })
+  })
+
+  test('migrates stale timestamp-only locks and emits lifecycle events', async () => {
+    const store = Store.memory()
+    const events: SponsorshipEvent[] = []
+    await store.put(key, now - 60_000)
+
+    await expect(
+      recoverSponsoredSenderLock({
+        ...target(store),
+        client: rpcClient({}),
+        onEvent(event) {
+          events.push(event)
+        },
+      }),
+    ).resolves.toEqual({ reason: 'legacy-expired', status: 'cleared' })
+    expect(events).toContainEqual(
+      expect.objectContaining({ reason: 'legacy-expired', type: 'cleared' }),
+    )
+  })
+})
+
+function parameters(store: Store.AtomicStore<any>, overrides: { leaseTimeoutMs?: number } = {}) {
+  return {
+    ...target(store),
+    inputHash,
+    nonce: '1',
+    nonceKey: 'expiring',
+    validBefore: now + 30_000,
+    ...overrides,
+  }
+}
+
+function target(store: Store.AtomicStore<any>) {
+  return { chainId, sender, store }
+}
+
+async function putPrepared(store: Store.AtomicStore<any>, validBefore = now + 30_000) {
+  const result = await acquire({ ...parameters(store), validBefore })
+  if (result.status !== 'acquired') throw new Error('failed to acquire test lock')
+  const prepared = await prepare({
+    ...target(store),
+    lock: result.lock,
+    transactionHash,
+  })
+  if (!prepared) throw new Error('failed to prepare test lock')
+  return prepared satisfies SponsoredSenderLockRecord
+}
+
+function rpcClient(options: { pending?: boolean; receiptStatus?: '0x0' | '0x1' }): Client {
+  return {
+    async request({ method }: { method: string }) {
+      if (method === 'eth_getTransactionReceipt')
+        return options.receiptStatus ? rawReceipt(options.receiptStatus) : null
+      if (method === 'eth_getTransactionByHash') return options.pending ? rawTransaction() : null
+      throw new Error(`Unexpected RPC method: ${method}`)
+    },
+  } as unknown as Client
+}
+
+function rawReceipt(status: '0x0' | '0x1') {
+  return {
+    blockHash: `0x${'4'.repeat(64)}`,
+    blockNumber: '0x1',
+    contractAddress: null,
+    cumulativeGasUsed: '0x5208',
+    effectiveGasPrice: '0x1',
+    from: sender,
+    gasUsed: '0x5208',
+    logs: [],
+    logsBloom: `0x${'0'.repeat(512)}`,
+    status,
+    to: `0x${'5'.repeat(40)}`,
+    transactionHash,
+    transactionIndex: '0x0',
+    type: '0x0',
+  }
+}
+
+function rawTransaction() {
+  return {
+    blockHash: null,
+    blockNumber: null,
+    from: sender,
+    gas: '0x5208',
+    gasPrice: '0x1',
+    hash: transactionHash,
+    input: '0x',
+    nonce: '0x1',
+    r: `0x${'1'.repeat(64)}`,
+    s: `0x${'2'.repeat(64)}`,
+    to: `0x${'5'.repeat(40)}`,
+    transactionIndex: null,
+    type: '0x0',
+    v: '0x1b',
+    value: '0x0',
+  }
+}

--- a/src/tempo/server/SponsoredSenderLock.ts
+++ b/src/tempo/server/SponsoredSenderLock.ts
@@ -1,0 +1,341 @@
+import type { Client } from 'viem'
+import { getTransaction, getTransactionReceipt } from 'viem/actions'
+
+import * as Store from '../../Store.js'
+
+const defaultLeaseTimeoutMs = 60_000
+
+export type SponsoredSenderLock = {
+  createdAt: number
+  inputHash: `0x${string}`
+  leaseUntil: number
+  nonce: string
+  nonceKey: string
+  owner: string
+  phase: 'preparing'
+  version: 1
+  validBefore: number
+}
+
+export type PreparedSponsoredSenderLock = Omit<SponsoredSenderLock, 'leaseUntil' | 'phase'> & {
+  phase: 'prepared'
+  transactionHash: `0x${string}`
+}
+
+export type SponsoredSenderLockRecord = SponsoredSenderLock | PreparedSponsoredSenderLock
+
+export type SponsorshipEvent =
+  | (SponsorshipEventBase & { type: 'acquired' })
+  | (SponsorshipEventBase & { ageMs: number; type: 'contended' })
+  | (SponsorshipEventBase & { transactionHash: `0x${string}`; type: 'prepared' })
+  | (SponsorshipEventBase & {
+      status: 'pending' | 'reverted' | 'success' | 'unknown'
+      type: 'reconciled'
+    })
+  | (SponsorshipEventBase & {
+      reason:
+        | 'expired'
+        | 'legacy-expired'
+        | 'manual'
+        | 'pre-broadcast-failure'
+        | 'submitted'
+        | 'terminal'
+      type: 'cleared'
+    })
+
+type SponsorshipEventBase = {
+  chainId: number
+  owner?: string | undefined
+  sender: `0x${string}`
+}
+
+type StoreItemMap = {
+  [key: `mppx:charge:${string}`]: number | SponsoredSenderLockRecord
+}
+
+type LockTarget = {
+  chainId: number
+  sender: `0x${string}`
+}
+
+type CommonParameters = LockTarget & {
+  onEvent?: ((event: SponsorshipEvent) => void | Promise<void>) | undefined
+  store: Store.AtomicStore<StoreItemMap>
+}
+
+export type AcquireParameters = CommonParameters & {
+  inputHash: `0x${string}`
+  leaseTimeoutMs?: number | undefined
+  nonce: string
+  nonceKey: string
+  validBefore: number
+}
+
+export type AcquireResult =
+  | { lock: SponsoredSenderLock; status: 'acquired' }
+  | { ageMs: number; lock: SponsoredSenderLockRecord | number; status: 'contended' }
+
+export type RecoverSponsoredSenderLockParameters = LockTarget & {
+  client: Client
+  /** Maximum age of legacy timestamp-only locks. @default 60000 */
+  leaseTimeoutMs?: number | undefined
+  /** Receives best-effort lock lifecycle events. */
+  onEvent?: ((event: SponsorshipEvent) => void | Promise<void>) | undefined
+  store: Store.AtomicStore
+  /** Prefix used by the charge method that owns the lock. */
+  storeKeyPrefix?: string | undefined
+}
+
+export type RecoverSponsoredSenderLockResult =
+  | { status: 'absent' }
+  | { ageMs: number; status: 'active' }
+  | { ageMs: number; status: 'unknown'; transactionHash: `0x${string}` }
+  | {
+      reason: 'expired' | 'legacy-expired' | 'pending' | 'reverted' | 'success'
+      status: 'cleared'
+    }
+
+/**
+ * Reconciles one persisted sponsored-sender lock without force-deleting an
+ * active or ambiguous transaction. Calling this repeatedly is safe.
+ */
+export async function recoverSponsoredSenderLock(
+  parameters: RecoverSponsoredSenderLockParameters,
+): Promise<RecoverSponsoredSenderLockResult> {
+  const store = Store.from(parameters.store as Store.AtomicStore<StoreItemMap>, {
+    keyPrefix: parameters.storeKeyPrefix ?? '',
+  })
+  return reconcile({
+    chainId: parameters.chainId,
+    client: parameters.client,
+    leaseTimeoutMs: parameters.leaseTimeoutMs,
+    onEvent: parameters.onEvent,
+    sender: parameters.sender,
+    store,
+  })
+}
+
+/** @internal */
+export async function acquire(parameters: AcquireParameters): Promise<AcquireResult> {
+  const now = Date.now()
+  const leaseTimeoutMs = parameters.leaseTimeoutMs ?? defaultLeaseTimeoutMs
+  const lock: SponsoredSenderLock = {
+    createdAt: now,
+    inputHash: parameters.inputHash,
+    leaseUntil: Math.min(now + leaseTimeoutMs, parameters.validBefore),
+    nonce: parameters.nonce,
+    nonceKey: parameters.nonceKey,
+    owner: crypto.randomUUID(),
+    phase: 'preparing',
+    validBefore: parameters.validBefore,
+    version: 1,
+  }
+  const result: AcquireResult = await parameters.store.update(
+    getStoreKey(parameters),
+    (current): Store.Change<number | SponsoredSenderLockRecord, AcquireResult> => {
+      if (current === null || isExpired(current, now, leaseTimeoutMs))
+        return { op: 'set', result: { lock, status: 'acquired' } as const, value: lock }
+      return {
+        op: 'noop',
+        result: { ageMs: getAge(current, now), lock: current, status: 'contended' } as const,
+      }
+    },
+  )
+  if (result.status === 'acquired')
+    await emit(parameters, { ...eventBase(parameters, lock.owner), type: 'acquired' })
+  else
+    await emit(parameters, {
+      ...eventBase(parameters, typeof result.lock === 'number' ? undefined : result.lock.owner),
+      ageMs: result.ageMs,
+      type: 'contended',
+    })
+  return result
+}
+
+/** @internal */
+export async function prepare(
+  parameters: CommonParameters & {
+    lock: SponsoredSenderLock
+    transactionHash: `0x${string}`
+  },
+): Promise<PreparedSponsoredSenderLock | null> {
+  const { leaseUntil: _, ...lock } = parameters.lock
+  const prepared: PreparedSponsoredSenderLock = {
+    ...lock,
+    phase: 'prepared',
+    transactionHash: parameters.transactionHash,
+  }
+  const updated = await parameters.store.update(getStoreKey(parameters), (current) => {
+    if (!isOwned(current, parameters.lock.owner)) return { op: 'noop', result: false }
+    return { op: 'set', result: true, value: prepared }
+  })
+  if (!updated) return null
+  await emit(parameters, {
+    ...eventBase(parameters, prepared.owner),
+    transactionHash: prepared.transactionHash,
+    type: 'prepared',
+  })
+  return prepared
+}
+
+/** @internal */
+export async function clear(
+  parameters: CommonParameters & {
+    lock: SponsoredSenderLockRecord
+    reason: Extract<SponsorshipEvent, { type: 'cleared' }>['reason']
+  },
+): Promise<boolean> {
+  const cleared = await parameters.store.update(getStoreKey(parameters), (current) => {
+    if (!isOwned(current, parameters.lock.owner)) return { op: 'noop', result: false }
+    return { op: 'delete', result: true }
+  })
+  if (cleared)
+    await emit(parameters, {
+      ...eventBase(parameters, parameters.lock.owner),
+      reason: parameters.reason,
+      type: 'cleared',
+    })
+  return cleared
+}
+
+/** @internal */
+export async function reconcile(
+  parameters: CommonParameters & {
+    client: Client
+    leaseTimeoutMs?: number | undefined
+  },
+): Promise<RecoverSponsoredSenderLockResult> {
+  const current = await parameters.store.get(getStoreKey(parameters))
+  if (current === null) return { status: 'absent' }
+
+  const now = Date.now()
+  const leaseTimeoutMs = parameters.leaseTimeoutMs ?? defaultLeaseTimeoutMs
+  const ageMs = getAge(current, now)
+  if (typeof current === 'number') {
+    if (!isExpired(current, now, leaseTimeoutMs)) return { ageMs, status: 'active' }
+    const cleared = await clearLegacy(parameters, current)
+    if (!cleared) return reconcile(parameters)
+    await emit(parameters, {
+      ...eventBase(parameters),
+      reason: 'legacy-expired',
+      type: 'cleared',
+    })
+    return { reason: 'legacy-expired', status: 'cleared' }
+  }
+
+  if (current.phase === 'preparing') {
+    if (!isExpired(current, now, leaseTimeoutMs)) return { ageMs, status: 'active' }
+    const cleared = await clear({ ...parameters, lock: current, reason: 'expired' })
+    if (!cleared) return reconcile(parameters)
+    return { reason: 'expired', status: 'cleared' }
+  }
+
+  const receipt = await findReceipt(parameters.client, current.transactionHash)
+  if (receipt) {
+    const status = receipt.status === 'success' ? 'success' : 'reverted'
+    await emit(parameters, {
+      ...eventBase(parameters, current.owner),
+      status,
+      type: 'reconciled',
+    })
+    await markSubmittedHashes(parameters.store, current)
+    const cleared = await clear({ ...parameters, lock: current, reason: 'terminal' })
+    if (!cleared) return reconcile(parameters)
+    return { reason: status, status: 'cleared' }
+  }
+
+  const pending = await findTransaction(parameters.client, current.transactionHash)
+  if (pending) {
+    await emit(parameters, {
+      ...eventBase(parameters, current.owner),
+      status: 'pending',
+      type: 'reconciled',
+    })
+    await markSubmittedHashes(parameters.store, current)
+    const cleared = await clear({ ...parameters, lock: current, reason: 'submitted' })
+    if (!cleared) return reconcile(parameters)
+    return { reason: 'pending', status: 'cleared' }
+  }
+
+  if (now >= current.validBefore) {
+    const cleared = await clear({ ...parameters, lock: current, reason: 'expired' })
+    if (!cleared) return reconcile(parameters)
+    return { reason: 'expired', status: 'cleared' }
+  }
+
+  await emit(parameters, {
+    ...eventBase(parameters, current.owner),
+    status: 'unknown',
+    type: 'reconciled',
+  })
+  return { ageMs, status: 'unknown', transactionHash: current.transactionHash }
+}
+
+function getStoreKey(parameters: LockTarget): `mppx:charge:${string}` {
+  return `mppx:charge:sponsor:${parameters.chainId}:${parameters.sender.toLowerCase()}`
+}
+
+function eventBase(parameters: LockTarget, owner?: string): SponsorshipEventBase {
+  return {
+    chainId: parameters.chainId,
+    ...(owner ? { owner } : {}),
+    sender: parameters.sender,
+  }
+}
+
+function getAge(lock: SponsoredSenderLockRecord | number, now: number) {
+  return Math.max(0, now - (typeof lock === 'number' ? lock : lock.createdAt))
+}
+
+function isExpired(lock: SponsoredSenderLockRecord | number, now: number, legacyTimeoutMs: number) {
+  if (typeof lock === 'number') return now - lock >= legacyTimeoutMs
+  if (lock.phase === 'prepared') return now >= lock.validBefore
+  return now >= lock.leaseUntil
+}
+
+function isOwned(
+  lock: SponsoredSenderLockRecord | number | null,
+  owner: string,
+): lock is SponsoredSenderLockRecord {
+  return typeof lock === 'object' && lock !== null && lock.owner === owner
+}
+
+async function clearLegacy(parameters: CommonParameters, expected: number) {
+  return parameters.store.update(getStoreKey(parameters), (current) => {
+    if (current !== expected) return { op: 'noop', result: false }
+    return { op: 'delete', result: true }
+  })
+}
+
+async function markSubmittedHashes(
+  store: Store.AtomicStore<StoreItemMap>,
+  lock: PreparedSponsoredSenderLock,
+) {
+  for (const hash of new Set([lock.inputHash, lock.transactionHash]))
+    await store.update(`mppx:charge:${hash.toLowerCase()}`, (current) => {
+      if (current !== null) return { op: 'noop', result: undefined }
+      return { op: 'set', result: undefined, value: Date.now() }
+    })
+}
+
+async function findReceipt(client: Client, hash: `0x${string}`) {
+  try {
+    return await getTransactionReceipt(client, { hash })
+  } catch {
+    return null
+  }
+}
+
+async function findTransaction(client: Client, hash: `0x${string}`) {
+  try {
+    return await getTransaction(client, { hash })
+  } catch {
+    return null
+  }
+}
+
+async function emit(parameters: Pick<CommonParameters, 'onEvent'>, event: SponsorshipEvent) {
+  try {
+    await parameters.onEvent?.(event)
+  } catch {}
+}

--- a/src/tempo/server/index.ts
+++ b/src/tempo/server/index.ts
@@ -2,6 +2,12 @@ export * as ChannelStore from '../session/server/ChannelStore.js'
 export * as Sse from '../session/server/Sse.js'
 export * as Ws from '../session/server/Ws.js'
 export { charge } from './Charge.js'
+export {
+  recoverSponsoredSenderLock,
+  type RecoverSponsoredSenderLockParameters,
+  type RecoverSponsoredSenderLockResult,
+  type SponsorshipEvent,
+} from './SponsoredSenderLock.js'
 export { sessionLegacy, settleLegacy, tempo } from './Methods.js'
 export { session, settle, settleBatch } from '../session/server/Session.js'
 export type {


### PR DESCRIPTION
## Summary
- replace timestamp-only sponsored-sender mutexes with versioned, owner-fenced preparation leases capped by the transaction's expiring `validBefore` nonce deadline
- persist input/final transaction identity before broadcast and lazily reconcile abandoned locks against receipts, positive mempool visibility, and nonce expiry
- add lock-age diagnostics, best-effort lifecycle observability, and idempotent `tempo.recoverSponsoredSenderLock(...)` operator recovery
- preserve exact-input replay protection across crashes while allowing stale preparers to be replaced safely

## Reconciliation behavior
- confirmed success/revert: finalize replay markers and clear
- positively visible pending transaction: finalize replay markers and clear (Tempo expiring nonces are independent)
- receipt and transaction both absent: retain as unknown until `validBefore`, then clear
- preparing process crash: replace after the bounded preparation lease
- legacy timestamp lock: retain for a 60-second grace period, then clear atomically

Tempo sponsored charges require expiring nonces, so generic Ethereum `(sender, nonce)` replacement detection is intentionally not used: it ignores Tempo `nonceKey` and would misclassify independent transactions. RPC absence is therefore not considered proof of drop/replacement before expiry.

## Migration / deployment
- no offline data migration is required; existing numeric lock values remain readable and self-expire after the default 60-second legacy grace period
- deploy all facilitator instances together and continue using the same shared `AtomicStore`; owner fencing protects mixed request concurrency, but old instances do not understand the new record shape
- operators may call `tempo.recoverSponsoredSenderLock` for one `(chainId, sender)` after deployment; it is idempotent and never force-deletes an active or ambiguous pre-expiry transaction
- `sponsorshipLockTimeoutMs` tunes only the preparation lease; prepared records remain bounded by the transaction's `validBefore`
- `onSponsorshipEvent` exposes acquired, contended, prepared, reconciled, and cleared transitions for metrics/logging

## Testing
- `VITE_TEMPO_NETWORK=none pnpm test -- src/tempo/server/SponsoredSenderLock.test.ts src/Store.test.ts` — 41 passed
  - covers success, revert, positive mempool presence, dropped/unknown transaction timeout, restart/manual recovery, legacy migration, owner fencing, and concurrent acquisition
  - verifies RPC misses are not incorrectly treated as Tempo replacements
- `pnpm check:types` — passed
- `pnpm check` — passed (existing repository warnings only)

The chain-backed Charge suite was not run locally because no Tempo localnet RPC was available at `localhost:18545`; reconciliation tests use deterministic mocked RPC responses.