### PR TITLE
refactor: remove legacy viem call shims

### DIFF
--- a/.changeset/remove-viem-call-shims.md
+++ b/.changeset/remove-viem-call-shims.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Removed obsolete compatibility shims for legacy viem Tempo call builders.

--- a/src/mcp/client/McpClient.integration.test.ts
+++ b/src/mcp/client/McpClient.integration.test.ts
@@ -33,15 +33,8 @@ const isLocalnet = tempoNetwork === 'localnet'
 
 let escrowContract: Address
 
-// TODO: Remove once the minimum viem version is >=2.54.0, which uses client-first Tempo call builders.
 function tokenGetBalanceCall(parameters: { account: Address; token: Address }) {
-  const call = Actions.token.getBalance.call as unknown as {
-    length: number
-    (parameters: { account: Address; token: Address }): unknown
-    (client: unknown, parameters: { account: Address; token: Address }): unknown
-  }
-  if (call.length >= 2) return call(testClient, parameters)
-  return call(parameters)
+  return Actions.token.getBalance.call(testClient, parameters)
 }
 
 beforeAll(async () => {

--- a/src/tempo/client/Charge.ts
+++ b/src/tempo/client/Charge.ts
@@ -7,7 +7,6 @@ import {
   signTransaction,
 } from 'viem/actions'
 import { Actions } from 'viem/tempo'
-import type { token as viem_token } from 'viem/tempo/actions'
 import { tempo as tempo_chain } from 'viem/tempo/chains'
 
 import * as Credential from '../../Credential.js'
@@ -35,23 +34,6 @@ const chargeContextSchema = z.object({
   autoSwap: z.optional(z.custom<ChargeContext['autoSwap']>()),
   mode: z.optional(z.enum(Methods.chargeModes)),
 })
-
-// TODO: Remove once the minimum viem version is >=2.54.0, which uses client-first Tempo call builders.
-function getTransferCall(
-  client: unknown,
-  parameters: viem_token.transfer.Args,
-): AccountResolution.ResolveAccountCall {
-  const call = Actions.token.transfer.call as unknown as {
-    length: number
-    (parameters: viem_token.transfer.Args): ReturnType<typeof viem_token.transfer.call>
-    (
-      client: unknown,
-      parameters: viem_token.transfer.Args,
-    ): ReturnType<typeof viem_token.transfer.call>
-  }
-  const result = call.length >= 2 ? call(client, parameters) : call(parameters)
-  return result
-}
 
 /**
  * Creates a Tempo charge method intent for usage on the client.
@@ -147,7 +129,7 @@ export function charge(parameters: charge.Parameters = {}) {
       })
       const transferCalls = transfers.map(
         (transfer): AccountResolution.ResolveAccountCall =>
-          getTransferCall(client, {
+          Actions.token.transfer.call(client, {
             amount: BigInt(transfer.amount),
             ...(transfer.memo && { memo: transfer.memo as Hex.Hex }),
             to: transfer.recipient as Address,

--- a/src/tempo/internal/auto-swap.test.ts
+++ b/src/tempo/internal/auto-swap.test.ts
@@ -103,7 +103,7 @@ describe('resolve', () => {
 })
 
 describe('findCalls', () => {
-  test('passes the client to viem 2.54 Tempo token call builders', async () => {
+  test('uses current viem Tempo call builder signatures', async () => {
     vi.resetModules()
     const account = '0x1111111111111111111111111111111111111111' as Address
     const tokenOut = '0x2222222222222222222222222222222222222222' as Address
@@ -122,8 +122,8 @@ describe('findCalls', () => {
       return { kind: 'approve' }
     }
 
-    function buyCall(client: unknown, parameters: Record<string, unknown>) {
-      builderCalls.push({ client, name: 'buy', parameters })
+    function buyCall(parameters: Record<string, unknown>) {
+      builderCalls.push({ client: undefined, name: 'buy', parameters })
       return { kind: 'buy' }
     }
 
@@ -158,7 +158,7 @@ describe('findCalls', () => {
       })
 
       expect(calls).toHaveLength(2)
-      expect(builderCalls.map((call) => call.client)).toEqual([client, client, client, client])
+      expect(builderCalls.map((call) => call.client)).toEqual([client, client, client, undefined])
       expect(builderCalls.map((call) => call.name)).toEqual([
         'getBalance',
         'getBalance',

--- a/src/tempo/internal/auto-swap.ts
+++ b/src/tempo/internal/auto-swap.ts
@@ -1,7 +1,6 @@
 import type { Address, Client } from 'viem'
 import { readContract } from 'viem/actions'
 import { Actions, Addresses } from 'viem/tempo'
-import type { dex as viem_dex, token as viem_token } from 'viem/tempo/actions'
 
 import * as TempoAddress from './address.js'
 import * as defaults from './defaults.js'
@@ -14,51 +13,6 @@ export const defaultCurrencies: readonly Address[] = [
   defaults.tokens.pathUsd as Address,
   defaults.tokens.usdc as Address,
 ]
-
-// TODO: Remove once the minimum viem version is >=2.54.0, which uses client-first Tempo call builders.
-function getBalanceCall(
-  client: Client,
-  parameters: viem_token.getBalance.Args,
-): ReturnType<typeof viem_token.getBalance.call> {
-  const call = Actions.token.getBalance.call as unknown as {
-    length: number
-    (parameters: viem_token.getBalance.Args): ReturnType<typeof viem_token.getBalance.call>
-    (
-      client: Client,
-      parameters: viem_token.getBalance.Args,
-    ): ReturnType<typeof viem_token.getBalance.call>
-  }
-  return call.length >= 2 ? call(client, parameters) : call(parameters)
-}
-
-// TODO: Remove once the minimum viem version is >=2.54.0, which uses client-first Tempo call builders.
-function getApproveCall(
-  client: Client,
-  parameters: viem_token.approve.Args,
-): ReturnType<typeof viem_token.approve.call> {
-  const call = Actions.token.approve.call as unknown as {
-    length: number
-    (parameters: viem_token.approve.Args): ReturnType<typeof viem_token.approve.call>
-    (
-      client: Client,
-      parameters: viem_token.approve.Args,
-    ): ReturnType<typeof viem_token.approve.call>
-  }
-  return call.length >= 2 ? call(client, parameters) : call(parameters)
-}
-
-// TODO: Remove once the minimum viem version is >=2.54.0, which uses client-first Tempo call builders.
-function getBuyCall(
-  client: Client,
-  parameters: viem_dex.buy.Args,
-): ReturnType<typeof viem_dex.buy.call> {
-  const call = Actions.dex.buy.call as unknown as {
-    length: number
-    (parameters: viem_dex.buy.Args): ReturnType<typeof viem_dex.buy.call>
-    (client: Client, parameters: viem_dex.buy.Args): ReturnType<typeof viem_dex.buy.call>
-  }
-  return call.length >= 2 ? call(client, parameters) : call(parameters)
-}
 
 /**
  * Finds the optimal swap calls to acquire `amountOut` of `tokenOut`,
@@ -76,9 +30,12 @@ export async function findCalls(
   const candidates = tokenIn.filter((t) => !TempoAddress.isEqual(t, tokenOut))
 
   const balanceResults = await Promise.allSettled([
-    readContract(client, getBalanceCall(client, { account, token: tokenOut }) as never),
+    readContract(
+      client,
+      Actions.token.getBalance.call(client, { account, token: tokenOut }) as never,
+    ),
     ...candidates.map((t) =>
-      readContract(client, getBalanceCall(client, { account, token: t }) as never),
+      readContract(client, Actions.token.getBalance.call(client, { account, token: t }) as never),
     ),
   ])
 
@@ -108,12 +65,12 @@ export async function findCalls(
         const maxAmountIn =
           quotedAmountIn + (quotedAmountIn * BigInt(Math.round(slippage * 100))) / bps
         return [
-          getApproveCall(client, {
+          Actions.token.approve.call(client, {
             amount: maxAmountIn,
             spender: Addresses.stablecoinDex,
             token: tokenIn,
           }),
-          getBuyCall(client, {
+          Actions.dex.buy.call({
             tokenIn,
             tokenOut,
             amountOut,

--- a/src/tempo/server/Charge.test.ts
+++ b/src/tempo/server/Charge.test.ts
@@ -58,18 +58,8 @@ function sponsoredFeeExposure(credential: string) {
   return transaction.gas * transaction.maxFeePerGas
 }
 
-// TODO: Remove once the minimum viem version is >=2.54.0, which uses client-first Tempo call builders.
 function tokenTransferCall(parameters: viem_token.transfer.Args) {
-  const call = Actions.token.transfer.call as unknown as {
-    length: number
-    (parameters: viem_token.transfer.Args): ReturnType<typeof viem_token.transfer.call>
-    (
-      client: unknown,
-      parameters: viem_token.transfer.Args,
-    ): ReturnType<typeof viem_token.transfer.call>
-  }
-  if (call.length >= 2) return call(client, parameters)
-  return call(parameters)
+  return Actions.token.transfer.call(client, parameters)
 }
 
 type ProofAccessKeyContext = {


### PR DESCRIPTION
## What

- remove legacy viem Tempo call-builder compatibility shims
- call token builders with their current client-first signatures
- call `dex.buy.call` with its current argument-only signature
- update focused tests to lock in those signatures

## Why

mppx now depends on a viem version with stable Tempo call-builder signatures. The runtime `Function.length` branches no longer provide compatibility and make the supported behavior harder to follow.

## Checks

- `VITE_TEMPO_NETWORK=none pnpm exec vp test --run src/tempo/client/Charge.test.ts src/tempo/internal/auto-swap.test.ts src/mcp/client/McpClient.integration.test.ts`
- `pnpm check:types`
- `pnpm check:ci`
