### PR TITLE
fix(tempo): refresh websocket session challenges

### DIFF
--- a/.changeset/fresh-websocket-vouchers.md
+++ b/.changeset/fresh-websocket-vouchers.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Refreshed expired session challenges before creating later WebSocket vouchers.

--- a/src/tempo/session/client/SessionManager.ts
+++ b/src/tempo/session/client/SessionManager.ts
@@ -58,6 +58,7 @@ import { applyTopUpResult, resolveManualTopUp, type TopUpRequirement } from './T
 import {
   openWebSocketSession,
   prepareWebSocketSession,
+  probeWebSocketSession,
   type WebSocketDriverOptions,
 } from './Transports.js'
 
@@ -868,6 +869,20 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
         getChannel: () => runtime.channel,
         setSocketSession(session) {
           runtime.socketSession = session
+        },
+        async refreshChallenge() {
+          const refreshed = await probeWebSocketSession({
+            fetch: config.fetch,
+            input: httpUrl,
+            probeInit: requestInitWithSessionHint(
+              httpUrl,
+              signalInit,
+              runtime.channel?.opened ? runtime.channel.channelId : undefined,
+            ),
+            signal: init?.signal,
+          })
+          runtime.lastChallenge = refreshed.challenge
+          return refreshed.challenge
         },
         assertVoucherWithinLocalLimit,
         acceptReceipt: updateSpentFromReceipt,

--- a/src/tempo/session/client/Transports.ts
+++ b/src/tempo/session/client/Transports.ts
@@ -47,6 +47,8 @@ export const WebSocketReadyState = {
 /** Client-side close code used for payment protocol errors. */
 export const ClientWebSocketProtocolErrorCloseCode = 3008
 
+const webSocketChallengeRefreshWindowMs = 5_000
+
 type EventType = 'close' | 'error' | 'message' | 'open'
 type ManagedEventMap = {
   close: { code: number; reason: string; type: 'close'; wasClean: boolean }
@@ -1117,6 +1119,15 @@ export type PrepareWebSocketSessionParameters = {
   signal?: AbortSignal | undefined
 }
 
+/** Inputs for probing a paid WebSocket endpoint without creating a credential. */
+export type ProbeWebSocketSessionParameters = Omit<
+  PrepareWebSocketSessionParameters,
+  'createSessionCredential'
+>
+
+/** Result of resolving the current payment challenge for a WebSocket endpoint. */
+export type ProbedWebSocketSession = Omit<PreparedWebSocketSession, 'credential'>
+
 /** Result of the HTTP probe and opening credential creation for a WebSocket session. */
 export type PreparedWebSocketSession = {
   /** Selected tempo/session challenge from the HTTP probe. */
@@ -1180,6 +1191,8 @@ export type OpenWebSocketSessionParameters = {
   getChannel(): ChannelEntry | null
   /** Stores the active socket state in the manager. */
   setSocketSession(session: ActiveSocketSession): void
+  /** Fetches the route's current challenge after the active one expires. */
+  refreshChallenge(): Promise<TempoSessionChallenge>
   /** Validates a cumulative amount against local client policy. */
   assertVoucherWithinLocalLimit(cumulativeAmount: bigint): void
   /** Applies an incoming receipt to manager state. */
@@ -1220,10 +1233,10 @@ export type ValidateSocketPaymentReceiptParameters = ExpectedSocketReceiptParame
   expectedCloseAmount: string | null
 }
 
-/** Probes a WebSocket endpoint over HTTP and creates the opening credential. */
-export async function prepareWebSocketSession(
-  parameters: PrepareWebSocketSessionParameters,
-): Promise<PreparedWebSocketSession> {
+/** Probes a WebSocket endpoint over HTTP and returns its current session challenge. */
+export async function probeWebSocketSession(
+  parameters: ProbeWebSocketSessionParameters,
+): Promise<ProbedWebSocketSession> {
   const wsUrl = new URL(parameters.input.toString())
   const httpUrl = webSocketProbeUrl(wsUrl)
   parameters.onProbeUrl?.(httpUrl)
@@ -1246,9 +1259,19 @@ export async function prepareWebSocketSession(
 
   return {
     challenge,
-    credential: await parameters.createSessionCredential(challenge, {}),
     httpUrl,
     wsUrl,
+  }
+}
+
+/** Probes a WebSocket endpoint over HTTP and creates the opening credential. */
+export async function prepareWebSocketSession(
+  parameters: PrepareWebSocketSessionParameters,
+): Promise<PreparedWebSocketSession> {
+  const probed = await probeWebSocketSession(parameters)
+  return {
+    ...probed,
+    credential: await parameters.createSessionCredential(probed.challenge, {}),
   }
 }
 
@@ -1459,9 +1482,18 @@ async function handleNeedVoucher(
   event: NeedVoucherEvent,
 ) {
   try {
+    let challenge = parameters.driver.challenge
+    if (
+      challenge.expires &&
+      new Date(challenge.expires).getTime() <= Date.now() + webSocketChallengeRefreshWindowMs
+    ) {
+      challenge = await parameters.driver.refreshChallenge()
+      parameters.driver.challenge = challenge
+      parameters.socketState.challenge = challenge
+    }
     const resolution = await resolveNeedVoucherContext({
       assertVoucherWithinLocalLimit: parameters.driver.assertVoucherWithinLocalLimit,
-      challenge: parameters.driver.challenge,
+      challenge,
       event,
       expectedChannelId: parameters.socketState.channelId,
       getChannel: parameters.driver.getChannel,
@@ -1476,10 +1508,7 @@ async function handleNeedVoucher(
       )
       return
     }
-    const voucher = await parameters.driver.createSessionCredential(
-      parameters.driver.challenge,
-      resolution.context,
-    )
+    const voucher = await parameters.driver.createSessionCredential(challenge, resolution.context)
     parameters.rawSocket.send(Ws.formatAuthorizationMessage(voucher))
   } catch (error) {
     parameters.failSocketFlow(

--- a/src/tempo/session/server/Session.test.ts
+++ b/src/tempo/session/server/Session.test.ts
@@ -2421,12 +2421,15 @@ describe('precompile server session unit guardrails', () => {
   })
 
   describe('WebSocket parity', () => {
-    async function createManagedWsHarness(options: { maxDeposit?: bigint } = {}) {
+    async function createManagedWsHarness(
+      options: { challengeTtlMs?: number; maxDeposit?: bigint } = {},
+    ) {
       const rawStore = Store.memory()
+      let challengeRequests = 0
       let currentPayload: SessionCredentialPayload | undefined
       let voucherPosts = 0
       const maxDeposit = options.maxDeposit ?? 3n
-      const routeHandler = Mppx_server.create({
+      const payment = Mppx_server.create({
         methods: [
           tempo_server.session({
             amount: '1',
@@ -2463,7 +2466,7 @@ describe('precompile server session unit guardrails', () => {
         ],
         realm: 'api.example.com',
         secretKey: 'test-secret-key-test-secret-key-32',
-      }).session({ amount: '1', decimals: 0, suggestedDeposit: maxDeposit.toString() })
+      })
 
       const route = async (request: Request) => {
         currentPayload = undefined
@@ -2472,7 +2475,15 @@ describe('precompile server session unit guardrails', () => {
             currentPayload = Credential.fromRequest<SessionCredentialPayload>(request).payload
             if (currentPayload.action === 'voucher') voucherPosts++
           } catch {}
-        }
+        } else challengeRequests++
+        const routeHandler = payment.session({
+          amount: '1',
+          decimals: 0,
+          suggestedDeposit: maxDeposit.toString(),
+          ...(options.challengeTtlMs === undefined
+            ? {}
+            : { expires: new Date(Date.now() + options.challengeTtlMs) }),
+        })
         return routeHandler(request)
       }
 
@@ -2510,6 +2521,9 @@ describe('precompile server session unit guardrails', () => {
         get port() {
           return port
         },
+        get challengeRequests() {
+          return challengeRequests
+        },
         get voucherPosts() {
           return voucherPosts
         },
@@ -2519,6 +2533,54 @@ describe('precompile server session unit guardrails', () => {
         },
       }
     }
+
+    test('refreshes an expired challenge before sending a later websocket voucher', async () => {
+      const harness = await createManagedWsHarness({ challengeTtlMs: 2_000, maxDeposit: 2n })
+      harness.wsServer.on('connection', (socket: import('ws').WebSocket) => {
+        void TempoWs.serve({
+          socket,
+          store: harness.rawStore,
+          url: `${harness.server.url}/ws`,
+          route: harness.route,
+          generate: async function* (stream: TempoWs.SessionController) {
+            await stream.charge()
+            yield 'chunk-1'
+            await new Promise((resolve) => setTimeout(resolve, 2_200))
+            await stream.charge()
+            yield 'chunk-2'
+          },
+        })
+      })
+
+      try {
+        const manager = precompileSessionManager({
+          account: payer,
+          client: createSigningClient(),
+          decimals: 0,
+          fetch: globalThis.fetch,
+          maxDeposit: '2',
+          webSocket: WebSocket as never,
+        })
+        const ws = await manager.ws(`ws://localhost:${harness.port}/ws`)
+        const chunks: string[] = []
+
+        await new Promise<void>((resolve, reject) => {
+          ws.addEventListener('message', (event) => {
+            if (typeof event.data === 'string') chunks.push(event.data)
+          })
+          ws.addEventListener('close', () => resolve(), { once: true })
+          ws.addEventListener('error', () => reject(new Error('websocket stream failed')), {
+            once: true,
+          })
+        })
+
+        expect(chunks).toEqual(['chunk-1', 'chunk-2'])
+        expect(harness.challengeRequests).toBeGreaterThan(1)
+        expect(harness.voucherPosts).toBe(1)
+      } finally {
+        harness.close()
+      }
+    })
 
     test('open -> stream -> need-voucher -> resume -> close', async () => {
       const harness = await createManagedWsHarness({ maxDeposit: 3n })

--- a/src/tempo/session/server/Ws.ts
+++ b/src/tempo/session/server/Ws.ts
@@ -220,6 +220,9 @@ export async function serve(options: serve.Options): Promise<void> {
     }
 
     const { receipt } = authorizationResult
+    if (payload.action === 'voucher' && runtime.streamContext) {
+      runtime.streamContext.challengeId = credential.challenge.id
+    }
     await send(socket, formatReceiptMessage(receipt))
 
     if (payload.action === 'close') {


### PR DESCRIPTION
Long-lived Tempo session WebSockets reuse the opening challenge for later vouchers. Once the default five-minute challenge expires, an otherwise healthy socket is rejected with `payment-expired`.

This change:
- re-probes the HTTP payment route when the active WebSocket challenge is expired or within five seconds of expiry
- creates later vouchers against the fresh challenge
- rotates client receipt validation and server close-ready bookkeeping to the fresh challenge ID while keeping the same socket/channel

Regression evidence:
- latest-main negative control: opening succeeds, the stream idles past the challenge lifetime, and the later voucher never resumes
- patched test: the same socket re-probes, sends one voucher, and delivers both chunks
- 183 focused client/server session and WebSocket tests pass
- `pnpm check:ci` and `pnpm check:types` pass

Found by a real 25-minute Nanocodex/OpenAI MPP WebSocket stress run, which ended with a terminal `payment-expired` response after its Code Mode phase.