### PR TITLE
DNM: Example B: stripe() returns Mppx instance directly

### DIFF
--- a/src/stripe/server/Methods.ts
+++ b/src/stripe/server/Methods.ts
@@ -1,24 +1,196 @@
+import crypto from 'node:crypto'
+import type * as Method from '../../Method.js'
+import * as Mppx from '../../server/Mppx.js'
+import * as tempoDefaults from '../../tempo/internal/defaults.js'
+import { charge as tempoCharge } from '../../tempo/server/Charge.js'
+import { charge as evmCharge } from '../../evm/server/Charge.js'
+import * as EvmAssets from '../../evm/Assets.js'
 import { charge as charge_ } from './Charge.js'
+import { resolveDepositAddress } from './internal/deposit-address.js'
+import { recordCryptoPayment } from './internal/record-payment.js'
+
+type TempoNetworkEntry = {
+  network: 'tempo'
+} & Partial<Omit<Parameters<typeof tempoCharge>[0], 'currency' | 'recipient'>>
+
+type BaseNetworkEntry = {
+  network: 'base'
+} & Omit<Parameters<typeof evmCharge>[0], 'currency' | 'recipient'>
+
+type CustomNetworkEntry = {
+  network: string
+  configure: (address: string) => Method.AnyServer | readonly Method.AnyServer[]
+}
+
+type AdditionalNetworkEntry = TempoNetworkEntry | BaseNetworkEntry | CustomNetworkEntry
 
 /**
- * Creates a Stripe `charge` method for usage on the server.
+ * Creates a fully configured Mppx server with all Stripe-supported payment methods.
+ *
+ * Opinionated: always enables Tempo crypto and SPT (card/link) payments.
+ * Pass `additional` to enable more crypto networks (e.g. Base, Solana).
+ *
+ * Crypto payments are automatically recorded as Stripe PaymentIntents
+ * via transaction verification for unified accounting in the Stripe Dashboard.
  *
  * @example
  * ```ts
- * import { Mppx, stripe } from 'mppx/server'
+ * import { stripe } from 'mppx/server'
  *
- * const mppx = Mppx.create({
- *   methods: [stripe({ secretKey: 'sk_...' })],
+ * const mppx = await stripe({
+ *   secretKey: process.env.STRIPE_SECRET_KEY!,
+ *   profileId: process.env.STRIPE_PROFILE_ID!,
+ * })
+ *
+ * export async function POST(request: Request) {
+ *   const result = await mppx.compose(
+ *     ['tempo/charge', { amount: '0.01', description: 'API call' }],
+ *     ['stripe/charge', { amount: '0.50', currency: 'usd', decimals: 2, description: 'API call' }],
+ *   )(request)
+ *   if (result.status === 402) return result.challenge
+ *   return result.withReceipt(Response.json({ data: '...' }))
+ * }
+ * ```
+ *
+ * @example
+ * ```ts
+ * import { stripe } from 'mppx/server'
+ * import { solana } from '@solana/mpp/server'
+ *
+ * const mppx = await stripe({
+ *   secretKey: 'sk_...',
+ *   profileId: '...',
+ *   additional: [
+ *     { network: 'base', x402: { facilitator } },
+ *     { network: 'solana', configure: (address) => solana.charge({ recipient: address, currency: USDC, decimals: 6 }) },
+ *   ],
  * })
  * ```
  */
-export function stripe<const parameters extends stripe.Parameters>(parameters: parameters) {
-  return [stripe.charge(parameters)] as const
+export async function stripe(parameters: stripe.Parameters) {
+  const { secretKey, profileId, paymentMethodTypes, realm } = parameters
+  const isTestMode = secretKey.includes('_test_')
+
+  const mppSecretKey = parameters.mppSecretKey
+    ?? crypto.createHmac('sha256', secretKey).update('mpp-challenge-signing').digest('base64')
+
+  // Resolve tempo deposit address (required)
+  const tempoAddress = await resolveDepositAddress(secretKey, 'tempo')
+  if (!tempoAddress) {
+    throw new Error(
+      'stripe(): failed to resolve Tempo deposit address. Ensure your Stripe account has crypto enabled.',
+    )
+  }
+
+  // Create tempo method (always on)
+  const tempoMethod = tempoCharge({
+    currency: (isTestMode
+      ? tempoDefaults.tokens.pathUsd
+      : tempoDefaults.tokens.usdc) as `0x${string}`,
+    recipient: tempoAddress as `0x${string}`,
+    ...(isTestMode && { testnet: true }),
+  })
+
+  // Create SPT method (always on)
+  const sptMethod = stripe.spt({
+    secretKey,
+    networkId: profileId,
+    paymentMethodTypes: paymentMethodTypes ?? ['card', 'link'],
+  })
+
+  // Resolve additional networks (best-effort)
+  const additional = await resolveAdditionalNetworks(secretKey, isTestMode, parameters.additional)
+
+  const methods = [tempoMethod, sptMethod, ...additional] as const
+  const mppx = Mppx.create({ methods, secretKey: mppSecretKey, realm })
+
+  // Record crypto payments as Stripe PaymentIntents via transaction verification
+  mppx.onPaymentSuccess(({ receipt, request }) => {
+    const amount = request?.amount
+    if (receipt.reference && amount) {
+      recordCryptoPayment({
+        secretKey,
+        method: receipt.method,
+        reference: receipt.reference,
+        amount: String(amount),
+      })
+    }
+  })
+
+  return mppx
+}
+
+export declare namespace stripe {
+  type Parameters = {
+    /** Stripe secret API key. */
+    secretKey: string
+    /** Stripe business network profile ID. */
+    profileId: string
+    /** Payment method types for SPT-based payments. @default ['card', 'link'] */
+    paymentMethodTypes?: string[] | undefined
+    /**
+     * Additional crypto networks to enable beyond the defaults.
+     * Entries with the same network name as a built-in override its config.
+     */
+    additional?: AdditionalNetworkEntry[] | undefined
+    /** MPP secret key for challenge signing. Derived from Stripe key if not provided. */
+    mppSecretKey?: string | undefined
+    /** Server realm (e.g. hostname). Auto-detected if not set. */
+    realm?: string | undefined
+  }
 }
 
 export namespace stripe {
-  export type Parameters = charge_.Parameters
+  /** Creates a Stripe SPT charge method for card/link payments. */
+  export const spt = charge_
 
-  /** Creates a Stripe `charge` method for SPT-based payments. */
+  /** @deprecated Use `stripe.spt()` instead. */
   export const charge = charge_
 }
+
+async function resolveAdditionalNetworks(
+  secretKey: string,
+  isTestMode: boolean,
+  additional: AdditionalNetworkEntry[] | undefined,
+): Promise<Method.AnyServer[]> {
+  if (!additional || additional.length === 0) return []
+
+  const methods: Method.AnyServer[] = []
+
+  const resolved = await Promise.all(
+    additional
+      .filter((entry) => entry.network !== 'tempo')
+      .map(async (entry) => ({
+        entry,
+        address: await resolveDepositAddress(secretKey, entry.network),
+      })),
+  )
+
+  for (const { entry, address } of resolved) {
+    if (!address) continue
+
+    let methodOrMethods: Method.AnyServer | readonly Method.AnyServer[]
+
+    if ('configure' in entry) {
+      methodOrMethods = entry.configure(address)
+    } else if (entry.network === 'base') {
+      const { network: _, ...config } = entry
+      methodOrMethods = evmCharge({
+        currency: isTestMode ? EvmAssets.baseSepolia.USDC : EvmAssets.base.USDC,
+        recipient: address as `0x${string}`,
+        ...config,
+      })
+    } else {
+      continue
+    }
+
+    if (Array.isArray(methodOrMethods)) {
+      methods.push(...(methodOrMethods as readonly Method.AnyServer[]))
+    } else {
+      methods.push(methodOrMethods as Method.AnyServer)
+    }
+  }
+
+  return methods
+}
+

--- a/src/stripe/server/internal/deposit-address.ts
+++ b/src/stripe/server/internal/deposit-address.ts
@@ -1,0 +1,39 @@
+import { stripePreviewVersion } from '../../internal/constants.js'
+
+/**
+ * Resolves a deposit address for a given network from the Stripe API.
+ * Fetches an existing address or creates a new one if none exist.
+ */
+export async function resolveDepositAddress(
+  secretKey: string,
+  network: string,
+): Promise<string | null> {
+  const headers = {
+    Authorization: `Basic ${btoa(`${secretKey}:`)}`,
+    'Content-Type': 'application/x-www-form-urlencoded',
+    'Stripe-Version': stripePreviewVersion,
+  }
+
+  try {
+    const listResponse = await fetch(
+      `https://api.stripe.com/v1/crypto/deposit_addresses?network=${network}&limit=1`,
+      { headers },
+    )
+    if (listResponse.ok) {
+      const list = (await listResponse.json()) as { data?: { address: string }[] }
+      if (list.data && list.data.length > 0) return list.data[0]!.address
+    }
+
+    const createResponse = await fetch('https://api.stripe.com/v1/crypto/deposit_addresses', {
+      method: 'POST',
+      headers,
+      body: new URLSearchParams({ network }),
+    })
+    if (!createResponse.ok) return null
+
+    const created = (await createResponse.json()) as { address: string }
+    return created.address
+  } catch {
+    return null
+  }
+}

--- a/src/stripe/server/internal/record-payment.ts
+++ b/src/stripe/server/internal/record-payment.ts
@@ -1,0 +1,48 @@
+import { stripePreviewVersion } from '../../internal/constants.js'
+
+const SUPPORTED_NETWORKS: Record<string, string> = {
+  tempo: 'tempo',
+  evm: 'base',
+}
+
+/**
+ * Records a crypto payment as a Stripe PaymentIntent using transaction_verification mode.
+ * Fire-and-forget: errors are logged but never thrown.
+ */
+export function recordCryptoPayment(parameters: {
+  secretKey: string
+  method: string
+  reference: string
+  amount: string
+}): void {
+  const { secretKey, method, reference, amount } = parameters
+  const network = SUPPORTED_NETWORKS[method]
+  if (!network) return
+
+  const amountCents = Math.round(parseFloat(amount) * 100)
+  if (amountCents < 1) return
+
+  const body = new URLSearchParams({
+    amount: String(amountCents),
+    currency: 'usd',
+    confirm: 'true',
+    'payment_method_data[type]': 'crypto',
+    'payment_method_types[0]': 'crypto',
+    'payment_method_options[crypto][mode]': 'transaction_verification',
+    'payment_method_options[crypto][transaction_verification_options][network]': network,
+    'payment_method_options[crypto][transaction_verification_options][transaction_hash]': reference,
+  })
+
+  fetch('https://api.stripe.com/v1/payment_intents', {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${btoa(`${secretKey}:`)}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Idempotency-Key': reference,
+      'Stripe-Version': stripePreviewVersion,
+    },
+    body,
+  }).catch((err) => {
+    console.error('[stripe] failed to record crypto payment:', err)
+  })
+}


### PR DESCRIPTION
Alternative to Option A where stripe() returns a fully configured Mppx server instance instead of a methods array. No Mppx.create step needed by the consumer.

- Always enables Tempo crypto and SPT (card/link) payments
- Resolves deposit addresses from the Stripe API automatically
- Wraps crypto verify to record payments as Stripe PaymentIntents
- Derives mppSecretKey from Stripe key if not provided
- Returns typed Mppx instance so compose works without casts
- Supports additional networks via `additional` array

Usage:
  const mppx = await stripe({ secretKey: 'sk_...', profileId: '...' }) await mppx.compose(['tempo/charge', {...}], ['stripe/charge', {...}])(req)