### PR TITLE
fix(tempo): preserve committed session top-ups

### DIFF
--- a/.changeset/calm-websockets-topup.md
+++ b/.changeset/calm-websockets-topup.md
@@ -2,4 +2,4 @@
 'mppx': patch
 ---
 
-Fixed automatic session top-ups before signing HTTP, SSE, and WebSocket credentials.
+Fixed automatic session top-ups before signing HTTP, SSE, and WebSocket credentials, including preserving a durable resumed channel after a committed top-up when the paid request failed.

--- a/src/tempo/session/client/Session.ts
+++ b/src/tempo/session/client/Session.ts
@@ -163,9 +163,9 @@ export function session(parameters: session.Parameters = {}) {
       })
     const nextDeposit = knownDeposit + additionalDeposit
     if (nextDeposit === channel.deposit) return
-    channel.deposit = nextDeposit
-    await store.set(channel)
-    sink.notifyUpdate(channel)
+    const updated = { ...channel, deposit: nextDeposit }
+    await store.set(updated)
+    sink.notifyUpdate(updated)
   }
 
   MethodChallenge.register(method, async ({ challenge, context, fetch, input }) => {
@@ -266,7 +266,10 @@ export declare namespace session {
       escrow?: Address | undefined
       /** Maximum channel deposit in human-readable units. Caps server-suggested opens and automatic top-ups. */
       maxDeposit?: string | undefined
-      /** Preferred automatic top-up size in human-readable units. Exact shortfalls are used when omitted. */
+      /**
+       * Preferred automatic top-up size in human-readable units. When omitted,
+       * a bounded server `suggestedDeposit` is preferred, then the exact shortfall.
+       */
       topUpAmount?: string | undefined
       /** Called whenever channel state changes. */
       onChannelUpdate?: ((entry: ChannelEntry) => void) | undefined

--- a/src/tempo/session/client/SessionManager.test.ts
+++ b/src/tempo/session/client/SessionManager.test.ts
@@ -609,6 +609,54 @@ describe('Session', () => {
       expect(s.channelId).not.toBe(storedChannelId)
     })
 
+    test('keeps a persisted channel after its committed top-up when the paid retry fails', async () => {
+      const seeded = channelEntry({ cumulativeAmount: 10_000_000n, deposit: 10_000_000n })
+      const { store, delete: remove, map } = makeChannelStore([seeded])
+      const postedPayloads: SessionCredentialPayload[] = []
+      let probes = 0
+      const mockFetch = vi.fn().mockImplementation((_input, init?: RequestInit) => {
+        const authorization = new Headers(init?.headers).get(Constants.Headers.authorization)
+        const payload = authorization
+          ? Credential.deserialize<SessionCredentialPayload>(authorization).payload
+          : undefined
+        if (!payload) {
+          probes++
+          if (probes > 1) throw new Error('unexpected fresh-channel retry')
+          return Promise.resolve(make402Response())
+        }
+
+        postedPayloads.push(payload)
+        if (payload.action === 'topUp') return Promise.resolve(new Response(null, { status: 204 }))
+        if (payload.action === 'voucher')
+          return Promise.resolve(new Response('upstream failed', { status: 500 }))
+        throw new Error(`unexpected ${payload.action} credential`)
+      })
+      const s = sessionManager({
+        account,
+        client,
+        fetch: mockFetch as typeof globalThis.fetch,
+        maxDeposit: '20',
+        channelStore: store,
+      })
+
+      const response = await s.fetch('https://api.example.com/data')
+
+      expect(response.status).toBe(500)
+      expect(postedPayloads.map((payload) => payload.action)).toEqual(['topUp', 'voucher'])
+      expect(remove).not.toHaveBeenCalled()
+      expect(map.get(entryKey(seeded))).toMatchObject({
+        channelId: storedChannelId,
+        cumulativeAmount: 10_000_000n,
+        deposit: 11_000_000n,
+      })
+      expect(s.channelId).toBe(storedChannelId)
+      expect(s.state).toMatchObject({
+        status: 'active',
+        channelId: storedChannelId,
+        deposit: '11000000',
+      })
+    })
+
     test('rolls back an optimistic open when a replacement challenge does not reference it', async () => {
       const { store, delete: remove } = makeChannelStore()
       const postedPayloads: SessionCredentialPayload[] = []

--- a/src/tempo/session/client/SessionManager.ts
+++ b/src/tempo/session/client/SessionManager.ts
@@ -112,7 +112,7 @@ type SessionManagerConfig = {
   fetch: typeof globalThis.fetch
   /** Local maximum cumulative voucher authorization, or null when uncapped. */
   maxVoucherCumulative: bigint | null
-  /** Preferred additional deposit for automatic top-ups, or null for exact shortfalls. */
+  /** Preferred top-up, or null to use a bounded server suggestion and then the exact shortfall. */
   topUpAmount: bigint | null
   /** WebSocket constructor available in the current runtime, when configured. */
   WebSocket: WebSocketConstructor | undefined
@@ -206,6 +206,7 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
   // Tracks one fetch's channel reuse so stale stored entries can be evicted once.
   type ChannelUse = {
     challengesReceived: number
+    committed: RuntimeSnapshot | undefined
     created: Map<string, ChannelEntry>
     seenExisting: Set<string>
     previous: RuntimeSnapshot
@@ -226,7 +227,7 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
       const entry = await getReusable(key)
       if (entry && channelUse) {
         channelUse.seenExisting.add(key)
-        if (!channelUse.created.has(key)) channelUse.resumed ??= entry
+        if (!channelUse.committed && !channelUse.created.has(key)) channelUse.resumed ??= entry
       }
       return entry
     },
@@ -275,6 +276,23 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
     return dispatchSessionEvent(runtime, event)
   }
 
+  function commitDurableTopUp(entry: ChannelEntry) {
+    const use = channelUse
+    const baseline = use?.committed?.channel?.entry ?? use?.resumed
+    if (
+      !use ||
+      baseline?.channelId.toLowerCase() !== entry.channelId.toLowerCase() ||
+      entry.deposit <= baseline.deposit
+    )
+      return
+    use.resumed = undefined
+    use.committed = captureRuntimeStateSnapshot({
+      channel: runtime.channel,
+      spent: runtime.spent,
+      state: runtime.state,
+    })
+  }
+
   const method = sessionPlugin({
     account: parameters.account,
     getClient: parameters.client ? () => parameters.client! : parameters.getClient,
@@ -296,6 +314,7 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
           units: 0,
         })
       }
+      commitDurableTopUp(entry)
     },
   })
   MethodResponse.unregister(method)
@@ -540,6 +559,7 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
         spent: runtime.spent.toString(),
         units: runtime.state.status === 'active' ? runtime.state.units : 0,
       })
+      commitDurableTopUp(applied.channel)
     }
     return receipt
   }
@@ -624,6 +644,7 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
     })
     const use: ChannelUse = {
       challengesReceived: 0,
+      committed: undefined,
       created: new Map(),
       previous,
       seenExisting: new Set(),
@@ -657,7 +678,7 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
         try {
           response = await wrappedFetch(input, effectiveInit)
         } catch (error) {
-          restoreRuntime(previous)
+          restoreRuntime(use.committed ?? previous)
           if (await retryWithoutResumed()) continue
           throw error
         }
@@ -684,7 +705,7 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
           }
         }
         if (!attemptedHttpManagement && !paymentResponse.ok && !paymentResponse.receipt) {
-          restoreRuntime(previous)
+          restoreRuntime(use.committed ?? previous)
           if (await retryWithoutResumed()) continue
           return paymentResponse
         }
@@ -911,7 +932,10 @@ export namespace sessionManager {
       fetch?: typeof globalThis.fetch | undefined
       /** Maximum deposit in human-readable units (e.g. `'10'` for 10 tokens). Converted to raw units via `decimals`. */
       maxDeposit?: string | undefined
-      /** Preferred automatic top-up size in human-readable units. Exact shortfalls are used when omitted. */
+      /**
+       * Preferred automatic top-up size in human-readable units. When omitted,
+       * a bounded server `suggestedDeposit` is preferred, then the exact shortfall.
+       */
       topUpAmount?: string | undefined
       /** Selects the account that signs session credentials. */
       resolveAccount?: sessionPlugin.ResolveAccount | undefined

--- a/src/tempo/session/client/Transports.ts
+++ b/src/tempo/session/client/Transports.ts
@@ -384,16 +384,16 @@ export function applyTopUpResult(
 
   const baseline =
     knownDeposit !== undefined && knownDeposit > channel.deposit ? knownDeposit : channel.deposit
-  channel.deposit = baseline + additionalDeposit
+  const updated = { ...channel, deposit: baseline + additionalDeposit }
 
-  if (receipt) return { channel, state: activeStateFromReceipt(receipt, channel) }
-  if (!challengeId) return { channel }
+  if (receipt) return { channel: updated, state: activeStateFromReceipt(receipt, updated) }
+  if (!challengeId) return { channel: updated }
 
   return {
-    channel,
+    channel: updated,
     state: activeStateFromChannel({
       challengeId,
-      entry: channel,
+      entry: updated,
       spent: spent.toString(),
       units: currentState.status === 'active' ? currentState.units : 0,
     }),


### PR DESCRIPTION
## Summary

- treat a successfully persisted automatic top-up as a management commit boundary
- roll later HTTP failures back to the latest committed channel state, not the cold-start snapshot
- keep the funded resumed channel eligible instead of deleting it as stale
- make top-up state updates immutable so the rollback baseline is not mutated in place
- clarify `topUpAmount` fallback to bounded `suggestedDeposit`, then exact shortfall

This is a focused follow-up to #687, which merged while this regression fix was being validated.

## Regression

Before this patch, a cold manager could load a durable channel, successfully top it up, receive a 500 for the paid voucher request, then restore its empty pre-request state and delete the now-funded channel. The next retry could open and fund a second channel.

The added test reproduces that sequence and asserts the same channel remains stored at the increased deposit with no delete or fresh-channel retry.

## Validation

- `pnpm check:ci`
- `pnpm build`
- `pnpm exec tsgo -b`
- `VITE_TEMPO_NETWORK=none pnpm exec vp test --run src/tempo/session/client` (196 passed)
- focused cold-resume regression after rebase onto `main` (passed)

Commit is SSH-signed for GitHub verification.