### PR TITLE
fix(tempo): expire session management transactions

### DIFF
--- a/.changeset/fresh-clocks-expire.md
+++ b/.changeset/fresh-clocks-expire.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Use expiring nonces for sponsored and unsponsored Tempo session management transactions.

--- a/src/tempo/legacy/client/ChannelOps.test.ts
+++ b/src/tempo/legacy/client/ChannelOps.test.ts
@@ -245,6 +245,13 @@ describe.runIf(isLocalnet)('createOpenPayload', () => {
     expect(result.payload).toHaveProperty('transaction')
     expect(result.payload).toHaveProperty('signature')
     expect(result.payload.channelId).toBe(result.entry.channelId)
+
+    if (result.payload.action !== 'open') throw new Error('unexpected action')
+    const transaction = Transaction.deserialize(result.payload.transaction)
+    if (!('nonceKey' in transaction)) throw new Error('unexpected transaction type')
+    expect(transaction.nonce).toBe(0)
+    expect(transaction.nonceKey).toBe((1n << 256n) - 1n)
+    expect((transaction as { validBefore?: bigint }).validBefore).toBeDefined()
   })
 
   test('defaults authorizedSigner to account.address', async () => {

--- a/src/tempo/legacy/client/ChannelOps.ts
+++ b/src/tempo/legacy/client/ChannelOps.ts
@@ -192,7 +192,8 @@ export async function createOpenPayload(
       { to: escrowContract, data: openData },
     ],
     feeToken: currency,
-    ...(feePayer ? { nonceKey: 'expiring', validBefore } : {}),
+    nonceKey: 'expiring',
+    validBefore,
   } as never)
   // Estimate before enabling fee-payer mode so Tempo includes sender
   // signature and access-key verification costs in the gas budget.

--- a/src/tempo/session/client/ChannelOps.test.ts
+++ b/src/tempo/session/client/ChannelOps.test.ts
@@ -194,10 +194,25 @@ describe('precompile client ChannelOps credential builders', () => {
     const now = Math.floor(Date.now() / 1_000)
 
     expect(requests).toMatchObject([
-      { feePayer: true, validAfter: expect.any(Number) },
-      { feePayer: true, validAfter: expect.any(Number) },
+      { feePayer: true, nonceKey: 'expiring', validAfter: expect.any(Number) },
+      { feePayer: true, nonceKey: 'expiring', validAfter: expect.any(Number) },
     ])
     expect(new Set(validAfter).size).toBe(2)
     expect(validAfter.every((value) => value >= 0 && value < now)).toBe(true)
+  })
+
+  test('uses expiring nonces and entropy for unsponsored management transactions', async () => {
+    mocks.prepareTransactionRequest.mockClear()
+
+    await ChannelOps.createTopUpPayload(client, account, descriptor, 10n, chainId, false)
+
+    expect(mocks.prepareTransactionRequest).toHaveBeenCalledWith(
+      client,
+      expect.objectContaining({
+        nonceKey: 'expiring',
+        validAfter: expect.any(Number),
+      }),
+    )
+    expect(mocks.prepareTransactionRequest.mock.calls[0]?.[1]).not.toHaveProperty('feePayer')
   })
 })

--- a/src/tempo/session/client/ChannelOps.ts
+++ b/src/tempo/session/client/ChannelOps.ts
@@ -91,14 +91,18 @@ async function prepareTempoChannelTransaction(
   },
 ) {
   const { account, calls, feePayer, feeToken, validAfter } = parameters
+  // Session management transactions are independent and short-lived, so they
+  // always use TIP-1009 expiring nonces. `feePayer` controls sponsorship only.
   // viem's stable transaction request type does not yet expose Tempo's
   // `calls`, `feePayer`, and `feeToken` fields together. Keep the cast at
   // this boundary so session credential builders stay typed.
   return prepareTransactionRequest(client, {
     account,
     calls,
-    ...(feePayer ? { feePayer: true, ...(validAfter !== undefined ? { validAfter } : {}) } : {}),
+    nonceKey: 'expiring',
+    ...(feePayer ? { feePayer: true } : {}),
     feeToken,
+    ...(validAfter !== undefined ? { validAfter } : {}),
   } as never)
 }
 
@@ -325,7 +329,7 @@ export async function createTopUpPayload(
     ],
     feePayer,
     feeToken: descriptor.token,
-    ...(feePayer ? { validAfter: randomValidAfter() } : {}),
+    validAfter: randomValidAfter(),
   })
   const transaction = await signPreparedTempoTransaction(client, prepared)
 

--- a/src/tempo/session/precompile/Chain.integration.test.ts
+++ b/src/tempo/session/precompile/Chain.integration.test.ts
@@ -1,5 +1,12 @@
 import { Hex } from 'ox'
-import { type Address, encodeFunctionData, isAddressEqual, parseEventLogs, zeroAddress } from 'viem'
+import {
+  type Address,
+  encodeFunctionData,
+  isAddressEqual,
+  maxUint256,
+  parseEventLogs,
+  zeroAddress,
+} from 'viem'
 import { sendTransaction, waitForTransactionReceipt } from 'viem/actions'
 import { Transaction } from 'viem/tempo'
 import { describe, expect, test } from 'vp/test'
@@ -40,6 +47,15 @@ function getSingleEvent(receipt: { logs: readonly unknown[] }, name: string) {
   })
   expect(logs).toHaveLength(1)
   return logs[0] as unknown as { args: Record<string, unknown> }
+}
+
+function expectExpiringNonce(serializedTransaction: Hex.Hex) {
+  const transaction = Transaction.deserialize(
+    serializedTransaction as Transaction.TransactionSerializedTempo,
+  ) as unknown as { nonce: number; nonceKey: bigint; validBefore?: bigint }
+  expect(transaction.nonce).toBe(0)
+  expect(transaction.nonceKey).toBe(maxUint256)
+  expect(transaction.validBefore).toBeDefined()
 }
 
 async function openChannel(parameters: { deposit?: bigint | undefined } = {}) {
@@ -120,6 +136,7 @@ describe.runIf(isPrecompileTestnet)('TIP20EscrowChannel precompile chain operati
       token: asset,
     })
     if (payload.action !== 'open') throw new Error('expected open payload')
+    expectExpiringNonce(payload.transaction)
 
     const transaction = Transaction.deserialize(
       payload.transaction as Transaction.TransactionSerializedTempo,
@@ -224,6 +241,7 @@ describe.runIf(isPrecompileTestnet)('TIP20EscrowChannel precompile chain operati
       chain.id,
     )
     if (topUp.action !== 'topUp') throw new Error('expected topUp payload')
+    expectExpiringNonce(topUp.transaction)
 
     const result = await Chain.broadcastTopUpTransaction({
       additionalDeposit,


### PR DESCRIPTION
## Summary

- use TIP-1009 expiring nonces for session management transactions regardless of sponsorship
- keep `feePayer` solely as the sponsorship switch
- add replay-hash entropy to sponsored and unsponsored top-ups
- cover native TIP-1034 and legacy session opens

## Why

Session opens and top-ups are independent transactions. Sequential nonces unnecessarily serialize unsponsored callers and make parallel session management vulnerable to nonce contention.

## Verification

- fail-before: unsponsored top-up request omitted `nonceKey` and `validAfter`
- `VITE_TEMPO_NETWORK=none pnpm exec vp test --run --project node src/tempo/session/client/ChannelOps.test.ts`
- clean Tempo localnet: real unsponsored TIP-1034 open and top-up broadcast successfully; decoded transactions use `nonce = 0`, `nonceKey = MAX`, and `validBefore`
- clean Tempo localnet: real legacy unsponsored open decoded with the same expiring nonce fields
- `pnpm run check:ci`
- `pnpm run check:types`