### PR TITLE
docs(examples): use Tempo relay configuration

### DIFF
--- a/examples/charge-relay/README.md
+++ b/examples/charge-relay/README.md
@@ -32,7 +32,7 @@ development-only default so it can run without one locally.
 
 1. The server returns a `tempo/charge` pull challenge for pathUSD.
 2. The payer signs a Tempo transaction and returns the MPP credential.
-3. `tempo.charge({ relay })` calls `POST /v1/mpp/verify`, then `POST /v1/mpp/broadcast`.
+3. `tempo.charge({ relay })` calls `POST /v1/mpp/validate`, then `POST /v1/mpp/broadcast`.
 4. The relay receipt becomes the `Payment-Receipt` response header.
 
 ## Relay configuration

--- a/examples/charge-relay/README.md
+++ b/examples/charge-relay/README.md
@@ -11,13 +11,13 @@ server process:
 
 ```bash
 export TEMPO_API_KEY=tempo:sk:...
-export TEMPO_API_URL=https://api.tempo.xyz
+export TEMPO_API_BASE_URL=https://api.tempo.xyz
 export MPP_SECRET_KEY=$(openssl rand -base64 32)
 pnpm install
 pnpm dev
 ```
 
-`TEMPO_API_URL` can target a compatible self-hosted or preview Tempo API.
+`TEMPO_API_BASE_URL` can target a compatible self-hosted or preview Tempo API.
 `MPP_SECRET_KEY` protects the server-issued challenges; the example has a
 development-only default so it can run without one locally.
 
@@ -32,5 +32,25 @@ development-only default so it can run without one locally.
 
 1. The server returns a `tempo/charge` pull challenge for pathUSD.
 2. The payer signs a Tempo transaction and returns the MPP credential.
-3. The server calls `POST /v1/mpp/verify`, then `POST /v1/mpp/broadcast`.
+3. `tempo.charge({ relay })` calls `POST /v1/mpp/verify`, then `POST /v1/mpp/broadcast`.
 4. The relay receipt becomes the `Payment-Receipt` response header.
+
+## Relay configuration
+
+The `relay` option keeps Tempo API credentials and the relay implementation in
+the Tempo server method instead of duplicating validation and broadcast hooks:
+
+```ts
+const method = tempo.charge({
+  currency,
+  recipient: account.address,
+  relay: {
+    apiBaseUrl: process.env.TEMPO_API_BASE_URL,
+    apiKey: process.env.TEMPO_API_KEY!,
+  },
+})
+```
+
+MPPX continues to issue and bind challenges. The relay only validates and
+broadcasts submitted credentials. Downstream relay errors are returned to the
+payer as generic MPPX payment failures, without exposing Tempo API details.

--- a/examples/charge-relay/README.md
+++ b/examples/charge-relay/README.md
@@ -2,7 +2,7 @@
 
 A single-file Hono API that accepts pathUSD on Tempo Moderato. Its
 `mppx/hono` middleware issues charges, then calls the Tempo API Moderato relay
-for verification and broadcast.
+for validation and broadcast.
 
 ## Setup
 
@@ -11,13 +11,13 @@ server process:
 
 ```bash
 export TEMPO_API_KEY=tempo:sk:...
-export TEMPO_API_BASE_URL=https://api.tempo.xyz
+export TEMPO_API_URL=https://api.tempo.xyz
 export MPP_SECRET_KEY=$(openssl rand -base64 32)
 pnpm install
 pnpm dev
 ```
 
-`TEMPO_API_BASE_URL` can target a compatible self-hosted or preview Tempo API.
+`TEMPO_API_URL` can target a compatible self-hosted or preview Tempo API.
 `MPP_SECRET_KEY` protects the server-issued challenges; the example has a
 development-only default so it can run without one locally.
 
@@ -32,25 +32,22 @@ development-only default so it can run without one locally.
 
 1. The server returns a `tempo/charge` pull challenge for pathUSD.
 2. The payer signs a Tempo transaction and returns the MPP credential.
-3. `tempo.charge({ relay })` calls `POST /v1/mpp/validate`, then `POST /v1/mpp/broadcast`.
+3. The local relay hooks call `POST /v1/mpp/validate`, then `POST /v1/mpp/broadcast`.
 4. The relay receipt becomes the `Payment-Receipt` response header.
 
 ## Relay configuration
 
-The `relay` option keeps Tempo API credentials and the relay implementation in
-the Tempo server method instead of duplicating validation and broadcast hooks:
+The source includes a commented `relay` option showing how to replace the
+local relay hooks with the Tempo server adapter:
 
 ```ts
 const method = tempo.charge({
   currency,
   recipient: account.address,
-  relay: {
-    apiBaseUrl: process.env.TEMPO_API_BASE_URL,
-    apiKey: process.env.TEMPO_API_KEY!,
-  },
+  // relay: { apiBaseUrl: process.env.TEMPO_API_URL, apiKey: process.env.TEMPO_API_KEY! },
 })
 ```
 
-MPPX continues to issue and bind challenges. The relay only validates and
-broadcasts submitted credentials. Downstream relay errors are returned to the
-payer as generic MPPX payment failures, without exposing Tempo API details.
+Uncommenting it lets MPPX issue and bind challenges while the adapter validates
+and broadcasts submitted credentials. Relay failures are returned as MPPX
+payment failures without exposing Tempo API details.

--- a/examples/charge-relay/src/server.ts
+++ b/examples/charge-relay/src/server.ts
@@ -1,5 +1,6 @@
 import { serve } from '@hono/node-server'
 import { Hono } from 'hono'
+import { Errors, Receipt } from 'mppx'
 import { Mppx } from 'mppx/hono'
 import { tempo } from 'mppx/server'
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
@@ -8,23 +9,46 @@ import { pathusd } from 'viem/tokens'
 
 const apiKey = process.env.TEMPO_API_KEY
 if (!apiKey) throw new Error('Set TEMPO_API_KEY to a Tempo API key with the mpp:write scope.')
+const tempoApiKey = apiKey
 
-const apiBaseUrl = process.env.TEMPO_API_BASE_URL ?? 'https://api.tempo.xyz'
+const apiUrl = process.env.TEMPO_API_URL ?? 'https://api.tempo.xyz'
 const currency = pathusd(Chain.testnet.id).address
 const account = privateKeyToAccount(generatePrivateKey())
 const method = tempo.charge({
   account,
   currency,
   recipient: account.address,
-  // MPPX still creates and binds the challenge. Tempo API validates the
-  // returned credential and broadcasts the transaction on the server's behalf.
-  // Relay failures are exposed to the payer as a generic MPPX 402 response.
-  relay: { apiBaseUrl, apiKey },
+  // To replace the local `relay` implementation below with the built-in adapter:
+  // relay: { apiBaseUrl: apiUrl, apiKey },
   supportedModes: ['pull'],
   testnet: true,
 })
 const payments = Mppx.create({
-  methods: [method],
+  methods: [
+    {
+      ...method,
+      async validate(parameters: Parameters<NonNullable<typeof method.validate>>[0]) {
+        const { credential, request } = parameters
+        await relay('/v1/mpp/validate', credential)
+        return {
+          challenge: credential.challenge,
+          credential,
+          details: {},
+          intent: method.intent,
+          method: method.name,
+          request,
+          ...(credential.source ? { source: credential.source } : {}),
+        }
+      },
+      async broadcast(parameters: Parameters<NonNullable<typeof method.broadcast>>[0]) {
+        const { credential } = parameters
+        const receipt = await relay('/v1/mpp/broadcast', credential, {
+          'idempotency-key': `mppx_${credential.challenge.id}`,
+        })
+        return Receipt.from({ ...receipt, status: 'success' })
+      },
+    },
+  ],
   secretKey: process.env.MPP_SECRET_KEY ?? 'mppx-demo-tempo-api-relay-secret-key',
 })
 
@@ -35,3 +59,47 @@ app.get('/api/photo', payments.charge({ amount: '0.01', description: 'Random sto
 )
 
 serve({ fetch: app.fetch, port: Number(process.env.PORT ?? 5173) })
+
+async function relay(
+  path: '/v1/mpp/broadcast' | '/v1/mpp/validate',
+  credential: { challenge: Record<string, unknown>; payload: unknown },
+  headers: Record<string, string> = {},
+) {
+  let response: Response
+  try {
+    response = await fetch(new URL(path, apiUrl), {
+      body: JSON.stringify({ challenge: credential.challenge, payload: credential.payload }),
+      headers: {
+        'content-type': 'application/json',
+        'tempo-api-key': tempoApiKey,
+        ...headers,
+      },
+      method: 'POST',
+    })
+  } catch {
+    throw new Errors.VerificationFailedError({ reason: 'Tempo API relay request failed' })
+  }
+
+  const result = (await response.json().catch(() => undefined)) as RelayResult | undefined
+  if (!response.ok)
+    throw new Errors.VerificationFailedError({
+      reason: `Tempo API relay returned HTTP ${response.status}`,
+    })
+  if (!result || result.success !== true)
+    throw new Errors.VerificationFailedError({
+      reason: result?.error?.message ?? result?.error?.code ?? 'Tempo API relay rejected payment',
+    })
+  return result.receipt
+}
+
+type RelayResult =
+  | {
+      receipt: {
+        externalId?: string | undefined
+        method: string
+        reference: string
+        timestamp: string
+      }
+      success: true
+    }
+  | { error: { code?: string | undefined; message?: string | undefined }; success: false }

--- a/examples/charge-relay/src/server.ts
+++ b/examples/charge-relay/src/server.ts
@@ -1,6 +1,5 @@
 import { serve } from '@hono/node-server'
 import { Hono } from 'hono'
-import { Errors, Receipt } from 'mppx'
 import { Mppx } from 'mppx/hono'
 import { tempo } from 'mppx/server'
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
@@ -9,44 +8,23 @@ import { pathusd } from 'viem/tokens'
 
 const apiKey = process.env.TEMPO_API_KEY
 if (!apiKey) throw new Error('Set TEMPO_API_KEY to a Tempo API key with the mpp:write scope.')
-const tempoApiKey = apiKey
 
-const apiUrl = process.env.TEMPO_API_URL ?? 'https://api.tempo.xyz'
+const apiBaseUrl = process.env.TEMPO_API_BASE_URL ?? 'https://api.tempo.xyz'
 const currency = pathusd(Chain.testnet.id).address
 const account = privateKeyToAccount(generatePrivateKey())
 const method = tempo.charge({
   account,
   currency,
   recipient: account.address,
+  // MPPX still creates and binds the challenge. Tempo API validates the
+  // returned credential and broadcasts the transaction on the server's behalf.
+  // Relay failures are exposed to the payer as a generic MPPX 402 response.
+  relay: { apiBaseUrl, apiKey },
   supportedModes: ['pull'],
   testnet: true,
 })
 const payments = Mppx.create({
-  methods: [
-    {
-      ...method,
-      async validate(parameters: Parameters<NonNullable<typeof method.validate>>[0]) {
-        const { credential, request } = parameters
-        await relay('/v1/mpp/verify', credential)
-        return {
-          challenge: credential.challenge,
-          credential,
-          details: {},
-          intent: method.intent,
-          method: method.name,
-          request,
-          ...(credential.source ? { source: credential.source } : {}),
-        }
-      },
-      async broadcast(parameters: Parameters<NonNullable<typeof method.broadcast>>[0]) {
-        const { credential } = parameters
-        const receipt = await relay('/v1/mpp/broadcast', credential, {
-          'idempotency-key': `mppx_${credential.challenge.id}`,
-        })
-        return Receipt.from({ ...receipt, status: 'success' })
-      },
-    },
-  ],
+  methods: [method],
   secretKey: process.env.MPP_SECRET_KEY ?? 'mppx-demo-tempo-api-relay-secret-key',
 })
 
@@ -57,47 +35,3 @@ app.get('/api/photo', payments.charge({ amount: '0.01', description: 'Random sto
 )
 
 serve({ fetch: app.fetch, port: Number(process.env.PORT ?? 5173) })
-
-async function relay(
-  path: '/v1/mpp/broadcast' | '/v1/mpp/verify',
-  credential: { challenge: Record<string, unknown>; payload: unknown },
-  headers: Record<string, string> = {},
-) {
-  let response: Response
-  try {
-    response = await fetch(new URL(path, apiUrl), {
-      body: JSON.stringify({ challenge: credential.challenge, payload: credential.payload }),
-      headers: {
-        'content-type': 'application/json',
-        'tempo-api-key': tempoApiKey,
-        ...headers,
-      },
-      method: 'POST',
-    })
-  } catch {
-    throw new Errors.VerificationFailedError({ reason: 'Tempo API relay request failed' })
-  }
-
-  const result = (await response.json().catch(() => undefined)) as RelayResult | undefined
-  if (!response.ok)
-    throw new Errors.VerificationFailedError({
-      reason: `Tempo API relay returned HTTP ${response.status}`,
-    })
-  if (!result || result.success !== true)
-    throw new Errors.VerificationFailedError({
-      reason: result?.error?.message ?? result?.error?.code ?? 'Tempo API relay rejected payment',
-    })
-  return result.receipt
-}
-
-type RelayResult =
-  | {
-      receipt: {
-        externalId?: string | undefined
-        method: string
-        reference: string
-        timestamp: string
-      }
-      success: true
-    }
-  | { error: { code?: string | undefined; message?: string | undefined }; success: false }


### PR DESCRIPTION
## Motivation

Use the first-class Tempo relay configuration in the Hono example.

## Summary

- Replaced the example-local relay helper with `tempo.charge({ relay })`
- Documented relay configuration and opaque payer-facing failures

## Key design considerations

- Depends on #695, which provides the Tempo relay adapter