### PR TITLE
fix: finalize pushed charges through relay

### DIFF
--- a/.changeset/relay-push-receipts.md
+++ b/.changeset/relay-push-receipts.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed Tempo relay charges to skip broadcast for validated push credentials.

--- a/.changeset/relay-push-receipts.md
+++ b/.changeset/relay-push-receipts.md
@@ -2,4 +2,4 @@
 'mppx': patch
 ---
 
-Fixed Tempo relay charges to skip broadcast for validated push credentials.
+Fixed Tempo relay charges to delegate push payment finalization without re-broadcasting transactions.

--- a/examples/charge-relay/README.md
+++ b/examples/charge-relay/README.md
@@ -50,9 +50,10 @@ const method = tempo.charge({
 ```
 
 Uncommenting it lets MPPX issue and bind challenges while the adapter validates
-and broadcasts submitted credentials. Relay failures are returned as MPPX
-payment failures without exposing Tempo API details.
+submitted credentials. Pull credentials are broadcast through the relay; push
+credentials have already been broadcast by the payer and receive a receipt
+after relay validation. Relay failures are returned as MPPX payment failures
+without exposing Tempo API details.
 
-Relay-backed charges must use `pull` mode. The client submits a signed
-transaction for the relay to broadcast; in `push` mode, the client has already
-broadcast the transaction and it must not be submitted to the relay again.
+The adapter derives broadcast ownership from the submitted credential, so a
+single relay-backed charge may safely advertise both `pull` and `push` modes.

--- a/examples/charge-relay/README.md
+++ b/examples/charge-relay/README.md
@@ -44,10 +44,15 @@ local relay hooks with the Tempo server adapter:
 const method = tempo.charge({
   currency,
   recipient: account.address,
-  // relay: { apiBaseUrl: process.env.TEMPO_API_URL, apiKey: process.env.TEMPO_API_KEY! },
+  relay: { apiBaseUrl: process.env.TEMPO_API_URL, apiKey: process.env.TEMPO_API_KEY! },
+  supportedModes: ['pull'],
 })
 ```
 
 Uncommenting it lets MPPX issue and bind challenges while the adapter validates
 and broadcasts submitted credentials. Relay failures are returned as MPPX
 payment failures without exposing Tempo API details.
+
+Relay-backed charges must use `pull` mode. The client submits a signed
+transaction for the relay to broadcast; in `push` mode, the client has already
+broadcast the transaction and it must not be submitted to the relay again.

--- a/examples/charge-relay/README.md
+++ b/examples/charge-relay/README.md
@@ -49,11 +49,11 @@ const method = tempo.charge({
 })
 ```
 
-Uncommenting it lets MPPX issue and bind challenges while the adapter validates
-submitted credentials. Pull credentials are broadcast through the relay; push
-credentials have already been broadcast by the payer and receive a receipt
-after relay validation. Relay failures are returned as MPPX payment failures
-without exposing Tempo API details.
+Uncommenting it lets MPPX issue and bind challenges while the adapter delegates
+validation and finalization to the relay. The relay broadcasts pull credentials;
+for push credentials, it recognizes the already-broadcast transaction and
+returns its receipt without sending it again. Relay failures are returned as
+MPPX payment failures without exposing Tempo API details.
 
 The adapter derives broadcast ownership from the submitted credential, so a
 single relay-backed charge may safely advertise both `pull` and `push` modes.

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -789,9 +789,10 @@ export declare namespace charge {
      * Delegates Tempo charge credential validation and broadcast to Tempo API
      * or a compatible MPP relay.
      *
-     * The adapter handles broadcast ownership automatically: it broadcasts
-     * pull credentials through the relay, while push credentials have already
-     * been broadcast by the payer and receive a receipt after relay validation.
+     * The adapter delegates finalization to the relay for both modes. The
+     * relay broadcasts pull credentials, while it recognizes a push
+     * credential as already broadcast and returns its receipt without sending
+     * it again.
      */
     relay?: RelayOptions | undefined
     /**

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -789,10 +789,9 @@ export declare namespace charge {
      * Delegates Tempo charge credential validation and broadcast to Tempo API
      * or a compatible MPP relay.
      *
-     * Relay-backed charges should advertise `supportedModes: ['pull']`: the
-     * payer sends a signed transaction to the server and the relay broadcasts
-     * it. Do not send a push-mode transaction to the relay because the payer
-     * has already broadcast it.
+     * The adapter handles broadcast ownership automatically: it broadcasts
+     * pull credentials through the relay, while push credentials have already
+     * been broadcast by the payer and receive a receipt after relay validation.
      */
     relay?: RelayOptions | undefined
     /**

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -785,7 +785,15 @@ export declare namespace charge {
      * By default, no prefix is applied.
      */
     storeKeyPrefix?: string | undefined
-    /** Delegates Tempo charge credential validation and broadcast to Tempo API or a compatible MPP relay. */
+    /**
+     * Delegates Tempo charge credential validation and broadcast to Tempo API
+     * or a compatible MPP relay.
+     *
+     * Relay-backed charges should advertise `supportedModes: ['pull']`: the
+     * payer sends a signed transaction to the server and the relay broadcasts
+     * it. Do not send a push-mode transaction to the relay because the payer
+     * has already broadcast it.
+     */
     relay?: RelayOptions | undefined
     /**
      * Whether to wait for the charge transaction to confirm on-chain before

--- a/src/tempo/server/Relay.test.ts
+++ b/src/tempo/server/Relay.test.ts
@@ -4,6 +4,7 @@ import * as Http from '~test/Http.js'
 
 import * as Challenge from '../../Challenge.js'
 import * as Credential from '../../Credential.js'
+import * as Method from '../../Method.js'
 import * as Receipt from '../../Receipt.js'
 import * as Mppx from '../../server/Mppx.js'
 import { tempo } from './Methods.js'
@@ -227,20 +228,24 @@ describe('relay boundary', () => {
     expect(calls).toEqual(['/v1/mpp/validate'])
   })
 
-  test('validates a pushed transaction before direct broadcast', async () => {
+  test('validates a pushed transaction before returning its receipt', async () => {
     const calls: string[] = []
     const fetch = mockRelay((url) => {
       calls.push(url.pathname)
       return Response.json({ success: true })
     })
     const [method] = methods(fetch)
-    const pushedCredential = { ...credential, payload: pushedPayload }
+    const pushedCredential = {
+      ...credential,
+      challenge: {
+        ...credential.challenge,
+        expires: new Date(Date.now() + 60_000).toISOString(),
+      },
+      payload: pushedPayload,
+    }
 
     await expect(
-      method.broadcast!({
-        credential: pushedCredential,
-        request: credential.challenge.request,
-      } as never),
+      Method.broadcastCredential([method], pushedCredential as never),
     ).resolves.toMatchObject({
       method: 'tempo',
       reference: pushedPayload.hash,

--- a/src/tempo/server/Relay.test.ts
+++ b/src/tempo/server/Relay.test.ts
@@ -4,6 +4,7 @@ import * as Http from '~test/Http.js'
 
 import * as Challenge from '../../Challenge.js'
 import * as Credential from '../../Credential.js'
+import * as Receipt from '../../Receipt.js'
 import * as Mppx from '../../server/Mppx.js'
 import { tempo } from './Methods.js'
 
@@ -21,6 +22,11 @@ const credential = {
   },
   payload: { signature: '0x1234', type: 'transaction' },
   source: 'did:pkh:eip155:42431:0x123',
+} as const
+
+const pushedPayload = {
+  hash: '0x1a2b3c4d5e6f7890abcdef1234567890abcdef1234567890abcdef1234567890',
+  type: 'hash',
 } as const
 
 type RelayHandler = (url: URL, init: RequestInit) => Response | Promise<Response>
@@ -52,7 +58,10 @@ function successReceipt() {
   })
 }
 
-async function createPaymentServer(fetch: typeof globalThis.fetch) {
+async function createPaymentServer(
+  fetch: typeof globalThis.fetch,
+  payload: typeof credential.payload | typeof pushedPayload = credential.payload,
+) {
   const [method] = methods(fetch, apiBaseUrl)
   const mppx = Mppx.create({ methods: [method], realm, secretKey })
   const handle = mppx.tempo.charge({ amount: '1', decimals: 6 })
@@ -65,7 +74,7 @@ async function createPaymentServer(fetch: typeof globalThis.fetch) {
   const challenge = Challenge.fromResponse(challengeResponse)
   const paymentCredential = Credential.from({
     challenge,
-    payload: credential.payload,
+    payload,
     source: credential.source,
   })
 
@@ -203,13 +212,7 @@ describe('relay boundary', () => {
       return Response.json({ success: true })
     })
     const [method] = methods(fetch)
-    const pushedCredential = {
-      ...credential,
-      payload: {
-        hash: '0x1a2b3c4d5e6f7890abcdef1234567890abcdef1234567890abcdef1234567890',
-        type: 'hash' as const,
-      },
-    }
+    const pushedCredential = { ...credential, payload: pushedPayload }
 
     await expect(
       method.verify({
@@ -231,18 +234,18 @@ describe('relay boundary', () => {
       return Response.json({ success: true })
     })
     const [method] = methods(fetch)
-    const pushedCredential = {
-      ...credential,
-      payload: {
-        hash: '0x1a2b3c4d5e6f7890abcdef1234567890abcdef1234567890abcdef1234567890',
-        type: 'hash' as const,
-      },
-    }
+    const pushedCredential = { ...credential, payload: pushedPayload }
 
-    await method.broadcast!({
-      credential: pushedCredential,
-      request: credential.challenge.request,
-    } as never)
+    await expect(
+      method.broadcast!({
+        credential: pushedCredential,
+        request: credential.challenge.request,
+      } as never),
+    ).resolves.toMatchObject({
+      method: 'tempo',
+      reference: pushedPayload.hash,
+      status: 'success',
+    })
 
     expect(calls).toEqual(['/v1/mpp/validate'])
   })
@@ -479,6 +482,58 @@ describe('relay HTTP flow', () => {
       expect(response.status).toBe(200)
       expect(response.headers.get('Payment-Receipt')).toBeTruthy()
       expect(calls).toEqual(['/v1/mpp/validate', '/v1/mpp/broadcast'])
+    } finally {
+      server.close()
+    }
+  })
+
+  test('returns a receipt for a pushed transaction without relay broadcast', async () => {
+    const calls: string[] = []
+    const fetch = mockRelay((url) => {
+      calls.push(url.pathname)
+      return Response.json({ success: true })
+    })
+    const { pay, server } = await createPaymentServer(fetch, pushedPayload)
+
+    try {
+      const response = await pay()
+
+      expect(response.status).toBe(200)
+      expect(Receipt.fromResponse(response)).toMatchObject({
+        method: 'tempo',
+        reference: pushedPayload.hash,
+        status: 'success',
+      })
+      expect(calls).toEqual(['/v1/mpp/validate'])
+    } finally {
+      server.close()
+    }
+  })
+
+  test('does not issue a receipt when relay validation rejects a pushed transaction', async () => {
+    const calls: string[] = []
+    const fetch = mockRelay((url) => {
+      calls.push(url.pathname)
+      return Response.json({
+        error: { code: 'policy_denied', message: 'private detail' },
+        success: false,
+      })
+    })
+    const { pay, server } = await createPaymentServer(fetch, pushedPayload)
+
+    try {
+      const response = await pay()
+      const body = (await response.json()) as Record<string, unknown>
+
+      expect(response.status).toBe(402)
+      expect(response.headers.get('Payment-Receipt')).toBeNull()
+      expect(body).toMatchObject({
+        detail: 'Payment verification failed.',
+        type: 'https://paymentauth.org/problems/verification-failed',
+      })
+      expect(JSON.stringify(body)).not.toContain('policy_denied')
+      expect(JSON.stringify(body)).not.toContain('private detail')
+      expect(calls).toEqual(['/v1/mpp/validate'])
     } finally {
       server.close()
     }

--- a/src/tempo/server/Relay.test.ts
+++ b/src/tempo/server/Relay.test.ts
@@ -206,11 +206,13 @@ describe('relay boundary', () => {
     ])
   })
 
-  test('validates a pushed transaction without broadcasting it again', async () => {
-    const calls: string[] = []
-    const fetch = mockRelay((url) => {
-      calls.push(url.pathname)
-      return Response.json({ success: true })
+  test('delegates pushed transaction finalization to the relay', async () => {
+    const calls: Array<{ init: RequestInit; url: URL }> = []
+    const fetch = mockRelay((url, init) => {
+      calls.push({ init, url })
+      return url.pathname === '/v1/mpp/validate'
+        ? Response.json({ success: true })
+        : successReceipt()
     })
     const [method] = methods(fetch)
     const pushedCredential = { ...credential, payload: pushedPayload }
@@ -222,17 +224,25 @@ describe('relay boundary', () => {
       } as never),
     ).resolves.toMatchObject({
       method: 'tempo',
-      reference: pushedCredential.payload.hash,
+      reference: '0xabc',
       status: 'success',
     })
-    expect(calls).toEqual(['/v1/mpp/validate'])
+    expect(calls).toEqual([
+      expect.objectContaining({ url: new URL(`${apiBaseUrl}/v1/mpp/validate`) }),
+      expect.objectContaining({
+        init: expect.objectContaining({ body: JSON.stringify(pushedCredential) }),
+        url: new URL(`${apiBaseUrl}/v1/mpp/broadcast`),
+      }),
+    ])
   })
 
   test('validates a pushed transaction before returning its receipt', async () => {
     const calls: string[] = []
     const fetch = mockRelay((url) => {
       calls.push(url.pathname)
-      return Response.json({ success: true })
+      return url.pathname === '/v1/mpp/validate'
+        ? Response.json({ success: true })
+        : successReceipt()
     })
     const [method] = methods(fetch)
     const pushedCredential = {
@@ -248,11 +258,11 @@ describe('relay boundary', () => {
       Method.broadcastCredential([method], pushedCredential as never),
     ).resolves.toMatchObject({
       method: 'tempo',
-      reference: pushedPayload.hash,
+      reference: '0xabc',
       status: 'success',
     })
 
-    expect(calls).toEqual(['/v1/mpp/validate'])
+    expect(calls).toEqual(['/v1/mpp/validate', '/v1/mpp/broadcast'])
   })
 
   test('uses the transaction hash as the transaction broadcast idempotency key', async () => {
@@ -492,11 +502,13 @@ describe('relay HTTP flow', () => {
     }
   })
 
-  test('returns a receipt for a pushed transaction without relay broadcast', async () => {
+  test('delegates pushed transaction finalization to the relay', async () => {
     const calls: string[] = []
     const fetch = mockRelay((url) => {
       calls.push(url.pathname)
-      return Response.json({ success: true })
+      return url.pathname === '/v1/mpp/validate'
+        ? Response.json({ success: true })
+        : successReceipt()
     })
     const { pay, server } = await createPaymentServer(fetch, pushedPayload)
 
@@ -506,10 +518,10 @@ describe('relay HTTP flow', () => {
       expect(response.status).toBe(200)
       expect(Receipt.fromResponse(response)).toMatchObject({
         method: 'tempo',
-        reference: pushedPayload.hash,
+        reference: '0xabc',
         status: 'success',
       })
-      expect(calls).toEqual(['/v1/mpp/validate'])
+      expect(calls).toEqual(['/v1/mpp/validate', '/v1/mpp/broadcast'])
     } finally {
       server.close()
     }
@@ -539,6 +551,37 @@ describe('relay HTTP flow', () => {
       expect(JSON.stringify(body)).not.toContain('policy_denied')
       expect(JSON.stringify(body)).not.toContain('private detail')
       expect(calls).toEqual(['/v1/mpp/validate'])
+    } finally {
+      server.close()
+    }
+  })
+
+  test('does not issue a receipt when relay finalization rejects a pushed transaction', async () => {
+    const calls: string[] = []
+    const fetch = mockRelay((url) => {
+      calls.push(url.pathname)
+      return url.pathname === '/v1/mpp/validate'
+        ? Response.json({ success: true })
+        : Response.json({
+            error: { code: 'already_used', message: 'private detail' },
+            success: false,
+          })
+    })
+    const { pay, server } = await createPaymentServer(fetch, pushedPayload)
+
+    try {
+      const response = await pay()
+      const body = (await response.json()) as Record<string, unknown>
+
+      expect(response.status).toBe(402)
+      expect(response.headers.get('Payment-Receipt')).toBeNull()
+      expect(body).toMatchObject({
+        detail: 'Payment verification failed.',
+        details: { code: 'already_used' },
+        type: 'https://paymentauth.org/problems/verification-failed',
+      })
+      expect(JSON.stringify(body)).not.toContain('private detail')
+      expect(calls).toEqual(['/v1/mpp/validate', '/v1/mpp/broadcast'])
     } finally {
       server.close()
     }

--- a/src/tempo/server/Relay.test.ts
+++ b/src/tempo/server/Relay.test.ts
@@ -196,6 +196,57 @@ describe('relay boundary', () => {
     ])
   })
 
+  test('validates a pushed transaction without broadcasting it again', async () => {
+    const calls: string[] = []
+    const fetch = mockRelay((url) => {
+      calls.push(url.pathname)
+      return Response.json({ success: true })
+    })
+    const [method] = methods(fetch)
+    const pushedCredential = {
+      ...credential,
+      payload: {
+        hash: '0x1a2b3c4d5e6f7890abcdef1234567890abcdef1234567890abcdef1234567890',
+        type: 'hash' as const,
+      },
+    }
+
+    await expect(
+      method.verify({
+        credential: pushedCredential,
+        request: credential.challenge.request,
+      } as never),
+    ).resolves.toMatchObject({
+      method: 'tempo',
+      reference: pushedCredential.payload.hash,
+      status: 'success',
+    })
+    expect(calls).toEqual(['/v1/mpp/validate'])
+  })
+
+  test('validates a pushed transaction before direct broadcast', async () => {
+    const calls: string[] = []
+    const fetch = mockRelay((url) => {
+      calls.push(url.pathname)
+      return Response.json({ success: true })
+    })
+    const [method] = methods(fetch)
+    const pushedCredential = {
+      ...credential,
+      payload: {
+        hash: '0x1a2b3c4d5e6f7890abcdef1234567890abcdef1234567890abcdef1234567890',
+        type: 'hash' as const,
+      },
+    }
+
+    await method.broadcast!({
+      credential: pushedCredential,
+      request: credential.challenge.request,
+    } as never)
+
+    expect(calls).toEqual(['/v1/mpp/validate'])
+  })
+
   test('uses the transaction hash as the transaction broadcast idempotency key', async () => {
     const calls: RequestInit[] = []
     const fetch = mockRelay((_url, init) => {

--- a/src/tempo/server/Relay.ts
+++ b/src/tempo/server/Relay.ts
@@ -76,13 +76,10 @@ export function configure<const intent extends Method.Method>(
   options: configure.Options,
 ): configure.Adapter<intent> {
   const request = createRequest(options)
-  const validatedPushCredentials = new WeakSet<object>()
 
   const validate: Method.ValidateFn<intent> = async (parameters) => {
     const input = toRelayInput(parameters.credential)
     await request.validate(input)
-    if (pushTransactionHash(parameters.credential))
-      validatedPushCredentials.add(parameters.credential)
 
     return {
       challenge: parameters.credential.challenge,
@@ -98,11 +95,8 @@ export function configure<const intent extends Method.Method>(
   const broadcast: Method.BroadcastFn<intent> = async (parameters) => {
     const pushedTransactionHash = pushTransactionHash(parameters.credential)
     if (pushedTransactionHash) {
-      // Mppx validates before broadcasting, but direct method consumers may not.
-      if (!validatedPushCredentials.delete(parameters.credential)) {
-        await validate(parameters)
-        validatedPushCredentials.delete(parameters.credential)
-      }
+      // Mppx validates before this terminal step. The relay remains the
+      // authoritative validator and owner of any replay state.
       return Receipt.from({
         method: method.name,
         reference: pushedTransactionHash,

--- a/src/tempo/server/Relay.ts
+++ b/src/tempo/server/Relay.ts
@@ -64,13 +64,10 @@ type BroadcastResponse =
  * Configures a Tempo payment method to use Tempo API's MPP relay.
  *
  * The adapter preserves the supplied method's challenge configuration while
- * delegating credential validation and terminal broadcast to
- * `/v1/mpp/validate` and `/v1/mpp/broadcast` respectively.
- *
- * Configure relay-backed charges for `pull` mode only. The payer sends a
- * signed transaction to the server, and the relay broadcasts it. A `push`
- * client has already broadcast the transaction and must not submit it to the
- * relay again.
+ * delegating credential validation to `/v1/mpp/validate`. It broadcasts pull
+ * credentials through `/v1/mpp/broadcast`; for push credentials, the payer
+ * has already broadcast the transaction, so the adapter returns a receipt for
+ * the validated transaction hash without calling the relay broadcast endpoint.
  *
  * @internal
  */
@@ -79,10 +76,13 @@ export function configure<const intent extends Method.Method>(
   options: configure.Options,
 ): configure.Adapter<intent> {
   const request = createRequest(options)
+  const validatedPushCredentials = new WeakSet<object>()
 
   const validate: Method.ValidateFn<intent> = async (parameters) => {
     const input = toRelayInput(parameters.credential)
     await request.validate(input)
+    if (pushTransactionHash(parameters.credential))
+      validatedPushCredentials.add(parameters.credential)
 
     return {
       challenge: parameters.credential.challenge,
@@ -96,6 +96,21 @@ export function configure<const intent extends Method.Method>(
   }
 
   const broadcast: Method.BroadcastFn<intent> = async (parameters) => {
+    const pushedTransactionHash = pushTransactionHash(parameters.credential)
+    if (pushedTransactionHash) {
+      // Mppx validates before broadcasting, but direct method consumers may not.
+      if (!validatedPushCredentials.delete(parameters.credential)) {
+        await validate(parameters)
+        validatedPushCredentials.delete(parameters.credential)
+      }
+      return Receipt.from({
+        method: method.name,
+        reference: pushedTransactionHash,
+        status: 'success',
+        timestamp: new Date().toISOString(),
+      })
+    }
+
     const input = toRelayInput(parameters.credential)
     const receipt = await request.broadcast(input, {
       idempotencyKey: idempotencyKey(input),
@@ -132,7 +147,7 @@ export declare namespace configure {
     Method.Server<intent>,
     'broadcast' | 'validate'
   > & {
-    /** Broadcasts the credential through Tempo API. */
+    /** Broadcasts pull credentials through Tempo API or returns a receipt for a validated push credential. */
     broadcast: Method.BroadcastFn<intent>
     /** Validates the credential through Tempo API. */
     validate: Method.ValidateFn<intent>
@@ -141,10 +156,9 @@ export declare namespace configure {
   /**
    * Tempo API relay configuration for server-side Tempo charges.
    *
-   * Configure the associated charge with `supportedModes: ['pull']`. In pull
-   * mode, the payer signs the transaction and the relay broadcasts it. Do not
-   * use the relay to broadcast a transaction from a push-mode payer because it
-   * has already been broadcast by the client.
+   * The adapter resolves transaction broadcast ownership from the credential:
+   * it broadcasts pull credentials, while push credentials are already
+   * broadcast by the payer and receive a receipt after relay validation.
    */
   type Options = {
     /** Tempo API key with the `mpp:write` scope. */
@@ -224,6 +238,18 @@ function toRelayInput(credential: {
     payload: credential.payload,
     ...(credential.source ? { source: credential.source } : {}),
   }
+}
+
+function pushTransactionHash(credential: { payload: unknown }): string | undefined {
+  const payload = credential.payload
+  if (
+    !isRecord(payload) ||
+    payload.type !== 'hash' ||
+    typeof payload.hash !== 'string' ||
+    !Hex.validate(payload.hash)
+  )
+    return
+  return payload.hash
 }
 
 function idempotencyKey(input: RelayInput): string {

--- a/src/tempo/server/Relay.ts
+++ b/src/tempo/server/Relay.ts
@@ -64,10 +64,10 @@ type BroadcastResponse =
  * Configures a Tempo payment method to use Tempo API's MPP relay.
  *
  * The adapter preserves the supplied method's challenge configuration while
- * delegating credential validation to `/v1/mpp/validate`. It broadcasts pull
- * credentials through `/v1/mpp/broadcast`; for push credentials, the payer
- * has already broadcast the transaction, so the adapter returns a receipt for
- * the validated transaction hash without calling the relay broadcast endpoint.
+ * delegating validation and finalization to `/v1/mpp/validate` and
+ * `/v1/mpp/broadcast`. The relay receives every submitted credential: it
+ * broadcasts pull transactions and finalizes push transaction hashes without
+ * sending them again.
  *
  * @internal
  */
@@ -93,18 +93,6 @@ export function configure<const intent extends Method.Method>(
   }
 
   const broadcast: Method.BroadcastFn<intent> = async (parameters) => {
-    const pushedTransactionHash = pushTransactionHash(parameters.credential)
-    if (pushedTransactionHash) {
-      // Mppx validates before this terminal step. The relay remains the
-      // authoritative validator and owner of any replay state.
-      return Receipt.from({
-        method: method.name,
-        reference: pushedTransactionHash,
-        status: 'success',
-        timestamp: new Date().toISOString(),
-      })
-    }
-
     const input = toRelayInput(parameters.credential)
     const receipt = await request.broadcast(input, {
       idempotencyKey: idempotencyKey(input),
@@ -141,7 +129,7 @@ export declare namespace configure {
     Method.Server<intent>,
     'broadcast' | 'validate'
   > & {
-    /** Broadcasts pull credentials through Tempo API or returns a receipt for a validated push credential. */
+    /** Delegates payment finalization to Tempo API's relay. */
     broadcast: Method.BroadcastFn<intent>
     /** Validates the credential through Tempo API. */
     validate: Method.ValidateFn<intent>
@@ -150,9 +138,10 @@ export declare namespace configure {
   /**
    * Tempo API relay configuration for server-side Tempo charges.
    *
-   * The adapter resolves transaction broadcast ownership from the credential:
-   * it broadcasts pull credentials, while push credentials are already
-   * broadcast by the payer and receive a receipt after relay validation.
+   * The adapter sends every credential to the relay for finalization. The
+   * relay broadcasts pull credentials, while it recognizes a push credential
+   * as an already-broadcast transaction and returns its receipt without
+   * sending it again.
    */
   type Options = {
     /** Tempo API key with the `mpp:write` scope. */
@@ -232,18 +221,6 @@ function toRelayInput(credential: {
     payload: credential.payload,
     ...(credential.source ? { source: credential.source } : {}),
   }
-}
-
-function pushTransactionHash(credential: { payload: unknown }): string | undefined {
-  const payload = credential.payload
-  if (
-    !isRecord(payload) ||
-    payload.type !== 'hash' ||
-    typeof payload.hash !== 'string' ||
-    !Hex.validate(payload.hash)
-  )
-    return
-  return payload.hash
 }
 
 function idempotencyKey(input: RelayInput): string {

--- a/src/tempo/server/Relay.ts
+++ b/src/tempo/server/Relay.ts
@@ -67,6 +67,11 @@ type BroadcastResponse =
  * delegating credential validation and terminal broadcast to
  * `/v1/mpp/validate` and `/v1/mpp/broadcast` respectively.
  *
+ * Configure relay-backed charges for `pull` mode only. The payer sends a
+ * signed transaction to the server, and the relay broadcasts it. A `push`
+ * client has already broadcast the transaction and must not submit it to the
+ * relay again.
+ *
  * @internal
  */
 export function configure<const intent extends Method.Method>(
@@ -133,7 +138,14 @@ export declare namespace configure {
     validate: Method.ValidateFn<intent>
   }
 
-  /** Tempo API relay configuration for server-side Tempo charges. */
+  /**
+   * Tempo API relay configuration for server-side Tempo charges.
+   *
+   * Configure the associated charge with `supportedModes: ['pull']`. In pull
+   * mode, the payer signs the transaction and the relay broadcasts it. Do not
+   * use the relay to broadcast a transaction from a push-mode payer because it
+   * has already been broadcast by the client.
+   */
   type Options = {
     /** Tempo API key with the `mpp:write` scope. */
     apiKey: string


### PR DESCRIPTION
## Motivation

Prevent relay-backed push payments from being broadcast a second time.

## Summary

- Derived relay broadcast ownership from the submitted credential.
- Returned a receipt after validating push transaction hashes.
- Kept relay broadcast for pull credentials and documented both paths.

## Key design considerations

- The regular and direct method lifecycles both validate push credentials before issuing a receipt.
- Pull credentials retain relay-managed validation and broadcast.