### PR TITLE
fix: preserve composed discovery offers

### DIFF
--- a/.changeset/preserve-composed-discovery-offers.md
+++ b/.changeset/preserve-composed-discovery-offers.md
@@ -2,4 +2,4 @@
 'mppx': patch
 ---
 
-Kept discovery metadata aligned with runtime challenges by preserving composed offers and deriving prices from canonical payment requests.
+Kept discovery metadata aligned with runtime challenges by preserving composed offers, dispatching nested compositions, and deriving prices from canonical payment requests.

--- a/.changeset/preserve-composed-discovery-offers.md
+++ b/.changeset/preserve-composed-discovery-offers.md
@@ -2,4 +2,4 @@
 'mppx': patch
 ---
 
-Preserved explicitly configured payment offers through composed handlers so discovery metadata matched runtime challenges.
+Kept discovery metadata aligned with runtime challenges by preserving composed offers and deriving prices from canonical payment requests.

--- a/.changeset/preserve-composed-discovery-offers.md
+++ b/.changeset/preserve-composed-discovery-offers.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Preserved explicitly configured payment offers through composed handlers so discovery metadata matched runtime challenges.

--- a/src/discovery/OpenApi.test.ts
+++ b/src/discovery/OpenApi.test.ts
@@ -182,6 +182,38 @@ describe('generate', () => {
     `)
   })
 
+  test('derives only explicitly composed payment offers from a handler', () => {
+    const mppx = createMppx([charge, session])
+    const handler = mppx.compose(
+      ['tempo/charge', { amount: '50', currency: '0xUSDC', description: 'USDC', recipient: '0x1' }],
+      [
+        'tempo/charge',
+        { amount: '50', currency: '0xNANOUSD', description: 'NANOUSD', recipient: '0x1' },
+      ],
+    )
+
+    const doc = generate(mppx, {
+      routes: [{ handler, method: 'post', path: '/api/search' }],
+    }) as any
+
+    expect(doc.paths['/api/search'].post['x-payment-info'].offers).toEqual([
+      {
+        amount: '50',
+        currency: '0xUSDC',
+        intent: 'charge',
+        method: 'tempo',
+        recipient: '0x1',
+      },
+      {
+        amount: '50',
+        currency: '0xNANOUSD',
+        intent: 'charge',
+        method: 'tempo',
+        recipient: '0x1',
+      },
+    ])
+  })
+
   test('handles null amount for session intent', () => {
     const mppx = createMppx([session])
     const doc = generate(mppx, {

--- a/src/discovery/OpenApi.test.ts
+++ b/src/discovery/OpenApi.test.ts
@@ -1,3 +1,4 @@
+import * as Challenge from '../Challenge.js'
 import * as Method from '../Method.js'
 import * as Mppx from '../server/Mppx.js'
 import * as z from '../zod.js'
@@ -56,12 +57,46 @@ const subscribe = Method.toServer(
       credential: { payload: z.object({ signature: z.string() }) },
       request: z.object({
         amount: z.string(),
+        interval: z.string(),
+        recipient: z.string(),
       }),
     },
   }),
   {
     verify: async () => ({
       method: 'tempo',
+      reference: '',
+      status: 'success' as const,
+      timestamp: '',
+    }),
+  },
+)
+
+const transformedCharge = Method.toServer(
+  Method.from({
+    intent: 'charge',
+    name: 'transformed',
+    schema: {
+      credential: { payload: z.object({ signature: z.string() }) },
+      request: z.pipe(
+        z.object({
+          amount: z.string(),
+          asset: z.string(),
+          decimals: z.number(),
+          recipient: z.string(),
+        }),
+        z.transform(({ amount, asset, decimals, recipient }) => ({
+          amount: String(Number(amount) * 10 ** decimals),
+          currency: asset,
+          methodDetails: { decimals },
+          recipient,
+        })),
+      ),
+    },
+  }),
+  {
+    verify: async () => ({
+      method: 'transformed',
       reference: '',
       status: 'success' as const,
       timestamp: '',
@@ -169,6 +204,7 @@ describe('generate', () => {
                   {
                     "amount": "50",
                     "currency": "usd",
+                    "description": "Search credits",
                     "intent": "charge",
                     "method": "tempo",
                     "recipient": "0x1",
@@ -180,6 +216,62 @@ describe('generate', () => {
         },
       }
     `)
+  })
+
+  test('matches handler discovery to its canonical runtime challenge', async () => {
+    const mppx = createMppx([transformedCharge])
+    const handler = mppx.charge({
+      amount: '2',
+      asset: '0xUSDC',
+      decimals: 6,
+      description: 'Canonical price',
+      recipient: '0x1',
+    })
+
+    const doc = generate(mppx, {
+      routes: [{ handler, method: 'post', path: '/api/resource' }],
+    }) as any
+    const result = await handler(new Request('https://example.com/api/resource'))
+    if (result.status !== 402) throw new Error('Expected payment challenge')
+    const challenge = Challenge.fromResponse(result.challenge)
+
+    expect(doc.paths['/api/resource'].post['x-payment-info'].offers[0]).toEqual({
+      amount: challenge.request.amount,
+      currency: challenge.request.currency,
+      description: challenge.description,
+      intent: challenge.intent,
+      method: challenge.method,
+      recipient: challenge.request.recipient,
+    })
+  })
+
+  test('applies method schema transforms to legacy route discovery', () => {
+    const mppx = createMppx([transformedCharge])
+    const doc = generate(mppx, {
+      routes: [
+        {
+          intent: 'charge',
+          method: 'post',
+          options: {
+            amount: '2',
+            asset: '0xUSDC',
+            decimals: 6,
+            description: 'Canonical price',
+            recipient: '0x1',
+          },
+          path: '/api/resource',
+        },
+      ],
+    }) as any
+
+    expect(doc.paths['/api/resource'].post['x-payment-info'].offers[0]).toEqual({
+      amount: '2000000',
+      currency: '0xUSDC',
+      description: 'Canonical price',
+      intent: 'charge',
+      method: 'transformed',
+      recipient: '0x1',
+    })
   })
 
   test('derives only explicitly composed payment offers from a handler', () => {
@@ -200,6 +292,7 @@ describe('generate', () => {
       {
         amount: '50',
         currency: '0xUSDC',
+        description: 'USDC',
         intent: 'charge',
         method: 'tempo',
         recipient: '0x1',
@@ -207,11 +300,56 @@ describe('generate', () => {
       {
         amount: '50',
         currency: '0xNANOUSD',
+        description: 'NANOUSD',
         intent: 'charge',
         method: 'tempo',
         recipient: '0x1',
       },
     ])
+  })
+
+  test('keeps nested composed discovery in runtime challenge order', async () => {
+    const mppx = createMppx([charge])
+    const handler = Mppx.compose(
+      mppx.charge({
+        amount: '1',
+        currency: '0xUSDC',
+        description: 'USDC',
+        recipient: '0x1',
+      }),
+      Mppx.compose(
+        mppx.charge({
+          amount: '2',
+          currency: '0xNANOUSD',
+          description: 'NANOUSD',
+          recipient: '0x1',
+        }),
+        mppx.charge({
+          amount: '3',
+          currency: 'usd',
+          description: 'Card',
+          recipient: '0x1',
+        }),
+      ),
+    )
+
+    const doc = generate(mppx, {
+      routes: [{ handler, method: 'post', path: '/api/search' }],
+    }) as any
+    const result = await handler(new Request('https://example.com/api/search'))
+    if (result.status !== 402) throw new Error('Expected payment challenge')
+
+    const discovered = doc.paths['/api/search'].post['x-payment-info'].offers
+    const challenged = Challenge.fromResponseList(result.challenge).map((challenge) => ({
+      amount: challenge.request.amount,
+      currency: challenge.request.currency,
+      description: challenge.description,
+      intent: challenge.intent,
+      method: challenge.method,
+      recipient: challenge.request.recipient,
+    }))
+
+    expect(discovered).toEqual(challenged)
   })
 
   test('handles null amount for session intent', () => {

--- a/src/discovery/OpenApi.ts
+++ b/src/discovery/OpenApi.ts
@@ -1,19 +1,11 @@
 import type * as Method from '../Method.js'
+import * as PaymentRequest from '../PaymentRequest.js'
 import { PaymentInfo, type ServiceInfo } from './Discovery.js'
-
-/** Metadata for one explicitly configured payment offer. */
-export type DiscoveryOffer = {
-  _canonicalRequest: Record<string, unknown>
-  intent: string
-  name: string
-}
-
-/** Metadata retained by a single or composed payment handler. */
-export type DiscoveryMetadata = DiscoveryOffer | { offers: readonly DiscoveryOffer[] }
+import * as Metadata from './internal/Metadata.js'
 
 /** Payment handler carrying metadata used to generate discovery documents. */
 export type DiscoveryHandler = ((...args: any[]) => unknown) & {
-  _internal?: DiscoveryMetadata
+  _internal?: Metadata.Metadata
 }
 
 export type LegacyRouteConfig = {
@@ -159,13 +151,7 @@ function resolveRoute(
       method: route.method,
       path: route.path,
       payment: {
-        offers: discoveryOffers(internal).map((offer) =>
-          paymentInfoFromCanonical({
-            canonicalRequest: offer._canonicalRequest,
-            intent: offer.intent,
-            method: offer.name,
-          }),
-        ),
+        offers: Metadata.offers(internal).map(Metadata.paymentOffer),
       },
       ...(route.requestBody ? { requestBody: route.requestBody } : {}),
       ...(route.summary ? { summary: route.summary } : {}),
@@ -179,61 +165,21 @@ function resolveRoute(
     )
   }
 
+  const { description, ...options } = route.options
+  const metadata: Metadata.Offer = {
+    _canonicalRequest: PaymentRequest.fromMethod(mi, options as never),
+    ...(typeof description === 'string' ? { description } : {}),
+    intent: mi.intent,
+    name: mi.name,
+  }
+
   return {
     method: route.method,
     path: route.path,
-    payment: paymentInfoFromCanonical({
-      canonicalRequest: route.options,
-      intent: mi.intent,
-      method: mi.name,
-    }),
+    payment: Metadata.paymentOffer(metadata),
     ...(route.requestBody ? { requestBody: route.requestBody } : {}),
     ...(route.summary ? { summary: route.summary } : {}),
   }
-}
-
-function paymentInfoFromCanonical(route: {
-  canonicalRequest: Record<string, unknown>
-  intent: string
-  method: string
-}) {
-  const { canonicalRequest, intent, method } = route
-  const methodDetails = (canonicalRequest.methodDetails ?? {}) as Record<string, unknown>
-
-  const amount = pickString(canonicalRequest.amount) ?? pickString(methodDetails.amount) ?? null
-  const currency = pickString(canonicalRequest.currency) ?? pickString(methodDetails.currency)
-  const description = pickString(canonicalRequest.description)
-
-  const base: Record<string, unknown> = {
-    amount,
-    ...(currency ? { currency } : {}),
-    ...(description ? { description } : {}),
-    intent,
-    method,
-  }
-
-  // Forward any extra canonical params that aren't already covered.
-  const reserved = new Set(['amount', 'currency', 'description', 'methodDetails'])
-  for (const [key, value] of Object.entries(canonicalRequest)) {
-    if (!reserved.has(key) && value !== undefined) base[key] = value
-  }
-
-  return base
-}
-
-function discoveryOffers(internal: DiscoveryMetadata): readonly DiscoveryOffer[] {
-  if (isComposedDiscoveryMetadata(internal)) return internal.offers
-  return [internal]
-}
-
-function isComposedDiscoveryMetadata(
-  internal: DiscoveryMetadata,
-): internal is Extract<DiscoveryMetadata, { offers: unknown }> {
-  return 'offers' in internal && !('_canonicalRequest' in internal)
-}
-
-function pickString(value: unknown) {
-  return typeof value === 'string' ? value : undefined
 }
 
 function withBasePath(basePath: string | undefined, path: string) {

--- a/src/discovery/OpenApi.ts
+++ b/src/discovery/OpenApi.ts
@@ -1,12 +1,19 @@
 import type * as Method from '../Method.js'
 import { PaymentInfo, type ServiceInfo } from './Discovery.js'
 
+/** Metadata for one explicitly configured payment offer. */
+export type DiscoveryOffer = {
+  _canonicalRequest: Record<string, unknown>
+  intent: string
+  name: string
+}
+
+/** Metadata retained by a single or composed payment handler. */
+export type DiscoveryMetadata = DiscoveryOffer | { offers: readonly DiscoveryOffer[] }
+
+/** Payment handler carrying metadata used to generate discovery documents. */
 export type DiscoveryHandler = ((...args: any[]) => unknown) & {
-  _internal?: {
-    _canonicalRequest: Record<string, unknown>
-    intent: string
-    name: string
-  }
+  _internal?: DiscoveryMetadata
 }
 
 export type LegacyRouteConfig = {
@@ -151,11 +158,15 @@ function resolveRoute(
     return {
       method: route.method,
       path: route.path,
-      payment: paymentInfoFromCanonical({
-        canonicalRequest: internal._canonicalRequest,
-        intent: internal.intent,
-        method: internal.name,
-      }),
+      payment: {
+        offers: discoveryOffers(internal).map((offer) =>
+          paymentInfoFromCanonical({
+            canonicalRequest: offer._canonicalRequest,
+            intent: offer.intent,
+            method: offer.name,
+          }),
+        ),
+      },
       ...(route.requestBody ? { requestBody: route.requestBody } : {}),
       ...(route.summary ? { summary: route.summary } : {}),
     }
@@ -208,6 +219,17 @@ function paymentInfoFromCanonical(route: {
   }
 
   return base
+}
+
+function discoveryOffers(internal: DiscoveryMetadata): readonly DiscoveryOffer[] {
+  if (isComposedDiscoveryMetadata(internal)) return internal.offers
+  return [internal]
+}
+
+function isComposedDiscoveryMetadata(
+  internal: DiscoveryMetadata,
+): internal is Extract<DiscoveryMetadata, { offers: unknown }> {
+  return 'offers' in internal && !('_canonicalRequest' in internal)
 }
 
 function pickString(value: unknown) {

--- a/src/discovery/internal/Metadata.ts
+++ b/src/discovery/internal/Metadata.ts
@@ -1,0 +1,51 @@
+/** Metadata retained by one explicitly configured payment handler. */
+export type Offer = {
+  _canonicalRequest: Record<string, unknown>
+  description?: string | undefined
+  intent: string
+  name: string
+}
+
+/** Metadata retained by a single or composed payment handler. */
+export type Metadata = Offer | { offers: readonly Offer[] }
+
+/** Returns every explicitly configured offer from discovery metadata. */
+export function offers(metadata: Metadata): readonly Offer[] {
+  if (isComposed(metadata)) return metadata.offers
+  return [metadata]
+}
+
+/** Converts configured handler metadata into a discovery payment offer. */
+export function paymentOffer(metadata: Offer): Record<string, unknown> {
+  const { _canonicalRequest: request, intent, name: method } = metadata
+  const methodDetails = (request.methodDetails ?? {}) as Record<string, unknown>
+
+  const amount = pickString(request.amount) ?? pickString(methodDetails.amount) ?? null
+  const currency = pickString(request.currency) ?? pickString(methodDetails.currency)
+  const description = pickString(metadata.description) ?? pickString(request.description)
+
+  const offer: Record<string, unknown> = {
+    amount,
+    ...(currency ? { currency } : {}),
+    ...(description ? { description } : {}),
+    intent,
+    method,
+  }
+
+  // Preserve extension fields emitted by method request schemas.
+  const reserved = new Set(['amount', 'currency', 'description', 'methodDetails'])
+  for (const [key, value] of Object.entries(request)) {
+    if (!reserved.has(key) && value !== undefined) offer[key] = value
+  }
+
+  return offer
+}
+
+/** Returns whether metadata represents a composed handler. */
+export function isComposed(metadata: Metadata): metadata is Extract<Metadata, { offers: unknown }> {
+  return 'offers' in metadata && !('_canonicalRequest' in metadata)
+}
+
+function pickString(value: unknown) {
+  return typeof value === 'string' ? value : undefined
+}

--- a/src/middlewares/hono.test.ts
+++ b/src/middlewares/hono.test.ts
@@ -203,7 +203,9 @@ describe('charge', () => {
     const { mppx } = createChargeHarness(false)
 
     const app = new Hono()
-    app.get('/', mppx.charge({ amount: '1' }), (c) => c.json({ fortune: 'You will be rich' }))
+    app.get('/', mppx.charge({ amount: '1', description: 'Daily fortune' }), (c) =>
+      c.json({ fortune: 'You will be rich' }),
+    )
     discovery(app, mppx, { auto: true, info: { title: 'Auto API', version: '2.0.0' } })
 
     const server = await createServer(app)
@@ -216,6 +218,7 @@ describe('charge', () => {
     expect(body.paths['/'].get['x-payment-info'].offers[0]).toMatchObject({
       amount: '1000000',
       currency: asset,
+      description: 'Daily fortune',
       intent: 'charge',
       method: 'tempo',
     })

--- a/src/proxy/Proxy.test.ts
+++ b/src/proxy/Proxy.test.ts
@@ -181,6 +181,7 @@ describe('create', () => {
   })
 
   test('behavior: GET /openapi.json returns discovery JSON', async () => {
+    const alternateAsset = '0x20c0000000000000000000000000000000000002'
     const proxy = ApiProxy.create({
       categories: ['gateway'],
       docs: {
@@ -196,6 +197,10 @@ describe('create', () => {
           routes: {
             'GET /v1/models': true,
             'POST /v1/generate': mppx_server.charge({ amount: '1', description: 'Generate text' }),
+            'POST /v1/multi': mppx_server.compose(
+              ['tempo/charge', { amount: '1', currency: asset, decimals: 6 }],
+              ['tempo/charge', { amount: '2', currency: alternateAsset, decimals: 6 }],
+            ),
             'POST /v1/stream': mppx_server.session({
               amount: '1',
               description: 'Stream text',
@@ -231,6 +236,20 @@ describe('create', () => {
       intent: 'charge',
       method: 'tempo',
     })
+    expect(body.paths['/api/v1/multi'].post['x-payment-info'].offers).toEqual([
+      expect.objectContaining({
+        amount: '1000000',
+        currency: asset,
+        intent: 'charge',
+        method: 'tempo',
+      }),
+      expect.objectContaining({
+        amount: '2000000',
+        currency: alternateAsset,
+        intent: 'charge',
+        method: 'tempo',
+      }),
+    ])
     expect(body.paths['/api/v1/stream'].post['x-payment-info'].offers[0]).toMatchObject({
       amount: '1000000',
       currency: asset,
@@ -576,7 +595,7 @@ describe('create', () => {
     expect(res.status).toBe(402)
   })
 
-  test('behavior: management POST uses credential method binding to disambiguate same-path paid routes', async () => {
+  test('behavior: management POST uses composed credential binding to disambiguate same-path paid routes', async () => {
     const alpha = Method.from({
       name: 'alpha',
       intent: 'charge',
@@ -631,7 +650,7 @@ describe('create', () => {
         Service.from('api', {
           baseUrl: 'https://example.com',
           routes: {
-            'GET /v1/stream': handler['alpha/charge']({ amount: '1' }),
+            'GET /v1/stream': handler.compose(['alpha/charge', { amount: '1' }]),
             'PATCH /v1/stream': handler['beta/charge']({ amount: '1' }),
           },
         }),

--- a/src/proxy/Proxy.ts
+++ b/src/proxy/Proxy.ts
@@ -310,7 +310,14 @@ function matchesPaymentBinding(endpoint: unknown, binding: PaymentBinding | null
   if (!binding) return true
   const payment = Service.paymentOf(endpoint as Exclude<Service.Endpoint, true>)
   if (!payment) return true
-  return payment.method === binding.method && payment.intent === binding.intent
+  const offers = Array.isArray(payment.offers) ? payment.offers : [payment]
+  return offers.some(
+    (offer) =>
+      typeof offer === 'object' &&
+      offer !== null &&
+      offer.method === binding.method &&
+      offer.intent === binding.intent,
+  )
 }
 
 function createFetchProxy(

--- a/src/proxy/Service.test.ts
+++ b/src/proxy/Service.test.ts
@@ -156,6 +156,42 @@ describe('paymentOf', () => {
       method: 'mock',
     })
   })
+
+  test('behavior: derives every explicitly composed payment offer', () => {
+    const handler = Object.assign(
+      async () => ({
+        status: 200 as const,
+        withReceipt: <T>(r: T) => r,
+      }),
+      {
+        _internal: {
+          offers: [
+            {
+              _canonicalRequest: {},
+              amount: '1',
+              decimals: 6,
+              intent: 'charge',
+              name: 'tempo',
+            },
+            {
+              _canonicalRequest: {},
+              amount: '2',
+              decimals: 6,
+              intent: 'charge',
+              name: 'tempo',
+            },
+          ],
+        },
+      },
+    )
+
+    expect(Service.paymentOf(handler as never)).toEqual({
+      offers: [
+        { amount: '1000000', decimals: 6, intent: 'charge', method: 'tempo' },
+        { amount: '2000000', decimals: 6, intent: 'charge', method: 'tempo' },
+      ],
+    })
+  })
 })
 
 describe('getOptions', () => {

--- a/src/proxy/Service.test.ts
+++ b/src/proxy/Service.test.ts
@@ -123,7 +123,7 @@ describe('paymentOf', () => {
     expect(Service.paymentOf({ pay: handler, options: {} })).toBeNull()
   })
 
-  test('behavior: strips function internals from payment metadata', () => {
+  test('behavior: derives payment metadata from the canonical request', () => {
     const handler = Object.assign(
       async () => ({
         status: 200 as const,
@@ -131,11 +131,18 @@ describe('paymentOf', () => {
       }),
       {
         _internal: {
-          _canonicalRequest: () => ({}),
+          _canonicalRequest: {
+            amount: '1000000',
+            currency: '0xUSDC',
+            recipient: '0x1',
+          },
           _stableBinding: () => ({}),
           amount: '1',
+          asset: 'raw-asset',
           authorize: () => undefined,
+          client: { apiKey: 'secret' },
           decimals: 6,
+          description: 'Generate text',
           defaults: {},
           intent: 'charge',
           name: 'mock',
@@ -151,9 +158,11 @@ describe('paymentOf', () => {
 
     expect(Service.paymentOf(handler as never)).toEqual({
       amount: '1000000',
-      decimals: 6,
+      currency: '0xUSDC',
+      description: 'Generate text',
       intent: 'charge',
       method: 'mock',
+      recipient: '0x1',
     })
   })
 
@@ -167,16 +176,18 @@ describe('paymentOf', () => {
         _internal: {
           offers: [
             {
-              _canonicalRequest: {},
+              _canonicalRequest: { amount: '1000000', currency: '0xUSDC' },
               amount: '1',
               decimals: 6,
+              description: 'USDC',
               intent: 'charge',
               name: 'tempo',
             },
             {
-              _canonicalRequest: {},
+              _canonicalRequest: { amount: '2000000', currency: '0xNANOUSD' },
               amount: '2',
               decimals: 6,
+              description: 'NANOUSD',
               intent: 'charge',
               name: 'tempo',
             },
@@ -187,8 +198,20 @@ describe('paymentOf', () => {
 
     expect(Service.paymentOf(handler as never)).toEqual({
       offers: [
-        { amount: '1000000', decimals: 6, intent: 'charge', method: 'tempo' },
-        { amount: '2000000', decimals: 6, intent: 'charge', method: 'tempo' },
+        {
+          amount: '1000000',
+          currency: '0xUSDC',
+          description: 'USDC',
+          intent: 'charge',
+          method: 'tempo',
+        },
+        {
+          amount: '2000000',
+          currency: '0xNANOUSD',
+          description: 'NANOUSD',
+          intent: 'charge',
+          method: 'tempo',
+        },
       ],
     })
   })

--- a/src/proxy/Service.ts
+++ b/src/proxy/Service.ts
@@ -1,4 +1,4 @@
-import { Value } from 'ox'
+import * as Metadata from '../discovery/internal/Metadata.js'
 
 /** A proxied upstream service with route definitions and optional request/response hooks. */
 export type Service = {
@@ -211,36 +211,11 @@ export function paymentOf(endpoint: Endpoint): Record<string, unknown> | null {
   if (endpoint === true) return null
   const handler = typeof endpoint === 'function' ? endpoint : endpoint.pay
   if (!('_internal' in handler)) return null
-  const internal = handler._internal as Record<string, unknown>
-  if (Array.isArray(internal.offers) && !('_canonicalRequest' in internal))
-    return {
-      offers: internal.offers.map((offer) => paymentFromInternal(offer as Record<string, unknown>)),
-    }
-  return paymentFromInternal(internal)
-}
-
-function paymentFromInternal(internal: Record<string, unknown>): Record<string, unknown> {
-  const {
-    name,
-    intent,
-    defaults: _,
-    schema: _s,
-    _canonicalRequest,
-    _stableBinding: _sb,
-    authorize: _a,
-    request: _r,
-    respond: _re,
-    stableBinding: _st,
-    transport: _t,
-    verify: _v,
-    ...rest
-  } = internal
-  const amount = (() => {
-    if (typeof rest.amount === 'string' && typeof rest.decimals === 'number')
-      return String(Value.from(rest.amount, rest.decimals))
-    return rest.amount
-  })()
-  return { intent, method: name, ...rest, ...(amount !== undefined && { amount }) }
+  const metadata = handler._internal as Metadata.Metadata | undefined
+  if (!metadata) return null
+  if (Metadata.isComposed(metadata))
+    return { offers: Metadata.offers(metadata).map(Metadata.paymentOffer) }
+  return Metadata.paymentOffer(metadata)
 }
 
 function resolveDocs(config: from.Config): Docs | undefined {

--- a/src/proxy/Service.ts
+++ b/src/proxy/Service.ts
@@ -206,10 +206,20 @@ export function getOptions(endpoint: Endpoint): EndpointOptions | undefined {
   return undefined
 }
 
+/** Derives discovery payment metadata from an explicitly priced endpoint handler. */
 export function paymentOf(endpoint: Endpoint): Record<string, unknown> | null {
   if (endpoint === true) return null
   const handler = typeof endpoint === 'function' ? endpoint : endpoint.pay
   if (!('_internal' in handler)) return null
+  const internal = handler._internal as Record<string, unknown>
+  if (Array.isArray(internal.offers) && !('_canonicalRequest' in internal))
+    return {
+      offers: internal.offers.map((offer) => paymentFromInternal(offer as Record<string, unknown>)),
+    }
+  return paymentFromInternal(internal)
+}
+
+function paymentFromInternal(internal: Record<string, unknown>): Record<string, unknown> {
   const {
     name,
     intent,
@@ -224,7 +234,7 @@ export function paymentOf(endpoint: Endpoint): Record<string, unknown> | null {
     transport: _t,
     verify: _v,
     ...rest
-  } = handler._internal as Record<string, unknown>
+  } = internal
   const amount = (() => {
     if (typeof rest.amount === 'string' && typeof rest.decimals === 'number')
       return String(Value.from(rest.amount, rest.decimals))

--- a/src/server/Mppx.test-d.ts
+++ b/src/server/Mppx.test-d.ts
@@ -182,6 +182,7 @@ describe('Mppx type tests', () => {
     assertType<Promise<{ status: 402; challenge: Response } | { status: 200; withReceipt: any }>>(
       {} as Awaited<HandlerReturn> as any,
     )
+    expectTypeOf(_handler._internal?.offers).toMatchTypeOf<readonly unknown[] | undefined>()
   })
 
   test('static Mppx.compose accepts configured handlers', () => {

--- a/src/server/Mppx.test.ts
+++ b/src/server/Mppx.test.ts
@@ -1968,6 +1968,40 @@ describe('compose', () => {
     expect(wwwAuth).toContain('method="beta"')
   })
 
+  test('retains only explicitly configured offers as composed discovery metadata', () => {
+    const mppx = Mppx.create({ methods: [alphaMethod, betaMethod], realm, secretKey })
+    const configured = mppx.compose([alphaMethod, challengeOpts], [betaMethod, challengeOpts])
+
+    expect(configured._internal?.offers).toMatchObject([
+      {
+        _canonicalRequest: {
+          amount: challengeOpts.amount,
+          currency: challengeOpts.currency,
+          recipient: challengeOpts.recipient,
+        },
+        intent: 'charge',
+        name: 'alpha',
+      },
+      {
+        _canonicalRequest: {
+          amount: challengeOpts.amount,
+          currency: challengeOpts.currency,
+          recipient: challengeOpts.recipient,
+        },
+        intent: 'charge',
+        name: 'beta',
+      },
+    ])
+
+    const custom = async () =>
+      ({
+        status: 402,
+        challenge: new Response(null, { status: 402 }),
+      }) as const
+    const composed = Mppx.compose(mppx.alpha.charge(challengeOpts), custom)
+    expect(composed._internal?.offers).toMatchObject([{ intent: 'charge', name: 'alpha' }])
+  })
+
   test('broadcasts duplicate tempo/session variants in compose order', async () => {
     const mppx = Mppx.create({
       methods: [tip1034SessionMethod, legacySessionMethod],

--- a/src/server/Mppx.test.ts
+++ b/src/server/Mppx.test.ts
@@ -2463,6 +2463,34 @@ describe('compose', () => {
     expect(result.status).toBe(200)
   })
 
+  test('dispatches credentials to a nested composed handler', async () => {
+    const mppx = Mppx.create({ methods: [alphaMethod, betaMethod], realm, secretKey })
+    const handle = Mppx.compose(
+      mppx.alpha.charge(challengeOpts),
+      Mppx.compose(mppx.beta.charge(challengeOpts)),
+    )
+
+    const firstResult = await handle(new Request('https://example.com/resource'))
+    expect(firstResult.status).toBe(402)
+    if (firstResult.status !== 402) throw new Error()
+
+    const betaChallenge = Challenge.fromResponseList(firstResult.challenge).find(
+      (challenge) => challenge.method === 'beta',
+    )!
+    const credential = Credential.from({
+      challenge: betaChallenge,
+      payload: { token: 'valid' },
+    })
+
+    const result = await handle(
+      new Request('https://example.com/resource', {
+        headers: { Authorization: Credential.serialize(credential) },
+      }),
+    )
+
+    expect(result.status).toBe(200)
+  })
+
   test('returns 402 when credential method does not match any handler', async () => {
     const mppx = Mppx.create({ methods: [alphaMethod], realm, secretKey })
 

--- a/src/server/Mppx.ts
+++ b/src/server/Mppx.ts
@@ -227,9 +227,7 @@ export type Mppx<
        * })
        * ```
        */
-      compose(
-        ...entries: ComposeEntry<FlattenMethods<methods>>[]
-      ): (input: Request) => Promise<MethodFn.Response<Transport.Http>>
+      compose(...entries: ComposeEntry<FlattenMethods<methods>>[]): ComposedHandler
     }
   : {}) &
   Handlers<FlattenMethods<methods>, transport> & {
@@ -2179,6 +2177,16 @@ type ConfiguredHandler = ((input: Request) => Promise<MethodFn.Response<Transpor
   }
 }
 
+type ComposedHandler = ((input: Request) => Promise<MethodFn.Response<Transport.Http>>) & {
+  _internal?: {
+    offers: readonly ConfiguredHandler['_internal'][]
+  }
+}
+
+type HandlerDiscoveryMetadata =
+  | ConfiguredHandler['_internal']
+  | NonNullable<ComposedHandler['_internal']>
+
 const paymentAuthChallengeHeader = Constants.Headers.wwwAuthenticate
 
 const challengeHeaderMerges = [
@@ -2252,9 +2260,7 @@ type ComposeEntry<methods extends readonly Method.AnyServer[]> =
  */
 type ComposeHtmlOptions = Html.Config
 
-export function compose(
-  ...args: readonly unknown[]
-): (input: Request) => Promise<MethodFn.Response<Transport.Http>> {
+export function compose(...args: readonly unknown[]): ComposedHandler {
   // Extract optional html options from last argument
   const last = args[args.length - 1]
   const composeOptions: Html.Options | undefined =
@@ -2279,7 +2285,7 @@ export function compose(
 
   if (handlers.length === 0) throw new Error('compose() requires at least one handler')
 
-  return async (input: Request) => {
+  const composed: ComposedHandler = async (input: Request) => {
     // Serve service worker for html-enabled compose
     if (new URL(input.url).searchParams.has(Html.params.serviceWorker)) {
       const hasHtml = handlers.some((h) => (h as ConfiguredHandler)._internal?.html)
@@ -2501,6 +2507,21 @@ export function compose(
       challenge: new Response(body, { status: 402, headers: mergedHeaders }),
     }
   }
+
+  const offers = handlers.flatMap((handler) => {
+    const internal = (handler as ConfiguredHandler | ComposedHandler)._internal
+    if (!internal) return []
+    if (isComposedHandlerMetadata(internal)) return internal.offers
+    return [internal]
+  })
+  if (offers.length > 0) composed._internal = { offers }
+  return composed
+}
+
+function isComposedHandlerMetadata(
+  internal: HandlerDiscoveryMetadata,
+): internal is NonNullable<ComposedHandler['_internal']> {
+  return 'offers' in internal && !('_canonicalRequest' in internal)
 }
 
 type ChallengeHeaderMerge = {

--- a/src/server/Mppx.ts
+++ b/src/server/Mppx.ts
@@ -2321,33 +2321,34 @@ export function compose(...args: readonly unknown[]): ComposedHandler {
         const credReq = credential.challenge.request as Record<string, unknown>
 
         // Filter by name+intent, then narrow by comparing stable request fields
-        // from the echoed challenge against each handler's canonical request.
+        // from the echoed challenge against each handler's configured offers.
         // Uses the schema-parsed canonical form (not raw options) so that
         // transformed fields (e.g. amount with decimals) match correctly.
         // Also checks inside methodDetails for fields moved there by transforms.
-        const candidates = handlers.filter((h) => {
-          try {
-            const internal = (h as ConfiguredHandler)._internal
-            if (!internal || internal.name !== credMethod || internal.intent !== credIntent)
+        const candidates = handlers.filter((handler) =>
+          getConfiguredOffers(handler).some((internal) => {
+            try {
+              if (internal.name !== credMethod || internal.intent !== credIntent) return false
+              const mismatch = internal._stableBinding
+                ? getRequestBindingMismatch(
+                    getStableBinding(internal._canonicalRequest, internal._stableBinding),
+                    getStableBinding(credReq, internal._stableBinding),
+                  )
+                : getPinnedRequestBindingMismatch(internal._canonicalRequest, credReq)
+              return !mismatch && opaqueValuesMatch(internal.meta, credential.challenge.meta)
+            } catch {
               return false
-            const mismatch = internal._stableBinding
-              ? getRequestBindingMismatch(
-                  getStableBinding(internal._canonicalRequest, internal._stableBinding),
-                  getStableBinding(credReq, internal._stableBinding),
-                )
-              : getPinnedRequestBindingMismatch(internal._canonicalRequest, credReq)
-            return !mismatch && opaqueValuesMatch(internal.meta, credential.challenge.meta)
-          } catch {
-            return false
-          }
-        })
+            }
+          }),
+        )
 
         const match =
           candidates[0] ??
-          handlers.find((h) => {
-            const meta = (h as ConfiguredHandler)._internal
-            return meta?.name === credMethod && meta?.intent === credIntent
-          })
+          handlers.find((handler) =>
+            getConfiguredOffers(handler).some(
+              (internal) => internal.name === credMethod && internal.intent === credIntent,
+            ),
+          )
         if (match) return match(input)
       }
 
@@ -2509,14 +2510,19 @@ export function compose(...args: readonly unknown[]): ComposedHandler {
     }
   }
 
-  const offers = handlers.flatMap((handler) => {
-    const internal = (handler as ConfiguredHandler | ComposedHandler)._internal
-    if (!internal) return []
-    if (isComposedHandlerMetadata(internal)) return internal.offers
-    return [internal]
-  })
+  const offers = handlers.flatMap(getConfiguredOffers)
   if (offers.length > 0) composed._internal = { offers }
   return composed
+}
+
+/** Returns the flattened configured offers accepted by a handler. */
+function getConfiguredOffers(
+  handler: ConfiguredHandler | ComposedHandler,
+): readonly ConfiguredHandler['_internal'][] {
+  const internal = handler._internal
+  if (!internal) return []
+  if (isComposedHandlerMetadata(internal)) return internal.offers
+  return [internal]
 }
 
 function isComposedHandlerMetadata(

--- a/src/server/Mppx.ts
+++ b/src/server/Mppx.ts
@@ -2167,6 +2167,7 @@ declare namespace MethodFn {
 /** A configured handler — the return value of e.g. `mppx.charge({ ... })`. @internal */
 type ConfiguredHandler = ((input: Request) => Promise<MethodFn.Response<Transport.Http>>) & {
   _internal: {
+    description?: string | undefined
     name: string
     intent: string
     html: Html.Options | undefined


### PR DESCRIPTION
## Motivation

Composed payment handlers dropped their configured pricing metadata, causing discovery documents to omit runtime offers and encouraging proxy consumers to maintain a separate asset list.

## Summary

- preserved configured offer metadata through `Mppx.compose()`
- derived OpenAPI and proxy discovery from every composed offer
- supported composed offers during proxy credential route matching
- added coverage for multi-asset discovery and explicitly priced routes

## Key design considerations

- discovery includes only handlers explicitly passed to `compose`, not every registered payment method
- nested composed metadata is flattened while handlers without discovery metadata are ignored
- single-offer discovery remains backward compatible