### PR TITLE
fix: scope session retry checkpoints

### DIFF
--- a/.changeset/fresh-session-retries.md
+++ b/.changeset/fresh-session-retries.md
@@ -2,4 +2,4 @@
 'mppx': patch
 ---
 
-Fixed repeated session challenge retries and durable session rollback after failed payments.
+Fixed repeated session challenge retries, channel-scoped rollback, and validated snapshot recovery.

--- a/src/tempo/session/client/CredentialState.ts
+++ b/src/tempo/session/client/CredentialState.ts
@@ -321,7 +321,7 @@ export type HydrateSessionSnapshotParameters = {
   account: ViemAccount
   /** Viem client used to read authoritative TIP-1034 channel state. */
   client: Client
-  /** Snapshot returned by an MPP server bootstrap. */
+  /** Snapshot returned by an MPP server. */
   snapshot: SessionSnapshot
   /** Optional state reader for deterministic tests. */
   readChannelState?: ReadReusableChannelState | undefined
@@ -331,8 +331,10 @@ export type HydrateSessionSnapshotParameters = {
 export type HydratedSessionSnapshot = {
   /** Reusable channel entry safe to cache locally. */
   entry: ChannelEntry
-  /** Server-accounted delivered spend at bootstrap time. */
+  /** Server-accounted delivered spend at snapshot time. */
   spent: bigint
+  /** Paid units delivered according to the validated server snapshot. */
+  units: number
 }
 
 /** Data-first description of the next credential operation the client should execute. */
@@ -556,12 +558,27 @@ export async function hydrateSessionSnapshot(
   const snapshotDeposit = BigInt(snapshot.deposit)
   const snapshotSettled = BigInt(snapshot.settled)
   const spent = BigInt(snapshot.spent)
+  const units = snapshot.units ?? 0
+  if (
+    acceptedCumulative < 0n ||
+    requiredCumulative < 0n ||
+    snapshotDeposit < 0n ||
+    snapshotSettled < 0n ||
+    spent < 0n
+  )
+    throw new Error('session snapshot amounts must not be negative')
   if (voucherCumulative !== acceptedCumulative)
     throw new Error('session snapshot voucher amount does not match acceptedCumulative')
   if (spent > acceptedCumulative)
     throw new Error('session snapshot spent exceeds acceptedCumulative')
   if (snapshotSettled > snapshotDeposit)
     throw new Error('session snapshot settled amount exceeds deposit')
+  if (snapshotSettled > acceptedCumulative)
+    throw new Error('session snapshot settled amount exceeds acceptedCumulative')
+  if (acceptedCumulative > snapshotDeposit)
+    throw new Error('session snapshot acceptedCumulative exceeds deposit')
+  if (!Number.isSafeInteger(units) || units < 0)
+    throw new Error('session snapshot units must be a non-negative safe integer')
 
   if (
     !Voucher.verifyVoucher(
@@ -591,17 +608,17 @@ export async function hydrateSessionSnapshot(
     },
     readChannelState,
   })
-  const cumulativeAmount = [acceptedCumulative, requiredCumulative, reusable.state.settled].reduce(
-    (highest, value) => (value > highest ? value : highest),
-    0n,
-  )
-  if (cumulativeAmount > reusable.state.deposit)
-    throw new Error('recovered session cumulative amount exceeds on-chain channel deposit')
+  if (reusable.state.settled > acceptedCumulative)
+    throw new Error('session snapshot acceptedCumulative is below on-chain settlement')
+  if (snapshotDeposit > reusable.state.deposit)
+    throw new Error('session snapshot deposit exceeds on-chain channel deposit')
+  if (acceptedCumulative > reusable.state.deposit)
+    throw new Error('session snapshot acceptedCumulative exceeds on-chain channel deposit')
 
   return {
     entry: {
       channelId: reusable.channelId,
-      cumulativeAmount,
+      cumulativeAmount: acceptedCumulative,
       deposit: reusable.state.deposit,
       descriptor: snapshot.descriptor,
       escrow: snapshot.escrow,
@@ -609,6 +626,7 @@ export async function hydrateSessionSnapshot(
       opened: true,
     },
     spent,
+    units,
   }
 }
 
@@ -790,7 +808,12 @@ async function voucher(
   sink: ChannelSink,
 ): Promise<SessionCredentialPayload> {
   const { account, entry, resolved } = plan
-  const cumulativeAmount = entry.cumulativeAmount + resolved.amount
+  const nextCumulative = entry.cumulativeAmount + resolved.amount
+  const snapshotRequired =
+    resolved.snapshot?.channelId.toLowerCase() === entry.channelId.toLowerCase()
+      ? BigInt(resolved.snapshot.requiredCumulative)
+      : nextCumulative
+  const cumulativeAmount = snapshotRequired > nextCumulative ? snapshotRequired : nextCumulative
   assertWithinMaxDeposit(cumulativeAmount, plan.maxDeposit)
   const payload = await createVoucherPayload(
     resolved.client,

--- a/src/tempo/session/client/SessionManager.test.ts
+++ b/src/tempo/session/client/SessionManager.test.ts
@@ -15,6 +15,7 @@ import type { NeedVoucherEvent, SessionReceipt } from '../precompile/Protocol.js
 import { formatNeedVoucherEvent, parseEvent } from '../precompile/Protocol.js'
 import type { SessionCredentialPayload } from '../precompile/Protocol.js'
 import * as Voucher from '../precompile/Voucher.js'
+import type { SessionSnapshot } from '../Snapshot.js'
 import { computeFallbackCloseAmount, sessionManager } from './SessionManager.js'
 
 const channelId = '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex
@@ -24,33 +25,17 @@ const account = privateKeyToAccount(
   '0xac0974bec39a17e36ba6a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
 )
 
-const client = createClient({
-  account,
-  chain: { id: 4217 } as never,
-  transport: custom({
-    async request(args) {
-      if (args.method === 'eth_chainId') return '0x1079'
-      if (args.method === 'eth_getTransactionCount') return '0x0'
-      if (args.method === 'eth_estimateGas') return '0x5208'
-      if (args.method === 'eth_maxPriorityFeePerGas') return '0x1'
-      if (args.method === 'eth_getBlockByNumber') return { baseFeePerGas: '0x1' }
-      if (args.method === 'eth_call')
-        return encodeFunctionResult({
-          abi: escrowAbi,
-          functionName: 'getChannelState',
-          result: { settled: 0n, deposit: 10_000_000n, closeRequestedAt: 0 },
-        })
-      throw new Error(`unexpected rpc request: ${args.method}`)
-    },
-  }),
-})
-
-function channelStateClient(state: { closeRequestedAt: number; deposit: bigint; settled: bigint }) {
+function sessionClient(state = { closeRequestedAt: 0, deposit: 10_000_000n, settled: 0n }) {
   return createClient({
     account,
     chain: { id: 4217 } as never,
     transport: custom({
       async request(args) {
+        if (args.method === 'eth_chainId') return '0x1079'
+        if (args.method === 'eth_getTransactionCount') return '0x0'
+        if (args.method === 'eth_estimateGas') return '0x5208'
+        if (args.method === 'eth_maxPriorityFeePerGas') return '0x1'
+        if (args.method === 'eth_getBlockByNumber') return { baseFeePerGas: '0x1' }
         if (args.method === 'eth_call')
           return encodeFunctionResult({
             abi: escrowAbi,
@@ -61,6 +46,12 @@ function channelStateClient(state: { closeRequestedAt: number; deposit: bigint; 
       },
     }),
   })
+}
+
+const client = sessionClient()
+
+function channelStateClient(state: { closeRequestedAt: number; deposit: bigint; settled: bigint }) {
+  return sessionClient(state)
 }
 
 const storedDescriptor = {
@@ -174,6 +165,49 @@ function make402Response(challenge?: Challenge.Challenge): Response {
 
 function makeOkResponse(body?: string): Response {
   return new Response(body ?? 'ok', { status: 200 })
+}
+
+function makeCloseResponse(
+  payload: Extract<SessionCredentialPayload, { action: 'close' }>,
+  challengeId: string,
+) {
+  const cumulativeAmount = BigInt(payload.cumulativeAmount)
+  return new Response(null, {
+    headers: {
+      [Constants.Headers.paymentReceipt]: serializeSessionReceipt(
+        createSessionReceipt({
+          acceptedCumulative: cumulativeAmount,
+          challengeId,
+          channelId: payload.channelId,
+          spent: cumulativeAmount,
+          txHash: `0x${'ab'.repeat(32)}`,
+        }),
+      ),
+    },
+  })
+}
+
+function snapshotFromCredential(
+  payload: Extract<SessionCredentialPayload, { action: 'open' | 'voucher' }>,
+  overrides: Partial<SessionSnapshot> = {},
+): SessionSnapshot {
+  return {
+    acceptedCumulative: payload.cumulativeAmount,
+    chainId: 4217,
+    channelId: payload.channelId,
+    deposit: '10000000',
+    descriptor: payload.descriptor,
+    escrow: tip20ChannelEscrow,
+    highestVoucher: {
+      channelId: payload.channelId,
+      cumulativeAmount: payload.cumulativeAmount,
+      signature: payload.signature,
+    },
+    requiredCumulative: payload.cumulativeAmount,
+    settled: '0',
+    spent: '0',
+    ...overrides,
+  }
 }
 
 function makeSseResponse(events: string[]): Response {
@@ -592,7 +626,8 @@ describe('Session', () => {
     test('drops a stale stored channel the server rejects and retries with a fresh one', async () => {
       const { store, delete: remove } = makeChannelStore([channelEntry()])
       const postedPayloads: SessionCredentialPayload[] = []
-      const mockFetch = vi.fn().mockImplementation((_input, init?: RequestInit) => {
+      let closeInput: string | undefined
+      const mockFetch = vi.fn().mockImplementation((input, init?: RequestInit) => {
         const headers = new Headers(init?.headers)
         const authorization = headers.get(Constants.Headers.authorization)
         const payload = authorization
@@ -601,6 +636,10 @@ describe('Session', () => {
         if (payload) postedPayloads.push(payload)
 
         if (!payload) return Promise.resolve(make402Response())
+        if (payload.action === 'close') {
+          closeInput = String(input)
+          return Promise.resolve(makeCloseResponse(payload, challengeId))
+        }
         // Reject any reuse of the stale stored channel; accept a freshly opened one.
         if (payload.channelId === storedChannelId)
           return Promise.resolve(new Response('gone', { status: 500 }))
@@ -621,6 +660,8 @@ describe('Session', () => {
       expect(postedPayloads.map((payload) => payload.action)).toEqual(['voucher', 'open'])
       expect(s.opened).toBe(true)
       expect(s.channelId).not.toBe(storedChannelId)
+      await s.close()
+      expect(closeInput).toBe('https://api.example.com/data')
     })
 
     test('keeps a persisted channel after its committed top-up when the paid retry fails', async () => {
@@ -685,8 +726,9 @@ describe('Session', () => {
         })
       const original = challenge(true)
       const replacement = challenge(false)
+      let closeInput: string | undefined
       let openCount = 0
-      const mockFetch = vi.fn().mockImplementation((_input, init?: RequestInit) => {
+      const mockFetch = vi.fn().mockImplementation((input, init?: RequestInit) => {
         const authorization = new Headers(init?.headers).get(Constants.Headers.authorization)
         const payload = authorization
           ? Credential.deserialize<SessionCredentialPayload>(authorization).payload
@@ -699,6 +741,10 @@ describe('Session', () => {
           if (openCount === 1) return Promise.resolve(make402Response(replacement))
           if (openCount === 2) return Promise.resolve(make402Response(original))
           return Promise.resolve(makeOkResponse())
+        }
+        if (payload.action === 'close') {
+          closeInput = String(input)
+          return Promise.resolve(makeCloseResponse(payload, original.id))
         }
         return Promise.resolve(new Response('unexpected voucher', { status: 500 }))
       })
@@ -717,6 +763,8 @@ describe('Session', () => {
       expect(new Set(postedPayloads.map((payload) => payload.channelId)).size).toBe(3)
       expect(remove).toHaveBeenCalledTimes(2)
       expect(s.channelId).toBe(postedPayloads[2]?.channelId)
+      await s.close()
+      expect(closeInput).toBe('https://api.example.com/data')
     })
 
     test('reuses prepared voucher state when an identical challenge succeeds', async () => {
@@ -964,18 +1012,12 @@ describe('Session', () => {
                   escrowContract: tip20ChannelEscrow,
                   chainId: 4217,
                   sessionProtocol: Constants.SessionProtocols.v2,
-                  sessionSnapshot: {
-                    acceptedCumulative: '2000000',
-                    chainId: 4217,
-                    channelId: payload.channelId,
+                  sessionSnapshot: snapshotFromCredential(payload, {
                     deposit: '1000000',
-                    descriptor: payload.descriptor,
-                    escrow: tip20ChannelEscrow,
                     requiredCumulative: '2000000',
-                    settled: '0',
                     spent: '1000000',
                     units: 1,
-                  },
+                  }),
                 },
               }),
             ),
@@ -1008,7 +1050,11 @@ describe('Session', () => {
 
       const s = sessionManager({
         account,
-        client,
+        client: channelStateClient({
+          closeRequestedAt: 0,
+          deposit: 1_000_000n,
+          settled: 0n,
+        }),
         fetch: mockFetch as typeof globalThis.fetch,
         maxDeposit: '10',
       })
@@ -1027,6 +1073,180 @@ describe('Session', () => {
       })
     })
 
+    test('rolls back only the attempted channel when another scope is active', async () => {
+      const { store } = makeDurableChannelStore()
+      const first = channelEntry()
+      const secondDescriptor = {
+        ...storedDescriptor,
+        payee: '0x742d35cc6634c0532925a3b844bc9e7595f8ef01' as Address,
+      }
+      const second = channelEntry({
+        channelId: Channel.computeId({
+          ...secondDescriptor,
+          chainId: 4217,
+          escrow: tip20ChannelEscrow,
+        }),
+        descriptor: secondDescriptor,
+      })
+      await store.set(first)
+      await store.set(second)
+
+      const scopedChallenge = (entry: ChannelEntry, id: string) =>
+        Challenge.from({
+          ...makeChallenge({
+            currency: entry.descriptor.token,
+            recipient: entry.descriptor.payee,
+          }),
+          id,
+        })
+      const firstChallenge = scopedChallenge(first, 'first-scope')
+      const secondChallenge = scopedChallenge(second, 'second-scope')
+      let closeInput: string | undefined
+      let stateDuringSecond: ReturnType<typeof sessionManager>['state'] | undefined
+      let s: ReturnType<typeof sessionManager>
+      const mockFetch = vi.fn().mockImplementation((input, init?: RequestInit) => {
+        const isSecond = String(input).endsWith('/second')
+        const authorization = new Headers(init?.headers).get(Constants.Headers.authorization)
+        if (!authorization)
+          return Promise.resolve(make402Response(isSecond ? secondChallenge : firstChallenge))
+        const payload = Credential.deserialize<SessionCredentialPayload>(authorization).payload
+        if (payload.action === 'close') {
+          closeInput = String(input)
+          return Promise.resolve(makeCloseResponse(payload, firstChallenge.id))
+        }
+        if (payload.action !== 'voucher') throw new Error('expected voucher payload')
+        if (isSecond) {
+          stateDuringSecond = s.state
+          return Promise.resolve(new Response('failed', { status: 500 }))
+        }
+        return Promise.resolve(
+          new Response('ok', {
+            headers: {
+              [Constants.Headers.paymentReceipt]: serializeSessionReceipt(
+                createSessionReceipt({
+                  acceptedCumulative: BigInt(payload.cumulativeAmount),
+                  challengeId: firstChallenge.id,
+                  channelId: payload.channelId,
+                  spent: 1_000_000n,
+                  units: 3,
+                }),
+              ),
+            },
+          }),
+        )
+      })
+      s = sessionManager({
+        account,
+        client,
+        fetch: mockFetch as typeof globalThis.fetch,
+        channelStore: store,
+      })
+
+      expect((await s.fetch('https://api.example.com/first')).status).toBe(200)
+      expect((await s.fetch('https://api.example.com/second')).status).toBe(500)
+
+      expect(stateDuringSecond).toMatchObject({
+        status: 'active',
+        channelId: second.channelId,
+        spent: '0',
+        units: 0,
+      })
+      await expect(store.get(entryKey(first))).resolves.toMatchObject({
+        cumulativeAmount: 2_000_000n,
+        opened: true,
+      })
+      await expect(store.get(entryKey(second))).resolves.toMatchObject({
+        cumulativeAmount: 1_000_000n,
+        opened: true,
+      })
+      expect(s.channelId).toBe(first.channelId)
+      expect(s.cumulative).toBe(2_000_000n)
+      expect(s.state).toMatchObject({
+        status: 'active',
+        challengeId: firstChallenge.id,
+        channelId: first.channelId,
+        units: 3,
+      })
+      await s.close()
+      expect(closeInput).toBe('https://api.example.com/first')
+    })
+
+    test('preserves newer receipt accounting when committing a stale snapshot', async () => {
+      const { store } = makeDurableChannelStore()
+      const seeded = channelEntry()
+      await store.set(seeded)
+      const payloads: Extract<SessionCredentialPayload, { action: 'voucher' }>[] = []
+      const mockFetch = vi.fn().mockImplementation((_input, init?: RequestInit) => {
+        const authorization = new Headers(init?.headers).get(Constants.Headers.authorization)
+        if (!authorization) return Promise.resolve(make402Response())
+        const payload = Credential.deserialize<SessionCredentialPayload>(authorization).payload
+        if (payload.action !== 'voucher') throw new Error('expected voucher payload')
+        payloads.push(payload)
+        if (payloads.length === 1)
+          return Promise.resolve(
+            new Response('ok', {
+              headers: {
+                [Constants.Headers.paymentReceipt]: serializeSessionReceipt(
+                  createSessionReceipt({
+                    acceptedCumulative: BigInt(payload.cumulativeAmount),
+                    challengeId,
+                    channelId: payload.channelId,
+                    spent: 2_000_000n,
+                    units: 3,
+                  }),
+                ),
+              },
+            }),
+          )
+        if (payloads.length > 2) return Promise.resolve(new Response('failed', { status: 500 }))
+        return Promise.resolve(
+          make402Response(
+            Challenge.from({
+              ...makeChallenge({
+                methodDetails: {
+                  escrowContract: tip20ChannelEscrow,
+                  chainId: 4217,
+                  sessionProtocol: Constants.SessionProtocols.v2,
+                  sessionSnapshot: snapshotFromCredential(payload, {
+                    requiredCumulative: '4000000',
+                    spent: '1000000',
+                    units: 1,
+                  }),
+                },
+              }),
+              id: 'acknowledged-voucher',
+            }),
+          ),
+        )
+      })
+      const s = sessionManager({
+        account,
+        client,
+        fetch: mockFetch as typeof globalThis.fetch,
+        channelStore: store,
+      })
+
+      expect((await s.fetch('https://api.example.com/data')).status).toBe(200)
+      expect((await s.fetch('https://api.example.com/data')).status).toBe(500)
+      expect(payloads.map((payload) => payload.cumulativeAmount)).toEqual([
+        '2000000',
+        '3000000',
+        '4000000',
+      ])
+      expect(s.cumulative).toBe(3_000_000n)
+      expect(s.state).toMatchObject({
+        status: 'active',
+        challengeId: 'acknowledged-voucher',
+        acceptedCumulative: '3000000',
+        spent: '2000000',
+        units: 3,
+      })
+      await expect(store.get(entryKey(seeded))).resolves.toMatchObject({
+        cumulativeAmount: 3_000_000n,
+        opened: true,
+      })
+    })
+
     test('preserves a snapshot-acknowledged open when its voucher fails', async () => {
       const { backend, store } = makeDurableChannelStore()
       const payloads: SessionCredentialPayload[] = []
@@ -1040,24 +1260,20 @@ describe('Session', () => {
           return Promise.resolve(new Response('failed', { status: 500 }))
         return Promise.resolve(
           make402Response(
-            makeChallenge({
-              methodDetails: {
-                escrowContract: tip20ChannelEscrow,
-                chainId: 4217,
-                sessionProtocol: Constants.SessionProtocols.v2,
-                sessionSnapshot: {
-                  acceptedCumulative: '1000000',
+            Challenge.from({
+              ...makeChallenge({
+                methodDetails: {
+                  escrowContract: tip20ChannelEscrow,
                   chainId: 4217,
-                  channelId: payload.channelId,
-                  deposit: '10000000',
-                  descriptor: payload.descriptor,
-                  escrow: tip20ChannelEscrow,
-                  requiredCumulative: '2000000',
-                  settled: '0',
-                  spent: '1000000',
-                  units: 1,
+                  sessionProtocol: Constants.SessionProtocols.v2,
+                  sessionSnapshot: snapshotFromCredential(payload, {
+                    requiredCumulative: '2000000',
+                    spent: '1000000',
+                    units: 1,
+                  }),
                 },
-              },
+              }),
+              id: 'acknowledged-open',
             }),
           ),
         )
@@ -1072,10 +1288,21 @@ describe('Session', () => {
 
       expect((await s.fetch('https://api.example.com/data')).status).toBe(500)
       expect(payloads.map((payload) => payload.action)).toEqual(['open', 'voucher'])
-      expect(s.channelId).toBe(payloads[0]?.channelId)
+      const opened = payloads[0]
+      if (opened?.action !== 'open') throw new Error('expected open payload')
+      expect(s.channelId).toBe(opened.channelId)
       expect(s.cumulative).toBe(1_000_000n)
+      expect(s.state).toMatchObject({
+        status: 'active',
+        challengeId: 'acknowledged-open',
+        channelId: opened.channelId,
+        acceptedCumulative: '1000000',
+        deposit: '10000000',
+        spent: '1000000',
+        units: 1,
+      })
       expect(JSON.parse([...backend.values()][0]!)).toMatchObject({
-        channelId: payloads[0]?.channelId,
+        channelId: opened.channelId,
         cumulativeAmount: '1000000',
         opened: true,
       })

--- a/src/tempo/session/client/SessionManager.ts
+++ b/src/tempo/session/client/SessionManager.ts
@@ -13,7 +13,11 @@ import { charge as chargePlugin } from '../../client/Charge.js'
 import * as defaults from '../../internal/defaults.js'
 import type { ChannelEntry } from '../client/ChannelOps.js'
 import { createChannelStore, entryKey, type ChannelStore } from '../client/ChannelStore.js'
-import { hydrateSessionSnapshot, type SessionContext } from '../client/CredentialState.js'
+import {
+  hydrateSessionSnapshot,
+  resolveChallengeContext,
+  type SessionContext,
+} from '../client/CredentialState.js'
 import { session as sessionPlugin } from '../client/Session.js'
 import * as Channel from '../precompile/Channel.js'
 import { deserializeSessionReceipt } from '../precompile/Protocol.js'
@@ -21,6 +25,7 @@ import type { SessionReceipt } from '../precompile/Protocol.js'
 import {
   deserializeSnapshot as deserializeSessionSnapshot,
   serializeSnapshot as serializeSessionSnapshot,
+  type SessionSnapshot,
 } from '../Snapshot.js'
 import { registerSessionManagerInternals } from './internal/SessionManager.js'
 import { createSessionReceiptCoordinator } from './ReceiptCoordinator.js'
@@ -204,17 +209,38 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
   const backing = parameters.channelStore ?? createChannelStore()
   const ignoredChannelIds = new Set<Hex.Hex>()
 
-  // Tracks one fetch's channel reuse so stale stored entries can be evicted once.
+  type ManagerSnapshot = {
+    lastChallenge: TempoSessionChallenge | null
+    lastUrl: RequestInfo | URL | null
+    runtime: RuntimeSnapshot
+  }
+  type ChannelChange = {
+    before: ChannelEntry | undefined
+    current: ChannelEntry
+  }
+
+  // Journals one fetch's channel mutations until the server accepts them.
   type ChannelUse = {
     challengesReceived: number
-    committed: RuntimeSnapshot | undefined
-    created: Map<string, ChannelEntry>
-    seenExisting: Set<string>
-    previous: RuntimeSnapshot
+    changes: Map<string, ChannelChange>
+    committed: ManagerSnapshot | undefined
+    previous: ManagerSnapshot
     resumed: ChannelEntry | undefined
     trackCreates: boolean
   }
   let channelUse: ChannelUse | undefined
+
+  function captureManagerSnapshot(): ManagerSnapshot {
+    return {
+      lastChallenge: runtime.lastChallenge,
+      lastUrl: runtime.lastUrl,
+      runtime: captureRuntimeStateSnapshot({
+        channel: runtime.channel,
+        spent: runtime.spent,
+        state: runtime.state,
+      }),
+    }
+  }
 
   /** Returns the backing entry for `key` only when it is open and not ignored. */
   async function getReusable(key: string): Promise<ChannelEntry | undefined> {
@@ -227,16 +253,21 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
     async get(key) {
       const entry = await getReusable(key)
       if (entry && channelUse) {
-        channelUse.seenExisting.add(key)
-        if (!channelUse.committed && !channelUse.created.has(key)) channelUse.resumed ??= entry
+        const change = channelUse.changes.get(key)
+        if (change) change.current = entry
+        else channelUse.changes.set(key, { before: { ...entry }, current: entry })
+        if (!channelUse.committed) channelUse.resumed ??= entry
       }
       return entry
     },
     async set(entry) {
       const key = entryKey(entry)
       if (entry.opened) ignoredChannelIds.delete(entry.channelId)
-      if (channelUse?.trackCreates && !channelUse.seenExisting.has(key))
-        channelUse.created.set(key, entry)
+      if (channelUse?.trackCreates) {
+        const change = channelUse.changes.get(key)
+        if (change) change.current = entry
+        else channelUse.changes.set(key, { before: undefined, current: entry })
+      }
       await backing.set(entry)
     },
     delete: (key) => backing.delete(key),
@@ -246,43 +277,85 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
   async function ignoreChannel(entry: ChannelEntry) {
     const key = entryKey(entry)
     ignoredChannelIds.add(entry.channelId)
-    channelUse?.seenExisting.delete(key)
-    if (channelUse?.resumed === entry) channelUse.resumed = undefined
+    channelUse?.changes.delete(key)
+    if (channelUse?.resumed && entryKey(channelUse.resumed) === key) channelUse.resumed = undefined
     await Promise.resolve(backing.delete(key)).catch(() => undefined)
   }
 
-  async function rollbackCreatedChannels() {
+  async function rollbackChannelChanges(preserveLastUrl = false) {
     const use = channelUse
-    if (!use?.created.size) return
-    for (const [key, entry] of use.created) {
-      ignoredChannelIds.add(entry.channelId)
-      await Promise.resolve(backing.delete(key)).catch(() => undefined)
+    if (!use) return
+    for (const [key, change] of use.changes) {
+      if (change.before) {
+        ignoredChannelIds.delete(change.before.channelId)
+        await backing.set({ ...change.before })
+      } else {
+        change.current.opened = false
+        ignoredChannelIds.add(change.current.channelId)
+        await Promise.resolve(backing.delete(key)).catch(() => undefined)
+      }
     }
-    use.created.clear()
-    await restoreRuntime(use.committed ?? use.previous)
+    use.changes.clear()
+    await restoreManagerSnapshot(use.committed ?? use.previous, preserveLastUrl)
   }
 
-  /** Commits a newly created channel once an authoritative server snapshot references it. */
-  function commitReferencedChannel(challenge: Challenge.Challenge): boolean {
-    const snapshot = Constants.getMethodDetail<{ channelId?: unknown }>(
-      challenge.request.methodDetails,
-      Constants.MethodDetailKeys.sessionSnapshot,
-    )
-    if (typeof snapshot?.channelId !== 'string') return false
+  function commitChannel(entry: ChannelEntry) {
     const use = channelUse
-    if (!use?.created.size || !runtime.channel) return false
-    for (const [key, entry] of use.created) {
+    const key = entryKey(entry)
+    const change = use?.changes.get(key)
+    if (!use || !change) return
+    change.before = { ...entry }
+    change.current = entry
+    if (use.resumed && entryKey(use.resumed) === key) use.resumed = undefined
+    use.committed = captureManagerSnapshot()
+  }
+
+  /** Commits a channel once an authoritative server snapshot acknowledges its voucher. */
+  async function commitReferencedChannel(challenge: TempoSessionChallenge): Promise<boolean> {
+    const snapshot = getSessionSnapshot(challenge)
+    if (!snapshot) return false
+    const use = channelUse
+    if (!use || !runtime.channel) return false
+    for (const [key, change] of use.changes) {
+      const entry = change.current
       if (
         entry.channelId.toLowerCase() !== snapshot.channelId.toLowerCase() ||
         runtime.channel.channelId.toLowerCase() !== snapshot.channelId.toLowerCase()
       )
         continue
-      use.created.delete(key)
-      use.committed = captureRuntimeStateSnapshot({
-        channel: runtime.channel,
-        spent: runtime.spent,
-        state: runtime.state,
+      const resolved = await resolveChallengeContext({
+        challenge,
+        escrowOverride: parameters.escrow,
+        getClient,
       })
+      if (resolved.key !== key)
+        throw new Error('session snapshot payment scope does not match opened channel')
+      const hydrated = await hydrateSnapshot(snapshot, resolved.client)
+      const replacesChannel =
+        !change.before || change.before.channelId.toLowerCase() !== entry.channelId.toLowerCase()
+      if (replacesChannel && hydrated.entry.cumulativeAmount !== entry.cumulativeAmount)
+        throw new Error('session snapshot acceptedCumulative does not match opened voucher')
+      if (
+        !replacesChannel &&
+        change.before &&
+        hydrated.entry.cumulativeAmount < change.before.cumulativeAmount
+      )
+        return false
+      const spent = runtime.spent > hydrated.spent ? runtime.spent : hydrated.spent
+      const units = Math.max(activeUnits(hydrated.entry.channelId), hydrated.units)
+      runtime.channel = hydrated.entry
+      runtime.spent = spent
+      runtime.lastChallenge = challenge
+      dispatch({
+        type: 'activated',
+        challengeId: challenge.id,
+        entry: hydrated.entry,
+        spent: spent.toString(),
+        units,
+      })
+      await backing.set(hydrated.entry)
+      change.current = hydrated.entry
+      commitChannel(hydrated.entry)
       return true
     }
     return false
@@ -292,29 +365,28 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
     return dispatchSessionEvent(runtime, event)
   }
 
-  function activeUnits() {
-    const state =
-      runtime.state.status === 'active'
-        ? runtime.state
-        : (channelUse?.committed?.state ?? channelUse?.previous.state)
-    return state?.status === 'active' ? state.units : 0
+  function activeUnits(channelId: Hex.Hex) {
+    const states = [
+      runtime.state,
+      channelUse?.committed?.runtime.state,
+      channelUse?.previous.runtime.state,
+    ]
+    for (const state of states)
+      if (state?.status === 'active' && state.channelId.toLowerCase() === channelId.toLowerCase())
+        return state.units
+    return 0
   }
 
   function commitDurableTopUp(entry: ChannelEntry) {
     const use = channelUse
-    const baseline = use?.committed?.channel?.entry ?? use?.resumed
+    const baseline = use?.changes.get(entryKey(entry))?.before
     if (
-      !use ||
-      baseline?.channelId.toLowerCase() !== entry.channelId.toLowerCase() ||
+      !baseline ||
+      baseline.channelId.toLowerCase() !== entry.channelId.toLowerCase() ||
       entry.deposit <= baseline.deposit
     )
       return
-    use.resumed = undefined
-    use.committed = captureRuntimeStateSnapshot({
-      channel: runtime.channel,
-      spent: runtime.spent,
-      state: runtime.state,
-    })
+    commitChannel(entry)
   }
 
   const method = sessionPlugin({
@@ -336,7 +408,7 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
           challengeId: runtime.lastChallenge.id,
           entry,
           spent: runtime.spent.toString(),
-          units: activeUnits(),
+          units: activeUnits(entry.channelId),
         })
       }
       commitDurableTopUp(entry)
@@ -361,10 +433,10 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
         Challenge.serialize(challenge) === Challenge.serialize(runtime.lastChallenge!)
       if (use) use.challengesReceived++
       if (isSameRetryChallenge) return undefined
-      if (!commitReferencedChannel(challenge)) {
-        if (use?.created.size) await rollbackCreatedChannels()
-        else if (isRepeatedRetryChallenge) await restoreRuntime(use.committed ?? use.previous)
-      }
+      if (await commitReferencedChannel(challenge)) return undefined
+      if (use?.changes.size) await rollbackChannelChanges(true)
+      else if (isRepeatedRetryChallenge)
+        await restoreManagerSnapshot(use.committed ?? use.previous, true)
       runtime.lastChallenge = challenge
       dispatch({ type: 'challengeReceived', challengeId: challenge.id })
       return undefined
@@ -402,13 +474,12 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
     })
   }
 
-  /** Persists a server snapshot into the channel store and returns the entry. */
-  async function storeSnapshotHeader(response: Response): Promise<ChannelEntry | undefined> {
-    const header = response.headers.get(Constants.Headers.paymentSessionSnapshot)
-    if (!header) return undefined
-    const snapshot = deserializeSessionSnapshot(header)
-    const client = await getClient({ chainId: snapshot.chainId })
-    const defaultAccount = getAccount(client)
+  async function hydrateSnapshot(
+    snapshot: SessionSnapshot,
+    client?: Awaited<ReturnType<typeof getClient>>,
+  ) {
+    const resolvedClient = client ?? (await getClient({ chainId: snapshot.chainId }))
+    const defaultAccount = getAccount(resolvedClient)
     const account =
       (await parameters.resolveAccount?.({
         account: defaultAccount,
@@ -418,8 +489,21 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
           kind: 'authorizePaymentChannel',
         },
       })) ?? defaultAccount
-    const { entry, spent } = await hydrateSessionSnapshot({ account, client, snapshot })
-    assertVoucherWithinLocalLimit(entry.cumulativeAmount)
+    const hydrated = await hydrateSessionSnapshot({
+      account,
+      client: resolvedClient,
+      snapshot,
+    })
+    assertVoucherWithinLocalLimit(hydrated.entry.cumulativeAmount)
+    return hydrated
+  }
+
+  /** Persists a server snapshot into the channel store and returns the entry. */
+  async function storeSnapshotHeader(response: Response): Promise<ChannelEntry | undefined> {
+    const header = response.headers.get(Constants.Headers.paymentSessionSnapshot)
+    if (!header) return undefined
+    const snapshot = deserializeSessionSnapshot(header)
+    const { entry, spent } = await hydrateSnapshot(snapshot)
     await Promise.resolve(store.set(entry)).catch(() => undefined)
     runtime.channel = entry
     runtime.spent = spent
@@ -586,7 +670,7 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
         challengeId: runtime.lastChallenge.id,
         entry: applied.channel,
         spent: runtime.spent.toString(),
-        units: activeUnits(),
+        units: activeUnits(applied.channel.channelId),
       })
       commitDurableTopUp(applied.channel)
     }
@@ -638,9 +722,12 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
     }
   }
 
-  async function restoreRuntime(snapshot: RuntimeSnapshot) {
-    const restored = restoreRuntimeStateSnapshot(snapshot, runtime.channel)
+  async function restoreManagerSnapshot(snapshot: ManagerSnapshot, preserveLastUrl = false) {
+    const lastUrl = runtime.lastUrl
+    const restored = restoreRuntimeStateSnapshot(snapshot.runtime, runtime.channel)
     runtime.channel = restored.channel
+    runtime.lastChallenge = snapshot.lastChallenge
+    runtime.lastUrl = preserveLastUrl ? lastUrl : snapshot.lastUrl
     runtime.spent = restored.spent
     runtime.state = restored.state
     if (runtime.channel?.opened) await backing.set(runtime.channel)
@@ -666,19 +753,14 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
       throw new Error(
         'SessionManager: a request is already in flight; concurrent requests on one manager are not supported',
       )
-    runtime.lastUrl = input
 
-    const previous = captureRuntimeStateSnapshot({
-      channel: runtime.channel,
-      spent: runtime.spent,
-      state: runtime.state,
-    })
+    const previous = captureManagerSnapshot()
+    runtime.lastUrl = input
     const use: ChannelUse = {
       challengesReceived: 0,
+      changes: new Map(),
       committed: undefined,
-      created: new Map(),
       previous,
-      seenExisting: new Set(),
       resumed: undefined,
       trackCreates: false,
     }
@@ -693,7 +775,7 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
 
       let effectiveInit = requestInitWithSessionHint(input, init, liveHint)
       // Stored channels may be stale, so retry once after evicting the resumed entry.
-      let canRetryResumed = !previous.channel?.opened
+      let canRetryResumed = !previous.runtime.channel?.opened
 
       async function retryWithoutResumed(): Promise<boolean> {
         const resumed = use.resumed
@@ -709,8 +791,7 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
         try {
           response = await wrappedFetch(input, effectiveInit)
         } catch (error) {
-          if (use.created.size) await rollbackCreatedChannels()
-          else await restoreRuntime(use.committed ?? previous)
+          await rollbackChannelChanges(true)
           if (await retryWithoutResumed()) continue
           throw error
         }
@@ -736,14 +817,19 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
             paymentResponse = toPaymentResponse(retry)
           }
         }
-        if (!attemptedHttpManagement && !paymentResponse.ok && !paymentResponse.receipt) {
-          if (use.created.size) await rollbackCreatedChannels()
-          else await restoreRuntime(use.committed ?? previous)
-          if (await retryWithoutResumed()) continue
+        if (!paymentResponse.ok && !paymentResponse.receipt) {
+          await rollbackChannelChanges()
+          if (!attemptedHttpManagement && (await retryWithoutResumed())) {
+            runtime.lastUrl = input
+            continue
+          }
           return paymentResponse
         }
         return paymentResponse
       }
+    } catch (error) {
+      await rollbackChannelChanges()
+      throw error
     } finally {
       channelUse = undefined
     }


### PR DESCRIPTION
Follow-up to #701.

Treat each `sessionManager.fetch` as one transaction over every channel and manager field it touches:

- journal channel entries by payment scope, committing only successful top-ups or validated signed server snapshots
- roll back all unacknowledged channel mutations plus runtime challenge, accounting, and close-target state
- hydrate snapshot acknowledgements from signed accepted state, using `requiredCumulative` only to size the next voucher

This fixes cross-scope failures leaving another durable channel advanced and snapshot-acknowledged vouchers restoring pre-snapshot spend, units, and challenge state.

## Validation

- 47 SessionManager tests
- 117 Session, Runtime, and Transport tests
- 40 Fetch retry-path tests
- `pnpm check:ci`
- `pnpm check:types`