### PR TITLE
fix: make mppx validate exercise real testnet payments reliably

### DIFF
--- a/.changeset/bump-postcss-tar-cves.md
+++ b/.changeset/bump-postcss-tar-cves.md
@@ -1,0 +1,7 @@
+---
+'mppx': patch
+---
+
+Bumped `postcss` (via `vite`/`vite-plus`) and `tar` (via `prool`) to patched
+versions, resolving a path-traversal advisory in `postcss`'s source map
+loading and a stack-overflow DoS advisory in `tar`'s path filtering.

--- a/.changeset/fix-validate-testnet-payments.md
+++ b/.changeset/fix-validate-testnet-payments.md
@@ -1,0 +1,8 @@
+---
+'mppx': patch
+---
+
+Fixed `mppx validate` intermittently reporting a false `InsufficientBalance`
+error when paying with an ephemeral Tempo testnet wallet, mislabeling
+resolved chains in payment errors, and skipping other payment methods after
+a Tempo testnet challenge succeeded.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,8 @@ overrides:
   ox: 0.14.29
   viem: https://pkg.pr.new/viem@4880
   path-to-regexp@<8.4.0: 8.4.0
-  tar@<=7.5.18: 7.5.19
+  tar@<=7.5.20: 7.5.21
+  postcss@<=8.5.17: 8.5.18
   '@modelcontextprotocol/sdk@>=1.10.0 <=1.25.3': 1.26.0
   '@modelcontextprotocol/server': 2.0.0-alpha.2
   qs@>=6.7.0 <=6.15.1: 6.15.2
@@ -3507,8 +3508,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.17:
-    resolution: {integrity: sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w==}
+  postcss@8.5.18:
+    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -3817,8 +3818,8 @@ packages:
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
 
-  tar@7.5.19:
-    resolution: {integrity: sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==}
+  tar@7.5.21:
+    resolution: {integrity: sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==}
     engines: {node: '>=18'}
 
   teex@1.0.1:
@@ -5431,7 +5432,7 @@ snapshots:
       '@oxc-project/runtime': 0.133.0
       '@oxc-project/types': 0.133.0
       lightningcss: 1.32.0
-      postcss: 8.5.17
+      postcss: 8.5.18
     optionalDependencies:
       '@types/node': 25.6.0
       esbuild: 0.28.1
@@ -6935,7 +6936,7 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.17:
+  postcss@8.5.18:
     dependencies:
       nanoid: 3.3.15
       picocolors: 1.1.1
@@ -6960,7 +6961,7 @@ snapshots:
       execa: 9.6.1
       get-port: 7.2.0
       http-proxy: 1.18.1
-      tar: 7.5.19
+      tar: 7.5.21
     optionalDependencies:
       testcontainers: 12.0.4
     transitivePeerDependencies:
@@ -7345,7 +7346,7 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
-  tar@7.5.19:
+  tar@7.5.21:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
@@ -7589,7 +7590,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
-      postcss: 8.5.17
+      postcss: 8.5.18
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -7603,7 +7604,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
-      postcss: 8.5.17
+      postcss: 8.5.18
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -7617,7 +7618,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
-      postcss: 8.5.17
+      postcss: 8.5.18
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -7631,7 +7632,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
-      postcss: 8.5.17
+      postcss: 8.5.18
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,7 +16,8 @@ overrides:
   ox: '0.14.29'
   viem: 'https://pkg.pr.new/viem@4880'
   path-to-regexp@<8.4.0: '8.4.0'
-  tar@<=7.5.18: '7.5.19'
+  tar@<=7.5.20: '7.5.21'
+  postcss@<=8.5.17: '8.5.18'
   '@modelcontextprotocol/sdk@>=1.10.0 <=1.25.3': '1.26.0'
   '@modelcontextprotocol/server': '2.0.0-alpha.2'
   qs@>=6.7.0 <=6.15.1: '6.15.2'
@@ -68,8 +69,9 @@ minimumReleaseAgeExclude:
   - hono@4.12.27
   - js-yaml@4.3.0
   - ox@0.14.29
+  - postcss@8.5.18
   - protobufjs@7.6.5
-  - tar@7.5.19
+  - tar@7.5.21
   - tmp@0.2.7
   - viem@2.54.1
   - vite@8.0.16

--- a/src/cli/validate.test.ts
+++ b/src/cli/validate.test.ts
@@ -707,6 +707,22 @@ describe('validate: multi-challenge', () => {
     const { output } = await serve(['validate', server.url])
     expect(output).toContain('Amount is valid integer string (Got: 1.50)')
   })
+
+  test("tempo doesn't block other testnet methods", { timeout: 15_000 }, async () => {
+    // makeChallenge() defaults to a tempo testnet challenge (chainId 42431),
+    // which takes the ephemeral-wallet fast path. That path used to return
+    // immediately, so a server offering evm/stripe alongside tempo would
+    // never have those methods exercised. It should now fall through and
+    // try them too, same as it does for tempo mainnet challenges.
+    const server = await multiChallengeServer([makeChallenge(), makeEvmChallenge()])
+    const { output } = await serve(['validate', server.url, '--outputJson', '--yes'])
+    const jsonStart = output.indexOf('{')
+    const jsonEnd = output.lastIndexOf('}')
+    const result = JSON.parse(output.slice(jsonStart, jsonEnd + 1))
+    const paymentLabels = result.endpoints[0].payment.map((r: { label: string }) => r.label)
+    expect(paymentLabels).toContain('Payment: submitted')
+    expect(paymentLabels.some((l: string) => l.includes('[evm]'))).toBe(true)
+  })
 })
 
 describe('validate: payment methods coverage', () => {

--- a/src/cli/validate/payment.ts
+++ b/src/cli/validate/payment.ts
@@ -46,6 +46,20 @@ async function provisionAndPayTestnet(
     await Promise.all(hashes.map((hash) => waitForTransactionReceipt(client, { hash })))
     if (!silent) console.log(pc.dim(`    Using wallet: ${account.address}`))
 
+    // The faucet tx receipt can land before the RPC's balance reads are
+    // consistent with it, so poll briefly for the funded balance to appear
+    // rather than racing straight into the charge.
+    const currency = (challenge.request as Record<string, unknown>).currency
+    if (typeof currency === 'string') {
+      for (let attempt = 0; attempt < 10; attempt++) {
+        const balance = await Actions.token
+          .getBalance(client, { account: account.address, token: currency as Address })
+          .catch(() => undefined)
+        if (balance && balance.amount > 0n) break
+        await new Promise((resolve) => setTimeout(resolve, 500))
+      }
+    }
+
     const methods = [...tempoMethods({ account })]
     return { methods }
   } catch (error) {
@@ -198,7 +212,7 @@ export async function validatePaymentFlow(
         const mppx = Mppx.create({ methods: provisioned.methods, polyfill: false })
         const cred = await mppx.createCredential(fakeResp)
         results.push(check('Payment: submitted', 'ephemeral testnet wallet'))
-        return await sendAndValidateResponse(
+        await sendAndValidateResponse(
           results,
           url,
           endpoint,
@@ -210,17 +224,17 @@ export async function validatePaymentFlow(
         )
       } catch (error) {
         results.push(fail('Payment: create credential', (error as Error).message))
-        return results
       }
     } else {
       results.push(
         fail('Payment: auto-provision wallet', 'Failed to create and fund testnet wallet'),
       )
-      return results
     }
+    options.onResults?.(results)
   }
 
-  // Try each challenge method (skip testnet challenge already handled above)
+  // Try each remaining challenge method (tempo testnet already handled above),
+  // so validate exercises every payment method the server offers, same as mainnet.
   const loaded = await loadConfig().catch(() => undefined)
   const isInteractive = options.interactive
   const stripeKey = process.env.MPPX_STRIPE_SECRET_KEY ?? resolveStripeKey(verbose)

--- a/src/viem/Client.test.ts
+++ b/src/viem/Client.test.ts
@@ -2,7 +2,7 @@ import { createClient, custom, defineChain, type Hex } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { signTransaction } from 'viem/actions'
 import { Account as TempoAccount, Transaction } from 'viem/tempo'
-import { tempoLocalnet } from 'viem/tempo/chains'
+import { tempo as tempoMainnetChain, tempoLocalnet, tempoModerato } from 'viem/tempo/chains'
 import { afterEach, describe, expect, test, vi } from 'vp/test'
 
 import * as Client from './Client.js'
@@ -46,6 +46,23 @@ describe('getResolver', () => {
 
     expect(client.chain?.id).toBe(99)
     expect(client.chain?.name).toBe('test')
+  })
+
+  test('behavior: resolves the correct named Tempo chain even when the default chain differs', async () => {
+    const getClient = Client.getResolver({
+      // Default chain is mainnet, but the resolved chain ID below is testnet.
+      chain: tempoMainnetChain as never,
+      rpcUrl: {
+        [tempoMainnetChain.id]: 'https://rpc.example.com',
+        [tempoModerato.id]: 'https://rpc2.example.com',
+      },
+    })
+
+    const client = await getClient({ chainId: tempoModerato.id })
+
+    expect(client.chain?.id).toBe(tempoModerato.id)
+    expect(client.chain?.name).toBe(tempoModerato.name)
+    expect(client.chain?.name).not.toBe(tempoMainnetChain.name)
   })
 
   test('error: throws when no rpcUrl provided', () => {

--- a/src/viem/Client.ts
+++ b/src/viem/Client.ts
@@ -1,7 +1,13 @@
 import { type Chain, type Client, createClient, createTransport, custom, http } from 'viem'
 import { withFeePayer } from 'viem/tempo'
+import { tempo as tempoMainnetChain, tempoModerato } from 'viem/tempo/chains'
 
 import type { MaybePromise } from '../internal/types.js'
+
+const knownTempoChains: Record<number, Chain> = {
+  [tempoMainnetChain.id]: tempoMainnetChain,
+  [tempoModerato.id]: tempoModerato,
+}
 
 export function getResolver(
   parameters: getResolver.Parameters & {
@@ -73,7 +79,7 @@ export function getResolver(
     if (!url) throw new Error(`No \`rpcUrl\` configured for \`chainId\` (${resolvedChainId}).`)
     const transport = feePayerUrl ? withFeePayer(http(url), http(feePayerUrl)) : http(url)
     return createClient({
-      chain: { ...chain, id: resolvedChainId } as never,
+      chain: (knownTempoChains[resolvedChainId] ?? { ...chain, id: resolvedChainId }) as never,
       transport,
     })
   }


### PR DESCRIPTION
Fixes three bugs found while running mppx validate end-to-end against a tempo testnet server:

- provisionAndPayTestnet raced the faucet funding tx against the charge: waitForTransactionReceipt confirms inclusion, but the RPC's balance reads can lag behind for ~1s, causing spurious InsufficientBalance errors. Now polls for the funded balance before attempting the charge.
- Client.ts's getResolver mislabeled resolved chains (e.g. "Tempo Mainnet" with a testnet chain id) by spreading the default chain object and only overriding `id`. Now looks up the correct named chain by resolved id.
- The ephemeral testnet payment path returned before the loop that tries additional challenge methods, so only tempo was ever exercised on testnet servers offering multiple methods (evm, stripe, etc). It now falls through to that loop, matching mainnet behavior.