### PR TITLE
fix(tempo): retain broadcasting sponsor reservations

### DIFF
--- a/.changeset/quiet-bags-listen.md
+++ b/.changeset/quiet-bags-listen.md
@@ -1,0 +1,6 @@
+---
+'mppx': patch
+---
+
+Prevent sponsored Tempo charges from returning a fresh payment challenge after
+a concurrent budget reconciliation observes their onchain receipt.

--- a/src/tempo/server/SponsorBudget.test.ts
+++ b/src/tempo/server/SponsorBudget.test.ts
@@ -74,6 +74,35 @@ describe('SponsorBudget', () => {
     expect(Object.keys(state!.reservations)).toEqual([hash2])
   })
 
+  test('does not reconcile a broadcasting reservation before its owner publishes pending', async () => {
+    const store = memoryStore()
+    const getReceipt = async (hash: Hex) => {
+      if (hash === hash1) return {}
+      throw new Error('not found')
+    }
+    const first = await SponsorBudget.reserve(store, parameters({ getReceipt }))
+    expect(await SponsorBudget.transition(store, first, 'broadcasting')).toBe(true)
+
+    const second = SponsorBudget.reserve(
+      store,
+      parameters({
+        getReceipt,
+        id: hash2,
+        owner: 'worker-2',
+        transactionHash: hash2,
+      }),
+    )
+    expect(
+      await Promise.race([
+        second.then(() => 'reserved' as const),
+        new Promise<'waiting'>((resolve) => setTimeout(() => resolve('waiting'), 40)),
+      ]),
+    ).toBe('waiting')
+
+    expect(await SponsorBudget.transition(store, first, 'pending')).toBe(true)
+    await expect(second).resolves.toMatchObject({ id: hash2, owner: 'worker-2' })
+  })
+
   test('fences release and transition by reservation owner', async () => {
     const store = memoryStore()
     const handle = await SponsorBudget.reserve(store, parameters())

--- a/src/tempo/server/SponsorBudget.ts
+++ b/src/tempo/server/SponsorBudget.ts
@@ -99,7 +99,13 @@ async function reconcile(
         await release(store, handle)
         return
       }
-      if (reservation.phase === 'prepared') return
+      // The broadcasting owner has submitted (or is about to submit) the
+      // transaction but has not yet published that outcome to this store.
+      // Releasing its reservation here races the owner's transition to
+      // `pending`: the transaction can settle while the owner observes a lost
+      // reservation and reports a retryable payment failure. Only reconcile
+      // receipts after the owner has completed that hand-off.
+      if (reservation.phase !== 'pending') return
 
       try {
         await parameters.getReceipt(reservation.transactionHash)


### PR DESCRIPTION
## Summary

- keep sponsored charge reservations in `broadcasting` until their owner publishes `pending`
- reconcile onchain receipts only for `pending` reservations
- cover the post-broadcast reconciliation race with a focused regression test

## Root cause

A concurrent sponsor-budget waiter could observe the receipt for a transaction
whose owner was still between `sendRawTransaction` and its transition to
`pending`. Reconciliation released that `broadcasting` reservation. The owner
then observed that it had lost the reservation and returned a verification
failure even though its transaction had already been broadcast and could
settle.

For an automatic MPP client, that failure becomes a fresh payable 402 and can
cause a second charge for one logical request.

`broadcasting` is the owner's hand-off phase, so receipt reconciliation now
waits until the owner has published `pending`. A crashed broadcasting worker is
still bounded by the transaction expiry already stored on the reservation.

## Validation

- New regression fails on current `main` (`reserved` wins while the original
  owner is still `broadcasting`)
- New regression and all `SponsorBudget` tests pass with this change: 5 passed
- `pnpm check:ci`
