### PR TITLE
feat(tempo): add API relay configuration

### DIFF
--- a/.changeset/tempo-relay-adapter.md
+++ b/.changeset/tempo-relay-adapter.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added Tempo API relay configuration for server-side charge validation and broadcast.

--- a/src/tempo/PublicExports.test-d.ts
+++ b/src/tempo/PublicExports.test-d.ts
@@ -8,6 +8,7 @@ import type {
   SessionManagerWebSocketOptions as ClientSessionManagerWebSocketOptions,
 } from './client/index.js'
 import * as Tempo from './index.js'
+import type { charge as ServerCharge } from './server/Charge.js'
 import type { SettlementSchedule as ServerSettlementSchedule } from './server/index.js'
 import type {
   ActiveSessionState,
@@ -31,6 +32,7 @@ test('tempo session public barrels expose manager and schedule interfaces', () =
   expectTypeOf(Tempo.Session.Precompile).toBeObject()
   expectTypeOf(Tempo.Session.Server).toBeObject()
   expectTypeOf<typeof Tempo>().not.toHaveProperty('Precompile')
+  expectTypeOf<serverTempo.RelayOptions>().toEqualTypeOf<ServerCharge.RelayOptions>()
 
   expectTypeOf<ClientPaymentResponse>().toEqualTypeOf<SessionPaymentResponse>()
   expectTypeOf<ClientSessionManager>().toEqualTypeOf<SessionManager>()

--- a/src/tempo/PublicExports.test-d.ts
+++ b/src/tempo/PublicExports.test-d.ts
@@ -33,6 +33,24 @@ test('tempo session public barrels expose manager and schedule interfaces', () =
   expectTypeOf(Tempo.Session.Server).toBeObject()
   expectTypeOf<typeof Tempo>().not.toHaveProperty('Precompile')
   expectTypeOf<serverTempo.RelayOptions>().toEqualTypeOf<ServerCharge.RelayOptions>()
+  expectTypeOf<serverTempo.RelayErrorCode>().toEqualTypeOf<
+    | 'already_used'
+    | 'broadcast_failed'
+    | 'expired'
+    | 'invalid_payment'
+    | 'insufficient_funds'
+    | 'policy_denied'
+    | 'screen_rejected'
+    | 'simulation_failed'
+    | 'temporarily_unavailable'
+    | 'unsupported'
+    | 'unknown'
+  >()
+  expectTypeOf<serverTempo.RelayErrorDetails>().toEqualTypeOf<
+    | { code: 'already_used' | 'broadcast_failed' | 'insufficient_funds' | 'invalid_payment' }
+    | { code: 'simulation_failed' | 'unsupported' }
+    | { code: 'temporarily_unavailable'; retry: 'same_credential' }
+  >()
 
   expectTypeOf<ClientPaymentResponse>().toEqualTypeOf<SessionPaymentResponse>()
   expectTypeOf<ClientSessionManager>().toEqualTypeOf<SessionManager>()

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -37,6 +37,7 @@ import * as Selectors from '../internal/selectors.js'
 import type * as types from '../internal/types.js'
 import * as Methods from '../Methods.js'
 import { html as htmlContent } from './internal/html.gen.js'
+import * as Relay from './Relay.js'
 
 /**
  * Creates a Tempo charge method intent for usage on the server.
@@ -53,7 +54,7 @@ export function charge<const parameters extends charge.Parameters>(
     parameters,
     charge.Parameters
   >,
-) {
+): Method.Server<typeof Methods.charge, charge.DeriveDefaults<parameters>> {
   const {
     amount,
     currency = defaults.resolveCurrency(parameters),
@@ -64,6 +65,7 @@ export function charge<const parameters extends charge.Parameters>(
     feePayerPolicy,
     html,
     memo,
+    relay,
     splits,
     supportedModes,
     validateSender,
@@ -343,7 +345,7 @@ export function charge<const parameters extends charge.Parameters>(
   }
 
   type Defaults = charge.DeriveDefaults<parameters>
-  return Method.toServer<typeof Methods.charge, Defaults>(Methods.charge, {
+  const method = Method.toServer<typeof Methods.charge, Defaults>(Methods.charge, {
     defaults: {
       amount,
       currency,
@@ -647,6 +649,7 @@ export function charge<const parameters extends charge.Parameters>(
       }
     },
   })
+  return relay ? (Relay.configure(method, relay) as typeof method) : method
 }
 
 export declare namespace charge {
@@ -721,6 +724,8 @@ export declare namespace charge {
      * By default, no prefix is applied.
      */
     storeKeyPrefix?: string | undefined
+    /** Delegates Tempo charge credential validation and broadcast to Tempo API's MPP relay. */
+    relay?: RelayOptions | undefined
     /**
      * Whether to wait for the charge transaction to confirm on-chain before
      * responding. @default true
@@ -747,6 +752,9 @@ export declare namespace charge {
   >
 
   type FeePayerPolicy = Partial<FeePayer.Policy>
+
+  /** Tempo API relay configuration for server-side charges. */
+  type RelayOptions = Relay.configure.Options
 }
 
 type ChargeRequest = z.output<typeof Methods.charge.schema.request>

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -724,7 +724,7 @@ export declare namespace charge {
      * By default, no prefix is applied.
      */
     storeKeyPrefix?: string | undefined
-    /** Delegates Tempo charge credential validation and broadcast to Tempo API's MPP relay. */
+    /** Delegates Tempo charge credential validation and broadcast to Tempo API or a compatible MPP relay. */
     relay?: RelayOptions | undefined
     /**
      * Whether to wait for the charge transaction to confirm on-chain before

--- a/src/tempo/server/Methods.ts
+++ b/src/tempo/server/Methods.ts
@@ -77,7 +77,7 @@ export namespace tempo {
   export type RelayOptions = charge_.RelayOptions
   /** Stable failure codes returned by Tempo API's MPP relay. */
   export type RelayErrorCode = Relay_.configure.ErrorCode
-  /** Safe relay failure details exposed by an opted-in Tempo API relay. */
+  /** Safe relay failure details exposed by the Tempo API relay. */
   export type RelayErrorDetails = Relay_.configure.ErrorDetails
 
   /** Creates a Tempo `charge` method for one-time TIP-20 token transfers. */

--- a/src/tempo/server/Methods.ts
+++ b/src/tempo/server/Methods.ts
@@ -9,6 +9,7 @@ import {
 import type { SessionController as SessionController_ } from '../session/server/Sse.js'
 import * as Ws_ from '../session/server/Ws.js'
 import { charge as charge_ } from './Charge.js'
+import type * as Relay_ from './Relay.js'
 import { renew as renewSubscription_, subscription as subscription_ } from './Subscription.js'
 
 const sessionServer = Object.assign(session_, {
@@ -74,6 +75,10 @@ export namespace tempo {
   export type Parameters = charge_.Parameters & session_.Parameters
   /** Tempo API relay configuration for server-side charges. */
   export type RelayOptions = charge_.RelayOptions
+  /** Stable failure codes returned by Tempo API's MPP relay. */
+  export type RelayErrorCode = Relay_.configure.ErrorCode
+  /** Safe relay failure details exposed by an opted-in Tempo API relay. */
+  export type RelayErrorDetails = Relay_.configure.ErrorDetails
 
   /** Creates a Tempo `charge` method for one-time TIP-20 token transfers. */
   export const charge = charge_

--- a/src/tempo/server/Methods.ts
+++ b/src/tempo/server/Methods.ts
@@ -53,6 +53,10 @@ function createSessionMethod<const parameters extends tempo.Parameters>(
 /**
  * Creates the common Tempo `charge` and `session` methods from shared parameters.
  *
+ * When configured, `relay` applies to the `charge` method. Session vouchers
+ * remain local state transitions and session relay delegation will be added
+ * with its action-specific lifecycle support.
+ *
  * @example
  * ```ts
  * import { Mppx, tempo } from 'mppx/server'
@@ -68,6 +72,8 @@ export function tempo<const parameters extends tempo.Parameters>(parameters?: pa
 
 export namespace tempo {
   export type Parameters = charge_.Parameters & session_.Parameters
+  /** Tempo API relay configuration for server-side charges. */
+  export type RelayOptions = charge_.RelayOptions
 
   /** Creates a Tempo `charge` method for one-time TIP-20 token transfers. */
   export const charge = charge_

--- a/src/tempo/server/Relay.test.ts
+++ b/src/tempo/server/Relay.test.ts
@@ -82,6 +82,18 @@ describe('relay', () => {
     })
   })
 
+  test('behavior: legacy verify does not broadcast', async () => {
+    const fetch = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
+      Response.json({ success: true }),
+    )
+    const [method_relay] = methods(fetch)
+
+    await expect(
+      method_relay.verify({ credential, request: credential.challenge.request } as never),
+    ).rejects.toMatchObject({ message: 'Payment verification failed.' })
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
   test('error: does not expose API relay failure details', async () => {
     const fetch = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
       Response.json(

--- a/src/tempo/server/Relay.test.ts
+++ b/src/tempo/server/Relay.test.ts
@@ -32,15 +32,11 @@ function mockRelay(handler: RelayHandler): typeof globalThis.fetch {
   }) as typeof globalThis.fetch
 }
 
-function methods(
-  fetch: typeof globalThis.fetch,
-  url = apiBaseUrl,
-  errorDetails: 'none' | 'safe' | undefined = undefined,
-) {
+function methods(fetch: typeof globalThis.fetch, url = apiBaseUrl) {
   return tempo({
     currency: '0x123',
     recipient: '0x456',
-    relay: { apiBaseUrl: url, apiKey: 'tempo_api_key', errorDetails, fetch },
+    relay: { apiBaseUrl: url, apiKey: 'tempo_api_key', fetch },
   })
 }
 
@@ -56,11 +52,8 @@ function successReceipt() {
   })
 }
 
-async function createPaymentServer(
-  fetch: typeof globalThis.fetch,
-  errorDetails: 'none' | 'safe' | undefined = undefined,
-) {
-  const [method] = methods(fetch, apiBaseUrl, errorDetails)
+async function createPaymentServer(fetch: typeof globalThis.fetch) {
+  const [method] = methods(fetch, apiBaseUrl)
   const mppx = Mppx.create({ methods: [method], realm, secretKey })
   const handle = mppx.tempo.charge({ amount: '1', decimals: 6 })
   const server = await Http.createServer(async (request, response) => {
@@ -320,11 +313,11 @@ describe('relay boundary', () => {
     ['simulation_failed', { code: 'simulation_failed' }],
     ['unsupported', { code: 'unsupported' }],
     ['temporarily_unavailable', { code: 'temporarily_unavailable', retry: 'same_credential' }],
-  ] as const)('exposes the safe %s code when opted in', async (code, details) => {
+  ] as const)('exposes the safe %s code', async (code, details) => {
     const fetch = mockRelay(() =>
       Response.json({ error: { code, message: 'Tempo API private message.' }, success: false }),
     )
-    const [method] = methods(fetch, apiBaseUrl, 'safe')
+    const [method] = methods(fetch, apiBaseUrl)
 
     try {
       await method.validate!({ credential, request: credential.challenge.request } as never)
@@ -341,14 +334,14 @@ describe('relay boundary', () => {
     }
   })
 
-  test('maps an opted-in expired relay response to payment-expired', async () => {
+  test('maps an expired relay response to payment-expired', async () => {
     const fetch = mockRelay(() =>
       Response.json({
         error: { code: 'expired', message: 'Tempo API private message.' },
         success: false,
       }),
     )
-    const [method] = methods(fetch, apiBaseUrl, 'safe')
+    const [method] = methods(fetch, apiBaseUrl)
 
     await expect(
       method.validate!({ credential, request: credential.challenge.request } as never),
@@ -361,12 +354,12 @@ describe('relay boundary', () => {
   })
 
   test.each(['policy_denied', 'screen_rejected', 'unknown'] as const)(
-    'keeps the sensitive %s code opaque when opted in',
+    'keeps the sensitive %s code opaque',
     async (code) => {
       const fetch = mockRelay(() =>
         Response.json({ error: { code, message: 'Tempo API private message.' }, success: false }),
       )
-      const [method] = methods(fetch, apiBaseUrl, 'safe')
+      const [method] = methods(fetch, apiBaseUrl)
 
       await expect(
         method.validate!({ credential, request: credential.challenge.request } as never),
@@ -374,14 +367,14 @@ describe('relay boundary', () => {
     },
   )
 
-  test('keeps non-2xx Tempo API responses opaque when opted in', async () => {
+  test('keeps non-2xx Tempo API responses opaque', async () => {
     const fetch = mockRelay(() =>
       Response.json(
         { error: { code: 'insufficient_funds', message: 'Tempo API private message.' } },
         { status: 403 },
       ),
     )
-    const [method] = methods(fetch, apiBaseUrl, 'safe')
+    const [method] = methods(fetch, apiBaseUrl)
 
     await expect(
       method.validate!({ credential, request: credential.challenge.request } as never),
@@ -472,14 +465,14 @@ describe('relay HTTP flow', () => {
     }
   })
 
-  test('includes an opted-in safe relay code in the 402 problem details', async () => {
+  test('includes a safe relay code in the 402 problem details', async () => {
     const fetch = mockRelay(() =>
       Response.json({
         error: { code: 'temporarily_unavailable', message: 'Tempo API private message.' },
         success: false,
       }),
     )
-    const { pay, server } = await createPaymentServer(fetch, 'safe')
+    const { pay, server } = await createPaymentServer(fetch)
 
     try {
       const response = await pay()

--- a/src/tempo/server/Relay.test.ts
+++ b/src/tempo/server/Relay.test.ts
@@ -11,6 +11,7 @@ const credential = {
     request: { amount: '100', currency: '0x123', recipient: '0x456' },
   },
   payload: { signature: '0x123', type: 'transaction' },
+  source: 'did:pkh:eip155:42431:0x123',
 } as const
 
 function methods(fetch: typeof globalThis.fetch, apiBaseUrl?: string) {
@@ -34,15 +35,20 @@ describe('relay', () => {
 
     const result = await method_relay.validate!({
       credential,
-      request: credential.challenge.request,
+      request: { amount: '1', currency: '0x123', decimals: 6, recipient: '0x456' },
     } as never)
 
     expect(result.details).toEqual({})
+    expect(result.request).toEqual(credential.challenge.request)
     expect(session.intent).toBe('session')
     expect(fetch).toHaveBeenCalledWith(
       new URL('https://relay.example/v1/mpp/validate'),
       expect.objectContaining({
-        body: JSON.stringify({ challenge: credential.challenge, payload: credential.payload }),
+        body: JSON.stringify({
+          challenge: credential.challenge,
+          payload: credential.payload,
+          source: credential.source,
+        }),
         headers: expect.objectContaining({
           Accept: 'application/json',
           'content-type': 'application/json',
@@ -53,7 +59,7 @@ describe('relay', () => {
     )
   })
 
-  test('behavior: broadcasts with a challenge-bound idempotency key', async () => {
+  test('behavior: broadcasts with a credential-bound idempotency key', async () => {
     const fetch = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
       Response.json({
         receipt: {
@@ -77,9 +83,22 @@ describe('relay', () => {
       status: 'success',
       timestamp: '2026-07-22T00:00:00.000Z',
     })
-    expect(fetch.mock.calls[0]?.[1]).toMatchObject({
-      headers: expect.objectContaining({ 'idempotency-key': 'mppx_challenge_123' }),
-    })
+    const firstHeaders = (fetch.mock.calls.at(0)![1] as RequestInit).headers as Record<
+      string,
+      string
+    >
+    expect(firstHeaders['idempotency-key']).toMatch(/^mppx_0x[\da-f]{64}$/)
+
+    await method_relay.broadcast!({
+      credential: { ...credential, payload: { signature: '0x456', type: 'transaction' } },
+      request: credential.challenge.request,
+    } as never)
+
+    const secondHeaders = (fetch.mock.calls.at(1)![1] as RequestInit).headers as Record<
+      string,
+      string
+    >
+    expect(secondHeaders['idempotency-key']).not.toBe(firstHeaders['idempotency-key'])
   })
 
   test('behavior: legacy verify does not broadcast', async () => {

--- a/src/tempo/server/Relay.test.ts
+++ b/src/tempo/server/Relay.test.ts
@@ -1,145 +1,391 @@
-import { Hash, Hex } from 'ox'
+import { Hash, Hex, Json, Bytes } from 'ox'
 import { afterEach, describe, expect, test, vi } from 'vp/test'
+import * as Http from '~test/Http.js'
 
+import * as Challenge from '../../Challenge.js'
+import * as Credential from '../../Credential.js'
+import * as Mppx from '../../server/Mppx.js'
 import { tempo } from './Methods.js'
+
+const apiBaseUrl = 'https://relay.example'
+const realm = 'api.example.com'
+const secretKey = 'test-secret-key-test-secret-key-32'
 
 const credential = {
   challenge: {
     id: 'challenge_123',
     intent: 'charge',
     method: 'tempo',
-    realm: 'api.example.com',
+    realm,
     request: { amount: '100', currency: '0x123', recipient: '0x456' },
   },
   payload: { signature: '0x1234', type: 'transaction' },
   source: 'did:pkh:eip155:42431:0x123',
 } as const
 
-function methods(fetch: typeof globalThis.fetch, apiBaseUrl?: string) {
+type RelayHandler = (url: URL, init: RequestInit) => Response | Promise<Response>
+
+function mockRelay(handler: RelayHandler): typeof globalThis.fetch {
+  return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = input instanceof URL ? input : new URL(input.toString())
+    return handler(url, init ?? {})
+  }) as typeof globalThis.fetch
+}
+
+function methods(fetch: typeof globalThis.fetch, url = apiBaseUrl) {
   return tempo({
     currency: '0x123',
     recipient: '0x456',
-    relay: { apiBaseUrl, apiKey: 'tempo_api_key', fetch },
+    relay: { apiBaseUrl: url, apiKey: 'tempo_api_key', fetch },
   })
+}
+
+function successReceipt() {
+  return Response.json({
+    receipt: {
+      externalId: 'order_123',
+      method: 'tempo',
+      reference: '0xabc',
+      timestamp: '2026-07-22T00:00:00.000Z',
+    },
+    success: true,
+  })
+}
+
+async function createPaymentServer(fetch: typeof globalThis.fetch) {
+  const [method] = methods(fetch)
+  const mppx = Mppx.create({ methods: [method], realm, secretKey })
+  const handle = mppx.tempo.charge({ amount: '1', decimals: 6 })
+  const server = await Http.createServer(async (request, response) => {
+    const result = await Mppx.toNodeListener(handle)(request, response)
+    if (result.status !== 402) response.end('OK')
+  })
+
+  const challengeResponse = await globalThis.fetch(server.url)
+  const challenge = Challenge.fromResponse(challengeResponse)
+  const paymentCredential = Credential.from({
+    challenge,
+    payload: credential.payload,
+    source: credential.source,
+  })
+
+  return {
+    pay: () =>
+      globalThis.fetch(server.url, {
+        headers: { Authorization: Credential.serialize(paymentCredential) },
+      }),
+    server,
+  }
+}
+
+function expectGenericFailure(error: unknown) {
+  expect(error).toMatchObject({
+    name: 'VerificationFailedError',
+    message: 'Payment verification failed.',
+  })
+  expect(error).not.toMatchObject({ details: expect.anything() })
+  return true
 }
 
 afterEach(() => {
   vi.unstubAllGlobals()
 })
 
-describe('relay', () => {
-  test('behavior: delegates validation to Tempo API', async () => {
-    const fetch = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
-      Response.json({ success: true }),
-    )
-    const [method_relay, session] = methods(fetch, 'https://relay.example')
+describe('relay boundary', () => {
+  test('sends the complete credential to the configured validation endpoint', async () => {
+    const fetch = mockRelay(() => Response.json({ success: true }))
+    const [method, session] = methods(fetch)
 
-    const result = await method_relay.validate!({
+    const result = await method.validate!({
       credential,
       request: { amount: '1', currency: '0x123', decimals: 6, recipient: '0x456' },
     } as never)
 
-    expect(result.details).toEqual({})
-    expect(result.request).toEqual(credential.challenge.request)
+    expect(result).toMatchObject({
+      challenge: credential.challenge,
+      credential,
+      details: {},
+      intent: 'charge',
+      method: 'tempo',
+      request: credential.challenge.request,
+      source: credential.source,
+    })
     expect(session.intent).toBe('session')
     expect(fetch).toHaveBeenCalledWith(
-      new URL('https://relay.example/v1/mpp/validate'),
+      new URL(`${apiBaseUrl}/v1/mpp/validate`),
       expect.objectContaining({
-        body: JSON.stringify({
-          challenge: credential.challenge,
-          payload: credential.payload,
-          source: credential.source,
-        }),
-        headers: expect.objectContaining({
+        body: JSON.stringify(credential),
+        headers: {
           Accept: 'application/json',
           'content-type': 'application/json',
           'tempo-api-key': 'tempo_api_key',
-        }),
+        },
         method: 'POST',
       }),
     )
   })
 
-  test('behavior: broadcasts with a credential-bound idempotency key', async () => {
-    const fetch = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
-      Response.json({
-        receipt: {
-          method: 'tempo',
-          reference: '0xabc',
-          timestamp: '2026-07-22T00:00:00.000Z',
-        },
-        success: true,
-      }),
-    )
-    const [method_relay] = methods(fetch)
+  test('uses the default Tempo API base URL and omits an absent source', async () => {
+    const fetch = mockRelay(() => Response.json({ success: true }))
+    const [method] = tempo({
+      currency: '0x123',
+      recipient: '0x456',
+      relay: { apiKey: 'tempo_api_key', fetch },
+    })
+    const sourceLessCredential = { ...credential, source: undefined }
 
-    const result = await method_relay.broadcast!({
-      credential,
+    await method.validate!({
+      credential: sourceLessCredential,
       request: credential.challenge.request,
     } as never)
 
-    expect(result).toEqual({
+    expect(fetch).toHaveBeenCalledWith(
+      new URL('https://api.tempo.xyz/v1/mpp/validate'),
+      expect.objectContaining({
+        body: JSON.stringify({
+          challenge: credential.challenge,
+          payload: credential.payload,
+        }),
+      }),
+    )
+  })
+
+  test('broadcasts a valid relay receipt and forwards its external ID', async () => {
+    const calls: Array<{ init: RequestInit; url: URL }> = []
+    const fetch = mockRelay((url, init) => {
+      calls.push({ init, url })
+      return successReceipt()
+    })
+    const [method] = methods(fetch)
+
+    await expect(
+      method.broadcast!({ credential, request: credential.challenge.request } as never),
+    ).resolves.toEqual({
+      externalId: 'order_123',
       method: 'tempo',
       reference: '0xabc',
       status: 'success',
       timestamp: '2026-07-22T00:00:00.000Z',
     })
-    const firstHeaders = (fetch.mock.calls.at(0)![1] as RequestInit).headers as Record<
-      string,
-      string
-    >
-    expect(firstHeaders['idempotency-key']).toBe(
-      `mppx_${Hash.keccak256(Hex.toBytes(credential.payload.signature), { as: 'Hex' })}`,
-    )
+    expect(calls).toEqual([
+      {
+        init: expect.objectContaining({
+          body: JSON.stringify(credential),
+          headers: expect.objectContaining({
+            Accept: 'application/json',
+            'content-type': 'application/json',
+            'idempotency-key': expect.stringMatching(/^mppx_0x/),
+            'tempo-api-key': 'tempo_api_key',
+          }),
+          method: 'POST',
+        }),
+        url: new URL(`${apiBaseUrl}/v1/mpp/broadcast`),
+      },
+    ])
+  })
 
-    await method_relay.broadcast!({
+  test('uses the transaction hash as the transaction broadcast idempotency key', async () => {
+    const calls: RequestInit[] = []
+    const fetch = mockRelay((_url, init) => {
+      calls.push(init)
+      return successReceipt()
+    })
+    const [method] = methods(fetch)
+
+    await method.broadcast!({ credential, request: credential.challenge.request } as never)
+    await method.broadcast!({ credential, request: credential.challenge.request } as never)
+    await method.broadcast!({
       credential: { ...credential, payload: { signature: '0x5678', type: 'transaction' } },
       request: credential.challenge.request,
     } as never)
 
-    const secondHeaders = (fetch.mock.calls.at(1)![1] as RequestInit).headers as Record<
-      string,
-      string
-    >
-    expect(secondHeaders['idempotency-key']).not.toBe(firstHeaders['idempotency-key'])
+    const keys = calls.map((init) => (init.headers as Record<string, string>)['idempotency-key'])
+    expect(keys).toEqual([
+      `mppx_${Hash.keccak256(Hex.toBytes(credential.payload.signature), { as: 'Hex' })}`,
+      `mppx_${Hash.keccak256(Hex.toBytes(credential.payload.signature), { as: 'Hex' })}`,
+      `mppx_${Hash.keccak256(Hex.toBytes('0x5678'), { as: 'Hex' })}`,
+    ])
   })
 
-  test('behavior: legacy verify does not broadcast', async () => {
-    const fetch = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
-      Response.json({ success: true }),
+  test('uses a canonical credential hash for non-transaction broadcasts', async () => {
+    const calls: RequestInit[] = []
+    const fetch = mockRelay((_url, init) => {
+      calls.push(init)
+      return successReceipt()
+    })
+    const [method] = methods(fetch)
+    const proofCredential = {
+      ...credential,
+      payload: { proof: 'proof_123', type: 'proof' },
+    }
+
+    await method.broadcast!({
+      credential: proofCredential,
+      request: credential.challenge.request,
+    } as never)
+
+    const headers = calls[0]!.headers as Record<string, string>
+    const expected = Hash.sha256(
+      Bytes.fromString(
+        Json.canonicalize({
+          challenge: proofCredential.challenge,
+          payload: proofCredential.payload,
+          source: proofCredential.source,
+        }),
+      ),
+      { as: 'Hex' },
     )
-    const [method_relay] = methods(fetch)
+    expect(headers['idempotency-key']).toBe(`mppx_${expected}`)
+  })
+
+  test('keeps the legacy combined verify hook inert', async () => {
+    const fetch = mockRelay(() => Response.json({ success: true }))
+    const [method] = methods(fetch)
 
     await expect(
-      method_relay.verify({ credential, request: credential.challenge.request } as never),
-    ).rejects.toMatchObject({ message: 'Payment verification failed.' })
+      method.verify({ credential, request: credential.challenge.request } as never),
+    ).rejects.toSatisfy(expectGenericFailure)
     expect(fetch).not.toHaveBeenCalled()
   })
 
-  test('error: does not expose API relay failure details', async () => {
-    const fetch = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
-      Response.json(
-        {
-          error: { code: 'policy_denied', message: 'Payment exceeds policy.' },
-        },
-        { status: 403 },
-      ),
-    )
-    const [method_relay] = methods(fetch)
+  test.each([
+    ['validate', () => Promise.reject(new TypeError('relay DNS failure'))],
+    [
+      'validate',
+      () =>
+        Response.json(
+          { error: { code: 'policy_denied', message: 'private detail' } },
+          { status: 403 },
+        ),
+    ],
+    ['validate', () => new Response('not JSON')],
+    [
+      'validate',
+      () =>
+        Response.json({
+          error: { code: 'policy_denied', message: 'private detail' },
+          success: false,
+        }),
+    ],
+    ['broadcast', () => Promise.reject(new TypeError('relay DNS failure'))],
+    [
+      'broadcast',
+      () =>
+        Response.json(
+          { error: { code: 'settlement_failed', message: 'private detail' } },
+          { status: 500 },
+        ),
+    ],
+    ['broadcast', () => new Response('not JSON')],
+    [
+      'broadcast',
+      () =>
+        Response.json({
+          error: { code: 'settlement_failed', message: 'private detail' },
+          success: false,
+        }),
+    ],
+    ['broadcast', () => Response.json({ receipt: { method: 'tempo' }, success: true })],
+    [
+      'broadcast',
+      () =>
+        Response.json({
+          receipt: { method: 'tempo', reference: '0xabc', timestamp: 'not a timestamp' },
+          success: true,
+        }),
+    ],
+  ] as const)('maps %s boundary failure to a generic payment error', async (operation, respond) => {
+    const fetch = mockRelay(() => respond())
+    const [method] = methods(fetch)
+    const invoke =
+      operation === 'validate'
+        ? method.validate!({ credential, request: credential.challenge.request } as never)
+        : method.broadcast!({ credential, request: credential.challenge.request } as never)
 
-    await expect(
-      method_relay.validate!({ credential, request: credential.challenge.request } as never),
-    ).rejects.toMatchObject({ message: 'Payment verification failed.' })
+    await expect(invoke).rejects.toSatisfy(expectGenericFailure)
+  })
+})
+
+describe('relay HTTP flow', () => {
+  test('validates, broadcasts, and returns a payment receipt', async () => {
+    const calls: string[] = []
+    const fetch = mockRelay((url) => {
+      calls.push(url.pathname)
+      return url.pathname === '/v1/mpp/validate'
+        ? Response.json({ success: true })
+        : successReceipt()
+    })
+    const { pay, server } = await createPaymentServer(fetch)
+
+    try {
+      const response = await pay()
+      expect(response.status).toBe(200)
+      expect(response.headers.get('Payment-Receipt')).toBeTruthy()
+      expect(calls).toEqual(['/v1/mpp/validate', '/v1/mpp/broadcast'])
+    } finally {
+      server.close()
+    }
   })
 
-  test('error: rejects malformed successful broadcast responses', async () => {
-    const fetch = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
-      Response.json({ success: true }),
-    )
-    const [method_relay] = methods(fetch)
+  test.each([
+    ['validation network failure', () => Promise.reject(new TypeError('tempo api unavailable')), 1],
+    [
+      'validation rejection',
+      () =>
+        Response.json({
+          error: { code: 'policy_denied', message: 'private detail' },
+          success: false,
+        }),
+      1,
+    ],
+    ['broadcast network failure', () => Promise.reject(new TypeError('tempo api unavailable')), 2],
+    [
+      'broadcast rejection',
+      () =>
+        Response.json({
+          error: { code: 'settlement_failed', message: 'private detail' },
+          success: false,
+        }),
+      2,
+    ],
+    [
+      'malformed broadcast receipt',
+      () => Response.json({ receipt: { method: 'tempo' }, success: true }),
+      2,
+    ],
+  ] as const)('returns an opaque 402 for %s', async (_name, failure, expectedCalls) => {
+    let call = 0
+    const fetch = mockRelay(() => {
+      call += 1
+      if (call === expectedCalls) return failure()
+      return Response.json({ success: true })
+    })
+    const { pay, server } = await createPaymentServer(fetch)
 
-    await expect(
-      method_relay.broadcast!({ credential, request: credential.challenge.request } as never),
-    ).rejects.toMatchObject({ message: 'Payment verification failed.' })
+    try {
+      const response = await pay()
+      const body = (await response.json()) as Record<string, unknown>
+
+      expect(response.status).toBe(402)
+      expect(response.headers.get('WWW-Authenticate')).toContain('Payment')
+      expect(response.headers.get('Payment-Receipt')).toBeNull()
+      expect(response.headers.get('Content-Type')).toContain('application/problem+json')
+      expect(body).toMatchObject({
+        challengeId: expect.any(String),
+        detail: 'Payment verification failed.',
+        status: 402,
+        title: 'Verification Failed',
+        type: 'https://paymentauth.org/problems/verification-failed',
+      })
+      expect(JSON.stringify(body)).not.toContain('tempo api unavailable')
+      expect(JSON.stringify(body)).not.toContain('policy_denied')
+      expect(JSON.stringify(body)).not.toContain('settlement_failed')
+      expect(JSON.stringify(body)).not.toContain('private detail')
+      expect(JSON.stringify(body)).not.toContain(apiBaseUrl)
+      expect(JSON.stringify(body)).not.toContain('tempo_api_key')
+      expect(call).toBe(expectedCalls)
+    } finally {
+      server.close()
+    }
   })
 })

--- a/src/tempo/server/Relay.test.ts
+++ b/src/tempo/server/Relay.test.ts
@@ -32,11 +32,15 @@ function mockRelay(handler: RelayHandler): typeof globalThis.fetch {
   }) as typeof globalThis.fetch
 }
 
-function methods(fetch: typeof globalThis.fetch, url = apiBaseUrl) {
+function methods(
+  fetch: typeof globalThis.fetch,
+  url = apiBaseUrl,
+  errorDetails: 'none' | 'safe' | undefined = undefined,
+) {
   return tempo({
     currency: '0x123',
     recipient: '0x456',
-    relay: { apiBaseUrl: url, apiKey: 'tempo_api_key', fetch },
+    relay: { apiBaseUrl: url, apiKey: 'tempo_api_key', errorDetails, fetch },
   })
 }
 
@@ -52,8 +56,11 @@ function successReceipt() {
   })
 }
 
-async function createPaymentServer(fetch: typeof globalThis.fetch) {
-  const [method] = methods(fetch)
+async function createPaymentServer(
+  fetch: typeof globalThis.fetch,
+  errorDetails: 'none' | 'safe' | undefined = undefined,
+) {
+  const [method] = methods(fetch, apiBaseUrl, errorDetails)
   const mppx = Mppx.create({ methods: [method], realm, secretKey })
   const handle = mppx.tempo.charge({ amount: '1', decimals: 6 })
   const server = await Http.createServer(async (request, response) => {
@@ -304,6 +311,82 @@ describe('relay boundary', () => {
 
     await expect(invoke).rejects.toSatisfy(expectGenericFailure)
   })
+
+  test.each([
+    ['already_used', { code: 'already_used' }],
+    ['broadcast_failed', { code: 'broadcast_failed' }],
+    ['invalid_payment', { code: 'invalid_payment' }],
+    ['insufficient_funds', { code: 'insufficient_funds' }],
+    ['simulation_failed', { code: 'simulation_failed' }],
+    ['unsupported', { code: 'unsupported' }],
+    ['temporarily_unavailable', { code: 'temporarily_unavailable', retry: 'same_credential' }],
+  ] as const)('exposes the safe %s code when opted in', async (code, details) => {
+    const fetch = mockRelay(() =>
+      Response.json({ error: { code, message: 'Tempo API private message.' }, success: false }),
+    )
+    const [method] = methods(fetch, apiBaseUrl, 'safe')
+
+    try {
+      await method.validate!({ credential, request: credential.challenge.request } as never)
+      throw new Error('Expected validation to fail.')
+    } catch (error) {
+      expect(error).toMatchObject({
+        details,
+        message: 'Payment verification failed.',
+        name: 'VerificationFailedError',
+      })
+      expect(error).not.toMatchObject({
+        message: expect.stringContaining('Tempo API private message.'),
+      })
+    }
+  })
+
+  test('maps an opted-in expired relay response to payment-expired', async () => {
+    const fetch = mockRelay(() =>
+      Response.json({
+        error: { code: 'expired', message: 'Tempo API private message.' },
+        success: false,
+      }),
+    )
+    const [method] = methods(fetch, apiBaseUrl, 'safe')
+
+    await expect(
+      method.validate!({ credential, request: credential.challenge.request } as never),
+    ).rejects.toMatchObject({
+      details: undefined,
+      message: 'Payment has expired.',
+      name: 'PaymentExpiredError',
+      type: 'https://paymentauth.org/problems/payment-expired',
+    })
+  })
+
+  test.each(['policy_denied', 'screen_rejected', 'unknown'] as const)(
+    'keeps the sensitive %s code opaque when opted in',
+    async (code) => {
+      const fetch = mockRelay(() =>
+        Response.json({ error: { code, message: 'Tempo API private message.' }, success: false }),
+      )
+      const [method] = methods(fetch, apiBaseUrl, 'safe')
+
+      await expect(
+        method.validate!({ credential, request: credential.challenge.request } as never),
+      ).rejects.toSatisfy(expectGenericFailure)
+    },
+  )
+
+  test('keeps non-2xx Tempo API responses opaque when opted in', async () => {
+    const fetch = mockRelay(() =>
+      Response.json(
+        { error: { code: 'insufficient_funds', message: 'Tempo API private message.' } },
+        { status: 403 },
+      ),
+    )
+    const [method] = methods(fetch, apiBaseUrl, 'safe')
+
+    await expect(
+      method.validate!({ credential, request: credential.challenge.request } as never),
+    ).rejects.toSatisfy(expectGenericFailure)
+  })
 })
 
 describe('relay HTTP flow', () => {
@@ -384,6 +467,32 @@ describe('relay HTTP flow', () => {
       expect(JSON.stringify(body)).not.toContain(apiBaseUrl)
       expect(JSON.stringify(body)).not.toContain('tempo_api_key')
       expect(call).toBe(expectedCalls)
+    } finally {
+      server.close()
+    }
+  })
+
+  test('includes an opted-in safe relay code in the 402 problem details', async () => {
+    const fetch = mockRelay(() =>
+      Response.json({
+        error: { code: 'temporarily_unavailable', message: 'Tempo API private message.' },
+        success: false,
+      }),
+    )
+    const { pay, server } = await createPaymentServer(fetch, 'safe')
+
+    try {
+      const response = await pay()
+      const body = (await response.json()) as Record<string, unknown>
+
+      expect(response.status).toBe(402)
+      expect(body).toMatchObject({
+        detail: 'Payment verification failed.',
+        details: { code: 'temporarily_unavailable', retry: 'same_credential' },
+        type: 'https://paymentauth.org/problems/verification-failed',
+      })
+      expect(JSON.stringify(body)).not.toContain('Tempo API private message.')
+      expect(JSON.stringify(body)).not.toContain(apiBaseUrl)
     } finally {
       server.close()
     }

--- a/src/tempo/server/Relay.test.ts
+++ b/src/tempo/server/Relay.test.ts
@@ -1,3 +1,4 @@
+import { Hash, Hex } from 'ox'
 import { afterEach, describe, expect, test, vi } from 'vp/test'
 
 import { tempo } from './Methods.js'
@@ -10,7 +11,7 @@ const credential = {
     realm: 'api.example.com',
     request: { amount: '100', currency: '0x123', recipient: '0x456' },
   },
-  payload: { signature: '0x123', type: 'transaction' },
+  payload: { signature: '0x1234', type: 'transaction' },
   source: 'did:pkh:eip155:42431:0x123',
 } as const
 
@@ -87,10 +88,12 @@ describe('relay', () => {
       string,
       string
     >
-    expect(firstHeaders['idempotency-key']).toMatch(/^mppx_0x[\da-f]{64}$/)
+    expect(firstHeaders['idempotency-key']).toBe(
+      `mppx_${Hash.keccak256(Hex.toBytes(credential.payload.signature), { as: 'Hex' })}`,
+    )
 
     await method_relay.broadcast!({
-      credential: { ...credential, payload: { signature: '0x456', type: 'transaction' } },
+      credential: { ...credential, payload: { signature: '0x5678', type: 'transaction' } },
       request: credential.challenge.request,
     } as never)
 

--- a/src/tempo/server/Relay.test.ts
+++ b/src/tempo/server/Relay.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, test, vi } from 'vp/test'
+
+import { tempo } from './Methods.js'
+
+const credential = {
+  challenge: {
+    id: 'challenge_123',
+    intent: 'charge',
+    method: 'tempo',
+    realm: 'api.example.com',
+    request: { amount: '100', currency: '0x123', recipient: '0x456' },
+  },
+  payload: { signature: '0x123', type: 'transaction' },
+} as const
+
+function methods(fetch: typeof globalThis.fetch, apiBaseUrl?: string) {
+  return tempo({
+    currency: '0x123',
+    recipient: '0x456',
+    relay: { apiBaseUrl, apiKey: 'tempo_api_key', fetch },
+  })
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('relay', () => {
+  test('behavior: delegates validation to Tempo API', async () => {
+    const fetch = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
+      Response.json({ success: true }),
+    )
+    const [method_relay, session] = methods(fetch, 'https://relay.example')
+
+    const result = await method_relay.validate!({
+      credential,
+      request: credential.challenge.request,
+    } as never)
+
+    expect(result.details).toEqual({})
+    expect(session.intent).toBe('session')
+    expect(fetch).toHaveBeenCalledWith(
+      new URL('https://relay.example/v1/mpp/verify'),
+      expect.objectContaining({
+        body: JSON.stringify({ challenge: credential.challenge, payload: credential.payload }),
+        headers: expect.objectContaining({
+          Accept: 'application/json',
+          'content-type': 'application/json',
+          'tempo-api-key': 'tempo_api_key',
+        }),
+        method: 'POST',
+      }),
+    )
+  })
+
+  test('behavior: broadcasts with a challenge-bound idempotency key', async () => {
+    const fetch = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
+      Response.json({
+        receipt: {
+          method: 'tempo',
+          reference: '0xabc',
+          timestamp: '2026-07-22T00:00:00.000Z',
+        },
+        success: true,
+      }),
+    )
+    const [method_relay] = methods(fetch)
+
+    const result = await method_relay.broadcast!({
+      credential,
+      request: credential.challenge.request,
+    } as never)
+
+    expect(result).toEqual({
+      method: 'tempo',
+      reference: '0xabc',
+      status: 'success',
+      timestamp: '2026-07-22T00:00:00.000Z',
+    })
+    expect(fetch.mock.calls[0]?.[1]).toMatchObject({
+      headers: expect.objectContaining({ 'idempotency-key': 'mppx_challenge_123' }),
+    })
+  })
+
+  test('error: exposes API relay failure details', async () => {
+    const fetch = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
+      Response.json(
+        {
+          error: { code: 'policy_denied', message: 'Payment exceeds policy.' },
+        },
+        { status: 403 },
+      ),
+    )
+    const [method_relay] = methods(fetch)
+
+    await expect(
+      method_relay.validate!({ credential, request: credential.challenge.request } as never),
+    ).rejects.toThrow('Payment exceeds policy')
+  })
+
+  test('error: rejects malformed successful broadcast responses', async () => {
+    const fetch = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
+      Response.json({ success: true }),
+    )
+    const [method_relay] = methods(fetch)
+
+    await expect(
+      method_relay.broadcast!({ credential, request: credential.challenge.request } as never),
+    ).rejects.toThrow('invalid broadcast response')
+  })
+})

--- a/src/tempo/server/Relay.test.ts
+++ b/src/tempo/server/Relay.test.ts
@@ -40,7 +40,7 @@ describe('relay', () => {
     expect(result.details).toEqual({})
     expect(session.intent).toBe('session')
     expect(fetch).toHaveBeenCalledWith(
-      new URL('https://relay.example/v1/mpp/verify'),
+      new URL('https://relay.example/v1/mpp/validate'),
       expect.objectContaining({
         body: JSON.stringify({ challenge: credential.challenge, payload: credential.payload }),
         headers: expect.objectContaining({

--- a/src/tempo/server/Relay.test.ts
+++ b/src/tempo/server/Relay.test.ts
@@ -82,7 +82,7 @@ describe('relay', () => {
     })
   })
 
-  test('error: exposes API relay failure details', async () => {
+  test('error: does not expose API relay failure details', async () => {
     const fetch = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
       Response.json(
         {
@@ -95,7 +95,7 @@ describe('relay', () => {
 
     await expect(
       method_relay.validate!({ credential, request: credential.challenge.request } as never),
-    ).rejects.toThrow('Payment exceeds policy')
+    ).rejects.toMatchObject({ message: 'Payment verification failed.' })
   })
 
   test('error: rejects malformed successful broadcast responses', async () => {
@@ -106,6 +106,6 @@ describe('relay', () => {
 
     await expect(
       method_relay.broadcast!({ credential, request: credential.challenge.request } as never),
-    ).rejects.toThrow('invalid broadcast response')
+    ).rejects.toMatchObject({ message: 'Payment verification failed.' })
   })
 })

--- a/src/tempo/server/Relay.ts
+++ b/src/tempo/server/Relay.ts
@@ -74,7 +74,11 @@ export function configure<const intent extends Method.Method>(
     const receipt = await request.broadcast(toRelayInput(parameters.credential), {
       idempotencyKey: `mppx_${parameters.credential.challenge.id}`,
     })
-    return Receipt.from({ ...receipt, status: 'success' })
+    try {
+      return Receipt.from({ ...receipt, status: 'success' })
+    } catch {
+      throw failure()
+    }
   }
 
   const verify: Method.VerifyFn<intent> = async (parameters) => {
@@ -135,26 +139,23 @@ function createRequest(options: configure.Options) {
         method: 'POST',
       })
     } catch {
-      throw failure('Tempo API relay request failed')
+      throw failure()
     }
 
-    const payload = await response.json().catch(() => undefined)
-    if (!response.ok) throw failure(`Tempo API relay returned HTTP ${response.status}`, payload)
-    return payload
+    if (!response.ok) throw failure()
+    return response.json().catch(() => undefined)
   }
 
   const verify = async (input: RelayInput) => {
     const response = await post('/v1/mpp/verify', input)
-    if (!isVerifySuccess(response))
-      throw failure('Tempo API relay returned an invalid verification response', response)
+    if (!isVerifySuccess(response)) throw failure()
   }
 
   const broadcast = async (input: RelayInput, options: { idempotencyKey: string }) => {
     const response = await post('/v1/mpp/broadcast', input, {
       'idempotency-key': options.idempotencyKey,
     })
-    if (!isBroadcastSuccess(response))
-      throw failure('Tempo API relay returned an invalid broadcast response', response)
+    if (!isBroadcastSuccess(response)) throw failure()
     return response.receipt
   }
 
@@ -171,18 +172,8 @@ function toRelayInput(credential: {
   return { challenge: credential.challenge, payload: credential.payload }
 }
 
-function failure(fallback: string, payload?: unknown): VerificationFailedError {
-  const error = getRelayError(payload)
-  return new VerificationFailedError({ reason: error?.message ?? error?.code ?? fallback })
-}
-
-function getRelayError(payload: unknown): RelayError | undefined {
-  if (!isRecord(payload) || !isRecord(payload.error) || typeof payload.error.code !== 'string')
-    return undefined
-  return {
-    code: payload.error.code,
-    ...(typeof payload.error.message === 'string' ? { message: payload.error.message } : {}),
-  }
+function failure(): VerificationFailedError {
+  return new VerificationFailedError()
 }
 
 function isVerifySuccess(value: unknown): value is Extract<VerifyResponse, { success: true }> {

--- a/src/tempo/server/Relay.ts
+++ b/src/tempo/server/Relay.ts
@@ -1,4 +1,4 @@
-import { Bytes, Hash, Json } from 'ox'
+import { Bytes, Hash, Hex, Json } from 'ox'
 
 import { VerificationFailedError } from '../../Errors.js'
 import type * as Method from '../../Method.js'
@@ -191,6 +191,17 @@ function toRelayInput(credential: {
 }
 
 function idempotencyKey(input: RelayInput): string {
+  const payload = input.payload
+  if (
+    isRecord(payload) &&
+    payload.type === 'transaction' &&
+    typeof payload.signature === 'string' &&
+    Hex.validate(payload.signature)
+  ) {
+    const transactionHash = Hash.keccak256(Hex.toBytes(payload.signature), { as: 'Hex' })
+    return `mppx_${transactionHash}`
+  }
+
   const hash = Hash.sha256(Bytes.fromString(Json.canonicalize(input)), { as: 'Hex' })
   return `mppx_${hash}`
 }

--- a/src/tempo/server/Relay.ts
+++ b/src/tempo/server/Relay.ts
@@ -81,9 +81,12 @@ export function configure<const intent extends Method.Method>(
     }
   }
 
-  const verify: Method.VerifyFn<intent> = async (parameters) => {
-    await validate(parameters)
-    return broadcast(parameters)
+  // `verify` is the legacy combined validation and settlement hook. A relay
+  // cannot safely implement it: its successful result must be a receipt, which
+  // requires broadcast. Keep it inert so direct legacy calls cannot settle a
+  // payment unexpectedly; use `validate` and `broadcast` instead.
+  const verify: Method.VerifyFn<intent> = async () => {
+    throw failure()
   }
 
   return {
@@ -95,7 +98,12 @@ export function configure<const intent extends Method.Method>(
 }
 
 export declare namespace configure {
-  /** Server method augmented with Tempo API validation and broadcast hooks. */
+  /**
+   * Server method augmented with Tempo API validation and broadcast hooks.
+   *
+   * The inherited `verify` method is legacy-only and always fails without
+   * settling. Use `validate` followed by `broadcast` for relay payments.
+   */
   type Adapter<intent extends Method.Method> = Omit<
     Method.Server<intent>,
     'broadcast' | 'validate'

--- a/src/tempo/server/Relay.ts
+++ b/src/tempo/server/Relay.ts
@@ -101,7 +101,7 @@ export declare namespace configure {
   /**
    * Server method augmented with Tempo API validation and broadcast hooks.
    *
-   * The inherited `verify` method is legacy-only and always fails without
+   * The `verify` method is legacy-only and always fails without
    * settling. Use `validate` followed by `broadcast` for relay payments.
    */
   type Adapter<intent extends Method.Method> = Omit<

--- a/src/tempo/server/Relay.ts
+++ b/src/tempo/server/Relay.ts
@@ -1,0 +1,210 @@
+import { VerificationFailedError } from '../../Errors.js'
+import type * as Method from '../../Method.js'
+import * as Receipt from '../../Receipt.js'
+
+const defaultApiBaseUrl = 'https://api.tempo.xyz'
+
+/** Error body returned by Tempo API's MPP relay. */
+type RelayError = {
+  /** Stable machine-readable reason the relay rejected the credential. */
+  code: string
+  /** Human-readable explanation of the relay result. */
+  message?: string | undefined
+}
+
+/** Challenge and payload accepted by Tempo API's MPP relay. */
+type RelayInput = {
+  /** Challenge from the submitted credential. */
+  challenge: Record<string, unknown>
+  /** Method-specific credential payload. */
+  payload: unknown
+}
+
+/** Response returned by the MPP relay verification endpoint. */
+type VerifyResponse = { success: true } | { error: RelayError; success: false }
+
+/** Receipt returned by the MPP relay after broadcast. */
+type RelayReceipt = {
+  /** Optional caller-provided payment reference. */
+  externalId?: string | undefined
+  /** Payment method that settled the credential. */
+  method: string
+  /** On-chain or payment-system settlement reference. */
+  reference: string
+  /** RFC 3339 settlement timestamp. */
+  timestamp: string
+}
+
+/** Response returned by the MPP relay broadcast endpoint. */
+type BroadcastResponse =
+  | { receipt: RelayReceipt; success: true }
+  | { error: RelayError; success: false }
+
+/**
+ * Configures a Tempo payment method to use Tempo API's MPP relay.
+ *
+ * The adapter preserves the supplied method's challenge configuration while
+ * delegating credential validation and terminal broadcast to
+ * `/v1/mpp/verify` and `/v1/mpp/broadcast` respectively.
+ *
+ * @internal
+ */
+export function configure<const intent extends Method.Method>(
+  method: Method.Server<intent>,
+  options: configure.Options,
+): configure.Adapter<intent> {
+  const request = createRequest(options)
+
+  const validate: Method.ValidateFn<intent> = async (parameters) => {
+    const input = toRelayInput(parameters.credential)
+    await request.verify(input)
+
+    return {
+      challenge: parameters.credential.challenge,
+      credential: parameters.credential,
+      details: {},
+      intent: method.intent,
+      method: method.name,
+      request: parameters.request,
+      ...(parameters.credential.source ? { source: parameters.credential.source } : {}),
+    } as Method.Validation<intent>
+  }
+
+  const broadcast: Method.BroadcastFn<intent> = async (parameters) => {
+    const receipt = await request.broadcast(toRelayInput(parameters.credential), {
+      idempotencyKey: `mppx_${parameters.credential.challenge.id}`,
+    })
+    return Receipt.from({ ...receipt, status: 'success' })
+  }
+
+  const verify: Method.VerifyFn<intent> = async (parameters) => {
+    await validate(parameters)
+    return broadcast(parameters)
+  }
+
+  return {
+    ...method,
+    broadcast,
+    verify,
+    validate,
+  } as configure.Adapter<intent>
+}
+
+export declare namespace configure {
+  /** Server method augmented with Tempo API validation and broadcast hooks. */
+  type Adapter<intent extends Method.Method> = Omit<
+    Method.Server<intent>,
+    'broadcast' | 'validate'
+  > & {
+    /** Broadcasts the credential through Tempo API. */
+    broadcast: Method.BroadcastFn<intent>
+    /** Validates the credential through Tempo API. */
+    validate: Method.ValidateFn<intent>
+  }
+
+  /** Tempo API relay configuration for server-side Tempo charges. */
+  type Options = {
+    /** Tempo API key with the `mpp:write` scope. */
+    apiKey: string
+    /** Fetch implementation used to call Tempo API. */
+    fetch?: typeof globalThis.fetch | undefined
+    /** Tempo API base URL. @default 'https://api.tempo.xyz' */
+    apiBaseUrl?: string | undefined
+  }
+}
+
+function createRequest(options: configure.Options) {
+  const fetch = options.fetch ?? globalThis.fetch
+  const apiBaseUrl = new URL(options.apiBaseUrl ?? defaultApiBaseUrl)
+
+  async function post(
+    path: '/v1/mpp/broadcast' | '/v1/mpp/verify',
+    input: RelayInput,
+    headers?: Record<string, string>,
+  ): Promise<unknown> {
+    let response: Response
+    try {
+      response = await fetch(new URL(path, apiBaseUrl), {
+        body: JSON.stringify(input),
+        headers: {
+          Accept: 'application/json',
+          'content-type': 'application/json',
+          'tempo-api-key': options.apiKey,
+          ...headers,
+        },
+        method: 'POST',
+      })
+    } catch {
+      throw failure('Tempo API relay request failed')
+    }
+
+    const payload = await response.json().catch(() => undefined)
+    if (!response.ok) throw failure(`Tempo API relay returned HTTP ${response.status}`, payload)
+    return payload
+  }
+
+  const verify = async (input: RelayInput) => {
+    const response = await post('/v1/mpp/verify', input)
+    if (!isVerifySuccess(response))
+      throw failure('Tempo API relay returned an invalid verification response', response)
+  }
+
+  const broadcast = async (input: RelayInput, options: { idempotencyKey: string }) => {
+    const response = await post('/v1/mpp/broadcast', input, {
+      'idempotency-key': options.idempotencyKey,
+    })
+    if (!isBroadcastSuccess(response))
+      throw failure('Tempo API relay returned an invalid broadcast response', response)
+    return response.receipt
+  }
+
+  return {
+    broadcast,
+    verify,
+  }
+}
+
+function toRelayInput(credential: {
+  challenge: Record<string, unknown>
+  payload: unknown
+}): RelayInput {
+  return { challenge: credential.challenge, payload: credential.payload }
+}
+
+function failure(fallback: string, payload?: unknown): VerificationFailedError {
+  const error = getRelayError(payload)
+  return new VerificationFailedError({ reason: error?.message ?? error?.code ?? fallback })
+}
+
+function getRelayError(payload: unknown): RelayError | undefined {
+  if (!isRecord(payload) || !isRecord(payload.error) || typeof payload.error.code !== 'string')
+    return undefined
+  return {
+    code: payload.error.code,
+    ...(typeof payload.error.message === 'string' ? { message: payload.error.message } : {}),
+  }
+}
+
+function isVerifySuccess(value: unknown): value is Extract<VerifyResponse, { success: true }> {
+  return isRecord(value) && value.success === true
+}
+
+function isBroadcastSuccess(
+  value: unknown,
+): value is Extract<BroadcastResponse, { success: true }> {
+  return isRecord(value) && value.success === true && isRelayReceipt(value.receipt)
+}
+
+function isRelayReceipt(value: unknown): value is RelayReceipt {
+  return (
+    isRecord(value) &&
+    typeof value.method === 'string' &&
+    typeof value.reference === 'string' &&
+    typeof value.timestamp === 'string' &&
+    (value.externalId === undefined || typeof value.externalId === 'string')
+  )
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}

--- a/src/tempo/server/Relay.ts
+++ b/src/tempo/server/Relay.ts
@@ -1,3 +1,5 @@
+import { Bytes, Hash, Json } from 'ox'
+
 import { VerificationFailedError } from '../../Errors.js'
 import type * as Method from '../../Method.js'
 import * as Receipt from '../../Receipt.js'
@@ -12,12 +14,14 @@ type RelayError = {
   message?: string | undefined
 }
 
-/** Challenge and payload accepted by Tempo API's MPP relay. */
+/** Credential fields accepted by Tempo API's MPP relay. */
 type RelayInput = {
   /** Challenge from the submitted credential. */
   challenge: Record<string, unknown>
   /** Method-specific credential payload. */
   payload: unknown
+  /** Optional payer identity. */
+  source?: string | undefined
 }
 
 /** Response returned by the MPP relay validation endpoint. */
@@ -65,14 +69,15 @@ export function configure<const intent extends Method.Method>(
       details: {},
       intent: method.intent,
       method: method.name,
-      request: parameters.request,
+      request: parameters.credential.challenge.request,
       ...(parameters.credential.source ? { source: parameters.credential.source } : {}),
     } as Method.Validation<intent>
   }
 
   const broadcast: Method.BroadcastFn<intent> = async (parameters) => {
-    const receipt = await request.broadcast(toRelayInput(parameters.credential), {
-      idempotencyKey: `mppx_${parameters.credential.challenge.id}`,
+    const input = toRelayInput(parameters.credential)
+    const receipt = await request.broadcast(input, {
+      idempotencyKey: idempotencyKey(input),
     })
     try {
       return Receipt.from({ ...receipt, status: 'success' })
@@ -176,8 +181,18 @@ function createRequest(options: configure.Options) {
 function toRelayInput(credential: {
   challenge: Record<string, unknown>
   payload: unknown
+  source?: string | undefined
 }): RelayInput {
-  return { challenge: credential.challenge, payload: credential.payload }
+  return {
+    challenge: credential.challenge,
+    payload: credential.payload,
+    ...(credential.source ? { source: credential.source } : {}),
+  }
+}
+
+function idempotencyKey(input: RelayInput): string {
+  const hash = Hash.sha256(Bytes.fromString(Json.canonicalize(input)), { as: 'Hex' })
+  return `mppx_${hash}`
 }
 
 function failure(): VerificationFailedError {

--- a/src/tempo/server/Relay.ts
+++ b/src/tempo/server/Relay.ts
@@ -20,8 +20,8 @@ type RelayInput = {
   payload: unknown
 }
 
-/** Response returned by the MPP relay verification endpoint. */
-type VerifyResponse = { success: true } | { error: RelayError; success: false }
+/** Response returned by the MPP relay validation endpoint. */
+type ValidateResponse = { success: true } | { error: RelayError; success: false }
 
 /** Receipt returned by the MPP relay after broadcast. */
 type RelayReceipt = {
@@ -45,7 +45,7 @@ type BroadcastResponse =
  *
  * The adapter preserves the supplied method's challenge configuration while
  * delegating credential validation and terminal broadcast to
- * `/v1/mpp/verify` and `/v1/mpp/broadcast` respectively.
+ * `/v1/mpp/validate` and `/v1/mpp/broadcast` respectively.
  *
  * @internal
  */
@@ -57,7 +57,7 @@ export function configure<const intent extends Method.Method>(
 
   const validate: Method.ValidateFn<intent> = async (parameters) => {
     const input = toRelayInput(parameters.credential)
-    await request.verify(input)
+    await request.validate(input)
 
     return {
       challenge: parameters.credential.challenge,
@@ -130,7 +130,7 @@ function createRequest(options: configure.Options) {
   const apiBaseUrl = new URL(options.apiBaseUrl ?? defaultApiBaseUrl)
 
   async function post(
-    path: '/v1/mpp/broadcast' | '/v1/mpp/verify',
+    path: '/v1/mpp/broadcast' | '/v1/mpp/validate',
     input: RelayInput,
     headers?: Record<string, string>,
   ): Promise<unknown> {
@@ -154,9 +154,9 @@ function createRequest(options: configure.Options) {
     return response.json().catch(() => undefined)
   }
 
-  const verify = async (input: RelayInput) => {
-    const response = await post('/v1/mpp/verify', input)
-    if (!isVerifySuccess(response)) throw failure()
+  const validate = async (input: RelayInput) => {
+    const response = await post('/v1/mpp/validate', input)
+    if (!isValidateSuccess(response)) throw failure()
   }
 
   const broadcast = async (input: RelayInput, options: { idempotencyKey: string }) => {
@@ -169,7 +169,7 @@ function createRequest(options: configure.Options) {
 
   return {
     broadcast,
-    verify,
+    validate,
   }
 }
 
@@ -184,7 +184,7 @@ function failure(): VerificationFailedError {
   return new VerificationFailedError()
 }
 
-function isVerifySuccess(value: unknown): value is Extract<VerifyResponse, { success: true }> {
+function isValidateSuccess(value: unknown): value is Extract<ValidateResponse, { success: true }> {
   return isRecord(value) && value.success === true
 }
 

--- a/src/tempo/server/Relay.ts
+++ b/src/tempo/server/Relay.ts
@@ -1,15 +1,31 @@
 import { Bytes, Hash, Hex, Json } from 'ox'
 
-import { VerificationFailedError } from '../../Errors.js'
+import { PaymentExpiredError, VerificationFailedError } from '../../Errors.js'
 import type * as Method from '../../Method.js'
 import * as Receipt from '../../Receipt.js'
 
 const defaultApiBaseUrl = 'https://api.tempo.xyz'
 
+const relayErrorCode = [
+  'already_used',
+  'broadcast_failed',
+  'expired',
+  'invalid_payment',
+  'insufficient_funds',
+  'policy_denied',
+  'screen_rejected',
+  'simulation_failed',
+  'temporarily_unavailable',
+  'unsupported',
+  'unknown',
+] as const
+
+type RelayErrorCode = (typeof relayErrorCode)[number]
+
 /** Error body returned by Tempo API's MPP relay. */
 type RelayError = {
   /** Stable machine-readable reason the relay rejected the credential. */
-  code: string
+  code: RelayErrorCode
   /** Human-readable explanation of the relay result. */
   message?: string | undefined
 }
@@ -82,7 +98,7 @@ export function configure<const intent extends Method.Method>(
     try {
       return Receipt.from({ ...receipt, status: 'success' })
     } catch {
-      throw failure()
+      throw failure(options)
     }
   }
 
@@ -91,7 +107,7 @@ export function configure<const intent extends Method.Method>(
   // requires broadcast. Keep it inert so direct legacy calls cannot settle a
   // payment unexpectedly; use `validate` and `broadcast` instead.
   const verify: Method.VerifyFn<intent> = async () => {
-    throw failure()
+    throw failure(options)
   }
 
   return {
@@ -127,7 +143,22 @@ export declare namespace configure {
     fetch?: typeof globalThis.fetch | undefined
     /** Tempo API base URL. @default 'https://api.tempo.xyz' */
     apiBaseUrl?: string | undefined
+    /**
+     * Exposes safe, stable relay failure codes in Payment Auth error details.
+     * Raw Tempo API messages and infrastructure errors are never exposed.
+     * @default 'none'
+     */
+    errorDetails?: 'none' | 'safe' | undefined
   }
+
+  /** Stable failure codes returned by Tempo API's MPP relay. */
+  type ErrorCode = RelayErrorCode
+
+  /** Safe relay error details exposed when `errorDetails` is `'safe'`. */
+  type ErrorDetails =
+    | { code: 'already_used' | 'broadcast_failed' | 'insufficient_funds' | 'invalid_payment' }
+    | { code: 'simulation_failed' | 'unsupported' }
+    | { code: 'temporarily_unavailable'; retry: 'same_credential' }
 }
 
 function createRequest(options: configure.Options) {
@@ -152,23 +183,23 @@ function createRequest(options: configure.Options) {
         method: 'POST',
       })
     } catch {
-      throw failure()
+      throw failure(options)
     }
 
-    if (!response.ok) throw failure()
+    if (!response.ok) throw failure(options)
     return response.json().catch(() => undefined)
   }
 
   const validate = async (input: RelayInput) => {
     const response = await post('/v1/mpp/validate', input)
-    if (!isValidateSuccess(response)) throw failure()
+    if (!isValidateSuccess(response)) throw failure(options, response)
   }
 
-  const broadcast = async (input: RelayInput, options: { idempotencyKey: string }) => {
+  const broadcast = async (input: RelayInput, broadcastOptions: { idempotencyKey: string }) => {
     const response = await post('/v1/mpp/broadcast', input, {
-      'idempotency-key': options.idempotencyKey,
+      'idempotency-key': broadcastOptions.idempotencyKey,
     })
-    if (!isBroadcastSuccess(response)) throw failure()
+    if (!isBroadcastSuccess(response)) throw failure(options, response)
     return response.receipt
   }
 
@@ -206,8 +237,12 @@ function idempotencyKey(input: RelayInput): string {
   return `mppx_${hash}`
 }
 
-function failure(): VerificationFailedError {
-  return new VerificationFailedError()
+function failure(options: configure.Options, value?: unknown) {
+  const code = options.errorDetails === 'safe' ? relayErrorCodeFrom(value) : undefined
+  if (code === 'expired') return new PaymentExpiredError()
+
+  const details = code && safeDetails(code)
+  return new VerificationFailedError(details ? { details } : undefined)
 }
 
 function isValidateSuccess(value: unknown): value is Extract<ValidateResponse, { success: true }> {
@@ -218,6 +253,31 @@ function isBroadcastSuccess(
   value: unknown,
 ): value is Extract<BroadcastResponse, { success: true }> {
   return isRecord(value) && value.success === true && isRelayReceipt(value.receipt)
+}
+
+function relayErrorCodeFrom(value: unknown): RelayErrorCode | undefined {
+  if (!isRecord(value) || !isRecord(value.error) || !isRelayErrorCode(value.error.code)) return
+  return value.error.code
+}
+
+function isRelayErrorCode(value: unknown): value is RelayErrorCode {
+  return typeof value === 'string' && (relayErrorCode as readonly string[]).includes(value)
+}
+
+function safeDetails(code: RelayErrorCode): configure.ErrorDetails | undefined {
+  switch (code) {
+    case 'already_used':
+    case 'broadcast_failed':
+    case 'insufficient_funds':
+    case 'invalid_payment':
+    case 'simulation_failed':
+    case 'unsupported':
+      return { code }
+    case 'temporarily_unavailable':
+      return { code, retry: 'same_credential' }
+    default:
+      return
+  }
 }
 
 function isRelayReceipt(value: unknown): value is RelayReceipt {

--- a/src/tempo/server/Relay.ts
+++ b/src/tempo/server/Relay.ts
@@ -98,7 +98,7 @@ export function configure<const intent extends Method.Method>(
     try {
       return Receipt.from({ ...receipt, status: 'success' })
     } catch {
-      throw failure(options)
+      throw failure()
     }
   }
 
@@ -107,7 +107,7 @@ export function configure<const intent extends Method.Method>(
   // requires broadcast. Keep it inert so direct legacy calls cannot settle a
   // payment unexpectedly; use `validate` and `broadcast` instead.
   const verify: Method.VerifyFn<intent> = async () => {
-    throw failure(options)
+    throw failure()
   }
 
   return {
@@ -143,18 +143,12 @@ export declare namespace configure {
     fetch?: typeof globalThis.fetch | undefined
     /** Tempo API base URL. @default 'https://api.tempo.xyz' */
     apiBaseUrl?: string | undefined
-    /**
-     * Exposes safe, stable relay failure codes in Payment Auth error details.
-     * Raw Tempo API messages and infrastructure errors are never exposed.
-     * @default 'none'
-     */
-    errorDetails?: 'none' | 'safe' | undefined
   }
 
   /** Stable failure codes returned by Tempo API's MPP relay. */
   type ErrorCode = RelayErrorCode
 
-  /** Safe relay error details exposed when `errorDetails` is `'safe'`. */
+  /** Safe relay error details exposed in Payment Auth problem details. */
   type ErrorDetails =
     | { code: 'already_used' | 'broadcast_failed' | 'insufficient_funds' | 'invalid_payment' }
     | { code: 'simulation_failed' | 'unsupported' }
@@ -183,23 +177,23 @@ function createRequest(options: configure.Options) {
         method: 'POST',
       })
     } catch {
-      throw failure(options)
+      throw failure()
     }
 
-    if (!response.ok) throw failure(options)
+    if (!response.ok) throw failure()
     return response.json().catch(() => undefined)
   }
 
   const validate = async (input: RelayInput) => {
     const response = await post('/v1/mpp/validate', input)
-    if (!isValidateSuccess(response)) throw failure(options, response)
+    if (!isValidateSuccess(response)) throw failure(response)
   }
 
   const broadcast = async (input: RelayInput, broadcastOptions: { idempotencyKey: string }) => {
     const response = await post('/v1/mpp/broadcast', input, {
       'idempotency-key': broadcastOptions.idempotencyKey,
     })
-    if (!isBroadcastSuccess(response)) throw failure(options, response)
+    if (!isBroadcastSuccess(response)) throw failure(response)
     return response.receipt
   }
 
@@ -237,8 +231,8 @@ function idempotencyKey(input: RelayInput): string {
   return `mppx_${hash}`
 }
 
-function failure(options: configure.Options, value?: unknown) {
-  const code = options.errorDetails === 'safe' ? relayErrorCodeFrom(value) : undefined
+function failure(value?: unknown) {
+  const code = relayErrorCodeFrom(value)
   if (code === 'expired') return new PaymentExpiredError()
 
   const details = code && safeDetails(code)


### PR DESCRIPTION
## Motivation

Enable Tempo charge servers to delegate credential validation and payment broadcast to Tempo API without exposing a standalone relay wrapper.

## Summary

- Added Tempo-scoped relay configuration for charge and common server setup.
- Routed relay verification and broadcast through Tempo API with challenge-bound idempotency.
- Validated relay error envelopes and malformed successful responses.

## Key design considerations

- The relay remains a charge configuration; session voucher lifecycles stay local.
- API key, custom fetch, and API base URL are typed under the Tempo server API.