### PR TITLE
fix: tighten relay lifecycle hooks

### DIFF
--- a/.changeset/clear-relay-lifecycle.md
+++ b/.changeset/clear-relay-lifecycle.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed Tempo relay verification fallback and restricted server lifecycle hook combinations to unambiguous configurations.

--- a/src/Method.test.ts
+++ b/src/Method.test.ts
@@ -99,6 +99,22 @@ describe('credential execution', () => {
     })
   }
 
+  test('types: requires broadcast with validate', () => {
+    // @ts-expect-error Split validation requires a terminal broadcast hook.
+    Method.toServer(base, {
+      validate: async () => ({}) as never,
+      verify: async () => ({}) as never,
+    })
+  })
+
+  test('types: excludes verify with broadcast', () => {
+    // @ts-expect-error A broadcast hook replaces the legacy verify hook.
+    Method.toServer(base, {
+      broadcast: async () => ({}) as never,
+      verify: async () => ({}) as never,
+    })
+  })
+
   test('validates without broadcasting', async () => {
     const calls: string[] = []
     const method = Method.toServer(base, {

--- a/src/Method.ts
+++ b/src/Method.ts
@@ -597,19 +597,15 @@ export declare namespace toServer {
     respond?: RespondFn<method> | undefined
     stableBinding?: StableBindingFn<method> | undefined
     transport?: transportOverride | Transport.AnyTransport | undefined
-    validate?: ValidateFn<method> | undefined
   } & (
     | {
         broadcast: BroadcastFn<method>
-        /**
-         * @deprecated Use `validate` and `broadcast` for new methods. This
-         * combined hook may mutate payment state and cannot power a safe
-         * validation-only endpoint.
-         */
-        verify?: VerifyFn<method> | undefined
+        validate?: ValidateFn<method> | undefined
+        verify?: undefined
       }
     | {
         broadcast?: undefined
+        validate?: undefined
         /**
          * @deprecated Use `validate` and `broadcast` for new methods. This
          * combined hook may mutate payment state and cannot power a safe

--- a/src/server/Mppx.test.ts
+++ b/src/server/Mppx.test.ts
@@ -4891,10 +4891,6 @@ describe('verifyCredential', () => {
         calls.push('broadcast')
         return mockReceipt('broadcast')
       },
-      async verify() {
-        calls.push('verify')
-        return mockReceipt('legacy')
-      },
     })
     const mppx = Mppx.create({ methods: [splitServer], realm, secretKey })
     const challenge = await mppx.challenge.alpha.charge(challengeOpts)
@@ -4925,10 +4921,6 @@ describe('verifyCredential', () => {
         calls.push('broadcast')
         return mockReceipt('broadcast')
       },
-      async verify() {
-        calls.push('verify')
-        return mockReceipt('legacy')
-      },
     })
     const mppx = Mppx.create({ methods: [splitServer], realm, secretKey })
     const challenge = await mppx.challenge.alpha.charge(challengeOpts)
@@ -4958,10 +4950,6 @@ describe('verifyCredential', () => {
       async broadcast() {
         calls.push('broadcast')
         return mockReceipt('broadcast')
-      },
-      async verify() {
-        calls.push('verify')
-        return mockReceipt('legacy')
       },
     })
     const mppx = Mppx.create({ methods: [splitServer], realm, secretKey })
@@ -5006,9 +4994,6 @@ describe('verifyCredential', () => {
       async broadcast() {
         return mockReceipt('broadcast')
       },
-      async verify() {
-        return mockReceipt('legacy')
-      },
     })
     const mppx = Mppx.create({ methods: [splitServer], realm, secretKey })
     const challenge = await mppx.challenge.alpha.charge(challengeOpts)
@@ -5038,10 +5023,6 @@ describe('verifyCredential', () => {
       async broadcast() {
         calls.push('broadcast')
         return mockReceipt('broadcast')
-      },
-      async verify() {
-        calls.push('verify')
-        return mockReceipt('legacy')
       },
     })
     const mppx = Mppx.create({ methods: [splitServer], realm, secretKey })
@@ -5075,10 +5056,6 @@ describe('verifyCredential', () => {
       async broadcast() {
         calls.push('broadcast')
         return mockReceipt('broadcast')
-      },
-      async verify() {
-        calls.push('verify')
-        return mockReceipt('legacy')
       },
     })
     const mppx = Mppx.create({ methods: [splitServer], realm, secretKey })

--- a/src/tempo/server/Relay.test.ts
+++ b/src/tempo/server/Relay.test.ts
@@ -150,6 +150,18 @@ describe('relay boundary', () => {
     )
   })
 
+  test('preserves a configured API base path', async () => {
+    const fetch = mockRelay(() => Response.json({ success: true }))
+    const [method] = methods(fetch, 'https://relay.example/mpp')
+
+    await method.validate!({ credential, request: credential.challenge.request } as never)
+
+    expect(fetch).toHaveBeenCalledWith(
+      new URL('https://relay.example/mpp/v1/mpp/validate'),
+      expect.anything(),
+    )
+  })
+
   test('broadcasts a valid relay receipt and forwards its external ID', async () => {
     const calls: Array<{ init: RequestInit; url: URL }> = []
     const fetch = mockRelay((url, init) => {
@@ -238,14 +250,20 @@ describe('relay boundary', () => {
     expect(headers['idempotency-key']).toBe(`mppx_${expected}`)
   })
 
-  test('keeps the legacy combined verify hook inert', async () => {
-    const fetch = mockRelay(() => Response.json({ success: true }))
+  test('preserves the legacy combined verify hook', async () => {
+    const calls: string[] = []
+    const fetch = mockRelay((url) => {
+      calls.push(url.pathname)
+      return url.pathname === '/v1/mpp/validate'
+        ? Response.json({ success: true })
+        : successReceipt()
+    })
     const [method] = methods(fetch)
 
     await expect(
       method.verify({ credential, request: credential.challenge.request } as never),
-    ).rejects.toSatisfy(expectGenericFailure)
-    expect(fetch).not.toHaveBeenCalled()
+    ).resolves.toMatchObject({ method: 'tempo', status: 'success' })
+    expect(calls).toEqual(['/v1/mpp/validate', '/v1/mpp/broadcast'])
   })
 
   test.each([
@@ -286,6 +304,18 @@ describe('relay boundary', () => {
         }),
     ],
     ['broadcast', () => Response.json({ receipt: { method: 'tempo' }, success: true })],
+    [
+      'broadcast',
+      () =>
+        Response.json({
+          receipt: {
+            method: 'stripe',
+            reference: '0xabc',
+            timestamp: '2026-07-22T00:00:00.000Z',
+          },
+          success: true,
+        }),
+    ],
     [
       'broadcast',
       () =>

--- a/src/tempo/server/Relay.ts
+++ b/src/tempo/server/Relay.ts
@@ -95,6 +95,7 @@ export function configure<const intent extends Method.Method>(
     const receipt = await request.broadcast(input, {
       idempotencyKey: idempotencyKey(input),
     })
+    if (receipt.method !== method.name) throw failure()
     try {
       return Receipt.from({ ...receipt, status: 'success' })
     } catch {
@@ -102,12 +103,10 @@ export function configure<const intent extends Method.Method>(
     }
   }
 
-  // `verify` is the legacy combined validation and settlement hook. A relay
-  // cannot safely implement it: its successful result must be a receipt, which
-  // requires broadcast. Keep it inert so direct legacy calls cannot settle a
-  // payment unexpectedly; use `validate` and `broadcast` instead.
-  const verify: Method.VerifyFn<intent> = async () => {
-    throw failure()
+  // Preserve the legacy combined hook for direct method consumers.
+  const verify: Method.VerifyFn<intent> = async (parameters) => {
+    await validate(parameters)
+    return broadcast(parameters)
   }
 
   return {
@@ -122,8 +121,7 @@ export declare namespace configure {
   /**
    * Server method augmented with Tempo API validation and broadcast hooks.
    *
-   * The `verify` method is legacy-only and always fails without
-   * settling. Use `validate` followed by `broadcast` for relay payments.
+   * The legacy `verify` method validates and broadcasts in one call.
    */
   type Adapter<intent extends Method.Method> = Omit<
     Method.Server<intent>,
@@ -141,7 +139,7 @@ export declare namespace configure {
     apiKey: string
     /** Fetch implementation used to call Tempo API. */
     fetch?: typeof globalThis.fetch | undefined
-    /** Tempo API base URL. @default 'https://api.tempo.xyz' */
+    /** Tempo API base URL, including an optional path prefix. @default 'https://api.tempo.xyz' */
     apiBaseUrl?: string | undefined
   }
 
@@ -158,9 +156,10 @@ export declare namespace configure {
 function createRequest(options: configure.Options) {
   const fetch = options.fetch ?? globalThis.fetch
   const apiBaseUrl = new URL(options.apiBaseUrl ?? defaultApiBaseUrl)
+  if (!apiBaseUrl.pathname.endsWith('/')) apiBaseUrl.pathname += '/'
 
   async function post(
-    path: '/v1/mpp/broadcast' | '/v1/mpp/validate',
+    path: 'v1/mpp/broadcast' | 'v1/mpp/validate',
     input: RelayInput,
     headers?: Record<string, string>,
   ): Promise<unknown> {
@@ -185,12 +184,12 @@ function createRequest(options: configure.Options) {
   }
 
   const validate = async (input: RelayInput) => {
-    const response = await post('/v1/mpp/validate', input)
+    const response = await post('v1/mpp/validate', input)
     if (!isValidateSuccess(response)) throw failure(response)
   }
 
   const broadcast = async (input: RelayInput, broadcastOptions: { idempotencyKey: string }) => {
-    const response = await post('/v1/mpp/broadcast', input, {
+    const response = await post('v1/mpp/broadcast', input, {
       'idempotency-key': broadcastOptions.idempotencyKey,
     })
     if (!isBroadcastSuccess(response)) throw failure(response)


### PR DESCRIPTION
## Motivation

Preserve relay compatibility while making payment lifecycle configuration unambiguous.

## Summary

- Restored legacy relay verification as validation followed by broadcast.
- Preserved relay API base-path prefixes and rejected mismatched receipt methods.
- Restricted server method configuration to either `verify` or `broadcast` with optional `validate`.

## Key design considerations

- `verify` remains synthesized internally for backward-compatible direct method consumers.
- Public method configuration cannot combine `broadcast` and `verify`.