### PR TITLE
fix: settle streaming session charges on schedule

### DIFF
--- a/.changeset/bind-session-websocket-server.md
+++ b/.changeset/bind-session-websocket-server.md
@@ -1,5 +1,0 @@
----
-'mppx': patch
----
-
-Added a session-bound WebSocket server helper that reused the configured store and settlement policy, and applied that policy to plain HTTP responses from SSE-enabled methods.

--- a/.changeset/bind-session-websocket-server.md
+++ b/.changeset/bind-session-websocket-server.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added a session-bound WebSocket server helper that reused the configured store and settlement policy, and applied that policy to plain HTTP responses from SSE-enabled methods.

--- a/.changeset/settle-streaming-session-charges.md
+++ b/.changeset/settle-streaming-session-charges.md
@@ -2,4 +2,4 @@
 'mppx': patch
 ---
 
-Fixed automatic settlement schedules after committed Tempo session SSE and WebSocket charges.
+Added a session-bound WebSocket server helper that reused the configured store and settlement policy, and applied that policy to plain HTTP responses from SSE-enabled methods. Fixed automatic settlement schedules after committed Tempo session SSE and WebSocket charges.

--- a/.changeset/settle-streaming-session-charges.md
+++ b/.changeset/settle-streaming-session-charges.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed automatic settlement schedules after committed Tempo session SSE and WebSocket charges.

--- a/examples/session/ws/src/server.ts
+++ b/examples/session/ws/src/server.ts
@@ -121,6 +121,7 @@ wsServer.on('connection', (socket, req) => {
     store,
     url,
     route,
+    settleScheduled: mppx.session.settleScheduled,
     generate: async function* (stream) {
       for await (const token of generateTokens(prompt)) {
         await stream.charge()

--- a/examples/session/ws/src/server.ts
+++ b/examples/session/ws/src/server.ts
@@ -104,24 +104,23 @@ const route = mppx.session({
 // WebSocket Upgrade Handler
 
 //
-// `tempo.Ws.serve()` does not perform the HTTP upgrade itself. We use `ws`
-// only for the low-level upgrade mechanics, then hand the accepted socket to
-// mppx's Tempo websocket helper for payment-aware streaming.
+// `mppx.session.serveWebSocket()` does not perform the HTTP upgrade itself. We
+// use `ws` only for the low-level upgrade mechanics, then hand the accepted
+// socket to the session-bound helper for payment-aware streaming.
 const wsServer = new WebSocketServer({ noServer: true })
 wsServer.on('connection', (socket, req) => {
   const url = new URL(req.url ?? '/ws/chat', `ws://${req.headers.host ?? 'localhost:5173'}`)
   const prompt = url.searchParams.get('prompt') ?? 'Tell me something interesting'
 
-  // `tempo.Ws.serve()` bridges websocket control frames to the existing
-  // Tempo session lifecycle. When it receives an in-band authorization frame,
-  // it verifies it through `route`. Once paid, it runs this generator and
-  // emits application chunks interleaved with payment control frames.
-  void tempo.Ws.serve({
+  // `serveWebSocket()` bridges websocket control frames to the existing Tempo
+  // session lifecycle and reuses its store and settlement policy. When it
+  // receives an in-band authorization frame, it verifies it through `route`.
+  // Once paid, it runs this generator and emits application chunks interleaved
+  // with payment control frames.
+  void mppx.session.serveWebSocket({
     socket,
-    store,
     url,
     route,
-    settleScheduled: mppx.session.settleScheduled,
     generate: async function* (stream) {
       for await (const token of generateTokens(prompt)) {
         await stream.charge()

--- a/src/server/Mppx.test-d.ts
+++ b/src/server/Mppx.test-d.ts
@@ -111,6 +111,15 @@ describe('Mppx type tests', () => {
     const mppx = Mppx.create({ methods: [sessionMethod], realm, secretKey })
 
     expectTypeOf(mppx.session.settleScheduled).toBeFunction()
+    expectTypeOf(mppx.session.serveWebSocket).toBeFunction()
+    type Options = Parameters<typeof mppx.session.serveWebSocket>[0]
+    expectTypeOf<Options>().toHaveProperty('route')
+    expectTypeOf<Options>().not.toHaveProperty('store')
+    expectTypeOf<Options>().not.toHaveProperty('onChargeCommitted')
+    expectTypeOf<Options>().not.toHaveProperty('settleScheduled')
+    type LowLevelOptions = Parameters<typeof tempo.Ws.serve>[0]
+    expectTypeOf<LowLevelOptions>().toHaveProperty('onChargeCommitted')
+    expectTypeOf<LowLevelOptions>().toHaveProperty('settleScheduled')
   })
 
   test('compose exists on the instance and returns a handler', () => {

--- a/src/server/Mppx.test-d.ts
+++ b/src/server/Mppx.test-d.ts
@@ -99,6 +99,20 @@ const secretKey = 'test-secret-key-test-secret-key-32'
 const realm = 'api.example.com'
 
 describe('Mppx type tests', () => {
+  test('method handlers expose method extensions', () => {
+    const sessionMethod = tempo.session({
+      amount: '1',
+      currency: '0x0000000000000000000000000000000000000001',
+      decimals: 6,
+      getClient: () => null as never,
+      recipient: '0x0000000000000000000000000000000000000002',
+      unitType: 'token',
+    })
+    const mppx = Mppx.create({ methods: [sessionMethod], realm, secretKey })
+
+    expectTypeOf(mppx.session.settleScheduled).toBeFunction()
+  })
+
   test('compose exists on the instance and returns a handler', () => {
     const mppx = Mppx.create({ methods: [alphaMethod, betaMethod], realm, secretKey })
 

--- a/src/tempo/server/internal/transport.test.ts
+++ b/src/tempo/server/internal/transport.test.ts
@@ -738,8 +738,15 @@ describe('sse transport', () => {
 
   test('respondReceipt with non-SSE upstream Response still deducts from channel', async () => {
     const store = memoryStore()
+    const settled: Array<{ spent: bigint; units: number }> = []
     await seedChannel(store, 10000000n)
-    const transport = sse({ store })
+    const transport = sse({
+      store,
+      async settleCharged(channel) {
+        settled.push({ spent: channel.spent, units: channel.units })
+        return undefined
+      },
+    })
     const request = new Request('https://test.example.com/session', {
       body: JSON.stringify({ prompt: 'hello' }),
       headers: makeAuthorizedRequest().headers,
@@ -768,6 +775,7 @@ describe('sse transport', () => {
     expect(channel!.units).toBe(1)
     expect(receipt.spent).toBe('1000000')
     expect(receipt.units).toBe(1)
+    expect(settled).toEqual([{ spent: 1000000n, units: 1 }])
 
     expect(JSON.parse(body)).toEqual({ content: 'hello' })
     expect(response.headers.get('Content-Type')).toBe('application/json')
@@ -806,8 +814,18 @@ describe('sse transport', () => {
 
   test('respondReceipt with 204 content response still deducts from channel', async () => {
     const store = memoryStore()
+    let resolveSettlement!: (channel: ChannelStore.State) => void
+    const settlement = new Promise<ChannelStore.State>((resolve) => {
+      resolveSettlement = resolve
+    })
     await seedChannel(store, 10000000n)
-    const transport = sse({ store })
+    const transport = sse({
+      store,
+      async settleCharged(channel) {
+        resolveSettlement(channel)
+        return undefined
+      },
+    })
     const request = new Request('https://test.example.com/session', {
       body: JSON.stringify({ prompt: 'hello' }),
       headers: makeAuthorizedRequest().headers,
@@ -827,11 +845,12 @@ describe('sse transport', () => {
     expect(await response.text()).toBe('')
     const receipt = deserializeSessionReceipt(response.headers.get('Payment-Receipt')!)
 
-    await Promise.resolve()
+    const settled = await settlement
 
     const channel = await store.getChannel(channelId)
     expect(channel!.spent).toBe(1000000n)
     expect(channel!.units).toBe(1)
+    expect(settled).toMatchObject({ spent: 1000000n, units: 1 })
     expect(receipt.spent).toBe('1000000')
     expect(receipt.units).toBe(1)
   })

--- a/src/tempo/server/internal/transport.ts
+++ b/src/tempo/server/internal/transport.ts
@@ -12,6 +12,7 @@ import * as Transport from '../../../server/Transport.js'
 import type { SessionReceipt } from '../../session/precompile/Protocol.js'
 import { requireSessionCredentialContext } from '../../session/precompile/Protocol.js'
 import * as ChannelStore from '../../session/server/ChannelStore.js'
+import type { SettleChargedSessionChannel } from '../../session/server/Settlement.js'
 import * as Sse_core from '../../session/server/Sse.js'
 import { captureRequestBodyProbe, shouldChargePlainResponse } from './request-body.js'
 
@@ -48,7 +49,12 @@ function hasPrepaidSessionTick(receipt: SessionReceipt): boolean {
  * - Auto-detection of upstream SSE responses
  * - Fallback to standard HTTP receipt handling for plain Response
  */
-export function sse(options: sse.Options & { store: ChannelStore.ChannelStore }): Sse {
+export function sse(
+  options: sse.Options & {
+    settleCharged?: SettleChargedSessionChannel | undefined
+    store: ChannelStore.ChannelStore
+  },
+): Sse {
   const { pollingInterval, poll } = options
 
   // When `poll` is true, strip `waitForUpdate` so the SSE charge loop
@@ -117,6 +123,7 @@ export function sse(options: sse.Options & { store: ChannelStore.ChannelStore })
           tickCost,
           pollIntervalMs: pollingInterval,
           generate,
+          onChargeCommitted: options.settleCharged,
           prepaidUnits: hasPrepaidSessionTick(receipt as SessionReceipt) ? 1 : 0,
           signal: input.signal,
         })

--- a/src/tempo/server/internal/transport.ts
+++ b/src/tempo/server/internal/transport.ts
@@ -181,20 +181,25 @@ export function sse(
         response: response as Response,
         challengeId: verifiedChallengeId,
       })
+      const chargePlainResponse = async () => {
+        const result = await ChannelStore.deductFromChannel(store, channelId, tickCost)
+        if (result.ok) await options.settleCharged?.(result.channel)
+        return result
+      }
 
       // Non-SSE response (e.g. upstream returned JSON instead of event-stream).
       // Need to deduct tickCost so request isn't free.
       // For null-body statuses, the request shape determines whether the
       // response is management (no charge) or plain content (charge one tick).
       if (isNullBodyStatus(chargedResponse.status)) {
-        void ChannelStore.deductFromChannel(store, channelId, tickCost)
+        void chargePlainResponse()
         return chargedResponse
       }
 
       const stream = new ReadableStream<Uint8Array>({
         async start(controller) {
           // deduction completes before consumer reads
-          const result = await ChannelStore.deductFromChannel(store, channelId, tickCost)
+          const result = await chargePlainResponse()
           if (!result.ok) {
             controller.error(
               new Errors.InsufficientBalanceError({

--- a/src/tempo/session/README.md
+++ b/src/tempo/session/README.md
@@ -186,6 +186,118 @@ sequenceDiagram
 The initial SSE POST is excluded from default HTTP charging to prevent double
 counting. Stream accounting remains owned by the transport driver.
 
+## Server transport configuration
+
+A session method owns the account, channel store, verification policy, and
+settlement schedule. Routes add prices and application content. HTTP and SSE
+run through configured route handlers; WebSocket uses a session-bound helper
+because its application messages no longer pass through HTTP.
+
+| Server shape           | Session option | Content API                         | Charging                            |
+| ---------------------- | -------------- | ----------------------------------- | ----------------------------------- |
+| HTTP only              | Omit `sse`     | `result.withReceipt(Response)`      | Once per billable request           |
+| SSE only               | `sse: true`    | `result.withReceipt(AsyncIterable)` | Each `stream.charge()`              |
+| WebSocket only         | Omit `sse`     | `mppx.session.serveWebSocket(...)`  | Each `stream.charge()`              |
+| HTTP + SSE + WebSocket | `sse: true`    | All three APIs                      | Selected by route and response type |
+
+All transports for one session service must share the same configured session
+method and store. `serveWebSocket` is bound to both the store and settlement
+policy, so callers pass neither dependency again. `tempo.Ws.serve` remains the
+low-level adapter for custom integrations.
+
+### Shared method configuration
+
+```ts
+const session = tempo.session({
+  account,
+  currency,
+  getClient: () => client,
+  settlementSchedule: { units: 100 },
+  store,
+  // Include when this instance serves any SSE route.
+  sse: true,
+})
+
+const mppx = Mppx.create({ methods: [session], secretKey })
+```
+
+`sse: true` enables async-iterable responses without changing ordinary
+`Response` handling, so a mixed server uses one session method.
+
+### HTTP
+
+```ts
+const httpRoute = mppx.session({ amount: '0.01', unitType: 'request' })
+const result = await httpRoute(request)
+
+if (result.status === 402) return result.challenge
+return result.withReceipt(Response.json({ ok: true }))
+```
+
+HTTP accounting charges the configured route amount before application content
+runs. A plain `Response` selects normal HTTP handling even when `sse: true`.
+
+### SSE
+
+```ts
+const sseRoute = mppx.session({ amount: '0.001', unitType: 'token' })
+const result = await sseRoute(request)
+
+if (result.status === 402) return result.challenge
+return result.withReceipt(async function* (stream) {
+  for await (const token of generateTokens()) {
+    await stream.charge()
+    yield token
+  }
+})
+```
+
+SSE requires `sse: true` on the shared session method. The async iterable
+selects SSE framing and transport-owned metering.
+
+### WebSocket
+
+```ts
+const wsRoute = mppx.session({ amount: '0.001', unitType: 'token' })
+
+webSocketServer.on('connection', (socket, request) => {
+  void mppx.session.serveWebSocket({
+    generate: async function* (stream) {
+      for await (const token of generateTokens()) {
+        await stream.charge()
+        yield token
+      }
+    },
+    route: wsRoute,
+    socket,
+    url: new URL(request.url!, `ws://${request.headers.host}`),
+  })
+})
+```
+
+The application still exposes `wsRoute` over HTTP for the initial challenge
+probe. The bound helper reuses the session store and automatic settlement
+schedule for in-band WebSocket vouchers and charges.
+
+### Mixed server
+
+```ts
+const httpRoute = mppx.session({ amount: '0.01', unitType: 'request' })
+const sseRoute = mppx.session({ amount: '0.001', unitType: 'token' })
+const wsRoute = mppx.session({ amount: '0.001', unitType: 'token' })
+
+async function handler(request: Request) {
+  const pathname = new URL(request.url).pathname
+  if (pathname === '/api/data') return serveHttp(httpRoute, request)
+  if (pathname === '/api/events') return serveSse(sseRoute, request)
+  if (pathname === '/ws') return serveWebSocketProbe(wsRoute, request)
+  return new Response('Not found', { status: 404 })
+}
+```
+
+Each route can choose its own price and unit type. Verification, channel state,
+and settlement policy remain shared through the single session method.
+
 ## Extension boundaries
 
 | Change                         | Preserve                                                                                        |

--- a/src/tempo/session/server/MeteredStream.ts
+++ b/src/tempo/session/server/MeteredStream.ts
@@ -1,5 +1,6 @@
 import type { Hex } from 'viem'
 
+import type { MaybePromise } from '../../../internal/types.js'
 import type { NeedVoucherEvent } from '../precompile/Protocol.js'
 import * as ChannelStore from './ChannelStore.js'
 import { commitReservedCharges, reserveChargeOrWait } from './Transports.js'
@@ -37,6 +38,8 @@ export type MeteredStreamOptions = {
   formatNeedVoucher(parameters: NeedVoucherEvent): string
   /** Async source or manual-charge source. */
   generate: SessionStreamGenerator
+  /** Runs after a nonzero reserved charge has been committed. */
+  onChargeCommitted?: ((channel: ChannelStore.State) => MaybePromise<unknown>) | undefined
   /** Store polling interval when `waitForUpdate` is unavailable. */
   pollIntervalMs: number
   /** Pre-authorized units that may be emitted without reserving new voucher headroom. */
@@ -82,7 +85,7 @@ export async function* meterIterable(options: MeteredStreamOptions): AsyncGenera
   for await (const value of iterable) {
     if (options.signal?.aborted) break
     if (typeof options.generate !== 'function') await charge()
-    await commitReservedCharges({
+    const channel = await commitReservedCharges({
       store: options.store,
       channelId: options.channelId,
       amount: reservedAmount,
@@ -90,6 +93,7 @@ export async function* meterIterable(options: MeteredStreamOptions): AsyncGenera
     })
     reservedAmount = 0n
     reservedUnits = 0
+    if (channel) await options.onChargeCommitted?.(channel)
     yield value
   }
 }

--- a/src/tempo/session/server/Session.test.ts
+++ b/src/tempo/session/server/Session.test.ts
@@ -3623,6 +3623,54 @@ describe('precompile server session unit guardrails', () => {
   })
 })
 
+describe('session settlement extensions', () => {
+  test.each([
+    ['no schedule is configured', undefined],
+    ['the configured threshold is not due', { units: 11 }],
+  ] as const)('does not resolve a client when %s', async (_label, settlementSchedule) => {
+    const rawStore = Store.memory()
+    const store = channelStore(rawStore)
+    const openPayload = await createOpenPayload()
+    let clientResolutions = 0
+    await persistPrecompileChannel(store, openPayload, {
+      highestVoucherAmount: 500n,
+      highestVoucher: {
+        channelId: openPayload.channelId,
+        cumulativeAmount: 500n,
+        signature: '0x1234',
+      },
+      spent: 500n,
+      units: 10,
+    })
+
+    const payment = Mppx_server.create({
+      methods: [
+        tempo_server.session({
+          account: payer,
+          amount: '1',
+          chainId,
+          currency: token,
+          decimals: 0,
+          getClient() {
+            clientResolutions++
+            throw new Error('client should not be resolved')
+          },
+          recipient: payee,
+          settlementSchedule,
+          store: rawStore,
+          unitType: 'token',
+        }),
+      ],
+      realm: 'api.example.com',
+      secretKey: 'test-secret-key-test-secret-key-32',
+    })
+    const channel = await store.getChannel(openPayload.channelId)
+
+    await expect(payment.session.settleScheduled(channel!)).resolves.toBeUndefined()
+    expect(clientResolutions).toBe(0)
+  })
+})
+
 describe('onSessionSettlement', () => {
   function createSettleClient(channelId: Hex, settledAmount: bigint) {
     return createClient({

--- a/src/tempo/session/server/Session.test.ts
+++ b/src/tempo/session/server/Session.test.ts
@@ -88,10 +88,16 @@ function createServerClient(
   _eventChannelId: Hex = `0x${'00'.repeat(32)}` as Hex,
   options: {
     descriptor?: Channel.ChannelDescriptor
-    receipt?: Record<string, unknown>
-    state?: ChainState
+    receipt?:
+      | Record<string, unknown>
+      | (() => Record<string, unknown> | Promise<Record<string, unknown>>)
+    sentReceipt?:
+      | Record<string, unknown>
+      | (() => Record<string, unknown> | Promise<Record<string, unknown>>)
+    state?: ChainState | (() => ChainState | Promise<ChainState>)
   } = {},
 ) {
+  let sentTransaction = false
   return createClient({
     ...(account ? { account } : {}),
     chain: testChain,
@@ -103,11 +109,24 @@ function createServerClient(
         if (args.method === 'eth_estimateGas') return '0x5208'
         if (args.method === 'eth_maxPriorityFeePerGas') return '0x1'
         if (args.method === 'eth_getBlockByNumber') return { baseFeePerGas: '0x1' }
-        if (args.method === 'eth_sendRawTransaction') return `0x${'aa'.repeat(32)}`
-        if (args.method === 'eth_getTransactionReceipt') return options.receipt ?? null
-        if (args.method === 'eth_sendTransaction') return `0x${'bb'.repeat(32)}`
+        if (args.method === 'eth_sendRawTransaction') {
+          sentTransaction = true
+          return `0x${'aa'.repeat(32)}`
+        }
+        if (args.method === 'eth_getTransactionReceipt') {
+          const receipt = sentTransaction
+            ? (options.sentReceipt ?? options.receipt)
+            : options.receipt
+          return typeof receipt === 'function' ? receipt() : (receipt ?? null)
+        }
+        if (args.method === 'eth_sendTransaction') {
+          sentTransaction = true
+          return `0x${'bb'.repeat(32)}`
+        }
         if (args.method === 'eth_call') {
-          const state = options.state ?? { settled: 100n, deposit: 1_000n, closeRequestedAt: 0 }
+          const configuredState =
+            typeof options.state === 'function' ? await options.state() : options.state
+          const state = configuredState ?? { settled: 100n, deposit: 1_000n, closeRequestedAt: 0 }
           const data = (args.params as [{ data?: Hex }])[0].data
           const getChannelSelector = options.descriptor
             ? encodeFunctionData({
@@ -2172,14 +2191,23 @@ describe('precompile server session unit guardrails', () => {
 
   describe('SSE parity', () => {
     function createManagedSseFetch(
-      options: { amount?: string; maxDeposit?: bigint; unitType?: 'request' | 'token' } = {},
+      options: {
+        amount?: string
+        chunkDelayMs?: number
+        maxDeposit?: bigint
+        onSessionSettlement?: session.Parameters['onSessionSettlement']
+        settlementSchedule?: session.Parameters['settlementSchedule']
+        unitType?: 'request' | 'token'
+      } = {},
     ) {
       const rawStore = Store.memory()
+      let activeChannelId: Hex | undefined
       let currentPayload: SessionCredentialPayload | undefined
       let voucherPosts = 0
       const amount = options.amount ?? '1'
       const maxDeposit = options.maxDeposit ?? 3n
       let deposit = maxDeposit
+      let settled = 0n
       const unitType = options.unitType ?? 'token'
       const route = Mppx_server.create({
         methods: [
@@ -2189,6 +2217,8 @@ describe('precompile server session unit guardrails', () => {
             currency: token,
             decimals: 0,
             recipient: payer.address,
+            onSessionSettlement: options.onSessionSettlement,
+            settlementSchedule: options.settlementSchedule,
             sse: true,
             store: rawStore,
             unitType,
@@ -2206,20 +2236,24 @@ describe('precompile server session unit guardrails', () => {
                   receipt: transactionReceipt([
                     closedLog(payload.channelId, BigInt(payload.cumulativeAmount), 0n),
                   ]),
-                  state: { settled: 0n, deposit, closeRequestedAt: 0 },
+                  state: { settled, deposit, closeRequestedAt: 0 },
                 })
               }
               if (payload?.action === 'topUp') {
                 deposit += BigInt(payload.additionalDeposit)
                 return createServerClient([], payer, payload.channelId, {
                   receipt: transactionReceipt([topUpLog(payload, deposit)]),
-                  state: { settled: 0n, deposit, closeRequestedAt: 0 },
+                  state: { settled, deposit, closeRequestedAt: 0 },
                 })
               }
-              return createStateClient(payer, {
-                settled: 0n,
-                deposit,
-                closeRequestedAt: 0,
+              return createServerClient([], payer, undefined, {
+                sentReceipt: async () => {
+                  if (!activeChannelId) throw new Error('missing channel context')
+                  const channel = await channelStore(rawStore).getChannel(activeChannelId)
+                  settled = channel?.highestVoucherAmount ?? settled
+                  return transactionReceipt([settledLog(activeChannelId, settled)])
+                },
+                state: () => ({ settled, deposit, closeRequestedAt: 0 }),
               })
             },
           }),
@@ -2233,6 +2267,7 @@ describe('precompile server session unit guardrails', () => {
         if (request.headers.has('Authorization')) {
           try {
             currentPayload = Credential.fromRequest<SessionCredentialPayload>(request).payload
+            activeChannelId = currentPayload.channelId
             if (currentPayload.action === 'voucher') voucherPosts++
           } catch {}
         }
@@ -2259,9 +2294,12 @@ describe('precompile server session unit guardrails', () => {
             )
           }
 
+          currentPayload = undefined
           return result.withReceipt(async function* (stream) {
             await stream.charge()
             yield 'chunk-1'
+            if (options.chunkDelayMs)
+              await new Promise((resolve) => setTimeout(resolve, options.chunkDelayMs))
             await stream.charge()
             yield 'chunk-2'
             await stream.charge()
@@ -2311,6 +2349,49 @@ describe('precompile server session unit guardrails', () => {
       const persisted = await channelStore(harness.rawStore).getChannel(channelId!)
       expect(persisted?.finalized).toBe(true)
     })
+
+    test.each([
+      ['unit', { units: 2 }, 0],
+      ['amount', { amount: '2' }, 0],
+      ['interval', { intervalMs: 500 }, 750],
+    ] as const)(
+      'applies the %s settlement schedule after SSE charges',
+      async (_label, settlementSchedule, chunkDelayMs) => {
+        const settlements: Array<{ delta: bigint; trigger: string }> = []
+        const harness = createManagedSseFetch({
+          chunkDelayMs,
+          maxDeposit: 3n,
+          settlementSchedule,
+          onSessionSettlement(context) {
+            settlements.push({ delta: context.delta, trigger: context.trigger })
+          },
+        })
+        const manager = precompileSessionManager({
+          account: payer,
+          client: createSigningClient(),
+          decimals: 0,
+          fetch: harness.fetch,
+          maxDeposit: '3',
+        })
+
+        const chunks: string[] = []
+        for await (const chunk of await manager.sse('https://api.example.com/stream')) {
+          chunks.push(chunk)
+        }
+
+        expect(chunks).toEqual(['chunk-1', 'chunk-2', 'chunk-3'])
+        expect(harness.voucherPosts).toBeGreaterThan(0)
+        expect(settlements).toEqual([{ delta: 2n, trigger: 'scheduled' }])
+        const persisted = await channelStore(harness.rawStore).getChannel(manager.channelId!)
+        expect(persisted?.lastSettlementUnits).toBe(2)
+
+        await manager.close()
+        expect(settlements).toEqual([
+          { delta: 2n, trigger: 'scheduled' },
+          { delta: 1n, trigger: 'close' },
+        ])
+      },
+    )
 
     test('handles empty management POST streams through a Node adapter', async () => {
       const harness = createManagedSseFetch({ maxDeposit: 1n })
@@ -2422,11 +2503,18 @@ describe('precompile server session unit guardrails', () => {
 
   describe('WebSocket parity', () => {
     async function createManagedWsHarness(
-      options: { challengeTtlMs?: number; maxDeposit?: bigint } = {},
+      options: {
+        challengeTtlMs?: number
+        maxDeposit?: bigint
+        onSessionSettlement?: session.Parameters['onSessionSettlement']
+        settlementSchedule?: session.Parameters['settlementSchedule']
+      } = {},
     ) {
       const rawStore = Store.memory()
+      let activeChannelId: Hex | undefined
       let challengeRequests = 0
       let currentPayload: SessionCredentialPayload | undefined
+      let settled = 0n
       let voucherPosts = 0
       const maxDeposit = options.maxDeposit ?? 3n
       const payment = Mppx_server.create({
@@ -2436,7 +2524,9 @@ describe('precompile server session unit guardrails', () => {
             chainId,
             currency: token,
             decimals: 0,
+            onSessionSettlement: options.onSessionSettlement,
             recipient: payer.address,
+            settlementSchedule: options.settlementSchedule,
             store: rawStore,
             unitType: 'token',
             getClient: () => {
@@ -2453,13 +2543,17 @@ describe('precompile server session unit guardrails', () => {
                   receipt: transactionReceipt([
                     closedLog(payload.channelId, BigInt(payload.cumulativeAmount), 0n),
                   ]),
-                  state: { settled: 0n, deposit: maxDeposit, closeRequestedAt: 0 },
+                  state: { settled, deposit: maxDeposit, closeRequestedAt: 0 },
                 })
               }
-              return createStateClient(payer, {
-                settled: 0n,
-                deposit: maxDeposit,
-                closeRequestedAt: 0,
+              return createServerClient([], payer, undefined, {
+                sentReceipt: async () => {
+                  if (!activeChannelId) throw new Error('missing channel context')
+                  const channel = await channelStore(rawStore).getChannel(activeChannelId)
+                  settled = channel?.highestVoucherAmount ?? settled
+                  return transactionReceipt([settledLog(activeChannelId, settled)])
+                },
+                state: () => ({ settled, deposit: maxDeposit, closeRequestedAt: 0 }),
               })
             },
           }),
@@ -2468,23 +2562,26 @@ describe('precompile server session unit guardrails', () => {
         secretKey: 'test-secret-key-test-secret-key-32',
       })
 
+      const routeOptions = () => ({
+        amount: '1',
+        decimals: 0,
+        suggestedDeposit: maxDeposit.toString(),
+        ...(options.challengeTtlMs === undefined
+          ? {}
+          : { expires: new Date(Date.now() + options.challengeTtlMs) }),
+      })
       const route = async (request: Request) => {
         currentPayload = undefined
         if (request.headers.has('Authorization')) {
           try {
             currentPayload = Credential.fromRequest<SessionCredentialPayload>(request).payload
+            activeChannelId = currentPayload.channelId
             if (currentPayload.action === 'voucher') voucherPosts++
           } catch {}
         } else challengeRequests++
-        const routeHandler = payment.session({
-          amount: '1',
-          decimals: 0,
-          suggestedDeposit: maxDeposit.toString(),
-          ...(options.challengeTtlMs === undefined
-            ? {}
-            : { expires: new Date(Date.now() + options.challengeTtlMs) }),
-        })
-        return routeHandler(request)
+        const result = await payment.session(routeOptions())(request)
+        currentPayload = undefined
+        return result
       }
 
       const httpHandler = NodeRequest.toNodeListener(async (request) => {
@@ -2516,6 +2613,7 @@ describe('precompile server session unit guardrails', () => {
       return {
         rawStore,
         route,
+        settleScheduled: payment.session.settleScheduled,
         server,
         wsServer,
         get port() {
@@ -2542,6 +2640,7 @@ describe('precompile server session unit guardrails', () => {
           store: harness.rawStore,
           url: `${harness.server.url}/ws`,
           route: harness.route,
+          settleScheduled: harness.settleScheduled,
           generate: async function* (stream: TempoWs.SessionController) {
             await stream.charge()
             yield 'chunk-1'
@@ -2590,6 +2689,7 @@ describe('precompile server session unit guardrails', () => {
           store: harness.rawStore,
           url: `${harness.server.url}/ws`,
           route: harness.route,
+          settleScheduled: harness.settleScheduled,
           generate: async function* (stream: TempoWs.SessionController) {
             await stream.charge()
             yield 'chunk-1'
@@ -2641,6 +2741,77 @@ describe('precompile server session unit guardrails', () => {
       }
     })
 
+    test.each([
+      ['unit', { units: 2 }, 0],
+      ['amount', { amount: '2' }, 0],
+      ['interval', { intervalMs: 500 }, 750],
+    ] as const)(
+      'applies the %s settlement schedule after websocket charges',
+      async (_label, settlementSchedule, chunkDelayMs) => {
+        const settlements: Array<{ delta: bigint; trigger: string }> = []
+        const harness = await createManagedWsHarness({
+          maxDeposit: 3n,
+          settlementSchedule,
+          onSessionSettlement(context) {
+            settlements.push({ delta: context.delta, trigger: context.trigger })
+          },
+        })
+        harness.wsServer.on('connection', (socket: import('ws').WebSocket) => {
+          void TempoWs.serve({
+            socket,
+            store: harness.rawStore,
+            url: `${harness.server.url}/ws`,
+            route: harness.route,
+            settleScheduled: harness.settleScheduled,
+            generate: async function* (stream: TempoWs.SessionController) {
+              for (const chunk of ['chunk-1', 'chunk-2', 'chunk-3']) {
+                if (chunk === 'chunk-2' && chunkDelayMs)
+                  await new Promise((resolve) => setTimeout(resolve, chunkDelayMs))
+                await stream.charge()
+                yield chunk
+              }
+            },
+          })
+        })
+
+        try {
+          const manager = precompileSessionManager({
+            account: payer,
+            client: createSigningClient(),
+            decimals: 0,
+            fetch: globalThis.fetch,
+            maxDeposit: '3',
+            webSocket: WebSocket as never,
+          })
+          const ws = await manager.ws(`ws://localhost:${harness.port}/ws`)
+          const chunks: string[] = []
+
+          await new Promise<void>((resolve, reject) => {
+            ws.addEventListener('message', (event) => {
+              if (typeof event.data === 'string') chunks.push(event.data)
+            })
+            ws.addEventListener('close', () => resolve(), { once: true })
+            ws.addEventListener('error', () => reject(new Error('websocket stream failed')), {
+              once: true,
+            })
+          })
+
+          expect(chunks).toEqual(['chunk-1', 'chunk-2', 'chunk-3'])
+          expect(harness.voucherPosts).toBeGreaterThan(0)
+          expect(settlements).toEqual([{ delta: 2n, trigger: 'scheduled' }])
+          await manager.close()
+          expect(settlements).toEqual([
+            { delta: 2n, trigger: 'scheduled' },
+            { delta: 1n, trigger: 'close' },
+          ])
+          const persisted = await channelStore(harness.rawStore).getChannel(manager.channelId!)
+          expect(persisted?.lastSettlementUnits).toBe(2)
+        } finally {
+          harness.close()
+        }
+      },
+    )
+
     test('treats control-shaped application payloads as content', async () => {
       const harness = await createManagedWsHarness({ maxDeposit: 1n })
       const controlLookingChunk = JSON.stringify({
@@ -2658,6 +2829,7 @@ describe('precompile server session unit guardrails', () => {
           store: harness.rawStore,
           url: `${harness.server.url}/ws`,
           route: harness.route,
+          settleScheduled: harness.settleScheduled,
           generate: async function* (stream: TempoWs.SessionController) {
             await stream.charge()
             yield controlLookingChunk
@@ -2708,6 +2880,7 @@ describe('precompile server session unit guardrails', () => {
           store: harness.rawStore,
           url: `${harness.server.url}/ws`,
           route: harness.route,
+          settleScheduled: harness.settleScheduled,
           generate: async function* (stream: TempoWs.SessionController) {
             await stream.charge()
             yield 'chunk-1'
@@ -2870,6 +3043,7 @@ describe('precompile server session unit guardrails', () => {
           store: harness.rawStore,
           url: `${harness.server.url}/ws`,
           route: harness.route,
+          settleScheduled: harness.settleScheduled,
           generate: async function* (stream: TempoWs.SessionController) {
             await stream.charge()
             yield 'chunk-1'

--- a/src/tempo/session/server/Session.test.ts
+++ b/src/tempo/session/server/Session.test.ts
@@ -2613,7 +2613,7 @@ describe('precompile server session unit guardrails', () => {
       return {
         rawStore,
         route,
-        settleScheduled: payment.session.settleScheduled,
+        serveWebSocket: payment.session.serveWebSocket,
         server,
         wsServer,
         get port() {
@@ -2635,12 +2635,10 @@ describe('precompile server session unit guardrails', () => {
     test('refreshes an expired challenge before sending a later websocket voucher', async () => {
       const harness = await createManagedWsHarness({ challengeTtlMs: 2_000, maxDeposit: 2n })
       harness.wsServer.on('connection', (socket: import('ws').WebSocket) => {
-        void TempoWs.serve({
+        void harness.serveWebSocket({
           socket,
-          store: harness.rawStore,
           url: `${harness.server.url}/ws`,
           route: harness.route,
-          settleScheduled: harness.settleScheduled,
           generate: async function* (stream: TempoWs.SessionController) {
             await stream.charge()
             yield 'chunk-1'
@@ -2684,12 +2682,10 @@ describe('precompile server session unit guardrails', () => {
     test('open -> stream -> need-voucher -> resume -> close', async () => {
       const harness = await createManagedWsHarness({ maxDeposit: 3n })
       harness.wsServer.on('connection', (socket: import('ws').WebSocket) => {
-        void TempoWs.serve({
+        void harness.serveWebSocket({
           socket,
-          store: harness.rawStore,
           url: `${harness.server.url}/ws`,
           route: harness.route,
-          settleScheduled: harness.settleScheduled,
           generate: async function* (stream: TempoWs.SessionController) {
             await stream.charge()
             yield 'chunk-1'
@@ -2757,12 +2753,10 @@ describe('precompile server session unit guardrails', () => {
           },
         })
         harness.wsServer.on('connection', (socket: import('ws').WebSocket) => {
-          void TempoWs.serve({
+          void harness.serveWebSocket({
             socket,
-            store: harness.rawStore,
             url: `${harness.server.url}/ws`,
             route: harness.route,
-            settleScheduled: harness.settleScheduled,
             generate: async function* (stream: TempoWs.SessionController) {
               for (const chunk of ['chunk-1', 'chunk-2', 'chunk-3']) {
                 if (chunk === 'chunk-2' && chunkDelayMs)
@@ -2824,12 +2818,10 @@ describe('precompile server session unit guardrails', () => {
         },
       })
       harness.wsServer.on('connection', (socket: import('ws').WebSocket) => {
-        void TempoWs.serve({
+        void harness.serveWebSocket({
           socket,
-          store: harness.rawStore,
           url: `${harness.server.url}/ws`,
           route: harness.route,
-          settleScheduled: harness.settleScheduled,
           generate: async function* (stream: TempoWs.SessionController) {
             await stream.charge()
             yield controlLookingChunk
@@ -2875,12 +2867,10 @@ describe('precompile server session unit guardrails', () => {
     test('refuses websocket voucher requests beyond local maxDeposit', async () => {
       const harness = await createManagedWsHarness({ maxDeposit: 1n })
       harness.wsServer.on('connection', (socket: import('ws').WebSocket) => {
-        void TempoWs.serve({
+        void harness.serveWebSocket({
           socket,
-          store: harness.rawStore,
           url: `${harness.server.url}/ws`,
           route: harness.route,
-          settleScheduled: harness.settleScheduled,
           generate: async function* (stream: TempoWs.SessionController) {
             await stream.charge()
             yield 'chunk-1'
@@ -3038,12 +3028,10 @@ describe('precompile server session unit guardrails', () => {
       let serverSocket: import('ws').WebSocket | null = null
       harness.wsServer.on('connection', (socket: import('ws').WebSocket) => {
         serverSocket = socket
-        void TempoWs.serve({
+        void harness.serveWebSocket({
           socket,
-          store: harness.rawStore,
           url: `${harness.server.url}/ws`,
           route: harness.route,
-          settleScheduled: harness.settleScheduled,
           generate: async function* (stream: TempoWs.SessionController) {
             await stream.charge()
             yield 'chunk-1'

--- a/src/tempo/session/server/Session.ts
+++ b/src/tempo/session/server/Session.ts
@@ -53,6 +53,7 @@ import {
   type OnSessionSettlement,
   type SettlementSchedule,
 } from './Settlement.js'
+import * as Ws from './Ws.js'
 
 /** Server-side automatic settlement schedule. */
 export type { SettlementSchedule } from './Settlement.js'
@@ -348,6 +349,12 @@ export function session<const parameters extends session.Parameters>(
       store,
     })
   }
+  const serveWebSocket: session.Extensions['serveWebSocket'] = (options) =>
+    Ws.serve({
+      ...options,
+      onChargeCommitted: settleScheduled,
+      store,
+    })
   const bootstrapCharge = ChargeServer.charge({
     account,
     chainId: parameters.chainId,
@@ -385,7 +392,7 @@ export function session<const parameters extends session.Parameters>(
       unitType,
     }),
 
-    extensions: { settleScheduled },
+    extensions: { serveWebSocket, settleScheduled },
 
     transport: deriveTransport<parameters>(transport),
 
@@ -515,7 +522,15 @@ export namespace session {
   export type Extensions = {
     /** Applies the configured automatic settlement policy to a committed channel charge. */
     settleScheduled: SettleChargedSessionChannel
+    /** Serves a WebSocket route from this handler using its configured store and settlement policy. */
+    serveWebSocket: (options: ServeWebSocketOptions) => Promise<void>
   }
+
+  /** WebSocket server options supplied after the session binds shared dependencies. */
+  export type ServeWebSocketOptions = Omit<
+    Ws.serve.Options,
+    'onChargeCommitted' | 'settleScheduled' | 'store'
+  >
 
   /** Request defaults inferred from the Tempo session method schema. */
   export type Defaults = LooseOmit<

--- a/src/tempo/session/server/Session.ts
+++ b/src/tempo/session/server/Session.ts
@@ -42,8 +42,12 @@ import {
   type SessionPaymentRequestInput,
 } from './RequestState.js'
 import { respondToSessionCredential } from './RequestState.js'
-import { applyVerifiedHttpAccounting, chargeSessionChannel } from './Settlement.js'
-import { maybeSettleScheduled } from './Settlement.js'
+import {
+  applyVerifiedHttpAccounting,
+  chargeSessionChannel,
+  type SettleChargedSessionChannel,
+} from './Settlement.js'
+import { isSettlementDue, maybeSettleScheduled } from './Settlement.js'
 import {
   resolveSettlementSchedule,
   type OnSessionSettlement,
@@ -330,6 +334,20 @@ export function session<const parameters extends session.Parameters>(
     getClient: parameters.getClient,
     rpcUrl: defaults.rpcUrl,
   })
+  const settleScheduled: SettleChargedSessionChannel = async (channel) => {
+    if (!isSettlementDue(channel, settlementSchedule)) return undefined
+    return maybeSettleScheduled({
+      account,
+      channel,
+      client: await getClient({ chainId: channel.chainId }),
+      ...(feePayer ? { feePayer } : {}),
+      feePayerPolicy: parameters.feePayerPolicy,
+      feeToken: parameters.feeToken,
+      onSessionSettlement,
+      schedule: settlementSchedule,
+      store,
+    })
+  }
   const bootstrapCharge = ChargeServer.charge({
     account,
     chainId: parameters.chainId,
@@ -341,16 +359,22 @@ export function session<const parameters extends session.Parameters>(
     store: rawStore,
   })
 
-  type Transport = parameters['sse'] extends false | undefined ? undefined : Transport.Sse
+  type SessionTransport = parameters['sse'] extends false | undefined ? undefined : Transport.Sse
   const transport = parameters.sse
     ? Transport.sse({
+        settleCharged: settleScheduled,
         store,
         ...(typeof parameters.sse === 'object' ? parameters.sse : undefined),
       })
     : undefined
 
   type Defaults = session.DeriveDefaults<parameters>
-  return Method.toServer<typeof Methods.session, Defaults, Transport>(Methods.session, {
+  const method = Method.toServer<
+    typeof Methods.session,
+    Defaults,
+    SessionTransport,
+    session.Extensions
+  >(Methods.session, {
     defaults: deriveServerDefaults<parameters>({
       amount,
       currency,
@@ -360,6 +384,8 @@ export function session<const parameters extends session.Parameters>(
       suggestedDeposit,
       unitType,
     }),
+
+    extensions: { settleScheduled },
 
     transport: deriveTransport<parameters>(transport),
 
@@ -478,11 +504,18 @@ export function session<const parameters extends session.Parameters>(
       })
     },
   })
+  return method
 }
 
 export namespace session {
   export const serializeSnapshot = serializeSessionSnapshot
   export const deserializeSnapshot = deserializeSessionSnapshot
+
+  /** Extensions attached to the Tempo session method handler. */
+  export type Extensions = {
+    /** Applies the configured automatic settlement policy to a committed channel charge. */
+    settleScheduled: SettleChargedSessionChannel
+  }
 
   /** Request defaults inferred from the Tempo session method schema. */
   export type Defaults = LooseOmit<

--- a/src/tempo/session/server/Sse.test.ts
+++ b/src/tempo/session/server/Sse.test.ts
@@ -260,6 +260,7 @@ describe('serve', () => {
 
   test('uses a prepaid unit for the first generated value', async () => {
     const storage = memoryStore()
+    const committed: Array<{ spent: bigint; units: number }> = []
     await seedChannel(storage, 3000000n)
     await storage.updateChannel(channelId, (current) =>
       current ? { ...current, spent: 1000000n, units: 1 } : current,
@@ -271,6 +272,9 @@ describe('serve', () => {
       challengeId,
       tickCost: 1000000n,
       generate: generate(['hello', 'world']),
+      onChargeCommitted(channel) {
+        committed.push({ spent: channel.spent, units: channel.units })
+      },
       prepaidUnits: 1,
     })
 
@@ -281,6 +285,79 @@ describe('serve', () => {
     const channel = await storage.getChannel(channelId)
     expect(channel!.spent).toBe(2000000n)
     expect(channel!.units).toBe(2)
+    expect(committed).toEqual([{ spent: 2000000n, units: 2 }])
+  })
+
+  test('runs the post-commit hook before emitting each charged value', async () => {
+    const storage = memoryStore()
+    const committed: Array<{ spent: bigint; units: number }> = []
+    await seedChannel(storage, 2000000n)
+
+    const output = await readStream(
+      serve({
+        store: storage,
+        channelId,
+        challengeId,
+        tickCost: 1000000n,
+        generate: generate(['first', 'second']),
+        onChargeCommitted(channel) {
+          committed.push({ spent: channel.spent, units: channel.units })
+        },
+      }),
+    )
+
+    expect(output).toContain('event: message\ndata: first\n\n')
+    expect(output).toContain('event: message\ndata: second\n\n')
+    expect(committed).toEqual([
+      { spent: 1000000n, units: 1 },
+      { spent: 2000000n, units: 2 },
+    ])
+  })
+
+  test('does not emit a charged value when the post-commit hook fails', async () => {
+    const storage = memoryStore()
+    await seedChannel(storage, 1000000n)
+
+    const reader = serve({
+      store: storage,
+      channelId,
+      challengeId,
+      tickCost: 1000000n,
+      generate: generate(['blocked']),
+      onChargeCommitted() {
+        throw new Error('settlement failed')
+      },
+    }).getReader()
+
+    await expect(reader.read()).rejects.toThrow('settlement failed')
+    const channel = await storage.getChannel(channelId)
+    expect(channel).toMatchObject({ spent: 1000000n, units: 1 })
+  })
+
+  test('does not run the post-commit hook for an unconsumed reservation', async () => {
+    const storage = memoryStore()
+    let commits = 0
+    await seedChannel(storage, 1000000n)
+
+    await readStream(
+      serve({
+        store: storage,
+        channelId,
+        challengeId,
+        tickCost: 1000000n,
+        generate: async function* (stream) {
+          await stream.charge()
+          yield* []
+        },
+        onChargeCommitted() {
+          commits++
+        },
+      }),
+    )
+
+    expect(commits).toBe(0)
+    const channel = await storage.getChannel(channelId)
+    expect(channel).toMatchObject({ spent: 0n, units: 0 })
   })
 
   test('emits multiline message values as a single SSE message event', async () => {

--- a/src/tempo/session/server/Sse.ts
+++ b/src/tempo/session/server/Sse.ts
@@ -12,7 +12,11 @@ import {
   requireSessionCredentialContext,
 } from '../precompile/Protocol.js'
 import * as ChannelStore from './ChannelStore.js'
-import { meterIterable, type SessionController } from './MeteredStream.js'
+import {
+  meterIterable,
+  type MeteredStreamOptions,
+  type SessionController,
+} from './MeteredStream.js'
 
 /**
  * SSE (Server-Sent Events) utilities for metered streaming payments.
@@ -81,6 +85,7 @@ export function serve(options: serve.Options): ReadableStream<Uint8Array> {
           channelId,
           tickCost,
           generate,
+          onChargeCommitted: options.onChargeCommitted,
           pollIntervalMs,
           prepaidUnits: options.prepaidUnits,
           signal,
@@ -121,6 +126,8 @@ export declare namespace serve {
     challengeId: string
     tickCost: bigint
     generate: AsyncIterable<string> | ((stream: SessionController) => AsyncIterable<string>)
+    /** Callback invoked after each nonzero stream charge is committed. */
+    onChargeCommitted?: MeteredStreamOptions['onChargeCommitted']
     pollIntervalMs?: number | undefined
     prepaidUnits?: number | undefined
     signal?: AbortSignal | undefined

--- a/src/tempo/session/server/Transports.ts
+++ b/src/tempo/session/server/Transports.ts
@@ -86,7 +86,7 @@ export async function reserveChargeOrWait(options: ReserveChargeParameters): Pro
 /** Atomically commits previously reserved stream charges to channel spend and unit counters. */
 export async function commitReservedCharges(
   options: CommitReservedChargesParameters,
-): Promise<void> {
+): Promise<ChannelStore.State | undefined> {
   const { amount, channelId, store, units } = options
   if (amount === 0n || units === 0) return
 
@@ -107,6 +107,7 @@ export async function commitReservedCharges(
   if (!channel) throw new Error('channel not found')
   throwIfChannelClosed(channel)
   if (!committed) throw new Error('reserved voucher coverage is no longer available')
+  return channel
 }
 
 /** Throws when a channel can no longer be used for streaming charges. */

--- a/src/tempo/session/server/Ws.test.ts
+++ b/src/tempo/session/server/Ws.test.ts
@@ -124,6 +124,27 @@ function seedChannel(
   }))
 }
 
+function acceptingRoute(acceptedCumulative: bigint): Ws.serve.Options['route'] {
+  return async () => ({
+    status: 200,
+    withReceipt(response = new Response(null, { status: 204 })) {
+      response.headers.set(
+        'Payment-Receipt',
+        serializeSessionReceipt(
+          createSessionReceipt({
+            challengeId: challenge.id,
+            channelId,
+            acceptedCumulative,
+            spent: 0n,
+            units: 0,
+          }),
+        ),
+      )
+      return response
+    },
+  })
+}
+
 describe('parseMessage', () => {
   test('rejects non-object data in payment-receipt', () => {
     expect(Ws.parseMessage('{"mpp":"payment-receipt","data":true}')).toBeNull()
@@ -348,6 +369,7 @@ describe('isows', () => {
   test('drops reserved charges when the stream ends without delivering a chunk', async () => {
     const socket = new MockSocket()
     const store = memoryChannelStore()
+    let commits = 0
     await seedChannel(store, 1n)
 
     await Ws.serve({
@@ -375,6 +397,9 @@ describe('isows', () => {
       generate: async function* (stream) {
         await stream.charge()
         yield* []
+      },
+      onChargeCommitted() {
+        commits++
       },
     })
 
@@ -406,6 +431,7 @@ describe('isows', () => {
     const channel = await store.getChannel(channelId)
     expect(channel?.spent).toBe(0n)
     expect(channel?.units).toBe(0)
+    expect(commits).toBe(0)
   })
 
   test('aborts a blocked application generator before sending close-ready', async () => {
@@ -519,6 +545,151 @@ describe('isows', () => {
 
     expect(await store.getChannel(channelId)).toMatchObject({ spent: 7n, units: 1 })
     expect(socket.sent.some((message) => message.includes('priced-response'))).toBe(true)
+  })
+
+  test.each(['onChargeCommitted', 'settleScheduled'] as const)(
+    'runs %s after each committed charge and before emitting its message',
+    async (hookName) => {
+      const socket = new MockSocket()
+      const store = memoryChannelStore()
+      const committed: Array<{ emitted: number; spent: bigint; units: number }> = []
+      await seedChannel(store, 2n)
+
+      const hook = async (channel: ChannelStore.State) => {
+        committed.push({
+          emitted: socket.sent.filter((message) => Ws.parseMessage(message)?.mpp === 'message')
+            .length,
+          spent: channel.spent,
+          units: channel.units,
+        })
+        return undefined
+      }
+
+      await Ws.serve({
+        socket,
+        store,
+        url: 'ws://example.test/stream',
+        route: acceptingRoute(2n),
+        generate: (async function* () {
+          yield 'first'
+          yield 'second'
+        })(),
+        ...(hookName === 'onChargeCommitted'
+          ? { onChargeCommitted: hook }
+          : { settleScheduled: hook }),
+      })
+
+      socket.receive(
+        Ws.formatAuthorizationMessage(
+          makeCredential({
+            action: 'open',
+            channelId,
+            cumulativeAmount: '2',
+            signature: `0x${'77'.repeat(65)}`,
+            transaction: '0x01',
+            type: 'transaction',
+          }),
+        ),
+      )
+
+      await sleep(10)
+
+      expect(committed).toEqual([
+        { emitted: 0, spent: 1n, units: 1 },
+        { emitted: 1, spent: 2n, units: 2 },
+      ])
+      expect(
+        socket.sent
+          .map((message) => Ws.parseMessage(message))
+          .filter((message) => message?.mpp === 'message')
+          .map((message) => (message?.mpp === 'message' ? message.data : undefined)),
+      ).toEqual(['first', 'second'])
+    },
+  )
+
+  test('prefers onChargeCommitted over the deprecated settlement callback', async () => {
+    const socket = new MockSocket()
+    const store = memoryChannelStore()
+    const callbacks: string[] = []
+    await seedChannel(store, 1n)
+
+    await Ws.serve({
+      socket,
+      store,
+      url: 'ws://example.test/stream',
+      route: acceptingRoute(1n),
+      generate: (async function* () {
+        yield 'message'
+      })(),
+      onChargeCommitted() {
+        callbacks.push('current')
+      },
+      async settleScheduled() {
+        callbacks.push('deprecated')
+        return undefined
+      },
+    })
+
+    socket.receive(
+      Ws.formatAuthorizationMessage(
+        makeCredential({
+          action: 'open',
+          channelId,
+          cumulativeAmount: '1',
+          signature: `0x${'77'.repeat(65)}`,
+          transaction: '0x01',
+          type: 'transaction',
+        }),
+      ),
+    )
+
+    await sleep(10)
+
+    expect(callbacks).toEqual(['current'])
+  })
+
+  test('closes without emitting a charged message when the post-commit hook fails', async () => {
+    const socket = new MockSocket()
+    const store = memoryChannelStore()
+    await seedChannel(store, 1n)
+
+    await Ws.serve({
+      socket,
+      store,
+      url: 'ws://example.test/stream',
+      route: acceptingRoute(1n),
+      generate: (async function* () {
+        yield 'blocked'
+      })(),
+      onChargeCommitted() {
+        throw new Error('settlement failed')
+      },
+    })
+
+    socket.receive(
+      Ws.formatAuthorizationMessage(
+        makeCredential({
+          action: 'open',
+          channelId,
+          cumulativeAmount: '1',
+          signature: `0x${'77'.repeat(65)}`,
+          transaction: '0x01',
+          type: 'transaction',
+        }),
+      ),
+    )
+
+    await sleep(10)
+
+    expect(socket.closed).toBe(true)
+    expect(socket.sent.some((message) => message.includes('settlement failed'))).toBe(true)
+    expect(
+      socket.sent.some((message) => {
+        const parsed = Ws.parseMessage(message)
+        return parsed?.mpp === 'message' && parsed.data === 'blocked'
+      }),
+    ).toBe(false)
+    expect(await store.getChannel(channelId)).toMatchObject({ spent: 1n, units: 1 })
   })
 
   test('does not meter or emit application messages after close is requested on-chain', async () => {

--- a/src/tempo/session/server/Ws.ts
+++ b/src/tempo/session/server/Ws.ts
@@ -16,6 +16,7 @@ import {
 } from '../precompile/Protocol.js'
 import * as ChannelStore from './ChannelStore.js'
 import type { SessionController } from './MeteredStream.js'
+import type { SettleChargedSessionChannel } from './Settlement.js'
 export type { SessionController } from './MeteredStream.js'
 export type { Socket } from './Transports.js'
 import { meterIterable } from './MeteredStream.js'
@@ -152,6 +153,7 @@ export async function serve(options: serve.Options): Promise<void> {
         channelId: context.channelId,
         tickCost: context.tickCost,
         generate,
+        onChargeCommitted: options.settleScheduled,
         pollIntervalMs,
         signal: abortController.signal,
         emitNeedVoucher: (message) => send(socket, message),
@@ -332,6 +334,8 @@ export declare namespace serve {
     /** Payment route handler. Receives synthetic `POST` requests with only
      *  the `Authorization` header — no cookies, bodies, or upgrade headers. */
     route: SessionRoute
+    /** Applies the session method's automatic settlement policy after each committed charge. */
+    settleScheduled?: SettleChargedSessionChannel | undefined
     socket: Socket
     store: ChannelStore.ChannelStore | import('../../../Store.js').Store
     url: string | URL

--- a/src/tempo/session/server/Ws.ts
+++ b/src/tempo/session/server/Ws.ts
@@ -15,7 +15,7 @@ import {
   type SessionReceipt,
 } from '../precompile/Protocol.js'
 import * as ChannelStore from './ChannelStore.js'
-import type { SessionController } from './MeteredStream.js'
+import type { MeteredStreamOptions, SessionController } from './MeteredStream.js'
 import type { SettleChargedSessionChannel } from './Settlement.js'
 export type { SessionController } from './MeteredStream.js'
 export type { Socket } from './Transports.js'
@@ -153,7 +153,7 @@ export async function serve(options: serve.Options): Promise<void> {
         channelId: context.channelId,
         tickCost: context.tickCost,
         generate,
-        onChargeCommitted: options.settleScheduled,
+        onChargeCommitted: options.onChargeCommitted ?? options.settleScheduled,
         pollIntervalMs,
         signal: abortController.signal,
         emitNeedVoucher: (message) => send(socket, message),
@@ -334,7 +334,9 @@ export declare namespace serve {
     /** Payment route handler. Receives synthetic `POST` requests with only
      *  the `Authorization` header — no cookies, bodies, or upgrade headers. */
     route: SessionRoute
-    /** Applies the session method's automatic settlement policy after each committed charge. */
+    /** Optional low-level hook invoked after each committed stream charge. */
+    onChargeCommitted?: MeteredStreamOptions['onChargeCommitted']
+    /** @deprecated Use `onChargeCommitted`. */
     settleScheduled?: SettleChargedSessionChannel | undefined
     socket: Socket
     store: ChannelStore.ChannelStore | import('../../../Store.js').Store


### PR DESCRIPTION
## Motivation

Tempo session settlement schedules were applied to ordinary HTTP accounting but not to charges committed by SSE and WebSocket streams. Long-running streams could therefore defer scheduled settlement until close.

## Summary

- Applied configured settlement schedules after committed SSE and WebSocket charges.
- Exposed settlement through the Tempo session method extension and wired it explicitly into `Ws.serve`.
- Added table-driven coverage for unit, amount, and interval schedules plus callback behavior.
- Added a patch changeset and updated the WebSocket example.

## Key design considerations

- Kept extensions method-scoped, matching the existing subscription renewal extension pattern.
- Invoked settlement only after a nonzero reserved charge commits successfully.
- Reused the same metered-stream callback path for SSE and WebSocket accounting.