### PR TITLE
fix: normalize Tempo address equality

### DIFF
--- a/.changeset/normalize-tempo-address-equality.md
+++ b/.changeset/normalize-tempo-address-equality.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed equality checks between equivalent hex and Tempo-formatted addresses.

--- a/src/tempo/internal/address.test.ts
+++ b/src/tempo/internal/address.test.ts
@@ -4,17 +4,39 @@ import { describe, expect, test } from 'vp/test'
 import { isEqual } from './address.js'
 
 const address = '0x742d35Cc6634C0532925a3b844Bc9e7595F2bD28'
+const otherAddress = '0x52908400098527886E0F7030069857D2E4169EE7'
 
 describe('isEqual', () => {
-  test('compares hex addresses case-insensitively', () => {
-    expect(isEqual(address, address.toLowerCase() as `0x${string}`)).toBe(true)
-  })
+  const representations = [
+    { name: 'mixed-case hex', value: address },
+    { name: 'lowercase hex', value: address.toLowerCase() as `0x${string}` },
+    { name: 'Tempo-formatted', value: TempoAddress.format(address) },
+  ] as const
 
-  test('treats equivalent hex and Tempo addresses as equal', () => {
-    expect(isEqual(address, TempoAddress.format(address))).toBe(true)
-  })
+  const otherRepresentations = [
+    { name: 'mixed-case hex', value: otherAddress },
+    { name: 'lowercase hex', value: otherAddress.toLowerCase() as `0x${string}` },
+    { name: 'Tempo-formatted', value: TempoAddress.format(otherAddress) },
+  ] as const
 
-  test('rejects different addresses', () => {
-    expect(isEqual(address, '0x0000000000000000000000000000000000000001')).toBe(false)
+  test.each([
+    ...representations.flatMap((a) =>
+      representations.map((b) => ({
+        a: a.value,
+        b: b.value,
+        expected: true,
+        name: `${a.name} and ${b.name} representations of the same address`,
+      })),
+    ),
+    ...representations.flatMap((a) =>
+      otherRepresentations.map((b) => ({
+        a: a.value,
+        b: b.value,
+        expected: false,
+        name: `${a.name} and ${b.name} representations of different addresses`,
+      })),
+    ),
+  ])('$name', ({ a, b, expected }) => {
+    expect(isEqual(a, b)).toBe(expected)
   })
 })

--- a/src/tempo/internal/address.test.ts
+++ b/src/tempo/internal/address.test.ts
@@ -1,0 +1,20 @@
+import { TempoAddress } from 'ox/tempo'
+import { describe, expect, test } from 'vp/test'
+
+import { isEqual } from './address.js'
+
+const address = '0x742d35Cc6634C0532925a3b844Bc9e7595F2bD28'
+
+describe('isEqual', () => {
+  test('compares hex addresses case-insensitively', () => {
+    expect(isEqual(address, address.toLowerCase() as `0x${string}`)).toBe(true)
+  })
+
+  test('treats equivalent hex and Tempo addresses as equal', () => {
+    expect(isEqual(address, TempoAddress.format(address))).toBe(true)
+  })
+
+  test('rejects different addresses', () => {
+    expect(isEqual(address, '0x0000000000000000000000000000000000000001')).toBe(false)
+  })
+})

--- a/src/tempo/internal/address.ts
+++ b/src/tempo/internal/address.ts
@@ -1,6 +1,6 @@
-// TODO: Add `isEqual` to `TempoAddress`.
-import type { TempoAddress } from 'ox/tempo'
+import { TempoAddress } from 'ox/tempo'
 
+/** Returns whether two hex or Tempo-formatted addresses resolve to the same address. */
 export function isEqual(a: TempoAddress.Address, b: TempoAddress.Address) {
-  return a.toLowerCase() === b.toLowerCase()
+  return TempoAddress.resolve(a).toLowerCase() === TempoAddress.resolve(b).toLowerCase()
 }


### PR DESCRIPTION
## What

- resolve Tempo-formatted and hex addresses before comparing them
- keep address comparison case-insensitive
- add focused coverage for hex, Tempo-formatted, and unequal addresses

## Why

The previous comparison lowercased the input strings directly, so equivalent hex and Tempo-formatted representations compared as different addresses.

## Checks

- `VITE_TEMPO_NETWORK=none pnpm exec vp test --run src/tempo/internal/address.test.ts src/tempo/internal/auto-swap.test.ts src/tempo/internal/fee-token.test.ts`
- `pnpm check:types`
- `pnpm check:ci`
