### PR TITLE
[DNM] fix: evaluate settlement schedules during SSE streams

### DIFF
--- a/.changeset/metered-stream-settlement-schedule.md
+++ b/.changeset/metered-stream-settlement-schedule.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added settlement schedule evaluation after successfully committed SSE charges in session handlers and exposed the same post-commit hook for standalone WebSocket metering.

--- a/src/tempo/server/internal/transport.ts
+++ b/src/tempo/server/internal/transport.ts
@@ -49,7 +49,7 @@ function hasPrepaidSessionTick(receipt: SessionReceipt): boolean {
  * - Fallback to standard HTTP receipt handling for plain Response
  */
 export function sse(options: sse.Options & { store: ChannelStore.ChannelStore }): Sse {
-  const { pollingInterval, poll } = options
+  const { onChargesCommitted, pollingInterval, poll } = options
 
   // When `poll` is true, strip `waitForUpdate` so the SSE charge loop
   // falls back to polling. This is needed for runtimes like Cloudflare Workers
@@ -115,6 +115,7 @@ export function sse(options: sse.Options & { store: ChannelStore.ChannelStore })
           channelId,
           challengeId: verifiedChallengeId,
           tickCost,
+          onChargesCommitted,
           pollIntervalMs: pollingInterval,
           generate,
           prepaidUnits: hasPrepaidSessionTick(receipt as SessionReceipt) ? 1 : 0,
@@ -227,6 +228,13 @@ export function sse(options: sse.Options & { store: ChannelStore.ChannelStore })
 /** Type helpers for the Tempo SSE transport adapter. */
 export declare namespace sse {
   type Options = {
+    /**
+     * Invoked after each successful stream charge commit.
+     *
+     * `session({ sse: true })` uses this to evaluate whether its server-owned
+     * `settlementSchedule` is due during SSE metering.
+     */
+    onChargesCommitted?: ((channel: ChannelStore.State) => void | Promise<void>) | undefined
     /**
      * When true, the charge loop uses polling instead of `waitForUpdate()`.
      *

--- a/src/tempo/session/server/MeteredStream.ts
+++ b/src/tempo/session/server/MeteredStream.ts
@@ -37,6 +37,14 @@ export type MeteredStreamOptions = {
   formatNeedVoucher(parameters: NeedVoucherEvent): string
   /** Async source or manual-charge source. */
   generate: SessionStreamGenerator
+  /**
+   * Invoked after a reserved charge is successfully committed to the channel.
+   *
+   * Used by session transports to evaluate server-owned settlement schedules without
+   * coupling generic stream accounting to settlement construction details. Not called
+   * when the commit is a no-op or when the commit fails.
+   */
+  onChargesCommitted?: ((channel: ChannelStore.State) => void | Promise<void>) | undefined
   /** Store polling interval when `waitForUpdate` is unavailable. */
   pollIntervalMs: number
   /** Pre-authorized units that may be emitted without reserving new voucher headroom. */
@@ -82,7 +90,7 @@ export async function* meterIterable(options: MeteredStreamOptions): AsyncGenera
   for await (const value of iterable) {
     if (options.signal?.aborted) break
     if (typeof options.generate !== 'function') await charge()
-    await commitReservedCharges({
+    const committed = await commitReservedCharges({
       store: options.store,
       channelId: options.channelId,
       amount: reservedAmount,
@@ -90,6 +98,7 @@ export async function* meterIterable(options: MeteredStreamOptions): AsyncGenera
     })
     reservedAmount = 0n
     reservedUnits = 0
+    if (committed && options.onChargesCommitted) await options.onChargesCommitted(committed)
     yield value
   }
 }

--- a/src/tempo/session/server/Session.test.ts
+++ b/src/tempo/session/server/Session.test.ts
@@ -31,7 +31,7 @@ import { sessionManager as precompileSessionManager } from '../client/SessionMan
 import * as Channel from '../precompile/Channel.js'
 import { escrowAbi } from '../precompile/escrow.abi.js'
 import { tip20ChannelEscrow } from '../precompile/Protocol.js'
-import { deserializeSessionReceipt } from '../precompile/Protocol.js'
+import { createSessionReceipt, deserializeSessionReceipt } from '../precompile/Protocol.js'
 import type { SessionReceipt } from '../precompile/Protocol.js'
 import type { SessionCredentialPayload } from '../precompile/Protocol.js'
 import * as Types from '../precompile/Protocol.js'
@@ -3570,6 +3570,87 @@ describe('onSessionSettlement', () => {
       channelId: openPayload.channelId,
       amount: 500n,
       delta: 500n,
+    })
+  })
+
+  test('evaluates the settlement schedule after committed SSE charges', async () => {
+    const events: { trigger: string; amount: bigint; delta: bigint }[] = []
+    const settlementCountsBeforeSecondCharge: number[] = []
+    const rawStore = Store.memory()
+    const store = channelStore(rawStore)
+    const openPayload = await createOpenPayload({ initialAmount: 200n })
+    await persistPrecompileChannel(store, openPayload, {
+      payee: payer.address,
+    })
+
+    const method = session({
+      account: payer,
+      amount: '100',
+      chainId,
+      currency: token,
+      decimals: 0,
+      recipient: payer.address,
+      settlementSchedule: { amount: 200n },
+      sse: true,
+      store: rawStore,
+      unitType: 'token',
+      getClient: () => createSettleClient(openPayload.channelId, 200n),
+      onSessionSettlement: (context) => {
+        events.push({
+          trigger: context.trigger,
+          amount: context.amount,
+          delta: context.delta,
+        })
+      },
+    })
+    const challenge = {
+      ...makeChallenge(openPayload.channelId),
+      request: {
+        ...makeChallenge(openPayload.channelId).request,
+        amount: '100',
+        recipient: payer.address,
+        unitType: 'token',
+      },
+    }
+    const credential = {
+      challenge,
+      payload: {
+        action: 'voucher' as const,
+        channelId: openPayload.channelId,
+        cumulativeAmount: '200',
+        signature: openPayload.signature,
+      },
+    }
+
+    const response = method.transport!.respondReceipt({
+      challengeId: challenge.id,
+      credential,
+      input: new Request('https://api.example.com/stream'),
+      receipt: createSessionReceipt({
+        acceptedCumulative: 200n,
+        challengeId: challenge.id,
+        channelId: openPayload.channelId,
+        spent: 0n,
+        units: 0,
+      }),
+      response: async function* (stream) {
+        await stream.charge(100n)
+        yield 'before-threshold'
+        settlementCountsBeforeSecondCharge.push(events.length)
+        await stream.charge(100n)
+        yield 'threshold-crossed'
+      },
+    })
+
+    await expect(response.text()).resolves.toContain('threshold-crossed')
+    expect(settlementCountsBeforeSecondCharge).toEqual([0])
+    expect(events).toEqual([{ trigger: 'scheduled', amount: 200n, delta: 200n }])
+    expect(await store.getChannel(openPayload.channelId)).toMatchObject({
+      lastSettlementSpent: 200n,
+      lastSettlementUnits: 2,
+      settledOnChain: 200n,
+      spent: 200n,
+      units: 2,
     })
   })
 

--- a/src/tempo/session/server/Session.ts
+++ b/src/tempo/session/server/Session.ts
@@ -346,6 +346,26 @@ export function session<const parameters extends session.Parameters>(
     ? Transport.sse({
         store,
         ...(typeof parameters.sse === 'object' ? parameters.sse : undefined),
+        ...(settlementSchedule
+          ? {
+              onChargesCommitted: async (channel) => {
+                const client = await getClient({ chainId: channel.chainId })
+                await maybeSettleScheduled({
+                  account,
+                  client,
+                  ...(typeof configuredFeePayer === 'object'
+                    ? { feePayer: configuredFeePayer }
+                    : {}),
+                  feePayerPolicy: parameters.feePayerPolicy,
+                  feeToken: parameters.feeToken,
+                  onSessionSettlement,
+                  schedule: settlementSchedule,
+                  store,
+                  channel,
+                })
+              },
+            }
+          : {}),
       })
     : undefined
 

--- a/src/tempo/session/server/Settlement.ts
+++ b/src/tempo/session/server/Settlement.ts
@@ -123,7 +123,13 @@ export type SettlementSchedule = {
   units?: number | undefined
   /** Settle after this much additional settlement amount since the previous scheduled settlement. */
   amount?: string | bigint | undefined
-  /** Settle after this many milliseconds since the previous scheduled settlement. */
+  /**
+   * Settle after this many milliseconds since the previous scheduled settlement.
+   *
+   * Evaluation is opportunistic on charge activity (ordinary paid requests and
+   * committed stream charges). There is no background timer: settlement occurs
+   * on the first charge after the interval elapses.
+   */
   intervalMs?: number | undefined
 }
 

--- a/src/tempo/session/server/Sse.ts
+++ b/src/tempo/session/server/Sse.ts
@@ -53,7 +53,8 @@ export type { SessionController } from './MeteredStream.js'
  * 3. If balance is exhausted, emits `event: payment-need-voucher`
  *    and polls store until the client tops up the channel.
  * 4. Commits the reserved charge immediately before the chunk is emitted.
- * 5. On generator completion, emits a final `event: payment-receipt`.
+ * 5. Optionally evaluates whether scheduled settlement is due after a successful commit.
+ * 6. On generator completion, emits a final `event: payment-receipt`.
  *
  * Returns a `ReadableStream<Uint8Array>` suitable for use as an HTTP response body.
  */
@@ -64,6 +65,7 @@ export function serve(options: serve.Options): ReadableStream<Uint8Array> {
     challengeId,
     tickCost,
     generate,
+    onChargesCommitted,
     pollIntervalMs = 100,
     signal,
   } = options
@@ -81,6 +83,7 @@ export function serve(options: serve.Options): ReadableStream<Uint8Array> {
           channelId,
           tickCost,
           generate,
+          onChargesCommitted,
           pollIntervalMs,
           prepaidUnits: options.prepaidUnits,
           signal,
@@ -121,6 +124,8 @@ export declare namespace serve {
     challengeId: string
     tickCost: bigint
     generate: AsyncIterable<string> | ((stream: SessionController) => AsyncIterable<string>)
+    /** Invoked after each successful stream charge commit, before the value is emitted. */
+    onChargesCommitted?: ((channel: ChannelStore.State) => void | Promise<void>) | undefined
     pollIntervalMs?: number | undefined
     prepaidUnits?: number | undefined
     signal?: AbortSignal | undefined

--- a/src/tempo/session/server/Transports.test.ts
+++ b/src/tempo/session/server/Transports.test.ts
@@ -1,9 +1,10 @@
 import type { Address, Hex } from 'viem'
-import { describe, expect, test } from 'vp/test'
+import { describe, expect, test, vi } from 'vp/test'
 
 import { ChannelClosedError } from '../../../Errors.js'
 import type { NeedVoucherEvent } from '../precompile/Protocol.js'
 import * as ChannelStore from './ChannelStore.js'
+import { meterIterable } from './MeteredStream.js'
 import {
   commitReservedCharges,
   reserveChargeOrWait,
@@ -186,6 +187,78 @@ describe('MeteredStream', () => {
           units: 1,
         }),
       ).rejects.toThrow(ChannelClosedError)
+    })
+
+    test('commitReservedCharges returns undefined when there is nothing to commit', async () => {
+      const store = memoryStore(channel())
+      await expect(
+        commitReservedCharges({ amount: 0n, channelId, store, units: 0 }),
+      ).resolves.toBeUndefined()
+    })
+
+    test('commitReservedCharges returns the updated channel after a successful commit', async () => {
+      const store = memoryStore(channel({ spent: 20n, units: 2, highestVoucherAmount: 50n }))
+      await expect(
+        commitReservedCharges({ amount: 10n, channelId, store, units: 1 }),
+      ).resolves.toMatchObject({ spent: 30n, units: 3 })
+    })
+
+    test('meterIterable invokes onChargesCommitted after a successful commit', async () => {
+      const store = memoryStore(channel({ spent: 0n, units: 0, highestVoucherAmount: 30n }))
+      const onChargesCommitted = vi.fn()
+
+      const values: string[] = []
+      for await (const value of meterIterable({
+        channelId,
+        emitNeedVoucher() {},
+        formatNeedVoucher,
+        generate: async function* (stream) {
+          await stream.charge(10n)
+          yield 'one'
+          await stream.charge(10n)
+          yield 'two'
+        },
+        onChargesCommitted,
+        pollIntervalMs: 1,
+        store,
+        tickCost: 10n,
+      })) {
+        values.push(value)
+      }
+
+      expect(values).toEqual(['one', 'two'])
+      expect(onChargesCommitted).toHaveBeenCalledTimes(2)
+      expect(onChargesCommitted.mock.calls[0]?.[0]).toMatchObject({ spent: 10n, units: 1 })
+      expect(onChargesCommitted.mock.calls[1]?.[0]).toMatchObject({ spent: 20n, units: 2 })
+    })
+
+    test('meterIterable does not invoke onChargesCommitted when commit fails', async () => {
+      const store = memoryStore(channel({ spent: 0n, units: 0, highestVoucherAmount: 10n }))
+      const onChargesCommitted = vi.fn()
+
+      await expect(async () => {
+        for await (const _value of meterIterable({
+          channelId,
+          emitNeedVoucher() {},
+          formatNeedVoucher,
+          generate: async function* (stream) {
+            await stream.charge(10n)
+            await store.updateChannel(channelId, (current) =>
+              current ? { ...current, highestVoucherAmount: 0n } : current,
+            )
+            yield 'blocked'
+          },
+          onChargesCommitted,
+          pollIntervalMs: 1,
+          store,
+          tickCost: 10n,
+        })) {
+          // drain
+        }
+      }).rejects.toThrow('reserved voucher coverage is no longer available')
+
+      expect(onChargesCommitted).not.toHaveBeenCalled()
+      expect(await store.getChannel(channelId)).toMatchObject({ spent: 0n, units: 0 })
     })
   })
 })

--- a/src/tempo/session/server/Transports.ts
+++ b/src/tempo/session/server/Transports.ts
@@ -83,12 +83,17 @@ export async function reserveChargeOrWait(options: ReserveChargeParameters): Pro
   }
 }
 
-/** Atomically commits previously reserved stream charges to channel spend and unit counters. */
+/**
+ * Atomically commits previously reserved stream charges to channel spend and unit counters.
+ *
+ * Returns the updated channel when a commit occurs, or `undefined` when there is nothing to
+ * commit (`amount`/`units` are zero).
+ */
 export async function commitReservedCharges(
   options: CommitReservedChargesParameters,
-): Promise<void> {
+): Promise<ChannelStore.State | undefined> {
   const { amount, channelId, store, units } = options
-  if (amount === 0n || units === 0) return
+  if (amount === 0n || units === 0) return undefined
 
   let committed = false
   const channel = await store.updateChannel(channelId, (current) => {
@@ -107,6 +112,7 @@ export async function commitReservedCharges(
   if (!channel) throw new Error('channel not found')
   throwIfChannelClosed(channel)
   if (!committed) throw new Error('reserved voucher coverage is no longer available')
+  return channel
 }
 
 /** Throws when a channel can no longer be used for streaming charges. */

--- a/src/tempo/session/server/Ws.ts
+++ b/src/tempo/session/server/Ws.ts
@@ -97,6 +97,7 @@ export async function serve(options: serve.Options): Promise<void> {
   const {
     amount: expectedAmount,
     generate,
+    onChargesCommitted,
     pollIntervalMs = 100,
     route,
     socket,
@@ -152,6 +153,7 @@ export async function serve(options: serve.Options): Promise<void> {
         channelId: context.channelId,
         tickCost: context.tickCost,
         generate,
+        onChargesCommitted,
         pollIntervalMs,
         signal: abortController.signal,
         emitNeedVoucher: (message) => send(socket, message),
@@ -328,6 +330,8 @@ export declare namespace serve {
     /** Application stream. A manual stream can call `charge(amount)` with a
      *  per-message raw-unit amount; omitting it uses the challenge tick cost. */
     generate: AsyncIterable<string> | ((stream: SessionController) => AsyncIterable<string>)
+    /** Optional hook invoked after each successful stream charge commit. */
+    onChargesCommitted?: ((channel: ChannelStore.State) => void | Promise<void>) | undefined
     pollIntervalMs?: number | undefined
     /** Payment route handler. Receives synthetic `POST` requests with only
      *  the `Authorization` header — no cookies, bodies, or upgrade headers. */


### PR DESCRIPTION
## Summary

Metered SSE charges updated channel spend and units without evaluating the server settlement schedule. Ordinary paid HTTP requests already evaluated the same schedule after charging.

This change:
- evaluates settlementSchedule after each successful non-zero SSE charge commit through the session-created SSE transport
- keeps settlement conditional on the existing amount, unit, or interval thresholds via maybeSettleScheduled
- documents intervalMs as opportunistic: the first charge after the interval elapses triggers evaluation; no background timer is added
- exposes the shared post-commit callback through standalone Ws.serve, but does not claim automatic WebSocket schedule wiring because session() only constructs the SSE transport

## Tests

- Added a session integration regression that constructs session({ settlementSchedule, sse: true }), drains its real SSE transport, verifies no settlement before the amount threshold, and verifies the scheduled settlement and persisted boundary after crossing it.
- Added metered transport coverage for successful commits, no-op commits, and failed commits.
- Passed: focused node tests for Transports, Settlement, and Sse (55 tests).
- Passed: repository-wide lint and format check.
- Locally blocked: Session.test.ts collection and root typecheck require generated HTML modules. pnpm build:html fails because the local esbuild service is stopped; example typechecks also cannot resolve the unbuilt mppx package. CI should run the session regression and complete typechecks.