### PR TITLE
fix(tempo): coordinate parallel sponsor fee exposure

### DIFF
--- a/.changeset/atomic-sponsor-budget.md
+++ b/.changeset/atomic-sponsor-budget.md
@@ -2,4 +2,4 @@
 'mppx': patch
 ---
 
-Replaced per-sender sponsored charge serialization with atomic aggregate fee-budget reservations so independent expiring-nonce transactions ran concurrently and waited for capacity when the sponsor budget was full.
+Replaced per-sender sponsored charge serialization with durable atomic aggregate fee-budget reservations. Independent expiring-nonce transactions ran concurrently, waited for capacity when the sponsor budget was full, and retained pending exposure until receipt reconciliation or transaction expiry.

--- a/.changeset/atomic-sponsor-budget.md
+++ b/.changeset/atomic-sponsor-budget.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Replaced per-sender sponsored charge serialization with atomic aggregate fee-budget reservations so independent expiring-nonce transactions ran concurrently and waited for capacity when the sponsor budget was full.

--- a/src/tempo/internal/fee-payer.test.ts
+++ b/src/tempo/internal/fee-payer.test.ts
@@ -1083,19 +1083,6 @@ describe('prepareSponsoredTransaction', () => {
     ).toThrow('total fee budget exceeds sponsor policy')
   })
 
-  test('error: rejects a transaction larger than the aggregate in-flight budget', () => {
-    expect(() =>
-      prepareSponsoredTransaction({
-        account: sponsor,
-        chainId: 42431,
-        details,
-        allowedFeeTokens: [bogus],
-        policy: { maxInFlightTotalFee: 100_000_000_000_000n },
-        transaction: baseTransaction as any,
-      }),
-    ).toThrow('total fee budget exceeds sponsor in-flight policy')
-  })
-
   test('error: rejects mismatched feeToken', () => {
     expect(() =>
       prepareSponsoredTransaction({

--- a/src/tempo/internal/fee-payer.test.ts
+++ b/src/tempo/internal/fee-payer.test.ts
@@ -1083,6 +1083,19 @@ describe('prepareSponsoredTransaction', () => {
     ).toThrow('total fee budget exceeds sponsor policy')
   })
 
+  test('error: rejects a transaction larger than the aggregate in-flight budget', () => {
+    expect(() =>
+      prepareSponsoredTransaction({
+        account: sponsor,
+        chainId: 42431,
+        details,
+        allowedFeeTokens: [bogus],
+        policy: { maxInFlightTotalFee: 100_000_000_000_000n },
+        transaction: baseTransaction as any,
+      }),
+    ).toThrow('total fee budget exceeds sponsor in-flight policy')
+  })
+
   test('error: rejects mismatched feeToken', () => {
     expect(() =>
       prepareSponsoredTransaction({

--- a/src/tempo/internal/fee-payer.ts
+++ b/src/tempo/internal/fee-payer.ts
@@ -32,7 +32,6 @@ export const callScopes = [
 export type Policy = {
   maxGas: bigint
   maxFeePerGas: bigint
-  maxInFlightTotalFee: bigint
   maxPriorityFeePerGas: bigint
   maxTotalFee: bigint
   maxValidityWindowSeconds: number
@@ -354,7 +353,6 @@ export async function preflightSponsorship<sponsorship extends PreflightSponsors
 const defaultPolicy: Policy = {
   maxGas: 2_000_000n,
   maxFeePerGas: 100_000_000_000n,
-  maxInFlightTotalFee: 500_000_000_000_000_000n,
   maxPriorityFeePerGas: 10_000_000_000n,
   maxTotalFee: 50_000_000_000_000_000n,
   maxValidityWindowSeconds: 15 * 60,
@@ -373,13 +371,11 @@ function getPolicy(chainId: number, overrides: Partial<Policy> | undefined): Pol
   const base = policyByChainId[chainId as defaults.ChainId] ?? defaultPolicy
   if (!overrides) return base
 
-  const maxTotalFee = overrides.maxTotalFee ?? base.maxTotalFee
   return {
     maxGas: overrides.maxGas ?? base.maxGas,
     maxFeePerGas: overrides.maxFeePerGas ?? base.maxFeePerGas,
-    maxInFlightTotalFee: overrides.maxInFlightTotalFee ?? maxTotalFee * 10n,
     maxPriorityFeePerGas: overrides.maxPriorityFeePerGas ?? base.maxPriorityFeePerGas,
-    maxTotalFee,
+    maxTotalFee: overrides.maxTotalFee ?? base.maxTotalFee,
     maxValidityWindowSeconds: overrides.maxValidityWindowSeconds ?? base.maxValidityWindowSeconds,
   }
 }
@@ -647,12 +643,6 @@ export function assertTransactionPolicy(parameters: {
       maxFeePerGas: maxFeePerGasValue.toString(),
       totalFee: maxTotalFee.toString(),
     })
-  if (maxTotalFee > policy.maxInFlightTotalFee)
-    fail('fee-sponsored transaction total fee budget exceeds sponsor in-flight policy', {
-      maxInFlightTotalFee: policy.maxInFlightTotalFee.toString(),
-      totalFee: maxTotalFee.toString(),
-    })
-
   if (maxPriorityFeePerGas !== undefined && maxPriorityFeePerGas > maxFeePerGasValue)
     fail('fee-sponsored transaction maxPriorityFeePerGas exceeds maxFeePerGas', {
       maxFeePerGas: maxFeePerGasValue.toString(),
@@ -689,7 +679,6 @@ export function assertTransactionPolicy(parameters: {
   return {
     gasLimit,
     maxFeePerGasValue,
-    maxInFlightTotalFee: policy.maxInFlightTotalFee,
     totalFee: maxTotalFee,
     validBeforeValue,
   }

--- a/src/tempo/internal/fee-payer.ts
+++ b/src/tempo/internal/fee-payer.ts
@@ -32,6 +32,7 @@ export const callScopes = [
 export type Policy = {
   maxGas: bigint
   maxFeePerGas: bigint
+  maxInFlightTotalFee: bigint
   maxPriorityFeePerGas: bigint
   maxTotalFee: bigint
   maxValidityWindowSeconds: number
@@ -353,6 +354,7 @@ export async function preflightSponsorship<sponsorship extends PreflightSponsors
 const defaultPolicy: Policy = {
   maxGas: 2_000_000n,
   maxFeePerGas: 100_000_000_000n,
+  maxInFlightTotalFee: 500_000_000_000_000_000n,
   maxPriorityFeePerGas: 10_000_000_000n,
   maxTotalFee: 50_000_000_000_000_000n,
   maxValidityWindowSeconds: 15 * 60,
@@ -371,11 +373,13 @@ function getPolicy(chainId: number, overrides: Partial<Policy> | undefined): Pol
   const base = policyByChainId[chainId as defaults.ChainId] ?? defaultPolicy
   if (!overrides) return base
 
+  const maxTotalFee = overrides.maxTotalFee ?? base.maxTotalFee
   return {
     maxGas: overrides.maxGas ?? base.maxGas,
     maxFeePerGas: overrides.maxFeePerGas ?? base.maxFeePerGas,
+    maxInFlightTotalFee: overrides.maxInFlightTotalFee ?? maxTotalFee * 10n,
     maxPriorityFeePerGas: overrides.maxPriorityFeePerGas ?? base.maxPriorityFeePerGas,
-    maxTotalFee: overrides.maxTotalFee ?? base.maxTotalFee,
+    maxTotalFee,
     maxValidityWindowSeconds: overrides.maxValidityWindowSeconds ?? base.maxValidityWindowSeconds,
   }
 }
@@ -636,11 +640,16 @@ export function assertTransactionPolicy(parameters: {
       maxFeePerGas: maxFeePerGasValue.toString(),
     })
 
-  const maxTotalFee = gasLimit * maxFeePerGasValue
+  const maxTotalFee = BigInt(gasLimit) * BigInt(maxFeePerGasValue)
   if (maxTotalFee > policy.maxTotalFee)
     fail('fee-sponsored transaction total fee budget exceeds sponsor policy', {
       gas: gasLimit.toString(),
       maxFeePerGas: maxFeePerGasValue.toString(),
+      totalFee: maxTotalFee.toString(),
+    })
+  if (maxTotalFee > policy.maxInFlightTotalFee)
+    fail('fee-sponsored transaction total fee budget exceeds sponsor in-flight policy', {
+      maxInFlightTotalFee: policy.maxInFlightTotalFee.toString(),
       totalFee: maxTotalFee.toString(),
     })
 
@@ -677,7 +686,13 @@ export function assertTransactionPolicy(parameters: {
       validBefore: String(validBeforeValue),
     })
 
-  return { gasLimit, maxFeePerGasValue, validBeforeValue }
+  return {
+    gasLimit,
+    maxFeePerGasValue,
+    maxInFlightTotalFee: policy.maxInFlightTotalFee,
+    totalFee: maxTotalFee,
+    validBeforeValue,
+  }
 }
 
 export function prepareSponsoredTransaction(parameters: {

--- a/src/tempo/server/Charge.test.ts
+++ b/src/tempo/server/Charge.test.ts
@@ -1951,25 +1951,25 @@ describe('tempo', () => {
     })
 
     test('behavior: fee payer allows concurrent expiring-nonce transactions from one sender', async () => {
-      let releaseSimulation!: () => void
-      let resolveSimulationStarted!: () => void
-      const simulationStarted = new Promise<void>((resolve) => {
-        resolveSimulationStarted = resolve
+      let releaseBroadcast!: () => void
+      let resolveBroadcastStarted!: () => void
+      const broadcastStarted = new Promise<void>((resolve) => {
+        resolveBroadcastStarted = resolve
       })
-      const releaseSimulationPromise = new Promise<void>((resolve) => {
-        releaseSimulation = resolve
+      const releaseBroadcastPromise = new Promise<void>((resolve) => {
+        releaseBroadcast = resolve
       })
-      let heldFirstSimulation = false
+      let heldFirstBroadcast = false
 
       const interceptingClient = createClient({
         account: accounts[0],
         chain: client.chain,
         transport: custom({
           async request(args: any) {
-            if (args.method === 'eth_call' && !heldFirstSimulation) {
-              heldFirstSimulation = true
-              resolveSimulationStarted()
-              await releaseSimulationPromise
+            if (args.method === 'eth_sendRawTransactionSync' && !heldFirstBroadcast) {
+              heldFirstBroadcast = true
+              resolveBroadcastStarted()
+              await releaseBroadcastPromise
             }
             return client.transport.request(args)
           },
@@ -2031,13 +2031,13 @@ describe('tempo', () => {
       ])
 
       const first = fetch(httpServer.url, { headers: { Authorization: credential1 } })
-      await simulationStarted
+      await broadcastStarted
       const sponsorBudgetKey =
-        `tenant:mppx:charge:sponsor-budget:${chain.id}:${accounts[0].address.toLowerCase()}` as const
+        `mppx:charge:sponsor-budget:${chain.id}:${accounts[0].address.toLowerCase()}` as const
       expect(await sponsoredStore.get(sponsorBudgetKey)).not.toBeNull()
       expect(
         await sponsoredStore.get(
-          `mppx:charge:sponsor-budget:${chain.id}:${accounts[0].address.toLowerCase()}`,
+          `tenant:mppx:charge:sponsor-budget:${chain.id}:${accounts[0].address.toLowerCase()}`,
         ),
       ).toBeNull()
       const second = fetch(httpServer.url, { headers: { Authorization: credential2 } })
@@ -2046,7 +2046,7 @@ describe('tempo', () => {
         const secondResponse = await second
         expect(secondResponse.status).toBe(200)
       } finally {
-        releaseSimulation()
+        releaseBroadcast()
       }
 
       const firstResponse = await first
@@ -2057,25 +2057,25 @@ describe('tempo', () => {
     })
 
     test('behavior: fee payer waits for atomic sponsor budget capacity', async () => {
-      let releaseSimulation!: () => void
-      let resolveSimulationStarted!: () => void
-      const simulationStarted = new Promise<void>((resolve) => {
-        resolveSimulationStarted = resolve
+      let releaseBroadcast!: () => void
+      let resolveBroadcastStarted!: () => void
+      const broadcastStarted = new Promise<void>((resolve) => {
+        resolveBroadcastStarted = resolve
       })
-      const releaseSimulationPromise = new Promise<void>((resolve) => {
-        releaseSimulation = resolve
+      const releaseBroadcastPromise = new Promise<void>((resolve) => {
+        releaseBroadcast = resolve
       })
-      let heldFirstSimulation = false
+      let heldFirstBroadcast = false
 
       const interceptingClient = createClient({
         account: accounts[0],
         chain: client.chain,
         transport: custom({
           async request(args: any) {
-            if (args.method === 'eth_call' && !heldFirstSimulation) {
-              heldFirstSimulation = true
-              resolveSimulationStarted()
-              await releaseSimulationPromise
+            if (args.method === 'eth_sendRawTransactionSync' && !heldFirstBroadcast) {
+              heldFirstBroadcast = true
+              resolveBroadcastStarted()
+              await releaseBroadcastPromise
             }
             return client.transport.request(args)
           },
@@ -2150,7 +2150,7 @@ describe('tempo', () => {
       ].reduce((maximum, exposure) => (exposure > maximum ? exposure : maximum))
 
       const first = fetch(httpServer.url, { headers: { Authorization: credential1 } })
-      await simulationStarted
+      await broadcastStarted
       const second = fetch(httpServer.url, { headers: { Authorization: credential2 } })
       try {
         const secondBeforeRelease = await Promise.race([
@@ -2159,7 +2159,7 @@ describe('tempo', () => {
         ])
         expect(secondBeforeRelease).toBe('waiting')
       } finally {
-        releaseSimulation()
+        releaseBroadcast()
       }
       const [firstResponse, secondResponse] = await Promise.all([first, second])
       expect(firstResponse.status).toBe(200)
@@ -2182,8 +2182,13 @@ describe('tempo', () => {
           stale: {
             expiresAt: Date.now() - 1,
             fee: '500000000000000000',
+            leaseUntil: Date.now() - 1,
+            owner: 'stale-worker',
+            phase: 'pending',
+            transactionHash: `0x${'01'.repeat(32)}`,
           },
         },
+        version: 1,
       })
       const serverWithStaleBudget = Mppx_server.create({
         methods: [
@@ -2983,6 +2988,71 @@ describe('tempo', () => {
         expect(receipt.method).toBe('tempo')
         expect(receipt.reference).toBeDefined()
       }
+
+      httpServer.close()
+    })
+
+    test('retains sponsored exposure until receipt reconciliation', async () => {
+      const sponsoredStore = Store.memory()
+      const serverNoWait = Mppx_server.create({
+        methods: [
+          tempo_server.charge({
+            getClient() {
+              return client
+            },
+            currency: asset,
+            account: accounts[0],
+            store: sponsoredStore,
+            waitForConfirmation: false,
+          }),
+        ],
+        realm,
+        secretKey,
+      })
+      const mppx = Mppx_client.create({
+        polyfill: false,
+        methods: [
+          tempo_client({
+            account: accounts[1],
+            getClient() {
+              return client
+            },
+          }),
+        ],
+      })
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await Mppx_server.toNodeListener(
+          serverNoWait.charge({
+            feePayer: accounts[0],
+            amount: '1',
+            currency: asset,
+            recipient: accounts[0].address,
+          }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
+      })
+
+      const challengeResponse = await fetch(httpServer.url)
+      const credential = await mppx.createCredential(challengeResponse)
+      const response = await fetch(httpServer.url, {
+        headers: { Authorization: credential },
+      })
+
+      expect(response.status).toBe(200)
+      const receipt = Receipt.fromResponse(response)
+      const sponsorBudgetKey =
+        `mppx:charge:sponsor-budget:${chain.id}:${accounts[0].address.toLowerCase()}` as const
+      expect(await sponsoredStore.get(sponsorBudgetKey)).toMatchObject({
+        reservations: {
+          [receipt.reference]: {
+            owner: expect.any(String),
+            phase: 'pending',
+            transactionHash: receipt.reference,
+          },
+        },
+        version: 1,
+      })
 
       httpServer.close()
     })

--- a/src/tempo/server/Charge.test.ts
+++ b/src/tempo/server/Charge.test.ts
@@ -47,6 +47,17 @@ function testAccount() {
   return privateKeyToAccount(generatePrivateKey())
 }
 
+function sponsoredFeeExposure(credential: string) {
+  const payload = Credential.deserialize<{ signature: string; type: string }>(credential).payload
+  if (payload.type !== 'transaction') throw new Error('expected transaction credential')
+  const transaction = Transaction.deserialize(
+    payload.signature as Parameters<typeof Transaction.deserialize>[0],
+  )
+  if (transaction.gas === undefined || transaction.maxFeePerGas === undefined)
+    throw new Error('expected sponsored transaction fee fields')
+  return transaction.gas * transaction.maxFeePerGas
+}
+
 // TODO: Remove once the minimum viem version is >=2.54.0, which uses client-first Tempo call builders.
 function tokenTransferCall(parameters: viem_token.transfer.Args) {
   const call = Actions.token.transfer.call as unknown as {
@@ -1939,7 +1950,7 @@ describe('tempo', () => {
       httpServer.close()
     })
 
-    test('behavior: fee payer rejects concurrent in-flight transactions from one sender', async () => {
+    test('behavior: fee payer allows concurrent expiring-nonce transactions from one sender', async () => {
       let releaseSimulation!: () => void
       let resolveSimulationStarted!: () => void
       const simulationStarted = new Promise<void>((resolve) => {
@@ -2021,29 +2032,200 @@ describe('tempo', () => {
 
       const first = fetch(httpServer.url, { headers: { Authorization: credential1 } })
       await simulationStarted
+      const sponsorBudgetKey =
+        `tenant:mppx:charge:sponsor-budget:${chain.id}:${accounts[0].address.toLowerCase()}` as const
+      expect(await sponsoredStore.get(sponsorBudgetKey)).not.toBeNull()
       expect(
         await sponsoredStore.get(
-          `tenant:mppx:charge:sponsor:${chain.id}:${accounts[1].address.toLowerCase()}`,
-        ),
-      ).not.toBeNull()
-      expect(
-        await sponsoredStore.get(
-          `mppx:charge:sponsor:${chain.id}:${accounts[1].address.toLowerCase()}`,
+          `mppx:charge:sponsor-budget:${chain.id}:${accounts[0].address.toLowerCase()}`,
         ),
       ).toBeNull()
       const second = fetch(httpServer.url, { headers: { Authorization: credential2 } })
 
       try {
         const secondResponse = await second
-        expect(secondResponse.status).toBe(402)
-        const body = (await secondResponse.json()) as { detail: string }
-        expect(body.detail).toContain('Sponsored transaction from this sender is already in flight')
+        expect(secondResponse.status).toBe(200)
       } finally {
         releaseSimulation()
       }
 
       const firstResponse = await first
       expect(firstResponse.status).toBe(200)
+      expect(await sponsoredStore.get(sponsorBudgetKey)).toBeNull()
+
+      httpServer.close()
+    })
+
+    test('behavior: fee payer waits for atomic sponsor budget capacity', async () => {
+      let releaseSimulation!: () => void
+      let resolveSimulationStarted!: () => void
+      const simulationStarted = new Promise<void>((resolve) => {
+        resolveSimulationStarted = resolve
+      })
+      const releaseSimulationPromise = new Promise<void>((resolve) => {
+        releaseSimulation = resolve
+      })
+      let heldFirstSimulation = false
+
+      const interceptingClient = createClient({
+        account: accounts[0],
+        chain: client.chain,
+        transport: custom({
+          async request(args: any) {
+            if (args.method === 'eth_call' && !heldFirstSimulation) {
+              heldFirstSimulation = true
+              resolveSimulationStarted()
+              await releaseSimulationPromise
+            }
+            return client.transport.request(args)
+          },
+        }),
+      })
+
+      const feePayerPolicy: { maxInFlightTotalFee?: bigint } = {}
+      const sponsoredStore = Store.memory()
+      const serverWithBudget = Mppx_server.create({
+        methods: [
+          tempo_server.charge({
+            feePayerPolicy,
+            getClient() {
+              return interceptingClient
+            },
+            currency: asset,
+            account: accounts[0],
+            store: sponsoredStore,
+          }),
+        ],
+        realm,
+        secretKey,
+      })
+
+      const mppx1 = Mppx_client.create({
+        polyfill: false,
+        methods: [
+          tempo_client({
+            account: accounts[1],
+            getClient() {
+              return client
+            },
+          }),
+        ],
+      })
+      const mppx2 = Mppx_client.create({
+        polyfill: false,
+        methods: [
+          tempo_client({
+            account: accounts[2],
+            getClient() {
+              return client
+            },
+          }),
+        ],
+      })
+
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await Mppx_server.toNodeListener(
+          serverWithBudget.charge({
+            feePayer: accounts[0],
+            amount: '1',
+            currency: asset,
+            recipient: accounts[0].address,
+          }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
+      })
+
+      const [challengeResponse1, challengeResponse2] = await Promise.all([
+        fetch(httpServer.url),
+        fetch(httpServer.url),
+      ])
+      const [credential1, credential2] = await Promise.all([
+        mppx1.createCredential(challengeResponse1),
+        mppx2.createCredential(challengeResponse2),
+      ])
+      feePayerPolicy.maxInFlightTotalFee = [
+        sponsoredFeeExposure(credential1),
+        sponsoredFeeExposure(credential2),
+      ].reduce((maximum, exposure) => (exposure > maximum ? exposure : maximum))
+
+      const first = fetch(httpServer.url, { headers: { Authorization: credential1 } })
+      await simulationStarted
+      const second = fetch(httpServer.url, { headers: { Authorization: credential2 } })
+      try {
+        const secondBeforeRelease = await Promise.race([
+          second.then(() => 'settled' as const),
+          new Promise<'waiting'>((resolve) => setTimeout(() => resolve('waiting'), 50)),
+        ])
+        expect(secondBeforeRelease).toBe('waiting')
+      } finally {
+        releaseSimulation()
+      }
+      const [firstResponse, secondResponse] = await Promise.all([first, second])
+      expect(firstResponse.status).toBe(200)
+      expect(secondResponse.status).toBe(200)
+      expect(
+        await sponsoredStore.get(
+          `mppx:charge:sponsor-budget:${chain.id}:${accounts[0].address.toLowerCase()}`,
+        ),
+      ).toBeNull()
+
+      httpServer.close()
+    })
+
+    test('behavior: fee payer reclaims expired sponsor budget reservations', async () => {
+      const sponsoredStore = Store.memory()
+      const sponsorBudgetKey =
+        `mppx:charge:sponsor-budget:${chain.id}:${accounts[0].address.toLowerCase()}` as const
+      await sponsoredStore.put(sponsorBudgetKey, {
+        reservations: {
+          stale: {
+            expiresAt: Date.now() - 1,
+            fee: '500000000000000000',
+          },
+        },
+      })
+      const serverWithStaleBudget = Mppx_server.create({
+        methods: [
+          tempo_server.charge({
+            getClient() {
+              return client
+            },
+            currency: asset,
+            account: accounts[0],
+            store: sponsoredStore,
+          }),
+        ],
+        realm,
+        secretKey,
+      })
+      const mppx = Mppx_client.create({
+        polyfill: false,
+        methods: [
+          tempo_client({
+            account: accounts[1],
+            getClient() {
+              return client
+            },
+          }),
+        ],
+      })
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await Mppx_server.toNodeListener(
+          serverWithStaleBudget.charge({
+            feePayer: accounts[0],
+            amount: '1',
+            currency: asset,
+            recipient: accounts[0].address,
+          }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
+      })
+
+      const response = await mppx.fetch(httpServer.url)
+      expect(response.status).toBe(200)
+      expect(await sponsoredStore.get(sponsorBudgetKey)).toBeNull()
 
       httpServer.close()
     })

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -2,8 +2,10 @@ import * as SignatureEnvelope from 'ox/tempo/SignatureEnvelope'
 import {
   decodeFunctionData,
   formatUnits,
+  isAddress,
   keccak256,
   parseEventLogs,
+  stringToHex,
   type TransactionReceipt,
 } from 'viem'
 import {
@@ -500,25 +502,40 @@ export function charge<const parameters extends charge.Parameters>(
           }
 
           let releaseReservation = true
-          let sponsoredSenderReservation: { chainId: number; sender: `0x${string}` } | undefined
+          let sponsorBudgetReservation: SponsorBudgetReservation | undefined
 
           try {
             if (isFeePayerTx) {
               const reservationChainId = chainId ?? client.chain!.id
-              if (
-                !(await markSponsoredSenderInFlight(store, {
-                  chainId: reservationChainId,
-                  sender: transaction.from as `0x${string}`,
-                }))
-              ) {
+              const sponsor = feePayerAccount?.address ?? feePayerUrl
+              if (!sponsor)
                 throw new VerificationFailedError({
-                  reason: 'Sponsored transaction from this sender is already in flight',
+                  reason: 'Sponsored transaction has no configured fee payer',
                 })
-              }
-              sponsoredSenderReservation = {
+              const { maxInFlightTotalFee, totalFee, validBeforeValue } =
+                FeePayer.assertTransactionPolicy({
+                  challengeExpires: expires,
+                  chainId: reservationChainId,
+                  details: { amount, currency, recipient },
+                  policy: feePayerPolicy,
+                  transaction,
+                })
+              const reservation: SponsorBudgetReservation = {
                 chainId: reservationChainId,
-                sender: transaction.from as `0x${string}`,
+                expiresAt: Math.min(
+                  validBeforeValue * 1_000,
+                  expires ? Date.parse(expires) : Number.MAX_SAFE_INTEGER,
+                ),
+                fee: totalFee,
+                hash,
+                sponsor,
               }
+              sponsorBudgetReservation = reservation
+              await reserveSponsorBudget(store, {
+                ...reservation,
+                maxInFlightTotalFee,
+              })
+              Expires.assert(challenge.expires, challenge.id)
             }
 
             const allowedFeeTokens = FeePayer.defaultAllowedFeeTokens(chainId)
@@ -642,8 +659,8 @@ export function charge<const parameters extends charge.Parameters>(
             if (releaseReservation) await releaseHashUse(store, hash)
             throw error
           } finally {
-            if (sponsoredSenderReservation)
-              await releaseSponsoredSenderInFlight(store, sponsoredSenderReservation)
+            if (sponsorBudgetReservation)
+              await releaseSponsorBudget(store, sponsorBudgetReservation)
           }
         }
       }
@@ -653,7 +670,9 @@ export function charge<const parameters extends charge.Parameters>(
 }
 
 export declare namespace charge {
-  type StoreItemMap = { [key: `mppx:charge:${string}`]: number }
+  type StoreItemMap = {
+    [key: `mppx:charge:${string}`]: number | SponsorBudgetState
+  }
 
   type Defaults = LooseOmit<Method.RequestDefaults<typeof Methods.charge>, 'feePayer' | 'recipient'>
 
@@ -681,10 +700,13 @@ export declare namespace charge {
     /**
      * Override the fee-sponsor policy used when co-signing Tempo charge
      * transactions. Defaults resolve per chain, including a higher
-     * priority-fee ceiling on Moderato.
+     * priority-fee ceiling on Moderato and a bounded aggregate in-flight fee
+     * budget. Sponsored transactions reserve their declared maximum fee
+     * atomically; independent expiring-nonce transactions run concurrently
+     * while capacity remains and wait for capacity when the budget is full.
      *
-     * If you increase `maxGas` or `maxFeePerGas`, you may also need to raise
-     * `maxTotalFee` so the combined fee budget remains valid.
+     * If you increase `maxGas`, `maxFeePerGas`, or `maxTotalFee`, you may also
+     * need to raise `maxInFlightTotalFee`.
      */
     feePayerPolicy?: FeePayerPolicy | undefined
     /**
@@ -1095,12 +1117,29 @@ function getProofStoreKey(challengeId: string): `mppx:charge:${string}` {
   return `mppx:charge:proof:${challengeId}`
 }
 
-/** @internal */
-function getSponsoredSenderStoreKey(parameters: {
+type SponsorBudgetState = {
+  reservations: Record<string, { expiresAt: number; fee: string }>
+}
+
+type SponsorBudgetReservation = {
   chainId: number
-  sender: `0x${string}`
+  expiresAt: number
+  fee: bigint
+  hash: `0x${string}`
+  sponsor: string
+}
+
+const sponsorBudgetPollIntervalMs = 10
+const sponsorBudgetMaxPollIntervalMs = 250
+
+/** @internal */
+function getSponsorBudgetStoreKey(parameters: {
+  chainId: number
+  sponsor: string
 }): `mppx:charge:${string}` {
-  return `mppx:charge:sponsor:${parameters.chainId}:${parameters.sender.toLowerCase()}`
+  const sponsor = parameters.sponsor.toLowerCase()
+  const scope = isAddress(sponsor) ? sponsor : keccak256(stringToHex(sponsor))
+  return `mppx:charge:sponsor-budget:${parameters.chainId}:${scope}`
 }
 
 async function markHashUsed(
@@ -1136,23 +1175,85 @@ function parseHashCredentialSource(parameters: {
   return parsed
 }
 
-/** @internal */
-async function markSponsoredSenderInFlight(
+/**
+ * Atomically reserves worst-case fee exposure for one sponsored transaction.
+ *
+ * Reservations share a sponsor-scoped budget across senders and server
+ * instances. Capacity contention waits instead of turning an otherwise valid
+ * expiring-nonce transaction into a terminal payment rejection. Stale entries
+ * expire with their transaction or challenge deadline.
+ *
+ * @internal
+ */
+async function reserveSponsorBudget(
   store: Store.AtomicStore<charge.StoreItemMap>,
-  parameters: { chainId: number; sender: `0x${string}` },
-): Promise<boolean> {
-  return store.update(getSponsoredSenderStoreKey(parameters), (current) => {
-    if (current !== null) return { op: 'noop', result: false }
-    return { op: 'set', value: Date.now(), result: true }
-  })
+  parameters: SponsorBudgetReservation & { maxInFlightTotalFee: bigint },
+): Promise<void> {
+  const key = getSponsorBudgetStoreKey(parameters)
+  let pollIntervalMs = sponsorBudgetPollIntervalMs
+  for (;;) {
+    const now = Date.now()
+    if (now >= parameters.expiresAt)
+      throw new VerificationFailedError({
+        reason: 'Sponsored transaction expired while waiting for sponsor budget',
+      })
+
+    const result = await store.update(key, (current) => {
+      if (typeof current === 'number') return { op: 'noop', result: 'invalid' as const }
+
+      const reservations = Object.fromEntries(
+        Object.entries(current?.reservations ?? {}).filter(
+          ([, reservation]) => reservation.expiresAt > now,
+        ),
+      )
+      const reserved = Object.values(reservations).reduce(
+        (total, reservation) => total + BigInt(reservation.fee),
+        0n,
+      )
+      if (reserved + parameters.fee > parameters.maxInFlightTotalFee)
+        return {
+          op: 'set',
+          value: { reservations },
+          result: 'wait' as const,
+        }
+
+      reservations[parameters.hash.toLowerCase()] = {
+        expiresAt: parameters.expiresAt,
+        fee: parameters.fee.toString(),
+      }
+      return {
+        op: 'set',
+        value: { reservations },
+        result: 'reserved' as const,
+      }
+    })
+
+    if (result === 'reserved') return
+    if (result === 'invalid')
+      throw new VerificationFailedError({
+        reason: 'Sponsor budget store contains incompatible state',
+      })
+    await new Promise((resolve) =>
+      setTimeout(resolve, Math.min(pollIntervalMs, parameters.expiresAt - now)),
+    )
+    pollIntervalMs = Math.min(pollIntervalMs * 2, sponsorBudgetMaxPollIntervalMs)
+  }
 }
 
-/** @internal */
-async function releaseSponsoredSenderInFlight(
+/** Releases one transaction's fee exposure without disturbing concurrent reservations. */
+async function releaseSponsorBudget(
   store: Store.AtomicStore<charge.StoreItemMap>,
-  parameters: { chainId: number; sender: `0x${string}` },
+  parameters: SponsorBudgetReservation,
 ): Promise<void> {
-  await store.delete(getSponsoredSenderStoreKey(parameters))
+  const key = getSponsorBudgetStoreKey(parameters)
+  await store.update(key, (current) => {
+    if (current === null || typeof current === 'number') return { op: 'noop', result: undefined }
+
+    const reservations = { ...current.reservations }
+    delete reservations[parameters.hash.toLowerCase()]
+    if (Object.keys(reservations).length === 0) return { op: 'delete', result: undefined }
+    return { op: 'set', value: { reservations }, result: undefined }
+  })
 }
 
 /** @internal */

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -2,10 +2,8 @@ import * as SignatureEnvelope from 'ox/tempo/SignatureEnvelope'
 import {
   decodeFunctionData,
   formatUnits,
-  isAddress,
   keccak256,
   parseEventLogs,
-  stringToHex,
   type TransactionReceipt,
 } from 'viem'
 import {
@@ -40,6 +38,7 @@ import type * as types from '../internal/types.js'
 import * as Methods from '../Methods.js'
 import { html as htmlContent } from './internal/html.gen.js'
 import * as Relay from './Relay.js'
+import * as SponsorBudget from './SponsorBudget.js'
 
 /**
  * Creates a Tempo charge method intent for usage on the server.
@@ -74,10 +73,23 @@ export function charge<const parameters extends charge.Parameters>(
     waitForConfirmation = true,
   } = parameters
   const storeKeyPrefix = parameters.storeKeyPrefix ?? ''
-  const store = Store.from(
-    (parameters.store ?? Store.memory()) as Store.AtomicStore<charge.StoreItemMap>,
-    { keyPrefix: storeKeyPrefix },
-  )
+  const rawStore = (parameters.store ?? Store.memory()) as Store.AtomicStore<charge.StoreItemMap>
+  const store = Store.from(rawStore, { keyPrefix: storeKeyPrefix })
+  // Aggregate exposure belongs to the actual sponsor, not a caller-specific
+  // replay namespace. Sharing the raw store gives every tenant/process the same
+  // atomic sponsor-wide budget.
+  const sponsorBudgetStore = Store.from(rawStore) as Store.AtomicStore<{
+    [key: `mppx:charge:sponsor-budget:${string}`]: SponsorBudget.State
+  }>
+  const {
+    maxInFlightReservations = 100,
+    maxInFlightTotalFee = (feePayerPolicy?.maxTotalFee ?? 50_000_000_000_000_000n) * 10n,
+    ...transactionFeePayerPolicy
+  } = feePayerPolicy ?? {}
+  if (!Number.isSafeInteger(maxInFlightReservations) || maxInFlightReservations <= 0)
+    throw new Error('`feePayerPolicy.maxInFlightReservations` must be a positive safe integer.')
+  if (maxInFlightTotalFee <= 0n)
+    throw new Error('`feePayerPolicy.maxInFlightTotalFee` must be greater than zero.')
   const proofStore = parameters.store
     ? Store.from(parameters.store as Store.AtomicStore<charge.StoreItemMap>, {
         keyPrefix: storeKeyPrefix,
@@ -501,48 +513,16 @@ export function charge<const parameters extends charge.Parameters>(
             })
           }
 
-          let releaseReservation = true
-          let sponsorBudgetReservation: SponsorBudgetReservation | undefined
+          let broadcastAttempted = false
+          let finalHash: `0x${string}` | undefined
+          let reservation: SponsorBudget.Handle | undefined
 
           try {
-            if (isFeePayerTx) {
-              const reservationChainId = chainId ?? client.chain!.id
-              const sponsor = feePayerAccount?.address ?? feePayerUrl
-              if (!sponsor)
-                throw new VerificationFailedError({
-                  reason: 'Sponsored transaction has no configured fee payer',
-                })
-              const { maxInFlightTotalFee, totalFee, validBeforeValue } =
-                FeePayer.assertTransactionPolicy({
-                  challengeExpires: expires,
-                  chainId: reservationChainId,
-                  details: { amount, currency, recipient },
-                  policy: feePayerPolicy,
-                  transaction,
-                })
-              const reservation: SponsorBudgetReservation = {
-                chainId: reservationChainId,
-                expiresAt: Math.min(
-                  validBeforeValue * 1_000,
-                  expires ? Date.parse(expires) : Number.MAX_SAFE_INTEGER,
-                ),
-                fee: totalFee,
-                hash,
-                sponsor,
-              }
-              sponsorBudgetReservation = reservation
-              await reserveSponsorBudget(store, {
-                ...reservation,
-                maxInFlightTotalFee,
-              })
-              Expires.assert(challenge.expires, challenge.id)
-            }
-
             const allowedFeeTokens = FeePayer.defaultAllowedFeeTokens(chainId)
             if (isFeePayerTx) FeePayer.assertAllowedFeeToken(transaction, allowedFeeTokens)
             const selectableFeeTokens = allowedFeeTokens as readonly `0x${string}`[]
 
-            const serializedTransaction_final = await (async () => {
+            const completedTransaction = await (async () => {
               if (feePayerAccount && methodDetails?.feePayer !== false) {
                 const completed = await FeePayer.preflightSponsorship({
                   transaction,
@@ -563,7 +543,7 @@ export function charge<const parameters extends charge.Parameters>(
                       challengeExpires: expires,
                       chainId: chainId ?? client.chain!.id,
                       details: { amount, currency, recipient },
-                      policy: feePayerPolicy,
+                      policy: transactionFeePayerPolicy,
                       transaction: {
                         ...transaction,
                         ...(feeToken ? { feeToken } : {}),
@@ -572,7 +552,13 @@ export function charge<const parameters extends charge.Parameters>(
                     return { feePayer: feePayerAccount.address, transaction: sponsored }
                   },
                 })
-                return signTransaction(client, completed.transaction as never)
+                return {
+                  serializedTransaction: await signTransaction(
+                    client,
+                    completed.transaction as never,
+                  ),
+                  sponsor: completed.feePayer,
+                }
               }
               if (feePayerUrl && isFeePayerTx) {
                 const completed = await FeePayer.preflightSponsorship({
@@ -584,17 +570,66 @@ export function charge<const parameters extends charge.Parameters>(
                       challengeExpires: expires,
                       chainId: chainId ?? client.chain!.id,
                       details: { amount, currency, recipient },
-                      policy: feePayerPolicy,
+                      policy: transactionFeePayerPolicy,
                       transaction,
                       url: feePayerUrl,
                     })
                     return { ...hosted, transaction }
                   },
                 })
-                return completed.serializedTransaction
+                return {
+                  serializedTransaction: completed.serializedTransaction,
+                  sponsor: completed.feePayer,
+                }
               }
-              return serializedTransaction
+              return { serializedTransaction, sponsor: undefined }
             })()
+            const serializedTransaction_final = completedTransaction.serializedTransaction
+            finalHash = keccak256(serializedTransaction_final)
+
+            if (
+              finalHash.toLowerCase() !== hash.toLowerCase() &&
+              !(await markHashUsed(store, finalHash))
+            )
+              throw new VerificationFailedError({
+                reason: 'Transaction hash has already been used',
+              })
+
+            if (isFeePayerTx) {
+              const sponsor = completedTransaction.sponsor
+              if (!sponsor)
+                throw new VerificationFailedError({
+                  reason: 'Sponsored transaction has no configured fee payer',
+                })
+              const reservationChainId = chainId ?? client.chain!.id
+              const { totalFee, validBeforeValue } = FeePayer.assertTransactionPolicy({
+                challengeExpires: expires,
+                chainId: reservationChainId,
+                details: { amount, currency, recipient },
+                policy: transactionFeePayerPolicy,
+                transaction,
+              })
+              const expiresAt = validBeforeValue * 1_000
+              const waitUntil = Math.min(
+                expiresAt,
+                expires ? Date.parse(expires) : Number.MAX_SAFE_INTEGER,
+              )
+              reservation = await SponsorBudget.reserve(sponsorBudgetStore, {
+                chainId: reservationChainId,
+                expiresAt,
+                fee: totalFee,
+                getReceipt: (transactionHash) =>
+                  getTransactionReceipt(client, { hash: transactionHash }),
+                id: finalHash.toLowerCase(),
+                maxReservations: maxInFlightReservations,
+                maxTotalFee: maxInFlightTotalFee,
+                owner: globalThis.crypto.randomUUID(),
+                sponsor,
+                transactionHash: finalHash,
+                waitUntil,
+              })
+              Expires.assert(challenge.expires, challenge.id)
+            }
 
             // Pre-broadcast simulation for non-sponsored transactions.
             if (!isFeePayerTx)
@@ -603,10 +638,20 @@ export function charge<const parameters extends charge.Parameters>(
                 FeePayer.simulationTransaction(transaction, { feePayer: false }) as never,
               )
 
+            if (
+              reservation &&
+              !(await SponsorBudget.transition(sponsorBudgetStore, reservation, 'broadcasting'))
+            )
+              throw new VerificationFailedError({
+                reason: 'Sponsor budget reservation ownership was lost before broadcast',
+              })
+
+            broadcastAttempted = true
             if (waitForConfirmation) {
               const receipt = await sendRawTransactionSync(client, {
                 serializedTransaction: serializedTransaction_final,
               })
+              if (reservation) await SponsorBudget.release(sponsorBudgetStore, reservation)
               const matchedLogs = await assertTransferLogs(receipt, {
                 currency,
                 sender: transaction.from! as `0x${string}`,
@@ -617,19 +662,10 @@ export function charge<const parameters extends charge.Parameters>(
                   challengeId: challenge.id,
                   realm: challenge.realm,
                 })
-              // Post-broadcast dedup: catch malleable input variants
-              // (different serialized bytes, same underlying tx) that
-              // bypass the pre-broadcast check. Skip if the broadcast
-              // hash matches the input hash (already stored above).
-              if (
-                receipt.transactionHash.toLowerCase() !== hash.toLowerCase() &&
-                !(await markHashUsed(store, receipt.transactionHash))
-              ) {
+              if (receipt.transactionHash.toLowerCase() !== finalHash.toLowerCase())
                 throw new VerificationFailedError({
-                  reason: 'Transaction hash has already been used',
+                  reason: 'Broadcast transaction hash does not match the signed transaction',
                 })
-              }
-              releaseReservation = false
               return toReceipt(receipt)
             }
 
@@ -639,16 +675,17 @@ export function charge<const parameters extends charge.Parameters>(
             const reference = await sendRawTransaction(client, {
               serializedTransaction: serializedTransaction_final,
             })
-            // Post-broadcast dedup: same
-            if (
-              reference.toLowerCase() !== hash.toLowerCase() &&
-              !(await markHashUsed(store, reference))
-            ) {
+            if (reference.toLowerCase() !== finalHash.toLowerCase())
               throw new VerificationFailedError({
-                reason: 'Transaction hash has already been used',
+                reason: 'Broadcast transaction hash does not match the signed transaction',
               })
-            }
-            releaseReservation = false
+            if (
+              reservation &&
+              !(await SponsorBudget.transition(sponsorBudgetStore, reservation, 'pending'))
+            )
+              throw new VerificationFailedError({
+                reason: 'Sponsor budget reservation ownership was lost after broadcast',
+              })
             return {
               method: 'tempo',
               status: 'success',
@@ -656,11 +693,13 @@ export function charge<const parameters extends charge.Parameters>(
               reference,
             } as const
           } catch (error) {
-            if (releaseReservation) await releaseHashUse(store, hash)
+            if (!broadcastAttempted) {
+              if (reservation) await SponsorBudget.release(sponsorBudgetStore, reservation)
+              if (finalHash && finalHash.toLowerCase() !== hash.toLowerCase())
+                await releaseHashUse(store, finalHash)
+              await releaseHashUse(store, hash)
+            }
             throw error
-          } finally {
-            if (sponsorBudgetReservation)
-              await releaseSponsorBudget(store, sponsorBudgetReservation)
           }
         }
       }
@@ -671,7 +710,7 @@ export function charge<const parameters extends charge.Parameters>(
 
 export declare namespace charge {
   type StoreItemMap = {
-    [key: `mppx:charge:${string}`]: number | SponsorBudgetState
+    [key: `mppx:charge:${string}`]: number | SponsorBudget.State
   }
 
   type Defaults = LooseOmit<Method.RequestDefaults<typeof Methods.charge>, 'feePayer' | 'recipient'>
@@ -773,7 +812,16 @@ export declare namespace charge {
     }
   >
 
-  type FeePayerPolicy = Partial<FeePayer.Policy>
+  type FeePayerPolicy = Partial<FeePayer.Policy> & {
+    /** Maximum number of sponsored transactions awaiting a terminal receipt. @default 100 */
+    maxInFlightReservations?: number | undefined
+    /**
+     * Maximum aggregate declared fee exposure awaiting terminal receipts.
+     *
+     * @default `maxTotalFee * 10`
+     */
+    maxInFlightTotalFee?: bigint | undefined
+  }
 
   /** Tempo API relay configuration for server-side charges. */
   type RelayOptions = Relay.configure.Options
@@ -1117,31 +1165,6 @@ function getProofStoreKey(challengeId: string): `mppx:charge:${string}` {
   return `mppx:charge:proof:${challengeId}`
 }
 
-type SponsorBudgetState = {
-  reservations: Record<string, { expiresAt: number; fee: string }>
-}
-
-type SponsorBudgetReservation = {
-  chainId: number
-  expiresAt: number
-  fee: bigint
-  hash: `0x${string}`
-  sponsor: string
-}
-
-const sponsorBudgetPollIntervalMs = 10
-const sponsorBudgetMaxPollIntervalMs = 250
-
-/** @internal */
-function getSponsorBudgetStoreKey(parameters: {
-  chainId: number
-  sponsor: string
-}): `mppx:charge:${string}` {
-  const sponsor = parameters.sponsor.toLowerCase()
-  const scope = isAddress(sponsor) ? sponsor : keccak256(stringToHex(sponsor))
-  return `mppx:charge:sponsor-budget:${parameters.chainId}:${scope}`
-}
-
 async function markHashUsed(
   store: Store.AtomicStore<charge.StoreItemMap>,
   hash: `0x${string}`,
@@ -1173,87 +1196,6 @@ function parseHashCredentialSource(parameters: {
   }
 
   return parsed
-}
-
-/**
- * Atomically reserves worst-case fee exposure for one sponsored transaction.
- *
- * Reservations share a sponsor-scoped budget across senders and server
- * instances. Capacity contention waits instead of turning an otherwise valid
- * expiring-nonce transaction into a terminal payment rejection. Stale entries
- * expire with their transaction or challenge deadline.
- *
- * @internal
- */
-async function reserveSponsorBudget(
-  store: Store.AtomicStore<charge.StoreItemMap>,
-  parameters: SponsorBudgetReservation & { maxInFlightTotalFee: bigint },
-): Promise<void> {
-  const key = getSponsorBudgetStoreKey(parameters)
-  let pollIntervalMs = sponsorBudgetPollIntervalMs
-  for (;;) {
-    const now = Date.now()
-    if (now >= parameters.expiresAt)
-      throw new VerificationFailedError({
-        reason: 'Sponsored transaction expired while waiting for sponsor budget',
-      })
-
-    const result = await store.update(key, (current) => {
-      if (typeof current === 'number') return { op: 'noop', result: 'invalid' as const }
-
-      const reservations = Object.fromEntries(
-        Object.entries(current?.reservations ?? {}).filter(
-          ([, reservation]) => reservation.expiresAt > now,
-        ),
-      )
-      const reserved = Object.values(reservations).reduce(
-        (total, reservation) => total + BigInt(reservation.fee),
-        0n,
-      )
-      if (reserved + parameters.fee > parameters.maxInFlightTotalFee)
-        return {
-          op: 'set',
-          value: { reservations },
-          result: 'wait' as const,
-        }
-
-      reservations[parameters.hash.toLowerCase()] = {
-        expiresAt: parameters.expiresAt,
-        fee: parameters.fee.toString(),
-      }
-      return {
-        op: 'set',
-        value: { reservations },
-        result: 'reserved' as const,
-      }
-    })
-
-    if (result === 'reserved') return
-    if (result === 'invalid')
-      throw new VerificationFailedError({
-        reason: 'Sponsor budget store contains incompatible state',
-      })
-    await new Promise((resolve) =>
-      setTimeout(resolve, Math.min(pollIntervalMs, parameters.expiresAt - now)),
-    )
-    pollIntervalMs = Math.min(pollIntervalMs * 2, sponsorBudgetMaxPollIntervalMs)
-  }
-}
-
-/** Releases one transaction's fee exposure without disturbing concurrent reservations. */
-async function releaseSponsorBudget(
-  store: Store.AtomicStore<charge.StoreItemMap>,
-  parameters: SponsorBudgetReservation,
-): Promise<void> {
-  const key = getSponsorBudgetStoreKey(parameters)
-  await store.update(key, (current) => {
-    if (current === null || typeof current === 'number') return { op: 'noop', result: undefined }
-
-    const reservations = { ...current.reservations }
-    delete reservations[parameters.hash.toLowerCase()]
-    if (Object.keys(reservations).length === 0) return { op: 'delete', result: undefined }
-    return { op: 'set', value: { reservations }, result: undefined }
-  })
 }
 
 /** @internal */

--- a/src/tempo/server/SponsorBudget.test.ts
+++ b/src/tempo/server/SponsorBudget.test.ts
@@ -1,0 +1,125 @@
+import type { Hex } from 'viem'
+import { describe, expect, test } from 'vp/test'
+
+import * as Store from '../../Store.js'
+import * as SponsorBudget from './SponsorBudget.js'
+
+const sponsor = '0x0000000000000000000000000000000000000001'
+const hash1 = `0x${'01'.repeat(32)}` as Hex
+const hash2 = `0x${'02'.repeat(32)}` as Hex
+const storeKey = `mppx:charge:sponsor-budget:42431:${sponsor}` as const
+
+function memoryStore() {
+  return Store.memory() as Parameters<typeof SponsorBudget.reserve>[0]
+}
+
+function parameters(overrides: Partial<Parameters<typeof SponsorBudget.reserve>[1]> = {}) {
+  return {
+    chainId: 42431,
+    expiresAt: Date.now() + 10_000,
+    fee: 1n,
+    getReceipt: async () => {
+      throw new Error('not found')
+    },
+    id: hash1,
+    maxReservations: 10,
+    maxTotalFee: 1n,
+    owner: 'worker-1',
+    sponsor,
+    transactionHash: hash1,
+    waitUntil: Date.now() + 10_000,
+    ...overrides,
+  } satisfies Parameters<typeof SponsorBudget.reserve>[1]
+}
+
+describe('SponsorBudget', () => {
+  test('rejects a transaction larger than the aggregate budget', async () => {
+    const store = memoryStore()
+    await expect(
+      SponsorBudget.reserve(store, parameters({ fee: 2n, maxTotalFee: 1n })),
+    ).rejects.toThrow('fee exceeds the aggregate sponsor budget')
+    expect(await store.get(storeKey)).toBeNull()
+  })
+
+  test('retains pending exposure until a receipt is observed', async () => {
+    const store = memoryStore()
+    let confirmed = false
+    const getReceipt = async (hash: Hex) => {
+      if (hash === hash1 && confirmed) return {}
+      throw new Error('not found')
+    }
+    const first = await SponsorBudget.reserve(store, parameters({ getReceipt }))
+    expect(await SponsorBudget.transition(store, first, 'broadcasting')).toBe(true)
+    expect(await SponsorBudget.transition(store, first, 'pending')).toBe(true)
+
+    const second = SponsorBudget.reserve(
+      store,
+      parameters({
+        getReceipt,
+        id: hash2,
+        owner: 'worker-2',
+        transactionHash: hash2,
+      }),
+    )
+    expect(
+      await Promise.race([
+        second.then(() => 'reserved' as const),
+        new Promise<'waiting'>((resolve) => setTimeout(() => resolve('waiting'), 40)),
+      ]),
+    ).toBe('waiting')
+
+    confirmed = true
+    await expect(second).resolves.toMatchObject({ id: hash2, owner: 'worker-2' })
+    const state = await store.get(storeKey)
+    expect(Object.keys(state!.reservations)).toEqual([hash2])
+  })
+
+  test('fences release and transition by reservation owner', async () => {
+    const store = memoryStore()
+    const handle = await SponsorBudget.reserve(store, parameters())
+    const staleHandle = { ...handle, owner: 'stale-worker' }
+
+    expect(await SponsorBudget.transition(store, staleHandle, 'broadcasting')).toBe(false)
+    expect(await SponsorBudget.release(store, staleHandle)).toBe(false)
+    expect(await store.get(storeKey)).toMatchObject({
+      reservations: {
+        [hash1]: {
+          owner: 'worker-1',
+          phase: 'prepared',
+          transactionHash: hash1,
+        },
+      },
+    })
+
+    expect(await SponsorBudget.release(store, handle)).toBe(true)
+    expect(await store.get(storeKey)).toBeNull()
+  })
+
+  test('caps reservation count independently of fee exposure', async () => {
+    const store = memoryStore()
+    const first = await SponsorBudget.reserve(
+      store,
+      parameters({ fee: 0n, maxReservations: 1, maxTotalFee: 100n }),
+    )
+    const second = SponsorBudget.reserve(
+      store,
+      parameters({
+        fee: 0n,
+        id: hash2,
+        maxReservations: 1,
+        maxTotalFee: 100n,
+        owner: 'worker-2',
+        transactionHash: hash2,
+      }),
+    )
+
+    expect(
+      await Promise.race([
+        second.then(() => 'reserved' as const),
+        new Promise<'waiting'>((resolve) => setTimeout(() => resolve('waiting'), 40)),
+      ]),
+    ).toBe('waiting')
+    await SponsorBudget.release(store, first)
+    await expect(second).resolves.toMatchObject({ id: hash2 })
+  })
+})

--- a/src/tempo/server/SponsorBudget.ts
+++ b/src/tempo/server/SponsorBudget.ts
@@ -1,0 +1,213 @@
+import type { Hex } from 'viem'
+
+import { VerificationFailedError } from '../../Errors.js'
+import type * as Store from '../../Store.js'
+
+export type Phase = 'prepared' | 'broadcasting' | 'pending'
+
+export type Reservation = {
+  expiresAt: number
+  fee: string
+  leaseUntil: number
+  owner: string
+  phase: Phase
+  transactionHash: Hex
+}
+
+export type State = {
+  reservations: Record<string, Reservation>
+  version: 1
+}
+
+export type Handle = {
+  chainId: number
+  id: string
+  owner: string
+  sponsor: Hex
+}
+
+type ItemMap = {
+  [key: `mppx:charge:sponsor-budget:${string}`]: State
+}
+
+type ReserveParameters = Handle & {
+  expiresAt: number
+  fee: bigint
+  getReceipt: (hash: Hex) => Promise<unknown>
+  maxReservations: number
+  maxTotalFee: bigint
+  transactionHash: Hex
+  waitUntil: number
+}
+
+const initialPollIntervalMs = 10
+const maxPollIntervalMs = 250
+const preparedLeaseMs = 30_000
+
+function key(parameters: Pick<Handle, 'chainId' | 'sponsor'>) {
+  return `mppx:charge:sponsor-budget:${parameters.chainId}:${parameters.sponsor.toLowerCase()}` as const
+}
+
+function isState(value: State | null): value is State {
+  return value?.version === 1 && typeof value.reservations === 'object'
+}
+
+async function mutateOwned(
+  store: Store.AtomicStore<ItemMap>,
+  handle: Handle,
+  mutate: (reservation: Reservation) => Reservation | null,
+) {
+  return store.update(key(handle), (current) => {
+    if (!isState(current)) return { op: 'noop', result: false }
+    const reservation = current.reservations[handle.id]
+    if (!reservation || reservation.owner !== handle.owner) return { op: 'noop', result: false }
+
+    const reservations = { ...current.reservations }
+    const next = mutate(reservation)
+    if (next) reservations[handle.id] = next
+    else delete reservations[handle.id]
+
+    if (Object.keys(reservations).length === 0) return { op: 'delete', result: true }
+    return {
+      op: 'set',
+      value: { reservations, version: 1 },
+      result: true,
+    }
+  })
+}
+
+async function reconcile(
+  store: Store.AtomicStore<ItemMap>,
+  parameters: Pick<ReserveParameters, 'chainId' | 'getReceipt' | 'sponsor'>,
+) {
+  const state = await store.get(key(parameters))
+  if (!isState(state)) return
+
+  const now = Date.now()
+  await Promise.all(
+    Object.entries(state.reservations).map(async ([id, reservation]) => {
+      const handle = {
+        chainId: parameters.chainId,
+        id,
+        owner: reservation.owner,
+        sponsor: parameters.sponsor,
+      }
+      if (
+        reservation.expiresAt <= now ||
+        (reservation.phase === 'prepared' && reservation.leaseUntil <= now)
+      ) {
+        await release(store, handle)
+        return
+      }
+      if (reservation.phase === 'prepared') return
+
+      try {
+        await parameters.getReceipt(reservation.transactionHash)
+      } catch {
+        return
+      }
+      await release(store, handle)
+    }),
+  )
+}
+
+/**
+ * Reserves aggregate sponsor fee capacity across processes.
+ *
+ * Pending broadcasts remain charged to the budget until a receipt is observed
+ * or their expiring nonce becomes invalid. Capacity waiters do not rewrite the
+ * shared state while waiting.
+ *
+ * @internal
+ */
+export async function reserve(
+  store: Store.AtomicStore<ItemMap>,
+  parameters: ReserveParameters,
+): Promise<Handle> {
+  if (parameters.fee > parameters.maxTotalFee)
+    throw new VerificationFailedError({
+      reason: 'Sponsored transaction fee exceeds the aggregate sponsor budget',
+    })
+
+  let pollIntervalMs = initialPollIntervalMs
+  for (;;) {
+    const now = Date.now()
+    if (now >= parameters.waitUntil)
+      throw new VerificationFailedError({
+        reason: 'Sponsored transaction expired while waiting for sponsor budget',
+      })
+
+    await reconcile(store, parameters)
+    const result = await store.update(key(parameters), (current) => {
+      if (current !== null && !isState(current)) return { op: 'noop', result: 'invalid' as const }
+
+      const reservations = { ...(current?.reservations ?? {}) }
+      const existing = reservations[parameters.id]
+      if (existing) return { op: 'noop', result: 'duplicate' as const }
+
+      const values = Object.values(reservations)
+      const totalFee = values.reduce((total, reservation) => total + BigInt(reservation.fee), 0n)
+      if (
+        values.length >= parameters.maxReservations ||
+        totalFee + parameters.fee > parameters.maxTotalFee
+      )
+        return { op: 'noop', result: 'wait' as const }
+
+      reservations[parameters.id] = {
+        expiresAt: parameters.expiresAt,
+        fee: parameters.fee.toString(),
+        leaseUntil: Math.min(parameters.expiresAt, now + preparedLeaseMs),
+        owner: parameters.owner,
+        phase: 'prepared',
+        transactionHash: parameters.transactionHash,
+      }
+      return {
+        op: 'set',
+        value: { reservations, version: 1 },
+        result: 'reserved' as const,
+      }
+    })
+
+    if (result === 'reserved') return parameters
+    if (result === 'invalid')
+      throw new VerificationFailedError({
+        reason: 'Sponsor budget store contains incompatible state',
+      })
+    if (result === 'duplicate')
+      throw new VerificationFailedError({
+        reason: 'Sponsored transaction already has a budget reservation',
+      })
+
+    await new Promise((resolve) =>
+      setTimeout(resolve, Math.min(pollIntervalMs, parameters.waitUntil - now)),
+    )
+    pollIntervalMs = Math.min(pollIntervalMs * 2, maxPollIntervalMs)
+  }
+}
+
+/**
+ * Advances a reservation before and after the broadcast call.
+ *
+ * The owner token fences stale workers from mutating a replacement reservation.
+ *
+ * @internal
+ */
+export async function transition(
+  store: Store.AtomicStore<ItemMap>,
+  handle: Handle,
+  phase: Exclude<Phase, 'prepared'>,
+): Promise<boolean> {
+  return mutateOwned(store, handle, (reservation) => ({
+    ...reservation,
+    phase,
+  }))
+}
+
+/**
+ * Releases a reservation only when the caller still owns it.
+ *
+ * @internal
+ */
+export async function release(store: Store.AtomicStore<ItemMap>, handle: Handle): Promise<boolean> {
+  return mutateOwned(store, handle, () => null)
+}


### PR DESCRIPTION
## What changed

- replace sender-level serialization with a sponsor-wide atomic fee budget
- key the budget by the recovered on-chain sponsor address, independent of replay-store prefixes
- persist the final sponsor-signed transaction hash and an owner-fenced lifecycle (`prepared` → `broadcasting` → `pending`)
- keep broadcast/pending exposure reserved until a receipt is observed or the expiring nonce reaches `validBefore`
- reconcile receipts lazily before admitting more work; stale workers cannot release replacement reservations
- bound both aggregate declared fee exposure and reservation count
- wait for capacity until the payment challenge deadline rather than rejecting parallel expiring-nonce submissions

## Why

Tempo expiring nonces are designed for independent transactions to be submitted in parallel. A sender mutex defeats that property, while releasing budget immediately after an optimistic RPC response fails to bound transactions that are still pending or whose response was lost.

This keeps the aggregate sponsor bound without coupling independent senders or same-sender expiring-nonce transactions. The final signed hash and owner token provide the useful lifecycle/reconciliation pieces discussed in #690; this PR intentionally does **not** take #690’s sender lock or add a manual recovery API. It supersedes #690 for this behavior.

Tempo references:
- https://docs.tempo.xyz/guide/payments/send-parallel-transactions
- https://docs.tempo.xyz/protocol/transactions

## Policy

`tempo.charge({ feePayerPolicy })` accepts:

- `maxInFlightTotalFee`: aggregate declared worst-case fee exposure; defaults to `maxTotalFee * 10`
- `maxInFlightReservations`: count bound protecting the budget from zero/low-fee request amplification; defaults to `100`

Per-transaction fee validation remains in the shared fee-payer policy. The aggregate settings are charge-broadcast policy and do not leak into session fee-payer configuration. A single transaction larger than the aggregate budget is rejected immediately instead of waiting until expiry.

Capacity waiters perform atomic no-op reads while full. A challenge expiry stops a waiter from beginning new work, but an already broadcast reservation remains counted through the transaction’s later `validBefore` boundary.

## Validation

- reproduced the previous same-sender rejection on pristine `main`
- verified concurrent same-sender expiring-nonce transactions succeed
- verified different senders sharing one sponsor coordinate against the same atomic budget
- verified capacity waits and proceeds after terminal receipt reconciliation
- verified optimistic sponsored broadcasts remain persisted as `pending`
- verified owner fencing rejects stale transitions/releases
- verified reservation-count limiting and oversized-transaction rejection
- local Tempo node: 180 focused fee-payer/charge/budget tests passed
- `pnpm check:ci`
- `pnpm exec tsgo -b`
- `pnpm build`

Both commits are SSH-signed for GitHub verification.