### PR TITLE
refactor: standardize transport challenge extraction

### DIFF
--- a/.changeset/standardize-get-challenges.md
+++ b/.changeset/standardize-get-challenges.md
@@ -1,0 +1,5 @@
+---
+'mppx': minor
+---
+
+Standardized client transports on `getChallenges` and removed the singular `getChallenge` hook.

--- a/src/client/Mppx.test-d.ts
+++ b/src/client/Mppx.test-d.ts
@@ -15,6 +15,19 @@ import { session, sessionManager, sessionMethod } from './Methods.js'
 import * as Mppx from './Mppx.js'
 import * as Transport from './Transport.js'
 
+describe('Transport', () => {
+  test('custom transports extract challenge collections', () => {
+    const transport = Transport.from({
+      name: 'custom',
+      isPaymentRequired: () => true,
+      getChallenges: () => [] as Challenge.Challenge[],
+      setCredential: (request: RequestInit) => request,
+    })
+
+    expectTypeOf(transport.getChallenges).toBeFunction()
+  })
+})
+
 describe('Mppx', () => {
   test('exports low-level session method and explicit managed session helper', () => {
     expectTypeOf(session({ account: {} as Account })).toMatchTypeOf<Method.AnyClient>()

--- a/src/client/Mppx.test-d.ts
+++ b/src/client/Mppx.test-d.ts
@@ -15,19 +15,6 @@ import { session, sessionManager, sessionMethod } from './Methods.js'
 import * as Mppx from './Mppx.js'
 import * as Transport from './Transport.js'
 
-describe('Transport', () => {
-  test('custom transports extract challenge collections', () => {
-    const transport = Transport.from({
-      name: 'custom',
-      isPaymentRequired: () => true,
-      getChallenges: () => [] as Challenge.Challenge[],
-      setCredential: (request: RequestInit) => request,
-    })
-
-    expectTypeOf(transport.getChallenges).toBeFunction()
-  })
-})
-
 describe('Mppx', () => {
   test('exports low-level session method and explicit managed session helper', () => {
     expectTypeOf(session({ account: {} as Account })).toMatchTypeOf<Method.AnyClient>()

--- a/src/client/Mppx.ts
+++ b/src/client/Mppx.ts
@@ -188,9 +188,7 @@ export function create<
       context?: unknown,
       options?: createCredential.Options<FlattenMethods<methods>>,
     ) {
-      const challenges = transport.getChallenges
-        ? await transport.getChallenges(response as never)
-        : [await transport.getChallenge(response as never)]
+      const challenges = await transport.getChallenges(response as never)
       const preferences = resolveChallengePreferences(acceptPayment.entries, options?.acceptPayment)
 
       let challenge: Challenge.Challenge | undefined

--- a/src/client/Transport.test.ts
+++ b/src/client/Transport.test.ts
@@ -77,38 +77,6 @@ describe('http', () => {
     })
   })
 
-  describe('getChallenge', () => {
-    test('default', () => {
-      const transport = Transport.http()
-      const response = new Response(null, {
-        status: 402,
-        headers: {
-          'WWW-Authenticate': Challenge.serialize(challenge),
-        },
-      })
-
-      expect(transport.getChallenge(response)).toMatchObject({
-        expires: '2025-01-01T00:00:00.000Z',
-        id: expect.any(String),
-        intent: 'charge',
-        method: 'tempo',
-        realm: 'api.example.com',
-        request: {
-          amount: '1000',
-          currency: '0x20c0000000000000000000000000000000000001',
-          recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00',
-        },
-      })
-    })
-
-    test('throws for non-402 response', () => {
-      const transport = Transport.http()
-      const response = new Response(null, { status: 200 })
-
-      expect(() => transport.getChallenge(response)).toThrow()
-    })
-  })
-
   describe('getChallenges', () => {
     test.each([
       {
@@ -188,7 +156,7 @@ describe('http', () => {
         status: 402,
         headers: headers(),
       })
-      const challenges = (await transport.getChallenges?.(response)) ?? []
+      const challenges = await transport.getChallenges(response)
 
       expect(challenges.map((entry) => entry.id)).toEqual(expectedIds)
       expect(challenges.map((entry) => entry.method)).toEqual(expectedMethods)
@@ -207,7 +175,7 @@ describe('http', () => {
         },
       })
 
-      const challenges = (await transport.getChallenges?.(response)) ?? []
+      const challenges = await transport.getChallenges(response)
 
       expect(challenges.map((entry) => entry.id)).toEqual([challenge.id])
       expect(challenges.map((entry) => entry.method)).toEqual(['tempo'])
@@ -225,9 +193,8 @@ describe('http', () => {
         },
       })
 
-      const challenges = (await transport.getChallenges?.(response)) ?? []
+      const challenges = await transport.getChallenges(response)
       expect(challenges).toEqual([])
-      expect(() => transport.getChallenge(response)).toThrow('No challenge in response.')
     })
   })
 
@@ -265,7 +232,7 @@ describe('http', () => {
 
     test('writes x402 credentials for x402 challenges from the same transport', () => {
       const transport = Transport.http()
-      const [x402Challenge] = transport.getChallenges!(
+      const [x402Challenge] = transport.getChallenges(
         new Response(null, {
           status: 402,
           headers: {
@@ -306,7 +273,7 @@ describe('http', () => {
         method: 'POST',
         body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: {} }),
       } satisfies RequestInit
-      const [nativeChallenge] = transport.getChallenges!(
+      const [nativeChallenge] = transport.getChallenges(
         new Response(null, {
           status: 402,
           headers: { 'WWW-Authenticate': Challenge.serialize(challenge) },
@@ -326,7 +293,7 @@ describe('http', () => {
     test('marks x402 challenges with the brand the evm charge client reads', async () => {
       // Provenance guard: `evm/client/Charge.ts` recognizes x402 challenges via the same
       // brand the x402 adapter stamps. If the marking site drifts, EVM x402 charges misroute.
-      const [x402Challenge] = await Transport.http().getChallenges!(
+      const [x402Challenge] = await Transport.http().getChallenges(
         new Response(null, {
           status: 402,
           headers: {
@@ -339,7 +306,7 @@ describe('http', () => {
 
     test('removes stale credential headers before setting the retry credential', async () => {
       const transport = Transport.http()
-      const [x402Challenge] = await transport.getChallenges!(
+      const [x402Challenge] = await transport.getChallenges(
         new Response(null, {
           status: 402,
           headers: {
@@ -497,16 +464,16 @@ describe('http (MCP-over-HTTP)', () => {
     expect(await Transport.http().isPaymentRequired(ok, jsonRpcRequest)).toBe(false)
   })
   test('getChallenges extracts the MCP challenge (via the mcp protocol)', async () => {
-    const challenges = await Transport.http().getChallenges!(sseBody(), jsonRpcRequest)
+    const challenges = await Transport.http().getChallenges(sseBody(), jsonRpcRequest)
     expect(challenges.map((entry) => entry.id)).toEqual([challenge.id])
   })
   test('getChallenges extracts an MCP result metadata challenge', async () => {
-    const challenges = await Transport.http().getChallenges!(jsonResultBody(), jsonRpcRequest)
+    const challenges = await Transport.http().getChallenges(jsonResultBody(), jsonRpcRequest)
     expect(challenges.map((entry) => entry.id)).toEqual([challenge.id])
   })
   test('setCredential routes the MCP challenge into the JSON-RPC _meta', async () => {
     const transport = Transport.http()
-    const [mcpChallenge] = await transport.getChallenges!(sseBody(), jsonRpcRequest)
+    const [mcpChallenge] = await transport.getChallenges(sseBody(), jsonRpcRequest)
     const result = transport.setCredential(jsonRpcRequest, Credential.serialize(credential), {
       challenge: mcpChallenge,
     }) as RequestInit
@@ -593,7 +560,7 @@ describe('mcp', () => {
     const transport = Transport.mcp()
 
     expect(await transport.isPaymentRequired(mcpResponse)).toBe(true)
-    expect((await transport.getChallenges?.(mcpResponse))?.map((entry) => entry.id)).toEqual([
+    expect((await transport.getChallenges(mcpResponse)).map((entry) => entry.id)).toEqual([
       challenge.id,
     ])
   })
@@ -602,7 +569,7 @@ describe('mcp', () => {
     const transport = Transport.mcp()
 
     expect(await transport.isPaymentRequired(mcpResult)).toBe(true)
-    expect((await transport.getChallenges?.(mcpResult))?.map((entry) => entry.id)).toEqual([
+    expect((await transport.getChallenges(mcpResult)).map((entry) => entry.id)).toEqual([
       challenge.id,
     ])
   })

--- a/src/client/Transport.ts
+++ b/src/client/Transport.ts
@@ -21,16 +21,11 @@ export type Transport<in out request = unknown, in out response = unknown> = {
    * body reads) and be async (to read a response body).
    */
   isPaymentRequired: (response: response, request?: request) => boolean | Promise<boolean>
-  /** Extracts all challenges from a payment-required response, when the transport supports multiple offers. */
-  getChallenges?: (
+  /** Extracts all challenges from a payment-required response. */
+  getChallenges: (
     response: response,
     request?: request,
   ) => Challenge.Challenge[] | Promise<Challenge.Challenge[]>
-  /** Extracts the challenge from a payment-required response. */
-  getChallenge: (
-    response: response,
-    request?: request,
-  ) => Challenge.Challenge | Promise<Challenge.Challenge>
   /** Attaches a credential to a request. */
   setCredential: (
     request: request,
@@ -65,7 +60,7 @@ export type RequestOf<transport extends Transport> =
  * const custom = Transport.from({
  *   name: 'custom',
  *   isPaymentRequired(response) { ... },
- *   getChallenge(response) { ... },
+ *   getChallenges(response) { ... },
  *   setCredential(request, credential) { ... },
  * })
  * ```
@@ -125,16 +120,6 @@ export function http(): Transport<RequestInit, Response> {
       return collect(response, request)
     },
 
-    getChallenge(response, request) {
-      const pick = (challenges: Challenge.Challenge[]): Challenge.Challenge => {
-        const challenge = challenges[0]
-        if (!challenge) throw new Error('No challenge in response.')
-        return challenge
-      }
-      const challenges = collect(response, request)
-      return challenges instanceof Promise ? challenges.then(pick) : pick(challenges)
-    },
-
     setCredential(request, credential, options) {
       const protocol = options?.challenge ? protocolForChallenge.get(options.challenge) : undefined
       const fallback = protocols[0]
@@ -166,12 +151,6 @@ export function mcp() {
 
     getChallenges(response) {
       return mcpPaymentRequiredChallenges(response)
-    },
-
-    getChallenge(response) {
-      const challenge = mcpPaymentRequiredChallenges(response)[0]
-      if (!challenge) throw new Error('No challenge in response.')
-      return challenge
     },
 
     setCredential(request, credential) {

--- a/src/client/internal/Fetch.ts
+++ b/src/client/internal/Fetch.ts
@@ -238,9 +238,7 @@ export function from<const methods extends readonly Method.AnyClient[]>(
 
     try {
       for (let retry = 0; retry < maxPaymentRetries; retry++) {
-        challenges = transport.getChallenges
-          ? await transport.getChallenges(response, transportRequest as never)
-          : [await transport.getChallenge(response, transportRequest as never)]
+        challenges = await transport.getChallenges(response, transportRequest as never)
 
         const candidates = AcceptPayment.selectChallengeCandidates(
           challenges,
@@ -420,9 +418,7 @@ export function from<const methods extends readonly Method.AnyClient[]>(
       }
       challenges = undefined
       try {
-        challenges = transport.getChallenges
-          ? await transport.getChallenges(response, transportRequest as never)
-          : [await transport.getChallenge(response, transportRequest as never)]
+        challenges = await transport.getChallenges(response, transportRequest as never)
       } catch {}
       await settleAttempt(preparedCredential, {
         challenges,


### PR DESCRIPTION
## Summary

- standardize client transports on `getChallenges()`
- remove the singular `getChallenge()` hook and internal fallback branches
- update built-in HTTP and MCP transports, tests, and the custom transport type example

## Why

The client transport contract required `getChallenge()` while optionally exposing `getChallenges()`, even though challenge negotiation already operates on collections. This duplicated the extraction API and forced every consumer to branch between singular and plural paths.

## Impact

Custom client transports must implement `getChallenges()` and return an array. The included minor changeset reflects that pre-v1 breaking migration.

## Validation

- `pnpm check:types`
- `pnpm check:types:html`
- `pnpm check:types:examples`
- `pnpm check:ci`
- `pnpm audit --ignore-registry-errors`
- 72 transport and MCP protocol tests
- 11 focused fetch negotiation and retry tests
- 5 focused `Mppx.createCredential` tests

Docker-backed Tempo localnet coverage is left to the required PR CI because Docker was not available locally.