### PR TITLE
feat: auto-swap session deposits

### DIFF
--- a/.changeset/session-autoswap.md
+++ b/.changeset/session-autoswap.md
@@ -1,5 +1,5 @@
 ---
-'mppx': minor
+'mppx': patch
 ---
 
 Added automatic stablecoin swaps for Tempo session channel opens and top-ups.

--- a/.changeset/session-autoswap.md
+++ b/.changeset/session-autoswap.md
@@ -1,0 +1,5 @@
+---
+'mppx': minor
+---
+
+Added automatic stablecoin swaps for Tempo session channel opens and top-ups.

--- a/src/client/Mppx.test-d.ts
+++ b/src/client/Mppx.test-d.ts
@@ -262,9 +262,9 @@ describe('fetch context', () => {
     type FetchInit = NonNullable<Parameters<typeof _mppx.fetch>[1]>
     type Context = NonNullable<FetchInit['context']>
 
-    // Context is a union of charge and session contexts.
-    // `account` exists on both; `autoSwap` only on charge.
+    // Context is a union of charge and session contexts; both support auto-swap.
     expectTypeOf<Context>().toHaveProperty('account')
-    expectTypeOf<Extract<Context, { autoSwap?: unknown }>>().toHaveProperty('autoSwap')
+    expectTypeOf<Context>().toHaveProperty('autoSwap')
+    expectTypeOf<Context['autoSwap']>().toEqualTypeOf<AutoSwap.resolve.Value | undefined>()
   })
 })

--- a/src/tempo/session/client/ChannelOps.ts
+++ b/src/tempo/session/client/ChannelOps.ts
@@ -28,7 +28,7 @@ import type {
 import { uint96 } from '../precompile/Protocol.js'
 import * as Voucher from '../precompile/Voucher.js'
 
-type TempoChannelCall = {
+export type TempoChannelCall = {
   to: Address
   data: Hex.Hex
 }
@@ -231,6 +231,8 @@ export async function createOpenPayload(
     initialAmount: bigint
     operator?: Address | undefined
     payee: Address
+    /** Calls executed atomically before the channel is opened. */
+    prefixCalls?: readonly TempoChannelCall[] | undefined
     token: Address
   },
 ): Promise<OpenCredentialPayload> {
@@ -248,7 +250,7 @@ export async function createOpenPayload(
   })
   const prepared = await prepareTempoChannelTransaction(client, {
     account,
-    calls: [{ to: escrow, data: openData }],
+    calls: [...(parameters.prefixCalls ?? []), { to: escrow, data: openData }],
     feePayer: parameters.feePayer,
     feeToken: parameters.token,
   })
@@ -308,6 +310,7 @@ export async function createTopUpPayload(
   chainId: number,
   feePayer?: boolean | undefined,
   escrow: Address = tip20ChannelEscrow,
+  prefixCalls: readonly TempoChannelCall[] = [],
 ): Promise<TopUpCredentialPayload> {
   const channelId = Channel.computeId({
     ...descriptor,
@@ -318,6 +321,7 @@ export async function createTopUpPayload(
   const prepared = await prepareTempoChannelTransaction(client, {
     account,
     calls: [
+      ...prefixCalls,
       {
         to: escrow,
         data: encodeFunctionData({

--- a/src/tempo/session/client/CredentialState.ts
+++ b/src/tempo/session/client/CredentialState.ts
@@ -11,6 +11,7 @@ import type * as Challenge from '../../../Challenge.js'
 import * as Constants from '../../../Constants.js'
 import * as Account from '../../../viem/Account.js'
 import * as z from '../../../zod.js'
+import * as AutoSwap from '../../internal/auto-swap.js'
 import * as Chain from '../precompile/Chain.js'
 import * as Channel from '../precompile/Channel.js'
 import type { SessionCredentialPayload } from '../precompile/Protocol.js'
@@ -25,6 +26,7 @@ import {
   resolveAuthorizedSigner,
   resolveEscrow,
   type ChannelEntry,
+  type TempoChannelCall,
 } from './ChannelOps.js'
 import { channelKey, entryKey, type ChannelSink } from './ChannelStore.js'
 import { assertWithinMaxDeposit, resolveOpeningDeposit } from './Runtime.js'
@@ -88,6 +90,7 @@ const hashSchema = z.custom<Hex>(
 /** Runtime schema for low-level TIP-1034 session credential context. */
 export const sessionContextSchema = z.object({
   account: z.optional(z.custom<Account.getResolver.Parameters['account']>()),
+  autoSwap: z.optional(z.custom<AutoSwap.resolve.Value>()),
   action: z.optional(z.enum(['open', 'topUp', 'voucher', 'close'])),
   channelId: z.optional(hashSchema),
   cumulativeAmount: z.optional(z.amount()),
@@ -103,6 +106,8 @@ export const sessionContextSchema = z.object({
 export type SessionContext = {
   /** Optional account override used for this credential only. */
   account?: Account.getResolver.Parameters['account'] | undefined
+  /** Automatically acquire the session currency from fallback stablecoins before open/top-up. */
+  autoSwap?: AutoSwap.resolve.Value | undefined
   /** Manual credential action. Omit for automatic open/recover/voucher management. */
   action?: 'open' | 'topUp' | 'voucher' | 'close' | undefined
   /** Channel ID being reused or manually operated on. */
@@ -658,22 +663,43 @@ export function planCredential(parameters: PlanCredentialParameters): Credential
 export async function executeCredentialPlan(
   plan: CredentialPlan,
   sink: ChannelSink,
+  autoSwap: AutoSwap.resolve.Resolved | false = false,
 ): Promise<SessionCredentialPayload> {
   switch (plan.type) {
     case 'open':
-      return open(plan, sink)
+      return open(plan, sink, autoSwap)
     case 'recover':
       return recover(plan, sink)
     case 'voucher':
       return voucher(plan, sink)
     case 'manual':
-      return manual(plan, sink)
+      return manual(plan, sink, autoSwap)
   }
+}
+
+async function resolveAutoSwapCalls(
+  autoSwap: AutoSwap.resolve.Resolved | false,
+  parameters: {
+    account: Address
+    amountOut: bigint
+    client: Client
+    tokenOut: Address
+  },
+): Promise<readonly TempoChannelCall[] | undefined> {
+  if (!autoSwap) return undefined
+  return (await AutoSwap.findCalls(parameters.client, {
+    account: parameters.account,
+    amountOut: parameters.amountOut,
+    tokenOut: parameters.tokenOut,
+    tokenIn: autoSwap.tokenIn,
+    slippage: autoSwap.slippage,
+  })) as readonly TempoChannelCall[] | undefined
 }
 
 async function open(
   plan: Extract<CredentialPlan, { type: 'open' }>,
   sink: ChannelSink,
+  autoSwap: AutoSwap.resolve.Resolved | false,
 ): Promise<SessionCredentialPayload> {
   const { account, resolved } = plan
   const deposit = resolveOpeningDeposit({
@@ -690,6 +716,12 @@ async function open(
     initialAmount: resolved.amount,
     operator: resolved.operator,
     payee: resolved.payee,
+    prefixCalls: await resolveAutoSwapCalls(autoSwap, {
+      account: account.address,
+      amountOut: deposit,
+      client: resolved.client,
+      tokenOut: resolved.token,
+    }),
     token: resolved.token,
   })
   await storeChannelEntry(sink, {
@@ -776,6 +808,7 @@ async function voucher(
 async function manual(
   plan: Extract<CredentialPlan, { type: 'manual' }>,
   sink: ChannelSink,
+  autoSwap: AutoSwap.resolve.Resolved | false,
 ): Promise<SessionCredentialPayload> {
   const { account, context, decimals, resolved } = plan
   const { descriptor } = context
@@ -794,26 +827,30 @@ async function manual(
     token: resolved.token,
   })
 
-  const payload = await executeManualCredential({
-    account,
-    channelId,
-    context,
-    decimals,
-    descriptor,
-    resolved,
-  })
+  const payload = await executeManualCredential(
+    {
+      account,
+      channelId,
+      context,
+      decimals,
+      descriptor,
+      resolved,
+    },
+    autoSwap,
+  )
   await applyCumulative(sink, resolved.key, payload)
   return payload
 }
 
 async function executeManualCredential(
   parameters: ManualCredentialParameters,
+  autoSwap: AutoSwap.resolve.Resolved | false,
 ): Promise<SessionCredentialPayload> {
   switch (parameters.context.action) {
     case 'open':
       return manualOpen(parameters)
     case 'topUp':
-      return manualTopUp(parameters)
+      return manualTopUp(parameters, autoSwap)
     case 'voucher':
       return manualVoucher(parameters)
     case 'close':
@@ -849,6 +886,7 @@ async function manualOpen(
 
 async function manualTopUp(
   parameters: ManualCredentialParameters,
+  autoSwap: AutoSwap.resolve.Resolved | false,
 ): Promise<SessionCredentialPayload> {
   const { account, channelId, context, decimals, descriptor, resolved } = parameters
   const additionalDeposit = requireContextAmount(context, decimals, 'additionalDeposit', 'topUp')
@@ -870,6 +908,12 @@ async function manualTopUp(
     resolved.chainId,
     resolved.feePayer,
     resolved.escrow,
+    await resolveAutoSwapCalls(autoSwap, {
+      account: account.address,
+      amountOut: additionalDeposit,
+      client: resolved.client,
+      tokenOut: resolved.token,
+    }),
   )
 }
 

--- a/src/tempo/session/client/Session.test.ts
+++ b/src/tempo/session/client/Session.test.ts
@@ -1,7 +1,7 @@
 import { type Address, createClient, custom, decodeFunctionData, encodeFunctionResult } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { Account as TempoAccount, Secp256k1, Transaction } from 'viem/tempo'
-import { describe, expect, test } from 'vp/test'
+import { describe, expect, test, vi } from 'vp/test'
 
 import { serialize as serializeChallenge, type Challenge } from '../../../Challenge.js'
 import * as Fetch from '../../../client/internal/Fetch.js'
@@ -9,6 +9,7 @@ import * as MethodChallenge from '../../../client/internal/MethodChallenge.js'
 import * as Constants from '../../../Constants.js'
 import * as Credential from '../../../Credential.js'
 import * as z from '../../../zod.js'
+import * as AutoSwap from '../../internal/auto-swap.js'
 import * as Methods from '../../Methods.js'
 import * as Channel from '../precompile/Channel.js'
 import { escrowAbi } from '../precompile/escrow.abi.js'
@@ -98,6 +99,14 @@ function openArgs(payload: Types.SessionCredentialPayload) {
 
 function openDeposit(payload: Types.SessionCredentialPayload): bigint {
   return openArgs(payload)[3]
+}
+
+function transactionCalls(payload: Types.SessionCredentialPayload) {
+  if (payload.action !== 'open' && payload.action !== 'topUp')
+    throw new Error('expected transaction payload')
+  const transaction = Transaction.deserialize(payload.transaction)
+  if (!('calls' in transaction)) throw new Error('expected tempo calls')
+  return transaction.calls as readonly { to?: Address; data?: `0x${string}` }[]
 }
 
 describe('precompile client session', () => {
@@ -374,6 +383,72 @@ describe('precompile client session', () => {
 
     expect(payload.action).toBe('open')
     expect(openDeposit(payload)).toBe(100n)
+  })
+
+  test('atomically auto-swaps before opening a session channel', async () => {
+    const sourceToken = '0x0000000000000000000000000000000000000007' as Address
+    const swapCalls = [
+      { to: sourceToken, data: '0x1234' as const },
+      { to: '0x0000000000000000000000000000000000000008' as Address, data: '0x5678' as const },
+    ]
+    const findCalls = vi.spyOn(AutoSwap, 'findCalls').mockResolvedValue(swapCalls)
+    try {
+      const method = session({
+        account,
+        autoSwap: { slippage: 2, tokenIn: [sourceToken] },
+        getClient: () => client,
+      })
+      const payload = deserialize(
+        await method.createCredential({ challenge: makeChallenge(), context: {} }),
+      )
+
+      expect(findCalls).toHaveBeenCalledWith(expect.any(Object), {
+        account: account.address,
+        amountOut: 100n,
+        slippage: 2,
+        tokenIn: expect.arrayContaining([sourceToken]),
+        tokenOut: descriptor.token,
+      })
+      const calls = transactionCalls(payload)
+      expect(calls.slice(0, 2)).toEqual(swapCalls)
+      expect(calls[2]!.to?.toLowerCase()).toBe(tip20ChannelEscrow.toLowerCase())
+      expect(decodeFunctionData({ abi: escrowAbi, data: calls[2]!.data! }).functionName).toBe(
+        'open',
+      )
+    } finally {
+      findCalls.mockRestore()
+    }
+  })
+
+  test('atomically auto-swaps before topping up a session channel', async () => {
+    const sourceToken = '0x0000000000000000000000000000000000000007' as Address
+    const swapCalls = [{ to: sourceToken, data: '0x1234' as const }]
+    const findCalls = vi.spyOn(AutoSwap, 'findCalls').mockResolvedValue(swapCalls)
+    try {
+      const method = session({ account, autoSwap: true, getClient: () => client })
+      const payload = deserialize(
+        await method.createCredential({
+          challenge: makeChallenge(),
+          context: { action: 'topUp', additionalDepositRaw: '250', descriptor },
+        }),
+      )
+
+      expect(findCalls).toHaveBeenCalledWith(expect.any(Object), {
+        account: account.address,
+        amountOut: 250n,
+        slippage: 1,
+        tokenIn: AutoSwap.defaultCurrencies,
+        tokenOut: descriptor.token,
+      })
+      const calls = transactionCalls(payload)
+      expect(calls[0]).toEqual(swapCalls[0])
+      expect(calls[1]!.to?.toLowerCase()).toBe(tip20ChannelEscrow.toLowerCase())
+      expect(decodeFunctionData({ abi: escrowAbi, data: calls[1]!.data! }).functionName).toBe(
+        'topUp',
+      )
+    } finally {
+      findCalls.mockRestore()
+    }
   })
 
   test('uses client chain ID when the challenge omits chain ID', async () => {

--- a/src/tempo/session/client/Session.ts
+++ b/src/tempo/session/client/Session.ts
@@ -11,6 +11,7 @@ import type {
   ResolveAccount as ResolveAccount_,
   ResolveAccountInfo as ResolveAccountInfo_,
 } from '../../client/ResolveAccount.js'
+import * as AutoSwap from '../../internal/auto-swap.js'
 import * as defaults from '../../internal/defaults.js'
 import * as Methods from '../../Methods.js'
 import * as Channel from '../precompile/Channel.js'
@@ -54,6 +55,7 @@ export { sessionContextSchema, type SessionContext } from './CredentialState.js'
 export function session(parameters: session.Parameters = {}) {
   const {
     account,
+    autoSwap: autoSwapParameter,
     channelStore,
     decimals = defaults.decimals,
     escrow: escrowOverride,
@@ -119,6 +121,7 @@ export function session(parameters: session.Parameters = {}) {
           resolved,
         }),
         sink,
+        AutoSwap.resolve(context?.autoSwap ?? autoSwapParameter, AutoSwap.defaultCurrencies),
       )
       return serializeCredential(challenge, payload, resolved.chainId, account)
     },
@@ -258,6 +261,8 @@ export declare namespace session {
 
   type Parameters = Account.getResolver.Parameters &
     Client.getResolver.Parameters & {
+      /** Automatically acquire the session currency from fallback stablecoins before open/top-up. */
+      autoSwap?: AutoSwap.resolve.Value | undefined
       /** Pluggable persistence for reusable channels. Defaults to an in-memory store. */
       channelStore?: ChannelStore | undefined
       /** Token decimals for parsing human-readable amounts (default: 6). */

--- a/src/tempo/session/client/SessionManager.ts
+++ b/src/tempo/session/client/SessionManager.ts
@@ -277,6 +277,7 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
 
   const method = sessionPlugin({
     account: parameters.account,
+    autoSwap: parameters.autoSwap,
     getClient: parameters.client ? () => parameters.client! : parameters.getClient,
     resolveAccount: parameters.resolveAccount,
     escrow: parameters.escrow,
@@ -899,6 +900,8 @@ export namespace sessionManager {
 
   export type Parameters = Account.getResolver.Parameters &
     Client.getResolver.Parameters & {
+      /** Automatically acquire the session currency from fallback stablecoins before open/top-up. */
+      autoSwap?: sessionPlugin.Parameters['autoSwap']
       /** Enables same-route HEAD bootstrap from a server session snapshot before opening a new channel. */
       bootstrap?: boolean | undefined
       /** Viem client instance. Shorthand for `getClient: () => client`. */

--- a/src/tempo/session/precompile/Chain.test.ts
+++ b/src/tempo/session/precompile/Chain.test.ts
@@ -12,7 +12,7 @@ import {
   type Hex,
 } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { Transaction } from 'viem/tempo'
+import { Abis, Addresses, Transaction } from 'viem/tempo'
 import { describe, expect, test } from 'vp/test'
 
 import { VerificationFailedError } from '../../../Errors.js'
@@ -36,6 +36,7 @@ const descriptor = {
 const deposit = Types.uint96(1_000_000n)
 const chainId = 42431
 const txHash = `0x${'ab'.repeat(32)}` as const
+const sourceToken = '0x6666666666666666666666666666666666666666' as const
 const feePayer = privateKeyToAccount(
   '0x59c6995e998f97a5a0044966f0945389d1fc6e60e7346d6c36c49d32f75b9a1b',
 )
@@ -192,6 +193,28 @@ async function createSerializedTransaction(parameters: {
   } as never)) as `0x${string}`
 }
 
+function autoSwapCalls(amountOut: bigint = deposit) {
+  const maxAmountIn = amountOut + 1_000n
+  return [
+    {
+      to: sourceToken,
+      data: encodeFunctionData({
+        abi: Abis.tip20,
+        functionName: 'approve',
+        args: [Addresses.stablecoinDex, maxAmountIn],
+      }),
+    },
+    {
+      to: Addresses.stablecoinDex,
+      data: encodeFunctionData({
+        abi: Abis.stablecoinDex,
+        functionName: 'swapExactAmountOut',
+        args: [sourceToken, descriptor.token, amountOut, maxAmountIn],
+      }),
+    },
+  ] as const
+}
+
 async function createOpenTransaction(
   parameters: {
     authorizedSigner?: `0x${string}` | undefined
@@ -201,6 +224,7 @@ async function createOpenTransaction(
     signed?: boolean | undefined
     token?: `0x${string}` | undefined
     to?: `0x${string}` | undefined
+    prefixCalls?: readonly { to: `0x${string}`; data: `0x${string}` }[] | undefined
   } = {},
 ) {
   const data = encodeFunctionData({
@@ -216,7 +240,7 @@ async function createOpenTransaction(
     ],
   })
   return createSerializedTransaction({
-    calls: [{ to: parameters.to ?? tip20ChannelEscrow, data }],
+    calls: [...(parameters.prefixCalls ?? []), { to: parameters.to ?? tip20ChannelEscrow, data }],
     gas: parameters.gas,
     signed: parameters.signed,
   })
@@ -229,6 +253,7 @@ async function createTopUpTransaction(
     gas?: bigint | undefined
     signed?: boolean | undefined
     to?: `0x${string}` | undefined
+    prefixCalls?: readonly { to: `0x${string}`; data: `0x${string}` }[] | undefined
   } = {},
 ) {
   const data = encodeFunctionData({
@@ -240,7 +265,7 @@ async function createTopUpTransaction(
     ],
   })
   return createSerializedTransaction({
-    calls: [{ to: parameters.to ?? tip20ChannelEscrow, data }],
+    calls: [...(parameters.prefixCalls ?? []), { to: parameters.to ?? tip20ChannelEscrow, data }],
     gas: parameters.gas,
     signed: parameters.signed,
   })
@@ -446,7 +471,31 @@ describe('precompile broadcastOpenTransaction', () => {
         expectedPayer: descriptor.payer,
         serializedTransaction,
       }),
-    ).rejects.toThrow('TIP-1034 open transaction must contain exactly one call')
+    ).rejects.toThrow(
+      'TIP-1034 open transaction must contain one management call, optionally preceded by an auto-swap',
+    )
+  })
+
+  test('rejects an auto-swap whose output does not match the open deposit', async () => {
+    const serializedTransaction = await createOpenTransaction({
+      prefixCalls: autoSwapCalls(deposit + 1n),
+    })
+
+    await expect(
+      Chain.broadcastOpenTransaction({
+        chainId,
+        client: createMockClient(),
+        escrowContract: tip20ChannelEscrow,
+        expectedAuthorizedSigner: descriptor.authorizedSigner,
+        expectedChannelId: `0x${'11'.repeat(32)}`,
+        expectedCurrency: descriptor.token,
+        expectedExpiringNonceHash: expectedExpiringNonceHash(serializedTransaction),
+        expectedOperator: descriptor.operator,
+        expectedPayee: descriptor.payee,
+        expectedPayer: descriptor.payer,
+        serializedTransaction,
+      }),
+    ).rejects.toThrow('TIP-1034 open auto-swap output amount does not match channel deposit')
   })
 
   test('rejects open transactions targeting the wrong escrow contract', async () => {
@@ -715,8 +764,8 @@ describe('precompile broadcastOpenTransaction', () => {
     ).rejects.toThrow('credential expiringNonceHash does not match transaction')
   })
 
-  test('returns tx hash, descriptor, event fields, and read-back state on success', async () => {
-    const serializedTransaction = await createOpenTransaction()
+  test('accepts an exact-output auto-swap before open', async () => {
+    const serializedTransaction = await createOpenTransaction({ prefixCalls: autoSwapCalls() })
     const expiringNonceHash = expectedExpiringNonceHash(serializedTransaction)
     const expectedDescriptor = { ...descriptor, expiringNonceHash }
     const channelId = Channel.computeId({
@@ -858,7 +907,9 @@ describe('precompile broadcastTopUpTransaction', () => {
         expectedCurrency: descriptor.token,
         serializedTransaction,
       }),
-    ).rejects.toThrow('TIP-1034 topUp transaction must contain exactly one call')
+    ).rejects.toThrow(
+      'TIP-1034 topUp transaction must contain one management call, optionally preceded by an auto-swap',
+    )
   })
 
   test('rejects top-up transactions targeting the wrong escrow contract', async () => {
@@ -1025,8 +1076,8 @@ describe('precompile broadcastTopUpTransaction', () => {
     ).rejects.toThrow('topUp deposit does not match credential')
   })
 
-  test('returns tx hash, new deposit, and read-back state on success', async () => {
-    const serializedTransaction = await createTopUpTransaction()
+  test('accepts an exact-output auto-swap before top-up', async () => {
+    const serializedTransaction = await createTopUpTransaction({ prefixCalls: autoSwapCalls() })
     const channelId = Channel.computeId({ ...descriptor, chainId, escrow: tip20ChannelEscrow })
     const newDeposit = deposit * 2n
     const state = { settled: 0n, deposit: newDeposit, closeRequestedAt: 0 }

--- a/src/tempo/session/precompile/Chain.test.ts
+++ b/src/tempo/session/precompile/Chain.test.ts
@@ -163,7 +163,11 @@ function topUpLog(parameters: { channelId: `0x${string}`; newDeposit: bigint }) 
 }
 
 async function createSerializedTransaction(parameters: {
-  calls: { to: `0x${string}`; data?: `0x${string}` | undefined }[]
+  calls: {
+    to?: `0x${string}` | undefined
+    data?: `0x${string}` | undefined
+    value?: bigint | undefined
+  }[]
   gas?: bigint | undefined
   signed?: boolean | undefined
 }) {
@@ -224,7 +228,13 @@ async function createOpenTransaction(
     signed?: boolean | undefined
     token?: `0x${string}` | undefined
     to?: `0x${string}` | undefined
-    prefixCalls?: readonly { to: `0x${string}`; data: `0x${string}` }[] | undefined
+    prefixCalls?:
+      | readonly {
+          to?: `0x${string}` | undefined
+          data?: `0x${string}` | undefined
+          value?: bigint | undefined
+        }[]
+      | undefined
   } = {},
 ) {
   const data = encodeFunctionData({
@@ -253,7 +263,13 @@ async function createTopUpTransaction(
     gas?: bigint | undefined
     signed?: boolean | undefined
     to?: `0x${string}` | undefined
-    prefixCalls?: readonly { to: `0x${string}`; data: `0x${string}` }[] | undefined
+    prefixCalls?:
+      | readonly {
+          to?: `0x${string}` | undefined
+          data?: `0x${string}` | undefined
+          value?: bigint | undefined
+        }[]
+      | undefined
   } = {},
 ) {
   const data = encodeFunctionData({
@@ -476,27 +492,147 @@ describe('precompile broadcastOpenTransaction', () => {
     )
   })
 
-  test('rejects an auto-swap whose output does not match the open deposit', async () => {
-    const serializedTransaction = await createOpenTransaction({
-      prefixCalls: autoSwapCalls(deposit + 1n),
-    })
-
-    await expect(
-      Chain.broadcastOpenTransaction({
-        chainId,
-        client: createMockClient(),
-        escrowContract: tip20ChannelEscrow,
-        expectedAuthorizedSigner: descriptor.authorizedSigner,
-        expectedChannelId: `0x${'11'.repeat(32)}`,
-        expectedCurrency: descriptor.token,
-        expectedExpiringNonceHash: expectedExpiringNonceHash(serializedTransaction),
-        expectedOperator: descriptor.operator,
-        expectedPayee: descriptor.payee,
-        expectedPayer: descriptor.payer,
-        serializedTransaction,
-      }),
-    ).rejects.toThrow('TIP-1034 open auto-swap output amount does not match channel deposit')
+  const [validApprove, validSwap] = autoSwapCalls()
+  const wrongToken = '0x7777777777777777777777777777777777777777' as const
+  const maxAmountIn = deposit + 1_000n
+  const approve = (parameters: {
+    amount?: bigint | undefined
+    spender?: Address | undefined
+    token?: Address | undefined
+  }) => ({
+    to: parameters.token ?? sourceToken,
+    data: encodeFunctionData({
+      abi: Abis.tip20,
+      functionName: 'approve',
+      args: [parameters.spender ?? Addresses.stablecoinDex, parameters.amount ?? maxAmountIn],
+    }),
   })
+  const swap = (parameters: {
+    amountOut?: bigint | undefined
+    maxAmount?: bigint | undefined
+    tokenIn?: Address | undefined
+    tokenOut?: Address | undefined
+  }) => ({
+    to: Addresses.stablecoinDex as Address,
+    data: encodeFunctionData({
+      abi: Abis.stablecoinDex,
+      functionName: 'swapExactAmountOut',
+      args: [
+        parameters.tokenIn ?? sourceToken,
+        parameters.tokenOut ?? descriptor.token,
+        parameters.amountOut ?? deposit,
+        parameters.maxAmount ?? maxAmountIn,
+      ],
+    }),
+  })
+  const invalidAutoSwapPrefixes = [
+    {
+      name: 'missing call target',
+      prefixCalls: [{ data: validApprove.data }, validSwap],
+      reason: 'call is missing a target or calldata',
+    },
+    {
+      name: 'native value',
+      prefixCalls: [{ ...validApprove, value: 1n }, validSwap],
+      reason: 'calls must not transfer native value',
+    },
+    {
+      name: 'wrong DEX target',
+      prefixCalls: [validApprove, { ...validSwap, to: wrongToken }],
+      reason: 'targets the wrong DEX',
+    },
+    {
+      name: 'invalid approval calldata',
+      prefixCalls: [{ ...validApprove, data: '0x12345678' as const }, validSwap],
+      reason: 'approval calldata is invalid',
+    },
+    {
+      name: 'invalid swap calldata',
+      prefixCalls: [validApprove, { ...validSwap, data: '0x12345678' as const }],
+      reason: 'swap calldata is invalid',
+    },
+    {
+      name: 'wrong approval function',
+      prefixCalls: [
+        {
+          to: sourceToken,
+          data: encodeFunctionData({
+            abi: Abis.tip20,
+            functionName: 'transfer',
+            args: [Addresses.stablecoinDex, maxAmountIn],
+          }),
+        },
+        validSwap,
+      ],
+      reason: 'must contain approve followed by swapExactAmountOut',
+    },
+    {
+      name: 'approval token mismatch',
+      prefixCalls: [approve({ token: wrongToken }), validSwap],
+      reason: 'approval token does not match swap input',
+    },
+    {
+      name: 'approval spender mismatch',
+      prefixCalls: [approve({ spender: wrongToken }), validSwap],
+      reason: 'approval spender is not the DEX',
+    },
+    {
+      name: 'approval amount mismatch',
+      prefixCalls: [approve({ amount: maxAmountIn + 1n }), validSwap],
+      reason: 'approval amount does not match swap maximum input',
+    },
+    {
+      name: 'output token mismatch',
+      prefixCalls: [validApprove, swap({ tokenOut: wrongToken })],
+      reason: 'output token does not match channel currency',
+    },
+    {
+      name: 'output amount mismatch',
+      prefixCalls: [
+        approve({ amount: maxAmountIn + 1n }),
+        swap({ amountOut: deposit + 1n, maxAmount: maxAmountIn + 1n }),
+      ],
+      reason: 'output amount does not match channel deposit',
+    },
+    {
+      name: 'identical input and output tokens',
+      prefixCalls: [approve({ token: descriptor.token }), swap({ tokenIn: descriptor.token })],
+      reason: 'input and output tokens must differ',
+    },
+    {
+      name: 'non-canonical approval calldata',
+      prefixCalls: [{ ...validApprove, data: `${validApprove.data}00` as Hex }, validSwap],
+      reason: 'approval calldata is not canonical',
+    },
+    {
+      name: 'non-canonical swap calldata',
+      prefixCalls: [validApprove, { ...validSwap, data: `${validSwap.data}00` as Hex }],
+      reason: 'swap calldata is not canonical',
+    },
+  ] as const
+
+  test.each(invalidAutoSwapPrefixes)(
+    'rejects an auto-swap with $name',
+    async ({ prefixCalls, reason }) => {
+      const serializedTransaction = await createOpenTransaction({ prefixCalls })
+
+      await expect(
+        Chain.broadcastOpenTransaction({
+          chainId,
+          client: createMockClient(),
+          escrowContract: tip20ChannelEscrow,
+          expectedAuthorizedSigner: descriptor.authorizedSigner,
+          expectedChannelId: `0x${'11'.repeat(32)}`,
+          expectedCurrency: descriptor.token,
+          expectedExpiringNonceHash: expectedExpiringNonceHash(serializedTransaction),
+          expectedOperator: descriptor.operator,
+          expectedPayee: descriptor.payee,
+          expectedPayer: descriptor.payer,
+          serializedTransaction,
+        }),
+      ).rejects.toThrow(`TIP-1034 open auto-swap ${reason}`)
+    },
+  )
 
   test('rejects open transactions targeting the wrong escrow contract', async () => {
     const serializedTransaction = await createOpenTransaction({ to: descriptor.token })

--- a/src/tempo/session/precompile/Chain.ts
+++ b/src/tempo/session/precompile/Chain.ts
@@ -1,5 +1,5 @@
 import type { Account, Address, Client, Hex } from 'viem'
-import { encodeFunctionData, isAddressEqual, parseEventLogs } from 'viem'
+import { decodeFunctionData, encodeFunctionData, isAddressEqual, parseEventLogs } from 'viem'
 import {
   call,
   prepareTransactionRequest,
@@ -10,7 +10,7 @@ import {
   signTransaction,
   waitForTransactionReceipt,
 } from 'viem/actions'
-import { Transaction } from 'viem/tempo'
+import { Abis, Addresses, Transaction } from 'viem/tempo'
 
 import { BadRequestError, VerificationFailedError } from '../../../Errors.js'
 import * as FeePayer from '../../internal/fee-payer.js'
@@ -401,6 +401,7 @@ export type ChannelTransactionOptions = {
 
 type ParsedPrecompileCredentialTransaction = {
   call: Transaction.TransactionTempo['calls'][number] & { data: Hex; to: Address }
+  prefixCalls: readonly Transaction.TransactionTempo['calls'][number][]
   transaction: ReturnType<(typeof Transaction)['deserialize']>
 }
 
@@ -418,11 +419,11 @@ function parsePrecompileCredentialTransaction(parameters: {
     serializedTransaction as Transaction.TransactionSerializedTempo,
   )
   const calls = transaction.calls
-  if (calls.length !== 1)
+  if (calls.length !== 1 && calls.length !== 3)
     throw new VerificationFailedError({
-      reason: `TIP-1034 ${label} transaction must contain exactly one call`,
+      reason: `TIP-1034 ${label} transaction must contain one management call, optionally preceded by an auto-swap`,
     })
-  const call = calls[0]!
+  const call = calls.at(-1)!
   if (!call.to || !isAddressEqual(call.to, escrowContract))
     throw new VerificationFailedError({
       reason: `TIP-1034 ${label} transaction targets the wrong address`,
@@ -431,7 +432,88 @@ function parsePrecompileCredentialTransaction(parameters: {
     throw new VerificationFailedError({
       reason: `TIP-1034 ${label} transaction is missing calldata`,
     })
-  return { transaction, call: { ...call, data: call.data, to: call.to } }
+  return {
+    transaction,
+    call: { ...call, data: call.data, to: call.to },
+    prefixCalls: calls.slice(0, -1),
+  }
+}
+
+function validateAutoSwapPrefix(parameters: {
+  amountOut: bigint
+  currency: Address
+  label: 'open' | 'topUp'
+  prefixCalls: readonly Transaction.TransactionTempo['calls'][number][]
+}) {
+  const { amountOut, currency, label, prefixCalls } = parameters
+  if (prefixCalls.length === 0) return
+
+  const fail = (reason: string): never => {
+    throw new VerificationFailedError({ reason: `TIP-1034 ${label} auto-swap ${reason}` })
+  }
+  if (prefixCalls.length !== 2) fail('must contain exactly approve and swap calls')
+
+  const approveCall = prefixCalls[0]!
+  const swapCall = prefixCalls[1]!
+  const approveTo = approveCall.to
+  const approveData = approveCall.data
+  const swapTo = swapCall.to
+  const swapData = swapCall.data
+  if (!approveTo || !approveData || !swapTo || !swapData)
+    fail('call is missing a target or calldata')
+  const checkedApproveTo = approveTo as Address
+  const checkedApproveData = approveData as Hex
+  const checkedSwapTo = swapTo as Address
+  const checkedSwapData = swapData as Hex
+  if ((approveCall.value ?? 0n) !== 0n || (swapCall.value ?? 0n) !== 0n)
+    fail('calls must not transfer native value')
+  if (!isAddressEqual(checkedSwapTo, Addresses.stablecoinDex)) fail('targets the wrong DEX')
+
+  const approve = (() => {
+    try {
+      return decodeFunctionData({ abi: Abis.tip20, data: checkedApproveData })
+    } catch {
+      return fail('approval calldata is invalid')
+    }
+  })()
+  const swap = (() => {
+    try {
+      return decodeFunctionData({ abi: Abis.stablecoinDex, data: checkedSwapData })
+    } catch {
+      return fail('swap calldata is invalid')
+    }
+  })()
+  if (approve.functionName !== 'approve' || swap.functionName !== 'swapExactAmountOut')
+    fail('must contain approve followed by swapExactAmountOut')
+
+  const [spender, approvedAmount] = approve.args as readonly [Address, bigint]
+  const [tokenIn, tokenOut, swapAmountOut, maxAmountIn] = swap.args as readonly [
+    Address,
+    Address,
+    bigint,
+    bigint,
+  ]
+  if (!isAddressEqual(checkedApproveTo, tokenIn)) fail('approval token does not match swap input')
+  if (!isAddressEqual(spender, Addresses.stablecoinDex)) fail('approval spender is not the DEX')
+  if (approvedAmount !== maxAmountIn) fail('approval amount does not match swap maximum input')
+  if (!isAddressEqual(tokenOut, currency)) fail('output token does not match channel currency')
+  if (swapAmountOut !== amountOut) fail('output amount does not match channel deposit')
+  if (isAddressEqual(tokenIn, tokenOut)) fail('input and output tokens must differ')
+
+  const canonicalApprove = encodeFunctionData({
+    abi: Abis.tip20,
+    functionName: 'approve',
+    args: [spender, approvedAmount],
+  })
+  const canonicalSwap = encodeFunctionData({
+    abi: Abis.stablecoinDex,
+    functionName: 'swapExactAmountOut',
+    args: [tokenIn, tokenOut, swapAmountOut, maxAmountIn],
+  })
+  if (checkedApproveData.toLowerCase() !== canonicalApprove.toLowerCase())
+    fail('approval calldata is not canonical')
+  if (checkedSwapData.toLowerCase() !== canonicalSwap.toLowerCase())
+    fail('swap calldata is not canonical')
 }
 
 async function simulateTempoTransaction(client: Client, request: unknown) {
@@ -796,7 +878,7 @@ export type BroadcastOpenTransactionParameters = {
 export async function broadcastOpenTransaction(
   parameters: BroadcastOpenTransactionParameters,
 ): Promise<BroadcastOpenTransactionResult> {
-  const { transaction, call } = parsePrecompileCredentialTransaction({
+  const { transaction, call, prefixCalls } = parsePrecompileCredentialTransaction({
     escrowContract: parameters.escrowContract,
     feePayer: parameters.feePayer,
     label: 'open',
@@ -811,6 +893,12 @@ export async function broadcastOpenTransaction(
       operator: parameters.expectedOperator,
       authorizedSigner: parameters.expectedAuthorizedSigner,
     },
+  })
+  validateAutoSwapPrefix({
+    amountOut: open.deposit,
+    currency: parameters.expectedCurrency,
+    label: 'open',
+    prefixCalls,
   })
   const descriptor = ChannelOps.descriptorFromOpen({
     chainId: parameters.chainId,
@@ -920,7 +1008,7 @@ export type BroadcastTopUpTransactionParameters = {
 export async function broadcastTopUpTransaction(
   parameters: BroadcastTopUpTransactionParameters,
 ): Promise<BroadcastTopUpTransactionResult> {
-  const { transaction, call } = parsePrecompileCredentialTransaction({
+  const { transaction, call, prefixCalls } = parsePrecompileCredentialTransaction({
     escrowContract: parameters.escrowContract,
     feePayer: parameters.feePayer,
     label: 'topUp',
@@ -932,6 +1020,12 @@ export async function broadcastTopUpTransaction(
       descriptor: parameters.descriptor,
       additionalDeposit: parameters.additionalDeposit,
     },
+  })
+  validateAutoSwapPrefix({
+    amountOut: parameters.additionalDeposit,
+    currency: parameters.expectedCurrency,
+    label: 'topUp',
+    prefixCalls,
   })
   const receipt = await sendCredentialTransaction({
     challengeExpires: parameters.challengeExpires,

--- a/src/tempo/session/precompile/Chain.ts
+++ b/src/tempo/session/precompile/Chain.ts
@@ -423,7 +423,7 @@ function parsePrecompileCredentialTransaction(parameters: {
     throw new VerificationFailedError({
       reason: `TIP-1034 ${label} transaction must contain one management call, optionally preceded by an auto-swap`,
     })
-  const call = calls.at(-1)!
+  const call = calls[calls.length - 1]!
   if (!call.to || !isAddressEqual(call.to, escrowContract))
     throw new VerificationFailedError({
       reason: `TIP-1034 ${label} transaction targets the wrong address`,


### PR DESCRIPTION
## Summary

- reuse the existing Tempo charge auto-swap resolver for TIP-1034 session deposits
- atomically prepend `approve` and `swapExactAmountOut` before session `open` and `topUp`
- validate the swap prefix server-side and bind its exact output to the channel deposit

## Behavior

When `autoSwap` is enabled, sessions use the same fallback ordering and slippage configuration as charge. If the payer already holds enough channel currency, no swap is added. An open acquires the resolved opening deposit; a top-up acquires only the additional deposit. Vouchers and session recovery do not trigger swaps.

The resulting transaction is either:

```
open / topUp
```

or:

```
approve → swapExactAmountOut → open / topUp
```

## Validation

- client tests cover atomic open and top-up call construction
- server tests accept a canonical exact-output swap and reject output that does not match the deposit
- full CI passes
- verified against the hosted OpenAI MPP service with a sponsored mainnet PathUSD → USDC.e session open, followed by session reuse without another swap