### PR TITLE
feat(examples): add Tempo API relay Hono example

### DIFF
--- a/.changeset/bright-relays-pay.md
+++ b/.changeset/bright-relays-pay.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added a single-file Hono Tempo API relay-backed charge example.

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,6 +7,7 @@ Standalone, runnable examples demonstrating the mppx HTTP 402 payment flow.
 | Example                                       | Description                                          |
 | --------------------------------------------- | ---------------------------------------------------- |
 | [charge](./charge/)                           | Payment-gated image generation API                   |
+| [charge-relay](./charge-relay/)               | Hono API settled by the Tempo API relay              |
 | [session/multi-fetch](./session/multi-fetch/) | Multiple paid requests over a single payment channel |
 | [session/sse](./session/sse/)                 | Pay-per-token LLM streaming with SSE                 |
 | [session/ws](./session/ws/)                   | Pay-per-token LLM streaming with WebSocket           |

--- a/examples/charge-relay/README.md
+++ b/examples/charge-relay/README.md
@@ -1,0 +1,36 @@
+# Hono Charge Relay
+
+A single-file Hono API that accepts pathUSD on Tempo Moderato. Its
+`mppx/hono` middleware issues charges, then calls the Tempo API Moderato relay
+for verification and broadcast.
+
+## Setup
+
+Create a Tempo API key with the `mpp:write` scope and provide it only to the
+server process:
+
+```bash
+export TEMPO_API_KEY=tempo:sk:...
+export TEMPO_API_URL=https://api.tempo.xyz
+export MPP_SECRET_KEY=$(openssl rand -base64 32)
+pnpm install
+pnpm dev
+```
+
+`TEMPO_API_URL` can target a compatible self-hosted or preview Tempo API.
+`MPP_SECRET_KEY` protects the server-issued challenges; the example has a
+development-only default so it can run without one locally.
+
+## Routes
+
+| Route         | Description             |
+| ------------- | ----------------------- |
+| `/api/photo`  | Payment-gated image URL |
+| `/api/health` | Free health check       |
+
+## Flow
+
+1. The server returns a `tempo/charge` pull challenge for pathUSD.
+2. The payer signs a Tempo transaction and returns the MPP credential.
+3. The server calls `POST /v1/mpp/verify`, then `POST /v1/mpp/broadcast`.
+4. The relay receipt becomes the `Payment-Receipt` response header.

--- a/examples/charge-relay/package.json
+++ b/examples/charge-relay/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "charge-relay",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "check:types": "tsgo -b",
+    "dev": "tsx src/server.ts"
+  },
+  "dependencies": {
+    "@hono/node-server": "2.0.8",
+    "@types/node": "^25.6.0",
+    "@typescript/native-preview": "^7.0.0-dev.20260416.1",
+    "hono": "4.12.27",
+    "mppx": "latest",
+    "tsx": "^4.22.4",
+    "typescript": "~6.0.3",
+    "viem": "^2.54.4"
+  }
+}

--- a/examples/charge-relay/src/server.ts
+++ b/examples/charge-relay/src/server.ts
@@ -1,0 +1,103 @@
+import { serve } from '@hono/node-server'
+import { Hono } from 'hono'
+import { Errors, Receipt } from 'mppx'
+import { Mppx } from 'mppx/hono'
+import { tempo } from 'mppx/server'
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
+import { Chain } from 'viem/tempo'
+import { pathusd } from 'viem/tokens'
+
+const apiKey = process.env.TEMPO_API_KEY
+if (!apiKey) throw new Error('Set TEMPO_API_KEY to a Tempo API key with the mpp:write scope.')
+const tempoApiKey = apiKey
+
+const apiUrl = process.env.TEMPO_API_URL ?? 'https://api.tempo.xyz'
+const currency = pathusd(Chain.testnet.id).address
+const account = privateKeyToAccount(generatePrivateKey())
+const method = tempo.charge({
+  account,
+  currency,
+  recipient: account.address,
+  supportedModes: ['pull'],
+  testnet: true,
+})
+const payments = Mppx.create({
+  methods: [
+    {
+      ...method,
+      async validate(parameters: Parameters<NonNullable<typeof method.validate>>[0]) {
+        const { credential, request } = parameters
+        await relay('/v1/mpp/verify', credential)
+        return {
+          challenge: credential.challenge,
+          credential,
+          details: {},
+          intent: method.intent,
+          method: method.name,
+          request,
+          ...(credential.source ? { source: credential.source } : {}),
+        }
+      },
+      async broadcast(parameters: Parameters<NonNullable<typeof method.broadcast>>[0]) {
+        const { credential } = parameters
+        const receipt = await relay('/v1/mpp/broadcast', credential, {
+          'idempotency-key': `mppx_${credential.challenge.id}`,
+        })
+        return Receipt.from({ ...receipt, status: 'success' })
+      },
+    },
+  ],
+  secretKey: process.env.MPP_SECRET_KEY ?? 'mppx-demo-tempo-api-relay-secret-key',
+})
+
+const app = new Hono()
+app.get('/api/health', (c) => c.json({ status: 'ok' }))
+app.get('/api/photo', payments.charge({ amount: '0.01', description: 'Random stock photo' }), (c) =>
+  c.json({ url: 'https://picsum.photos/1024/1024' }),
+)
+
+serve({ fetch: app.fetch, port: Number(process.env.PORT ?? 5173) })
+
+async function relay(
+  path: '/v1/mpp/broadcast' | '/v1/mpp/verify',
+  credential: { challenge: Record<string, unknown>; payload: unknown },
+  headers: Record<string, string> = {},
+) {
+  let response: Response
+  try {
+    response = await fetch(new URL(path, apiUrl), {
+      body: JSON.stringify({ challenge: credential.challenge, payload: credential.payload }),
+      headers: {
+        'content-type': 'application/json',
+        'tempo-api-key': tempoApiKey,
+        ...headers,
+      },
+      method: 'POST',
+    })
+  } catch {
+    throw new Errors.VerificationFailedError({ reason: 'Tempo API relay request failed' })
+  }
+
+  const result = (await response.json().catch(() => undefined)) as RelayResult | undefined
+  if (!response.ok)
+    throw new Errors.VerificationFailedError({
+      reason: `Tempo API relay returned HTTP ${response.status}`,
+    })
+  if (!result || result.success !== true)
+    throw new Errors.VerificationFailedError({
+      reason: result?.error?.message ?? result?.error?.code ?? 'Tempo API relay rejected payment',
+    })
+  return result.receipt
+}
+
+type RelayResult =
+  | {
+      receipt: {
+        externalId?: string | undefined
+        method: string
+        reference: string
+        timestamp: string
+      }
+      success: true
+    }
+  | { error: { code?: string | undefined; message?: string | undefined }; success: false }

--- a/examples/charge-relay/tsconfig.json
+++ b/examples/charge-relay/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "lib": ["ESNext", "DOM"],
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,6 +176,33 @@ importers:
         specifier: ^8.1.3
         version: 8.1.3(@types/node@25.6.0)(esbuild@0.28.1)(tsx@4.23.1)(yaml@2.9.0)
 
+  examples/charge-relay:
+    dependencies:
+      '@hono/node-server':
+        specifier: 2.0.10
+        version: 2.0.10(hono@4.12.27)
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      '@typescript/native-preview':
+        specifier: ^7.0.0-dev.20260416.1
+        version: 7.0.0-dev.20260707.2
+      hono:
+        specifier: 4.12.27
+        version: 4.12.27
+      mppx:
+        specifier: workspace:*
+        version: link:../..
+      tsx:
+        specifier: ^4.22.4
+        version: 4.23.1
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+      viem:
+        specifier: https://pkg.pr.new/viem@4880
+        version: https://pkg.pr.new/viem@4880(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+
   examples/charge-wagmi:
     dependencies:
       '@metamask/sdk':
@@ -3963,7 +3990,7 @@ packages:
     engines: {node: '>= 0.8'}
 
   viem@https://pkg.pr.new/viem@4880:
-    resolution: {tarball: https://pkg.pr.new/viem@4880}
+    resolution: {integrity: sha512-ZC30AIkbk2zdGhVARNvyrnXo9BWbN4T49YhWuIAHmHd/MOjNg+tskVqhiXF72I843x7BtCPRv7/KfROdJ1MpbQ==, tarball: https://pkg.pr.new/viem@4880}
     version: 2.55.6
     peerDependencies:
       typescript: ~5.9.3


### PR DESCRIPTION
## Motivation

Provide a minimal server-only Hono example for handling Tempo charges through the Tempo API relay.

## Summary

- Added a single-file `charge-relay` Hono example.
- Routed payment validation and broadcast through the Tempo API relay.
- Documented setup and added the example to the examples index.

## Key design considerations

- Uses the relay's verify and broadcast endpoints directly, without a browser client, local relay, or separate settlement lookup.
- Uses viem's pathUSD token primitive for the Moderato charge currency.