### PR TITLE
fix: support interoperable x402 POST challenges

### DIFF
--- a/.changeset/x402-post-interoperability.md
+++ b/.changeset/x402-post-interoperability.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed body-bearing EVM routes to advertise `PAYMENT-REQUIRED` alongside MPP challenges and accept standard x402 payments when mppx route binding is not required.

--- a/examples/x402-mpp/README.md
+++ b/examples/x402-mpp/README.md
@@ -10,12 +10,12 @@ pnpm dev
 
 ## Routes
 
-| Route         | Protocols        |
-| ------------- | ---------------- |
-| `/api/mpp`    | mpp              |
-| `/api/x402`   | x402 exact       |
-| `/api/paid`   | mpp or x402      |
-| `/api/health` | free healthcheck |
+| Route         | Payment options                  | Challenge headers                      |
+| ------------- | -------------------------------- | -------------------------------------- |
+| `/api/mpp`    | MPP (Tempo)                      | `WWW-Authenticate`                     |
+| `/api/x402`   | MPP (EVM) or x402 exact          | `WWW-Authenticate`, `PAYMENT-REQUIRED` |
+| `/api/paid`   | MPP (Tempo or EVM) or x402 exact | `WWW-Authenticate`, `PAYMENT-REQUIRED` |
+| `/api/health` | free healthcheck                 | none                                   |
 
 The x402 route defaults to the free no-key `https://facilitator.x402.rs` testnet facilitator.
 Set `X402_FACILITATOR_URL` to use another facilitator.
@@ -60,15 +60,23 @@ curl -i http://localhost:5173/api/x402
 curl -i http://localhost:5173/api/paid
 ```
 
+These example endpoints are GET routes. EVM-backed handlers emit both `WWW-Authenticate` and
+`PAYMENT-REQUIRED` for GET and body-bearing requests. This app invokes the core `mppx/server`
+handlers directly from Hono, so it does not attach an automatic route scope. Standard x402 clients
+can pay when no digest, scope, opaque value, or metadata binding is required. Routes using
+`mppx/hono` are automatically scoped and require a client that implements the mppx route-binding
+extension.
+
 ## Test with purl
 
 Install the current purl CLI:
 
 ```bash
 brew install stripe/purl/purl
+purl wallet add
 ```
 
-`purl v0.2.7` can inspect both Payment-auth and x402 headers:
+`purl v0.2.7` recognizes MPP and x402 challenges:
 
 ```bash
 purl inspect http://localhost:5173/api/mpp

--- a/src/x402/Exact.e2e.test.ts
+++ b/src/x402/Exact.e2e.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from 'vp/test'
 import * as Http from '~test/Http.js'
 import { accounts, asset, client } from '~test/tempo/viem.js'
 
+import * as evm_Types from '../evm/Types.js'
 import * as Header from './Header.js'
 import * as RouteBinding from './internal/RouteBinding.js'
 import * as Types from './Types.js'
@@ -157,22 +158,8 @@ describe('x402 exact e2e', () => {
     const paymentRequired = Header.decodePaymentRequired(
       routeAChallenge.challenge.headers.get(Types.paymentRequiredHeader)!,
     )
-    const accepted = paymentRequired.accepts[0]!
-    const paymentSignature = Header.encodePaymentSignature({
-      accepted,
-      payload: {
-        authorization: {
-          from: accounts[0].address,
-          nonce: `0x${'1'.repeat(64)}`,
-          to: accepted.payTo as `0x${string}`,
-          validAfter: '0',
-          validBefore: '9999999999',
-          value: accepted.amount,
-        },
-        signature: `0x${'2'.repeat(130)}`,
-      },
-      resource: paymentRequired.resource,
-      x402Version: 2,
+    const paymentSignature = await standardPaymentSignature(paymentRequired, {
+      nonce: `0x${'1'.repeat(64)}`,
     })
 
     const result = await route(
@@ -185,7 +172,7 @@ describe('x402 exact e2e', () => {
     expect(verifyCalls).toBe(0)
   })
 
-  test('rejects x402 route extensions with extra binding fields', async () => {
+  test('rejects invalid x402 route bindings', async () => {
     let verifyCalls = 0
     const payment = ServerMppx.create({
       methods: [
@@ -223,49 +210,54 @@ describe('x402 exact e2e', () => {
     const accepted = paymentRequired.accepts[0]!
     const mppxExtension = paymentRequired.extensions!.mppx
     if (!mppxExtension) throw new Error()
-    const extensions: Types.Extensions = {
+    const extensionsWithExtra: Types.Extensions = {
       ...paymentRequired.extensions!,
       mppx: {
         schema: mppxExtension.schema,
         info: {
           ...mppxExtension.info,
           extra: 'not allowed',
+          nonce: '1'.repeat(64),
         },
       },
     }
-    const paymentSignature = Header.encodePaymentSignature({
-      accepted,
-      extensions,
-      payload: {
-        authorization: {
-          from: accounts[0].address,
-          nonce: RouteBinding.nonce({
-            accepted,
-            extensions,
-            resource: paymentRequired.resource,
-          }),
-          to: accepted.payTo as `0x${string}`,
-          validAfter: '0',
-          validBefore: '9999999999',
-          value: accepted.amount,
+    const extensionsWithNonce: Types.Extensions = {
+      ...paymentRequired.extensions!,
+      mppx: {
+        schema: mppxExtension.schema,
+        info: {
+          ...mppxExtension.info,
+          nonce: 'client-salt',
         },
-        signature: `0x${'2'.repeat(130)}`,
       },
-      resource: paymentRequired.resource,
-      x402Version: 2,
-    })
-
-    const result = await route(
-      new Request('https://example.com/a', {
-        headers: { [Types.paymentSignatureHeader]: paymentSignature },
+    }
+    const paymentSignatures = await Promise.all([
+      standardPaymentSignature(paymentRequired, {
+        extensions: extensionsWithExtra,
+        nonce: RouteBinding.nonce({
+          accepted,
+          extensions: extensionsWithExtra,
+          resource: paymentRequired.resource,
+        }),
       }),
-    )
+      standardPaymentSignature(paymentRequired, {
+        extensions: extensionsWithNonce,
+        nonce: `0x${'5'.repeat(64)}`,
+      }),
+    ])
 
-    expect(result.status).toBe(402)
+    for (const paymentSignature of paymentSignatures) {
+      const result = await route(
+        new Request('https://example.com/a', {
+          headers: { [Types.paymentSignatureHeader]: paymentSignature },
+        }),
+      )
+      expect(result.status).toBe(402)
+    }
     expect(verifyCalls).toBe(0)
   })
 
-  test('does not advertise x402 for body-bearing requests without a digest', async () => {
+  test('accepts standard x402 payments for body-bearing requests without a digest', async () => {
     let verifyCalls = 0
     const payment = ServerMppx.create({
       methods: [
@@ -292,56 +284,57 @@ describe('x402 exact e2e', () => {
       secretKey,
     })
     const route = payment.evm.charge({ amount: '0.01' })
+    const body = JSON.stringify({ a: 1 })
 
-    const result = await route(
+    const first = await route(
       new Request('https://example.com/body', {
-        body: JSON.stringify({ a: 1 }),
+        body,
         method: 'POST',
       }),
     )
 
-    expect(result.status).toBe(402)
-    if (result.status !== 402) throw new Error()
-    expect(result.challenge.headers.has('WWW-Authenticate')).toBe(true)
-    expect(result.challenge.headers.has(Types.paymentRequiredHeader)).toBe(false)
-
-    const getChallenge = await route(new Request('https://example.com/body'))
-    expect(getChallenge.status).toBe(402)
-    if (getChallenge.status !== 402) throw new Error()
+    expect(first.status).toBe(402)
+    if (first.status !== 402) throw new Error()
+    expect(first.challenge.headers.has('WWW-Authenticate')).toBe(true)
+    expect(first.challenge.headers.has(Types.paymentRequiredHeader)).toBe(true)
     const paymentRequired = Header.decodePaymentRequired(
-      getChallenge.challenge.headers.get(Types.paymentRequiredHeader)!,
+      first.challenge.headers.get(Types.paymentRequiredHeader)!,
     )
-    const accepted = paymentRequired.accepts[0]!
-    const paymentSignature = Header.encodePaymentSignature({
-      accepted,
-      extensions: paymentRequired.extensions,
-      payload: {
-        authorization: {
-          from: accounts[0].address,
-          nonce: RouteBinding.nonce({
-            accepted,
-            extensions: paymentRequired.extensions!,
-            resource: paymentRequired.resource,
-          }),
-          to: accepted.payTo as `0x${string}`,
-          validAfter: '0',
-          validBefore: '9999999999',
-          value: accepted.amount,
-        },
-        signature: `0x${'2'.repeat(130)}`,
-      },
-      resource: paymentRequired.resource,
-      x402Version: 2,
+
+    const paymentSignatures = await Promise.all([
+      standardPaymentSignature(paymentRequired, {
+        nonce: `0x${'3'.repeat(64)}`,
+      }),
+      standardPaymentSignature(paymentRequired, {
+        extensions: paymentRequired.extensions,
+        nonce: `0x${'4'.repeat(64)}`,
+      }),
+    ])
+    for (const paymentSignature of paymentSignatures) {
+      const result = await route(
+        new Request('https://example.com/body', {
+          body,
+          headers: { [Types.paymentSignatureHeader]: paymentSignature },
+          method: 'POST',
+        }),
+      )
+      expect(result.status).toBe(200)
+    }
+    expect(verifyCalls).toBe(2)
+
+    const scopedRoute = payment.evm.charge({
+      amount: '0.01',
+      scope: 'POST /body',
     })
-    const replay = await route(
+    const scopedResult = await scopedRoute(
       new Request('https://example.com/body', {
-        body: JSON.stringify({ a: 2 }),
-        headers: { [Types.paymentSignatureHeader]: paymentSignature },
+        body,
+        headers: { [Types.paymentSignatureHeader]: paymentSignatures[0]! },
         method: 'POST',
       }),
     )
-    expect(replay.status).toBe(402)
-    expect(verifyCalls).toBe(0)
+    expect(scopedResult.status).toBe(402)
+    expect(verifyCalls).toBe(2)
   })
 
   test('serves tempo and x402 from one composed live endpoint', async () => {
@@ -436,6 +429,53 @@ describe('x402 exact e2e', () => {
 function payerOf(paymentPayload: Types.PaymentPayload): string {
   if ('authorization' in paymentPayload.payload) return paymentPayload.payload.authorization.from
   return paymentPayload.payload.permit2Authorization.from
+}
+
+async function standardPaymentSignature(
+  paymentRequired: Types.PaymentRequired,
+  options: {
+    extensions?: Types.Extensions | undefined
+    nonce: `0x${string}`
+  },
+): Promise<string> {
+  const accepted = paymentRequired.accepts[0]!
+  const name = accepted.extra?.name
+  const version = accepted.extra?.version
+  if (typeof name !== 'string' || typeof version !== 'string') throw new Error()
+  const authorization = {
+    from: accounts[0].address,
+    nonce: options.nonce,
+    to: accepted.payTo as `0x${string}`,
+    validAfter: '0',
+    validBefore: '9999999999',
+    value: accepted.amount,
+  }
+  const signature = await accounts[0].signTypedData({
+    domain: {
+      chainId: Number(accepted.network.slice('eip155:'.length)),
+      name,
+      verifyingContract: accepted.asset as `0x${string}`,
+      version,
+    },
+    message: {
+      ...authorization,
+      validAfter: BigInt(authorization.validAfter),
+      validBefore: BigInt(authorization.validBefore),
+      value: BigInt(authorization.value),
+    },
+    primaryType: 'TransferWithAuthorization',
+    types: evm_Types.authorizationTypes,
+  })
+  return Header.encodePaymentSignature({
+    accepted,
+    ...(options.extensions ? { extensions: options.extensions } : {}),
+    payload: {
+      authorization,
+      signature,
+    },
+    resource: paymentRequired.resource,
+    x402Version: 2,
+  })
 }
 
 function pureX402Challenge(response: Response): Response {

--- a/src/x402/server/EvmCharge.ts
+++ b/src/x402/server/EvmCharge.ts
@@ -111,27 +111,48 @@ export function createPath(config: ResolvedOptions): Path {
         })
 
       const expectedResource = { url: input.url }
-      if (!isDeepStrictEqual(paymentPayload.resource, expectedResource))
+      const clientNonce = paymentPayload.extensions?.[mppxExtensionKey]?.info.nonce
+      const isRouteBound = clientNonce !== undefined
+      const routeRequiresBinding =
+        challenge.digest !== undefined ||
+        challenge.opaque !== undefined ||
+        challenge.meta !== undefined
+      if (routeRequiresBinding && !isRouteBound)
+        throw new VerificationFailedError({
+          reason: 'x402 payment payload does not bind required route metadata',
+        })
+
+      if (isRouteBound) {
+        if (!isDeepStrictEqual(paymentPayload.resource, expectedResource))
+          throw new VerificationFailedError({
+            reason: 'x402 payment payload resource does not match route resource',
+          })
+
+        const expectedExtensions = routeExtensions(challenge, input)
+        if (!containsExtensions(paymentPayload.extensions, expectedExtensions))
+          throw new VerificationFailedError({
+            reason: 'x402 payment payload extensions do not match route binding',
+          })
+      } else if (
+        paymentPayload.resource !== undefined &&
+        paymentPayload.resource.url !== expectedResource.url
+      )
         throw new VerificationFailedError({
           reason: 'x402 payment payload resource does not match route resource',
         })
 
-      const expectedExtensions = routeExtensions(challenge, input)
-      if (!containsExtensions(paymentPayload.extensions, expectedExtensions))
-        throw new VerificationFailedError({
-          reason: 'x402 payment payload extensions do not match route binding',
-        })
-
       const payload = payloadToAuthorization(paymentPayload)
-      const expectedNonce = x402_RouteBinding.nonce({
-        accepted: paymentRequirements,
-        extensions: paymentPayload.extensions!,
-        resource: expectedResource,
-      })
-      if (payload.nonce !== expectedNonce)
-        throw new VerificationFailedError({
-          reason: 'x402 authorization nonce does not match route binding',
+      if (isRouteBound) {
+        const expectedNonce = x402_RouteBinding.nonce({
+          accepted: paymentRequirements,
+          extensions: paymentPayload.extensions!,
+          resource: expectedResource,
         })
+        if (payload.nonce !== expectedNonce)
+          throw new VerificationFailedError({
+            reason: 'x402 authorization nonce does not match route binding',
+          })
+      }
 
       return markCredential(
         Credential_.from({
@@ -147,7 +168,6 @@ export function createPath(config: ResolvedOptions): Path {
 
     respondChallenge(options, response) {
       if (!response) throw new Error('x402 path requires a base challenge response.')
-      if (options.input.body !== null && options.challenge.digest === undefined) return response
       const headers = new Headers(response.headers)
       const request = options.challenge.request as Types.ChargeRequest
       headers.set(
@@ -354,11 +374,7 @@ function stripClientNonce(info: Record<string, unknown>): Record<string, unknown
 }
 
 async function assertBodyDigest(challenge: Challenge.Challenge, input: Request): Promise<void> {
-  if (input.body === null) return
-  if (challenge.digest === undefined)
-    throw new VerificationFailedError({
-      reason: 'x402 payment requires a body digest for body-bearing requests',
-    })
+  if (input.body === null || challenge.digest === undefined) return
   let body: string
   try {
     body = await input.clone().text()


### PR DESCRIPTION
## Summary

- emit x402 `PAYMENT-REQUIRED` alongside MPP `WWW-Authenticate` for x402-enabled EVM POST routes, even when no body digest is configured
- accept standard x402 credentials on unbound routes
- reject mismatched resources and retain strict digest, scope, extension, and derived-nonce checks when binding is signaled or required
- document serving MPP and x402 from one endpoint

## Why

mppx withheld the x402 challenge for body-bearing requests without a digest and required every x402 credential to use mppx route binding. Standard x402 clients therefore could not discover or complete payment on otherwise unbound POST routes.

## Validation

- x402 and MPP E2E coverage for bound and unbound POST routes
- repository typechecks, lint, formatting, and CI
