### PR TITLE
fix: preserve session state across retries

### DIFF
--- a/.changeset/fresh-session-retries.md
+++ b/.changeset/fresh-session-retries.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed repeated session challenge retries and durable session rollback after failed payments.

--- a/src/client/internal/Fetch.test.ts
+++ b/src/client/internal/Fetch.test.ts
@@ -10,6 +10,7 @@ import { rpcUrl } from '~test/tempo/rpc.js'
 import { accounts, asset, chain, client, http } from '~test/tempo/viem.js'
 
 import * as Fetch from './Fetch.js'
+import * as MethodChallenge from './MethodChallenge.js'
 import * as MethodResponse from './MethodResponse.js'
 
 const realm = 'api.example.com'
@@ -1871,6 +1872,41 @@ describe('Fetch.from: 402 retry path', () => {
     expect(
       calls.slice(1).map((call) => new Headers(call.init?.headers).get('Authorization')),
     ).toEqual(['credential-first', 'credential-second', 'credential-third'])
+  })
+
+  test('invalidates a prepared credential across a generic challenge', async () => {
+    const firstCredential = vi.fn(async () => 'first')
+    const first = { ...noopMethod, name: 'first', createCredential: firstCredential }
+    const second = { ...noopMethod, name: 'second', createCredential: async () => 'second' }
+    MethodChallenge.register(first, () => undefined)
+    const responses = [
+      make402({ id: 'first', method: 'first' }),
+      make402({ id: 'second', method: 'second' }),
+      make402({ id: 'first', method: 'first' }),
+      new Response('OK'),
+    ]
+    const mockFetch = vi.fn(async () => responses.shift()!)
+    const fetch = Fetch.from({ fetch: mockFetch, methods: [first, second] })
+
+    expect((await fetch('https://example.com/api')).status).toBe(200)
+    expect(firstCredential).toHaveBeenCalledTimes(2)
+  })
+
+  test('invalidates a prepared credential after an explicit context', async () => {
+    const createCredential = vi.fn(async () => 'credential')
+    const method = { ...noopMethod, createCredential }
+    MethodChallenge.register(method, () => undefined)
+    let challenges = 0
+    const mockFetch = vi.fn(async () => (++challenges <= 3 ? make402() : new Response('OK')))
+    const fetch = Fetch.from({
+      fetch: mockFetch as typeof globalThis.fetch,
+      methods: [method],
+      onChallenge: async (_challenge, { createCredential: create }) =>
+        challenges === 2 ? create({ override: true } as never) : undefined,
+    })
+
+    expect((await fetch('https://example.com/api')).status).toBe(200)
+    expect(createCredential).toHaveBeenCalledTimes(3)
   })
 
   test('caps repeated 402 retries at three', async () => {

--- a/src/client/internal/Fetch.ts
+++ b/src/client/internal/Fetch.ts
@@ -210,6 +210,9 @@ export function from<const methods extends readonly Method.AnyClient[]>(
     let challenge: Challenge.Challenge | undefined
     let challenges: readonly Challenge.Challenge[] | undefined
     let mi: methods[number] | undefined
+    let preparedCredential:
+      | { key: string; method: Method.AnyClient; promise: Promise<string> }
+      | undefined
 
     try {
       for (let retry = 0; retry < maxPaymentRetries; retry++) {
@@ -247,16 +250,35 @@ export function from<const methods extends readonly Method.AnyClient[]>(
           initialRequest.input,
           initialRequest.input,
         )
+        const previousCredential = preparedCredential
+        preparedCredential = undefined
         const createCredential = memoizeCreateCredential(
-          async (overrideContext?: AnyContextFor<methods>) => {
-            const credentialContext = overrideContext ?? context
-            await MethodChallenge.handle(selected.method, {
-              challenge: selectedChallenge,
-              context: credentialContext,
-              fetch: baseFetch,
-              input: paymentInput,
-            })
-            return resolveCredential(selectedChallenge, selected.method, credentialContext)
+          (overrideContext?: AnyContextFor<methods>) => {
+            const create = async () => {
+              const credentialContext = overrideContext ?? context
+              await MethodChallenge.handle(selected.method, {
+                challenge: selectedChallenge,
+                context: credentialContext,
+                fetch: baseFetch,
+                input: paymentInput,
+              })
+              return resolveCredential(selectedChallenge, selected.method, credentialContext)
+            }
+            if (overrideContext !== undefined || !MethodChallenge.has(selected.method))
+              return create()
+
+            const key = Challenge.serialize(selectedChallenge)
+            if (
+              previousCredential &&
+              previousCredential.method === selected.method &&
+              previousCredential.key === key
+            ) {
+              preparedCredential = previousCredential
+              return previousCredential.promise
+            }
+            const promise = create()
+            preparedCredential = { key, method: selected.method, promise }
+            return promise
           },
         )
         const eventCredential = await events.emit(

--- a/src/client/internal/MethodChallenge.ts
+++ b/src/client/internal/MethodChallenge.ts
@@ -24,6 +24,11 @@ export function register<const method extends Method.AnyClient>(
   return method
 }
 
+/** Returns whether a method registered pre-credential work. */
+export function has(method: Method.AnyClient): boolean {
+  return handlers.has(method)
+}
+
 /** Runs method-specific work before creating a challenge credential. */
 export function handle(method: Method.AnyClient, parameters: HandlerParameters): Promise<void> {
   return Promise.resolve(handlers.get(method)?.(parameters))

--- a/src/tempo/session/client/Session.test.ts
+++ b/src/tempo/session/client/Session.test.ts
@@ -233,14 +233,16 @@ describe('precompile client session', () => {
       header: string | null
       method: string | undefined
     }[] = []
+    const vouchers: string[] = []
     let opened: Extract<Types.SessionCredentialPayload, { action: 'open' }> | undefined
+    const paymentRequired = () =>
+      new Response(null, {
+        status: 402,
+        headers: { [Constants.Headers.wwwAuthenticate]: serializeChallenge(challenge) },
+      })
     const rawFetch: typeof globalThis.fetch = async (_input, init) => {
       const authorization = new Headers(init?.headers).get(Constants.Headers.authorization)
-      if (!authorization)
-        return new Response(null, {
-          status: 402,
-          headers: { [Constants.Headers.wwwAuthenticate]: serializeChallenge(challenge) },
-        })
+      if (!authorization) return paymentRequired()
 
       const payload = deserialize(authorization)
       actions.push(payload.action)
@@ -250,6 +252,8 @@ describe('precompile client session', () => {
       }
       if (payload.action === 'topUp') return new Response(null, { status: 204 })
       if (payload.action !== 'voucher' || !opened) throw new Error('expected open voucher')
+      vouchers.push(authorization)
+      if (vouchers.length === 1) return paymentRequired()
 
       paidRequests.push({
         body: init?.body ?? null,
@@ -278,7 +282,8 @@ describe('precompile client session', () => {
     })
 
     expect(await response.text()).toBe('paid')
-    expect(actions).toEqual(['open', 'topUp', 'voucher'])
+    expect(actions).toEqual(['open', 'topUp', 'voucher', 'voucher'])
+    expect(new Set(vouchers).size).toBe(1)
     expect(paidRequests).toEqual([{ body: 'request-body', header: 'preserved', method: 'POST' }])
   })
 

--- a/src/tempo/session/client/SessionManager.test.ts
+++ b/src/tempo/session/client/SessionManager.test.ts
@@ -113,6 +113,20 @@ function makeChannelStore(seed: readonly ChannelEntry[] = []) {
   return { store, set, delete: remove, map }
 }
 
+function makeDurableChannelStore() {
+  const backend = new Map<string, string>()
+  const store = createJsonChannelStore({
+    get: (key) => backend.get(key),
+    set: (key, value) => {
+      backend.set(key, value)
+    },
+    delete: (key) => {
+      backend.delete(key)
+    },
+  })
+  return { backend, store }
+}
+
 function makeChallenge(overrides: Record<string, unknown> = {}): Challenge.Challenge {
   return Challenge.from({
     id: challengeId,
@@ -657,7 +671,7 @@ describe('Session', () => {
       })
     })
 
-    test('rolls back an optimistic open when a replacement challenge does not reference it', async () => {
+    test('rolls back optimistic opens across replacement challenges', async () => {
       const { store, delete: remove } = makeChannelStore()
       const postedPayloads: SessionCredentialPayload[] = []
       const challenge = (feePayer: boolean) =>
@@ -669,6 +683,8 @@ describe('Session', () => {
             feePayer,
           },
         })
+      const original = challenge(true)
+      const replacement = challenge(false)
       let openCount = 0
       const mockFetch = vi.fn().mockImplementation((_input, init?: RequestInit) => {
         const authorization = new Headers(init?.headers).get(Constants.Headers.authorization)
@@ -677,10 +693,11 @@ describe('Session', () => {
           : undefined
         if (payload) postedPayloads.push(payload)
 
-        if (!payload) return Promise.resolve(make402Response(challenge(true)))
+        if (!payload) return Promise.resolve(make402Response(original))
         if (payload.action === 'open') {
           openCount++
-          if (openCount === 1) return Promise.resolve(make402Response(challenge(false)))
+          if (openCount === 1) return Promise.resolve(make402Response(replacement))
+          if (openCount === 2) return Promise.resolve(make402Response(original))
           return Promise.resolve(makeOkResponse())
         }
         return Promise.resolve(new Response('unexpected voucher', { status: 500 }))
@@ -696,12 +713,33 @@ describe('Session', () => {
       const response = await s.fetch('https://api.example.com/data')
 
       expect(response.status).toBe(200)
-      // A replacement challenge with no snapshot means the server did not
-      // acknowledge the optimistic open, so the next credential must open again.
-      expect(postedPayloads.map((payload) => payload.action)).toEqual(['open', 'open'])
-      expect(postedPayloads[0]?.channelId).not.toBe(postedPayloads[1]?.channelId)
-      expect(remove).toHaveBeenCalledOnce()
-      expect(s.channelId).toBe(postedPayloads[1]?.channelId)
+      expect(postedPayloads.map((payload) => payload.action)).toEqual(['open', 'open', 'open'])
+      expect(new Set(postedPayloads.map((payload) => payload.channelId)).size).toBe(3)
+      expect(remove).toHaveBeenCalledTimes(2)
+      expect(s.channelId).toBe(postedPayloads[2]?.channelId)
+    })
+
+    test('reuses prepared voucher state when an identical challenge succeeds', async () => {
+      const vouchers: Extract<SessionCredentialPayload, { action: 'voucher' }>[] = []
+      const mockFetch = vi.fn().mockImplementation((_input, init?: RequestInit) => {
+        const authorization = new Headers(init?.headers).get(Constants.Headers.authorization)
+        if (!authorization) return Promise.resolve(make402Response())
+        const payload = Credential.deserialize<SessionCredentialPayload>(authorization).payload
+        if (payload.action !== 'voucher') throw new Error('expected voucher')
+        vouchers.push(payload)
+        return Promise.resolve(vouchers.length === 1 ? make402Response() : makeOkResponse())
+      })
+      const s = sessionManager({
+        account,
+        client,
+        fetch: mockFetch as typeof globalThis.fetch,
+        channelStore: makeChannelStore([channelEntry()]).store,
+      })
+
+      expect((await s.fetch('https://api.example.com/data')).status).toBe(200)
+      expect(vouchers.map((voucher) => voucher.cumulativeAmount)).toEqual(['2000000', '2000000'])
+      expect(s.cumulative).toBe(2_000_000n)
+      expect(s.state.status).toBe('active')
     })
 
     test('does not bootstrap when disabled', async () => {
@@ -989,6 +1027,60 @@ describe('Session', () => {
       })
     })
 
+    test('preserves a snapshot-acknowledged open when its voucher fails', async () => {
+      const { backend, store } = makeDurableChannelStore()
+      const payloads: SessionCredentialPayload[] = []
+      const mockFetch = vi.fn().mockImplementation((_input, init?: RequestInit) => {
+        const authorization = new Headers(init?.headers).get(Constants.Headers.authorization)
+        if (!authorization)
+          return Promise.resolve(make402Response(makeChallenge({ suggestedDeposit: '10000000' })))
+        const payload = Credential.deserialize<SessionCredentialPayload>(authorization).payload
+        payloads.push(payload)
+        if (payload.action !== 'open')
+          return Promise.resolve(new Response('failed', { status: 500 }))
+        return Promise.resolve(
+          make402Response(
+            makeChallenge({
+              methodDetails: {
+                escrowContract: tip20ChannelEscrow,
+                chainId: 4217,
+                sessionProtocol: Constants.SessionProtocols.v2,
+                sessionSnapshot: {
+                  acceptedCumulative: '1000000',
+                  chainId: 4217,
+                  channelId: payload.channelId,
+                  deposit: '10000000',
+                  descriptor: payload.descriptor,
+                  escrow: tip20ChannelEscrow,
+                  requiredCumulative: '2000000',
+                  settled: '0',
+                  spent: '1000000',
+                  units: 1,
+                },
+              },
+            }),
+          ),
+        )
+      })
+      const s = sessionManager({
+        account,
+        client,
+        fetch: mockFetch as typeof globalThis.fetch,
+        maxDeposit: '10',
+        channelStore: store,
+      })
+
+      expect((await s.fetch('https://api.example.com/data')).status).toBe(500)
+      expect(payloads.map((payload) => payload.action)).toEqual(['open', 'voucher'])
+      expect(s.channelId).toBe(payloads[0]?.channelId)
+      expect(s.cumulative).toBe(1_000_000n)
+      expect(JSON.parse([...backend.values()][0]!)).toMatchObject({
+        channelId: payloads[0]?.channelId,
+        cumulativeAmount: '1000000',
+        opened: true,
+      })
+    })
+
     test('preemptively top-ups before signing an HTTP voucher that exceeds deposit', async () => {
       const postedPayloads: SessionCredentialPayload[] = []
       let challengeCount = 0
@@ -1054,6 +1146,121 @@ describe('Session', () => {
         spent: '2000000',
         units: 2,
       })
+    })
+
+    test('preserves a successful automatic top-up when the paid retry fails', async () => {
+      const { map, store } = makeChannelStore()
+      const payloads: SessionCredentialPayload[] = []
+      const mockFetch = vi.fn().mockImplementation((_input, init?: RequestInit) => {
+        const authorization = new Headers(init?.headers).get(Constants.Headers.authorization)
+        if (!authorization)
+          return Promise.resolve(make402Response(makeChallenge({ suggestedDeposit: '1000000' })))
+        const payload = Credential.deserialize<SessionCredentialPayload>(authorization).payload
+        payloads.push(payload)
+        if (payload.action === 'open')
+          return Promise.resolve(
+            new Response('ok', {
+              headers: {
+                [Constants.Headers.paymentReceipt]: serializeSessionReceipt(
+                  createSessionReceipt({
+                    acceptedCumulative: 1_000_000n,
+                    challengeId,
+                    channelId: payload.channelId,
+                    spent: 1_000_000n,
+                    units: 3,
+                  }),
+                ),
+              },
+            }),
+          )
+        if (payload.action === 'topUp') return Promise.resolve(new Response(null, { status: 204 }))
+        return Promise.resolve(make402Response(makeChallenge({ suggestedDeposit: '1000000' })))
+      })
+      const s = sessionManager({
+        account,
+        client,
+        fetch: mockFetch as typeof globalThis.fetch,
+        maxDeposit: '3',
+        channelStore: store,
+      })
+
+      await s.fetch('https://api.example.com/data')
+      expect((await s.fetch('https://api.example.com/data')).status).toBe(402)
+
+      expect(payloads.map((payload) => payload.action)).toEqual([
+        'open',
+        'topUp',
+        'voucher',
+        'voucher',
+        'voucher',
+      ])
+      expect(s.cumulative).toBe(1_000_000n)
+      expect(s.state).toMatchObject({ status: 'active', deposit: '2000000', units: 3 })
+      expect([...map.values()][0]).toMatchObject({
+        cumulativeAmount: 1_000_000n,
+        deposit: 2_000_000n,
+      })
+    })
+
+    test('preserves a topped-up resumed channel in durable storage after payment fails', async () => {
+      const { store } = makeDurableChannelStore()
+      const seeded = channelEntry({ cumulativeAmount: 1_000_000n, deposit: 1_000_000n })
+      await store.set(seeded)
+      const payloads: SessionCredentialPayload[] = []
+      const mockFetch = vi.fn().mockImplementation((_input, init?: RequestInit) => {
+        const authorization = new Headers(init?.headers).get(Constants.Headers.authorization)
+        if (!authorization)
+          return Promise.resolve(make402Response(makeChallenge({ suggestedDeposit: '1000000' })))
+        const payload = Credential.deserialize<SessionCredentialPayload>(authorization).payload
+        payloads.push(payload)
+        return Promise.resolve(
+          payload.action === 'topUp'
+            ? new Response(null, { status: 204 })
+            : new Response('failed', { status: 500 }),
+        )
+      })
+      const s = sessionManager({
+        account,
+        client,
+        fetch: mockFetch as typeof globalThis.fetch,
+        maxDeposit: '3',
+        channelStore: store,
+      })
+
+      expect((await s.fetch('https://api.example.com/data')).status).toBe(500)
+
+      expect(payloads.map((payload) => payload.action)).toEqual(['topUp', 'voucher'])
+      expect(s.cumulative).toBe(1_000_000n)
+      expect(s.state).toMatchObject({ status: 'active', deposit: '2000000' })
+      await expect(store.get(entryKey(seeded))).resolves.toMatchObject({
+        cumulativeAmount: 1_000_000n,
+        deposit: 2_000_000n,
+        opened: true,
+      })
+    })
+
+    test.each([
+      ['new', false],
+      ['replacement', true],
+    ] as const)('removes a failed %s durable channel', async (_kind, seeded) => {
+      const { backend, store } = makeDurableChannelStore()
+      if (seeded) await store.set(channelEntry())
+      const mockFetch = vi.fn().mockImplementation((_input, init?: RequestInit) => {
+        const authorization = new Headers(init?.headers).get(Constants.Headers.authorization)
+        return Promise.resolve(
+          authorization ? new Response('failed', { status: 500 }) : make402Response(),
+        )
+      })
+      const s = sessionManager({
+        account,
+        client,
+        fetch: mockFetch as typeof globalThis.fetch,
+        channelStore: store,
+      })
+
+      expect((await s.fetch('https://api.example.com/data')).status).toBe(500)
+      expect(s.channelId).toBeUndefined()
+      expect(backend.size).toBe(0)
     })
   })
 

--- a/src/tempo/session/client/SessionManager.ts
+++ b/src/tempo/session/client/SessionManager.ts
@@ -243,11 +243,14 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
 
   /** Removes a failed channel from candidacy for the rest of this manager's life. */
   async function ignoreChannel(entry: ChannelEntry) {
+    const key = entryKey(entry)
     ignoredChannelIds.add(entry.channelId)
-    await Promise.resolve(backing.delete(entryKey(entry))).catch(() => undefined)
+    channelUse?.seenExisting.delete(key)
+    if (channelUse?.resumed === entry) channelUse.resumed = undefined
+    await Promise.resolve(backing.delete(key)).catch(() => undefined)
   }
 
-  async function rollbackCreatedChannelsForRetry() {
+  async function rollbackCreatedChannels() {
     const use = channelUse
     if (!use?.created.size) return
     for (const [key, entry] of use.created) {
@@ -255,25 +258,45 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
       await Promise.resolve(backing.delete(key)).catch(() => undefined)
     }
     use.created.clear()
-    restoreRuntime(use.previous)
+    await restoreRuntime(use.committed ?? use.previous)
   }
 
-  function referencesCreatedChannel(challenge: Challenge.Challenge): boolean {
+  /** Commits a newly created channel once an authoritative server snapshot references it. */
+  function commitReferencedChannel(challenge: Challenge.Challenge): boolean {
     const snapshot = Constants.getMethodDetail<{ channelId?: unknown }>(
       challenge.request.methodDetails,
       Constants.MethodDetailKeys.sessionSnapshot,
     )
     if (typeof snapshot?.channelId !== 'string') return false
     const use = channelUse
-    if (!use?.created.size) return false
-    for (const entry of use.created.values()) {
-      if (entry.channelId.toLowerCase() === snapshot.channelId.toLowerCase()) return true
+    if (!use?.created.size || !runtime.channel) return false
+    for (const [key, entry] of use.created) {
+      if (
+        entry.channelId.toLowerCase() !== snapshot.channelId.toLowerCase() ||
+        runtime.channel.channelId.toLowerCase() !== snapshot.channelId.toLowerCase()
+      )
+        continue
+      use.created.delete(key)
+      use.committed = captureRuntimeStateSnapshot({
+        channel: runtime.channel,
+        spent: runtime.spent,
+        state: runtime.state,
+      })
+      return true
     }
     return false
   }
 
   function dispatch(event: Parameters<typeof dispatchSessionEvent>[1]) {
     return dispatchSessionEvent(runtime, event)
+  }
+
+  function activeUnits() {
+    const state =
+      runtime.state.status === 'active'
+        ? runtime.state
+        : (channelUse?.committed?.state ?? channelUse?.previous.state)
+    return state?.status === 'active' ? state.units : 0
   }
 
   function commitDurableTopUp(entry: ChannelEntry) {
@@ -312,7 +335,7 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
           challengeId: runtime.lastChallenge.id,
           entry,
           spent: runtime.spent.toString(),
-          units: 0,
+          units: activeUnits(),
         })
       }
       commitDurableTopUp(entry)
@@ -332,11 +355,15 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
       const use = channelUse
       const isRepeatedRetryChallenge =
         use && use.challengesReceived > 0 && challenge.id === runtime.lastChallenge?.id
-      if (!referencesCreatedChannel(challenge)) {
-        if (use?.created.size) await rollbackCreatedChannelsForRetry()
-        else if (isRepeatedRetryChallenge) restoreRuntime(use.previous)
-      }
+      const isSameRetryChallenge =
+        isRepeatedRetryChallenge &&
+        Challenge.serialize(challenge) === Challenge.serialize(runtime.lastChallenge!)
       if (use) use.challengesReceived++
+      if (isSameRetryChallenge) return undefined
+      if (!commitReferencedChannel(challenge)) {
+        if (use?.created.size) await rollbackCreatedChannels()
+        else if (isRepeatedRetryChallenge) await restoreRuntime(use.committed ?? use.previous)
+      }
       runtime.lastChallenge = challenge
       dispatch({ type: 'challengeReceived', challengeId: challenge.id })
       return undefined
@@ -558,7 +585,7 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
         challengeId: runtime.lastChallenge.id,
         entry: applied.channel,
         spent: runtime.spent.toString(),
-        units: runtime.state.status === 'active' ? runtime.state.units : 0,
+        units: activeUnits(),
       })
       commitDurableTopUp(applied.channel)
     }
@@ -589,7 +616,7 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
     })
   }
 
-  function restoreCumulative(channelId: Hex.Hex, cumulativeAmount: bigint) {
+  async function restoreCumulative(channelId: Hex.Hex, cumulativeAmount: bigint) {
     const restored = restoreCumulativeAuthorization({
       channel: runtime.channel,
       channelId,
@@ -606,14 +633,16 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
         spent: restored.spent,
         units: restored.units,
       })
+      await backing.set(runtime.channel)
     }
   }
 
-  function restoreRuntime(snapshot: RuntimeSnapshot) {
+  async function restoreRuntime(snapshot: RuntimeSnapshot) {
     const restored = restoreRuntimeStateSnapshot(snapshot, runtime.channel)
     runtime.channel = restored.channel
     runtime.spent = restored.spent
     runtime.state = restored.state
+    if (runtime.channel?.opened) await backing.set(runtime.channel)
   }
 
   function toPaymentResponse(response: Response): PaymentResponse {
@@ -679,7 +708,8 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
         try {
           response = await wrappedFetch(input, effectiveInit)
         } catch (error) {
-          restoreRuntime(use.committed ?? previous)
+          if (use.created.size) await rollbackCreatedChannels()
+          else await restoreRuntime(use.committed ?? previous)
           if (await retryWithoutResumed()) continue
           throw error
         }
@@ -706,7 +736,8 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
           }
         }
         if (!attemptedHttpManagement && !paymentResponse.ok && !paymentResponse.receipt) {
-          restoreRuntime(use.committed ?? previous)
+          if (use.created.size) await rollbackCreatedChannels()
+          else await restoreRuntime(use.committed ?? previous)
           if (await retryWithoutResumed()) continue
           return paymentResponse
         }

--- a/src/tempo/session/client/Transports.test.ts
+++ b/src/tempo/session/client/Transports.test.ts
@@ -310,6 +310,28 @@ describe('HttpManagement', () => {
       expect(restoreCumulative).toHaveBeenCalledWith(channelId, 5n)
     })
 
+    test('retryHttpPaymentRequired restores cumulative authorization when retry throws', async () => {
+      const entry = channel({ cumulativeAmount: 5n })
+      const restoreCumulative = vi.fn()
+
+      await expect(
+        retryHttpPaymentRequired({
+          createSessionCredential: async () => 'voucher-credential',
+          fetch: async () => {
+            throw new Error('network failed')
+          },
+          getChannel: () => entry,
+          input: 'https://example.test/resource',
+          response: response402(challenge(snapshot())),
+          restoreCumulative,
+          setChallenge() {},
+          topUpIfNeeded: async () => {},
+        }),
+      ).rejects.toThrow('network failed')
+
+      expect(restoreCumulative).toHaveBeenCalledWith(channelId, 5n)
+    })
+
     test('closeHttpSession posts a close credential and parses the receipt', async () => {
       const entry = channel()
       const createSessionCredential = vi.fn(async (_challenge, context: SessionContext) => {

--- a/src/tempo/session/client/Transports.ts
+++ b/src/tempo/session/client/Transports.ts
@@ -489,7 +489,7 @@ export type RetryHttpPaymentRequiredParameters = {
   /** Failed HTTP response that may contain a session challenge. */
   response: Response
   /** Restores local cumulative authorization if the voucher retry fails. */
-  restoreCumulative(channelId: Hex.Hex, cumulativeAmount: bigint): void
+  restoreCumulative(channelId: Hex.Hex, cumulativeAmount: bigint): void | Promise<void>
   /** Stores the selected follow-up challenge on the manager. */
   setChallenge(challenge: TempoSessionChallenge): void
   /** Performs automatic top-up before the voucher retry when deposit is insufficient. */
@@ -692,18 +692,25 @@ export async function retryHttpPaymentRequired(
     currentChannel.cumulativeAmount > requiredCumulative
       ? currentChannel.cumulativeAmount
       : requiredCumulative
-  const credential = await parameters.createSessionCredential(challenge, {
-    action: 'voucher',
-    channelId: snapshot.channelId,
-    descriptor: currentChannel.descriptor,
-    cumulativeAmountRaw: cumulativeAmount.toString(),
-  })
-  const retry = await parameters.fetch(
-    parameters.input,
-    requestInitWithAuthorization(parameters.input, parameters.init, credential),
-  )
+  const restore = () => parameters.restoreCumulative(snapshot.channelId, cumulativeBeforeVoucher)
+  let retry: Response
+  try {
+    const credential = await parameters.createSessionCredential(challenge, {
+      action: 'voucher',
+      channelId: snapshot.channelId,
+      descriptor: currentChannel.descriptor,
+      cumulativeAmountRaw: cumulativeAmount.toString(),
+    })
+    retry = await parameters.fetch(
+      parameters.input,
+      requestInitWithAuthorization(parameters.input, parameters.init, credential),
+    )
+  } catch (error) {
+    await restore()
+    throw error
+  }
   if (!retry.ok && !retry.headers.get(Constants.Headers.paymentReceipt)) {
-    parameters.restoreCumulative(snapshot.channelId, cumulativeBeforeVoucher)
+    await restore()
   }
   return retry
 }


### PR DESCRIPTION
Follow-up to #687 and #702.

Repeated identical session challenges could advance local state more than once. Intervening credential paths and failed retries could also reuse rolled-back credentials or leave runtime and durable storage out of sync.

- reuse prepared credentials only for consecutive identical method/challenge rounds
- treat generic and explicit-context rounds as invalidation boundaries
- roll back unacknowledged opens and failed vouchers in runtime and durable storage
- preserve snapshot-acknowledged opens and successful top-ups

## Validation

- 120 focused session and transport tests
- 40 Fetch retry-path tests
- pnpm check:ci
- pnpm check:types