### PR TITLE
feat(tempo): batch automatic session top-ups

### DIFF
--- a/.changeset/batched-session-top-ups.md
+++ b/.changeset/batched-session-top-ups.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added an optional `topUpAmount` policy for batching automatic Tempo session top-ups while preserving exact-shortfall behavior by default.

--- a/src/tempo/session/client/Session.ts
+++ b/src/tempo/session/client/Session.ts
@@ -50,6 +50,7 @@ export function session(parameters: session.Parameters = {}) {
     escrow: escrowOverride,
     getClient: getClientParameter,
     maxDeposit: maxDepositParameter,
+    topUpAmount: topUpAmountParameter,
     onChannelUpdate,
     resolveAccount,
   } = parameters
@@ -61,6 +62,8 @@ export function session(parameters: session.Parameters = {}) {
   const getAccount = Account.getResolver({ account })
   const maxDeposit =
     maxDepositParameter !== undefined ? parseUnits(maxDepositParameter, decimals) : undefined
+  const topUpAmount =
+    topUpAmountParameter !== undefined ? parseUnits(topUpAmountParameter, decimals) : undefined
   const store = channelStore ?? createChannelStore()
   const sink = { store, notifyUpdate: (entry: ChannelEntry) => onChannelUpdate?.(entry) }
 
@@ -145,7 +148,11 @@ export function session(parameters: session.Parameters = {}) {
         managementInput,
         async topUpIfNeeded({ channelId, deposit, requiredCumulative }) {
           if (requiredCumulative <= deposit || !channel) return
-          const additionalDeposit = requiredCumulative - deposit
+          const shortfall = requiredCumulative - deposit
+          const preferred = topUpAmount ?? shortfall
+          const proposed = preferred > shortfall ? preferred : shortfall
+          const available = maxDeposit === undefined ? proposed : maxDeposit - deposit
+          const additionalDeposit = proposed < available ? proposed : available
           await postTopUp({
             additionalDeposit,
             challenge,
@@ -187,6 +194,8 @@ export declare namespace session {
       escrow?: Address | undefined
       /** Maximum channel deposit in human-readable units. Caps server-suggested opens and automatic top-ups. */
       maxDeposit?: string | undefined
+      /** Preferred automatic top-up size in human-readable units. Exact shortfalls are used when omitted. */
+      topUpAmount?: string | undefined
       /** Called whenever channel state changes. */
       onChannelUpdate?: ((entry: ChannelEntry) => void) | undefined
       /** Selects the account that signs this session credential after the challenge is known. */

--- a/src/tempo/session/client/SessionManager.test.ts
+++ b/src/tempo/session/client/SessionManager.test.ts
@@ -987,6 +987,7 @@ describe('Session', () => {
         client,
         fetch: mockFetch as typeof globalThis.fetch,
         maxDeposit: '10',
+        topUpAmount: '5',
       })
 
       await s.fetch('https://api.example.com/data')
@@ -994,10 +995,13 @@ describe('Session', () => {
 
       expect(response.status).toBe(200)
       expect(postedPayloads.map((payload) => payload.action)).toEqual(['open', 'topUp', 'voucher'])
+      const topUp = postedPayloads[1]
+      if (topUp?.action !== 'topUp') throw new Error('expected top-up payload')
+      expect(topUp.additionalDeposit).toBe('5000000')
       expect(s.state).toMatchObject({
         status: 'active',
         acceptedCumulative: '2000000',
-        deposit: '2000000',
+        deposit: '6000000',
         spent: '2000000',
         units: 2,
       })

--- a/src/tempo/session/client/SessionManager.ts
+++ b/src/tempo/session/client/SessionManager.ts
@@ -111,6 +111,8 @@ type SessionManagerConfig = {
   fetch: typeof globalThis.fetch
   /** Local maximum cumulative voucher authorization, or null when uncapped. */
   maxVoucherCumulative: bigint | null
+  /** Preferred additional deposit for automatic top-ups, or null for exact shortfalls. */
+  topUpAmount: bigint | null
   /** WebSocket constructor available in the current runtime, when configured. */
   WebSocket: WebSocketConstructor | undefined
 }
@@ -168,6 +170,8 @@ function resolveSessionManagerConfig(parameters: sessionManager.Parameters): Ses
     fetch: parameters.fetch ?? globalThis.fetch.bind(globalThis),
     maxVoucherCumulative:
       parameters.maxDeposit !== undefined ? parseUnits(parameters.maxDeposit, decimals) : null,
+    topUpAmount:
+      parameters.topUpAmount !== undefined ? parseUnits(parameters.topUpAmount, decimals) : null,
     WebSocket,
   }
 }
@@ -553,11 +557,18 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
   async function topUpIfNeeded(parameters: TopUpRequirement) {
     if (parameters.requiredCumulative <= parameters.deposit) return
     assertVoucherWithinLocalLimit(parameters.requiredCumulative)
+    const shortfall = parameters.requiredCumulative - parameters.deposit
+    const preferred = config.topUpAmount ?? shortfall
+    const proposed = preferred > shortfall ? preferred : shortfall
+    const available =
+      config.maxVoucherCumulative === null
+        ? proposed
+        : config.maxVoucherCumulative - parameters.deposit
     await postTopUpAndApply({
       challenge: parameters.challenge,
       input: parameters.input,
       channelId: parameters.channelId,
-      additionalDeposit: parameters.requiredCumulative - parameters.deposit,
+      additionalDeposit: proposed < available ? proposed : available,
     })
   }
 
@@ -896,6 +907,8 @@ export namespace sessionManager {
       fetch?: typeof globalThis.fetch | undefined
       /** Maximum deposit in human-readable units (e.g. `'10'` for 10 tokens). Converted to raw units via `decimals`. */
       maxDeposit?: string | undefined
+      /** Preferred automatic top-up size in human-readable units. Exact shortfalls are used when omitted. */
+      topUpAmount?: string | undefined
       /** Selects the account that signs session credentials. */
       resolveAccount?: sessionPlugin.ResolveAccount | undefined
       /** Store for reusable session channels. Defaults to in-memory. */


### PR DESCRIPTION
## Summary

- add an optional `topUpAmount` policy to the low-level session client and `sessionManager`
- use the configured refill quantum when a voucher crosses the current deposit
- continue to cap every refill at `maxDeposit` and preserve exact-shortfall behavior by default

## Why

Services that omit `suggestedDeposit` currently trigger an on-chain top-up for every request after a channel is exhausted. A client can now choose a refill quantum (for example, $5) without changing the server protocol or the default behavior.

## Validation

- `VITE_TEMPO_NETWORK=none vp test --run src/tempo/session/client/SessionManager.test.ts src/tempo/session/client/Session.test.ts` (70 passed)
- `vp fmt --check` on the three changed files
- `vp lint` on the three changed files (one pre-existing `__test_setChannel` warning)

The repository install is currently blocked by the existing `viem@2.55.6` workspace resolution from the pkg.pr.new override; the focused suite was run from the already-cached packages.