### PR TITLE
fix: bump postcss and tar to patched versions

### DIFF
--- a/.changeset/bump-postcss-tar-cves.md
+++ b/.changeset/bump-postcss-tar-cves.md
@@ -1,0 +1,7 @@
+---
+'mppx': patch
+---
+
+Bumped `postcss` (via `vite`/`vite-plus`) and `tar` (via `prool`) to patched
+versions, resolving a path-traversal advisory in `postcss`'s source map
+loading and a stack-overflow DoS advisory in `tar`'s path filtering.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,8 @@ overrides:
   ox: 0.14.29
   viem: https://pkg.pr.new/viem@4880
   path-to-regexp@<8.4.0: 8.4.0
-  tar@<=7.5.18: 7.5.19
+  tar@<=7.5.20: 7.5.21
+  postcss@<=8.5.17: 8.5.18
   '@modelcontextprotocol/sdk@>=1.10.0 <=1.25.3': 1.26.0
   '@modelcontextprotocol/server': 2.0.0-alpha.2
   qs@>=6.7.0 <=6.15.1: 6.15.2
@@ -3507,8 +3508,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.17:
-    resolution: {integrity: sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w==}
+  postcss@8.5.18:
+    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -3817,8 +3818,8 @@ packages:
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
 
-  tar@7.5.19:
-    resolution: {integrity: sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==}
+  tar@7.5.21:
+    resolution: {integrity: sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==}
     engines: {node: '>=18'}
 
   teex@1.0.1:
@@ -5431,7 +5432,7 @@ snapshots:
       '@oxc-project/runtime': 0.133.0
       '@oxc-project/types': 0.133.0
       lightningcss: 1.32.0
-      postcss: 8.5.17
+      postcss: 8.5.18
     optionalDependencies:
       '@types/node': 25.6.0
       esbuild: 0.28.1
@@ -6935,7 +6936,7 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.17:
+  postcss@8.5.18:
     dependencies:
       nanoid: 3.3.15
       picocolors: 1.1.1
@@ -6960,7 +6961,7 @@ snapshots:
       execa: 9.6.1
       get-port: 7.2.0
       http-proxy: 1.18.1
-      tar: 7.5.19
+      tar: 7.5.21
     optionalDependencies:
       testcontainers: 12.0.4
     transitivePeerDependencies:
@@ -7345,7 +7346,7 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
-  tar@7.5.19:
+  tar@7.5.21:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
@@ -7589,7 +7590,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
-      postcss: 8.5.17
+      postcss: 8.5.18
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -7603,7 +7604,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
-      postcss: 8.5.17
+      postcss: 8.5.18
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -7617,7 +7618,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
-      postcss: 8.5.17
+      postcss: 8.5.18
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -7631,7 +7632,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
-      postcss: 8.5.17
+      postcss: 8.5.18
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,7 +16,8 @@ overrides:
   ox: '0.14.29'
   viem: 'https://pkg.pr.new/viem@4880'
   path-to-regexp@<8.4.0: '8.4.0'
-  tar@<=7.5.18: '7.5.19'
+  tar@<=7.5.20: '7.5.21'
+  postcss@<=8.5.17: '8.5.18'
   '@modelcontextprotocol/sdk@>=1.10.0 <=1.25.3': '1.26.0'
   '@modelcontextprotocol/server': '2.0.0-alpha.2'
   qs@>=6.7.0 <=6.15.1: '6.15.2'
@@ -68,8 +69,9 @@ minimumReleaseAgeExclude:
   - hono@4.12.27
   - js-yaml@4.3.0
   - ox@0.14.29
+  - postcss@8.5.18
   - protobufjs@7.6.5
-  - tar@7.5.19
+  - tar@7.5.21
   - tmp@0.2.7
   - viem@2.54.1
   - vite@8.0.16


### PR DESCRIPTION
CI's dependency audit was failing on two known advisories in transitive deps: postcss and tar. The existing tar override was pinned to 7.5.19, itself a vulnerable version. Bumped overrides to postcss 8.5.18 and tar 7.5.21.

This should help resolve CI failures on [my other PR](https://github.com/wevm/mppx/pull/711) (which I'll land after this).