### PR TITLE
feat: add session-bound WebSocket server helper

### DIFF
--- a/.changeset/bind-session-websocket-server.md
+++ b/.changeset/bind-session-websocket-server.md
@@ -2,4 +2,4 @@
 'mppx': patch
 ---
 
-Added a session-bound WebSocket server helper that reused the configured store and settlement policy.
+Added a session-bound WebSocket server helper that reused the configured store and settlement policy, and applied that policy to plain HTTP responses from SSE-enabled methods.

--- a/.changeset/bind-session-websocket-server.md
+++ b/.changeset/bind-session-websocket-server.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added a session-bound WebSocket server helper that reused the configured store and settlement policy.

--- a/examples/session/ws/src/server.ts
+++ b/examples/session/ws/src/server.ts
@@ -104,24 +104,23 @@ const route = mppx.session({
 // WebSocket Upgrade Handler
 
 //
-// `tempo.Ws.serve()` does not perform the HTTP upgrade itself. We use `ws`
-// only for the low-level upgrade mechanics, then hand the accepted socket to
-// mppx's Tempo websocket helper for payment-aware streaming.
+// `mppx.session.serveWebSocket()` does not perform the HTTP upgrade itself. We
+// use `ws` only for the low-level upgrade mechanics, then hand the accepted
+// socket to the session-bound helper for payment-aware streaming.
 const wsServer = new WebSocketServer({ noServer: true })
 wsServer.on('connection', (socket, req) => {
   const url = new URL(req.url ?? '/ws/chat', `ws://${req.headers.host ?? 'localhost:5173'}`)
   const prompt = url.searchParams.get('prompt') ?? 'Tell me something interesting'
 
-  // `tempo.Ws.serve()` bridges websocket control frames to the existing
-  // Tempo session lifecycle. When it receives an in-band authorization frame,
-  // it verifies it through `route`. Once paid, it runs this generator and
-  // emits application chunks interleaved with payment control frames.
-  void tempo.Ws.serve({
+  // `serveWebSocket()` bridges websocket control frames to the existing Tempo
+  // session lifecycle and reuses its store and settlement policy. When it
+  // receives an in-band authorization frame, it verifies it through `route`.
+  // Once paid, it runs this generator and emits application chunks interleaved
+  // with payment control frames.
+  void mppx.session.serveWebSocket({
     socket,
-    store,
     url,
     route,
-    settleScheduled: mppx.session.settleScheduled,
     generate: async function* (stream) {
       for await (const token of generateTokens(prompt)) {
         await stream.charge()

--- a/src/server/Mppx.test-d.ts
+++ b/src/server/Mppx.test-d.ts
@@ -110,11 +110,16 @@ describe('Mppx type tests', () => {
     })
     const mppx = Mppx.create({ methods: [sessionMethod], realm, secretKey })
 
+    expectTypeOf(mppx.session.settleScheduled).toBeFunction()
     expectTypeOf(mppx.session.serveWebSocket).toBeFunction()
     type Options = Parameters<typeof mppx.session.serveWebSocket>[0]
     expectTypeOf<Options>().toHaveProperty('route')
     expectTypeOf<Options>().not.toHaveProperty('store')
     expectTypeOf<Options>().not.toHaveProperty('onChargeCommitted')
+    expectTypeOf<Options>().not.toHaveProperty('settleScheduled')
+    type LowLevelOptions = Parameters<typeof tempo.Ws.serve>[0]
+    expectTypeOf<LowLevelOptions>().toHaveProperty('onChargeCommitted')
+    expectTypeOf<LowLevelOptions>().toHaveProperty('settleScheduled')
   })
 
   test('compose exists on the instance and returns a handler', () => {

--- a/src/server/Mppx.test-d.ts
+++ b/src/server/Mppx.test-d.ts
@@ -110,7 +110,11 @@ describe('Mppx type tests', () => {
     })
     const mppx = Mppx.create({ methods: [sessionMethod], realm, secretKey })
 
-    expectTypeOf(mppx.session.settleScheduled).toBeFunction()
+    expectTypeOf(mppx.session.serveWebSocket).toBeFunction()
+    type Options = Parameters<typeof mppx.session.serveWebSocket>[0]
+    expectTypeOf<Options>().toHaveProperty('route')
+    expectTypeOf<Options>().not.toHaveProperty('store')
+    expectTypeOf<Options>().not.toHaveProperty('onChargeCommitted')
   })
 
   test('compose exists on the instance and returns a handler', () => {

--- a/src/tempo/server/internal/transport.test.ts
+++ b/src/tempo/server/internal/transport.test.ts
@@ -738,8 +738,15 @@ describe('sse transport', () => {
 
   test('respondReceipt with non-SSE upstream Response still deducts from channel', async () => {
     const store = memoryStore()
+    const settled: Array<{ spent: bigint; units: number }> = []
     await seedChannel(store, 10000000n)
-    const transport = sse({ store })
+    const transport = sse({
+      store,
+      async settleCharged(channel) {
+        settled.push({ spent: channel.spent, units: channel.units })
+        return undefined
+      },
+    })
     const request = new Request('https://test.example.com/session', {
       body: JSON.stringify({ prompt: 'hello' }),
       headers: makeAuthorizedRequest().headers,
@@ -768,6 +775,7 @@ describe('sse transport', () => {
     expect(channel!.units).toBe(1)
     expect(receipt.spent).toBe('1000000')
     expect(receipt.units).toBe(1)
+    expect(settled).toEqual([{ spent: 1000000n, units: 1 }])
 
     expect(JSON.parse(body)).toEqual({ content: 'hello' })
     expect(response.headers.get('Content-Type')).toBe('application/json')
@@ -806,8 +814,18 @@ describe('sse transport', () => {
 
   test('respondReceipt with 204 content response still deducts from channel', async () => {
     const store = memoryStore()
+    let resolveSettlement!: (channel: ChannelStore.State) => void
+    const settlement = new Promise<ChannelStore.State>((resolve) => {
+      resolveSettlement = resolve
+    })
     await seedChannel(store, 10000000n)
-    const transport = sse({ store })
+    const transport = sse({
+      store,
+      async settleCharged(channel) {
+        resolveSettlement(channel)
+        return undefined
+      },
+    })
     const request = new Request('https://test.example.com/session', {
       body: JSON.stringify({ prompt: 'hello' }),
       headers: makeAuthorizedRequest().headers,
@@ -827,11 +845,12 @@ describe('sse transport', () => {
     expect(await response.text()).toBe('')
     const receipt = deserializeSessionReceipt(response.headers.get('Payment-Receipt')!)
 
-    await Promise.resolve()
+    const settled = await settlement
 
     const channel = await store.getChannel(channelId)
     expect(channel!.spent).toBe(1000000n)
     expect(channel!.units).toBe(1)
+    expect(settled).toMatchObject({ spent: 1000000n, units: 1 })
     expect(receipt.spent).toBe('1000000')
     expect(receipt.units).toBe(1)
   })

--- a/src/tempo/server/internal/transport.ts
+++ b/src/tempo/server/internal/transport.ts
@@ -181,20 +181,25 @@ export function sse(
         response: response as Response,
         challengeId: verifiedChallengeId,
       })
+      const chargePlainResponse = async () => {
+        const result = await ChannelStore.deductFromChannel(store, channelId, tickCost)
+        if (result.ok) await options.settleCharged?.(result.channel)
+        return result
+      }
 
       // Non-SSE response (e.g. upstream returned JSON instead of event-stream).
       // Need to deduct tickCost so request isn't free.
       // For null-body statuses, the request shape determines whether the
       // response is management (no charge) or plain content (charge one tick).
       if (isNullBodyStatus(chargedResponse.status)) {
-        void ChannelStore.deductFromChannel(store, channelId, tickCost)
+        void chargePlainResponse()
         return chargedResponse
       }
 
       const stream = new ReadableStream<Uint8Array>({
         async start(controller) {
           // deduction completes before consumer reads
-          const result = await ChannelStore.deductFromChannel(store, channelId, tickCost)
+          const result = await chargePlainResponse()
           if (!result.ok) {
             controller.error(
               new Errors.InsufficientBalanceError({

--- a/src/tempo/session/README.md
+++ b/src/tempo/session/README.md
@@ -186,6 +186,118 @@ sequenceDiagram
 The initial SSE POST is excluded from default HTTP charging to prevent double
 counting. Stream accounting remains owned by the transport driver.
 
+## Server transport configuration
+
+A session method owns the account, channel store, verification policy, and
+settlement schedule. Routes add prices and application content. HTTP and SSE
+run through configured route handlers; WebSocket uses a session-bound helper
+because its application messages no longer pass through HTTP.
+
+| Server shape           | Session option | Content API                         | Charging                            |
+| ---------------------- | -------------- | ----------------------------------- | ----------------------------------- |
+| HTTP only              | Omit `sse`     | `result.withReceipt(Response)`      | Once per billable request           |
+| SSE only               | `sse: true`    | `result.withReceipt(AsyncIterable)` | Each `stream.charge()`              |
+| WebSocket only         | Omit `sse`     | `mppx.session.serveWebSocket(...)`  | Each `stream.charge()`              |
+| HTTP + SSE + WebSocket | `sse: true`    | All three APIs                      | Selected by route and response type |
+
+All transports for one session service must share the same configured session
+method and store. `serveWebSocket` is bound to both the store and settlement
+policy, so callers pass neither dependency again. `tempo.Ws.serve` remains the
+low-level adapter for custom integrations.
+
+### Shared method configuration
+
+```ts
+const session = tempo.session({
+  account,
+  currency,
+  getClient: () => client,
+  settlementSchedule: { units: 100 },
+  store,
+  // Include when this instance serves any SSE route.
+  sse: true,
+})
+
+const mppx = Mppx.create({ methods: [session], secretKey })
+```
+
+`sse: true` enables async-iterable responses without changing ordinary
+`Response` handling, so a mixed server uses one session method.
+
+### HTTP
+
+```ts
+const httpRoute = mppx.session({ amount: '0.01', unitType: 'request' })
+const result = await httpRoute(request)
+
+if (result.status === 402) return result.challenge
+return result.withReceipt(Response.json({ ok: true }))
+```
+
+HTTP accounting charges the configured route amount before application content
+runs. A plain `Response` selects normal HTTP handling even when `sse: true`.
+
+### SSE
+
+```ts
+const sseRoute = mppx.session({ amount: '0.001', unitType: 'token' })
+const result = await sseRoute(request)
+
+if (result.status === 402) return result.challenge
+return result.withReceipt(async function* (stream) {
+  for await (const token of generateTokens()) {
+    await stream.charge()
+    yield token
+  }
+})
+```
+
+SSE requires `sse: true` on the shared session method. The async iterable
+selects SSE framing and transport-owned metering.
+
+### WebSocket
+
+```ts
+const wsRoute = mppx.session({ amount: '0.001', unitType: 'token' })
+
+webSocketServer.on('connection', (socket, request) => {
+  void mppx.session.serveWebSocket({
+    generate: async function* (stream) {
+      for await (const token of generateTokens()) {
+        await stream.charge()
+        yield token
+      }
+    },
+    route: wsRoute,
+    socket,
+    url: new URL(request.url!, `ws://${request.headers.host}`),
+  })
+})
+```
+
+The application still exposes `wsRoute` over HTTP for the initial challenge
+probe. The bound helper reuses the session store and automatic settlement
+schedule for in-band WebSocket vouchers and charges.
+
+### Mixed server
+
+```ts
+const httpRoute = mppx.session({ amount: '0.01', unitType: 'request' })
+const sseRoute = mppx.session({ amount: '0.001', unitType: 'token' })
+const wsRoute = mppx.session({ amount: '0.001', unitType: 'token' })
+
+async function handler(request: Request) {
+  const pathname = new URL(request.url).pathname
+  if (pathname === '/api/data') return serveHttp(httpRoute, request)
+  if (pathname === '/api/events') return serveSse(sseRoute, request)
+  if (pathname === '/ws') return serveWebSocketProbe(wsRoute, request)
+  return new Response('Not found', { status: 404 })
+}
+```
+
+Each route can choose its own price and unit type. Verification, channel state,
+and settlement policy remain shared through the single session method.
+
 ## Extension boundaries
 
 | Change                         | Preserve                                                                                        |

--- a/src/tempo/session/server/Session.test.ts
+++ b/src/tempo/session/server/Session.test.ts
@@ -2613,7 +2613,7 @@ describe('precompile server session unit guardrails', () => {
       return {
         rawStore,
         route,
-        settleScheduled: payment.session.settleScheduled,
+        serveWebSocket: payment.session.serveWebSocket,
         server,
         wsServer,
         get port() {
@@ -2635,12 +2635,10 @@ describe('precompile server session unit guardrails', () => {
     test('refreshes an expired challenge before sending a later websocket voucher', async () => {
       const harness = await createManagedWsHarness({ challengeTtlMs: 2_000, maxDeposit: 2n })
       harness.wsServer.on('connection', (socket: import('ws').WebSocket) => {
-        void TempoWs.serve({
+        void harness.serveWebSocket({
           socket,
-          store: harness.rawStore,
           url: `${harness.server.url}/ws`,
           route: harness.route,
-          settleScheduled: harness.settleScheduled,
           generate: async function* (stream: TempoWs.SessionController) {
             await stream.charge()
             yield 'chunk-1'
@@ -2684,12 +2682,10 @@ describe('precompile server session unit guardrails', () => {
     test('open -> stream -> need-voucher -> resume -> close', async () => {
       const harness = await createManagedWsHarness({ maxDeposit: 3n })
       harness.wsServer.on('connection', (socket: import('ws').WebSocket) => {
-        void TempoWs.serve({
+        void harness.serveWebSocket({
           socket,
-          store: harness.rawStore,
           url: `${harness.server.url}/ws`,
           route: harness.route,
-          settleScheduled: harness.settleScheduled,
           generate: async function* (stream: TempoWs.SessionController) {
             await stream.charge()
             yield 'chunk-1'
@@ -2757,12 +2753,10 @@ describe('precompile server session unit guardrails', () => {
           },
         })
         harness.wsServer.on('connection', (socket: import('ws').WebSocket) => {
-          void TempoWs.serve({
+          void harness.serveWebSocket({
             socket,
-            store: harness.rawStore,
             url: `${harness.server.url}/ws`,
             route: harness.route,
-            settleScheduled: harness.settleScheduled,
             generate: async function* (stream: TempoWs.SessionController) {
               for (const chunk of ['chunk-1', 'chunk-2', 'chunk-3']) {
                 if (chunk === 'chunk-2' && chunkDelayMs)
@@ -2824,12 +2818,10 @@ describe('precompile server session unit guardrails', () => {
         },
       })
       harness.wsServer.on('connection', (socket: import('ws').WebSocket) => {
-        void TempoWs.serve({
+        void harness.serveWebSocket({
           socket,
-          store: harness.rawStore,
           url: `${harness.server.url}/ws`,
           route: harness.route,
-          settleScheduled: harness.settleScheduled,
           generate: async function* (stream: TempoWs.SessionController) {
             await stream.charge()
             yield controlLookingChunk
@@ -2875,12 +2867,10 @@ describe('precompile server session unit guardrails', () => {
     test('refuses websocket voucher requests beyond local maxDeposit', async () => {
       const harness = await createManagedWsHarness({ maxDeposit: 1n })
       harness.wsServer.on('connection', (socket: import('ws').WebSocket) => {
-        void TempoWs.serve({
+        void harness.serveWebSocket({
           socket,
-          store: harness.rawStore,
           url: `${harness.server.url}/ws`,
           route: harness.route,
-          settleScheduled: harness.settleScheduled,
           generate: async function* (stream: TempoWs.SessionController) {
             await stream.charge()
             yield 'chunk-1'
@@ -3038,12 +3028,10 @@ describe('precompile server session unit guardrails', () => {
       let serverSocket: import('ws').WebSocket | null = null
       harness.wsServer.on('connection', (socket: import('ws').WebSocket) => {
         serverSocket = socket
-        void TempoWs.serve({
+        void harness.serveWebSocket({
           socket,
-          store: harness.rawStore,
           url: `${harness.server.url}/ws`,
           route: harness.route,
-          settleScheduled: harness.settleScheduled,
           generate: async function* (stream: TempoWs.SessionController) {
             await stream.charge()
             yield 'chunk-1'

--- a/src/tempo/session/server/Session.ts
+++ b/src/tempo/session/server/Session.ts
@@ -392,7 +392,7 @@ export function session<const parameters extends session.Parameters>(
       unitType,
     }),
 
-    extensions: { serveWebSocket },
+    extensions: { serveWebSocket, settleScheduled },
 
     transport: deriveTransport<parameters>(transport),
 
@@ -520,12 +520,17 @@ export namespace session {
 
   /** Extensions attached to the Tempo session method handler. */
   export type Extensions = {
+    /** Applies the configured automatic settlement policy to a committed channel charge. */
+    settleScheduled: SettleChargedSessionChannel
     /** Serves a WebSocket route from this handler using its configured store and settlement policy. */
     serveWebSocket: (options: ServeWebSocketOptions) => Promise<void>
   }
 
   /** WebSocket server options supplied after the session binds shared dependencies. */
-  export type ServeWebSocketOptions = Omit<Ws.serve.Options, 'onChargeCommitted' | 'store'>
+  export type ServeWebSocketOptions = Omit<
+    Ws.serve.Options,
+    'onChargeCommitted' | 'settleScheduled' | 'store'
+  >
 
   /** Request defaults inferred from the Tempo session method schema. */
   export type Defaults = LooseOmit<

--- a/src/tempo/session/server/Session.ts
+++ b/src/tempo/session/server/Session.ts
@@ -53,6 +53,7 @@ import {
   type OnSessionSettlement,
   type SettlementSchedule,
 } from './Settlement.js'
+import * as Ws from './Ws.js'
 
 /** Server-side automatic settlement schedule. */
 export type { SettlementSchedule } from './Settlement.js'
@@ -348,6 +349,12 @@ export function session<const parameters extends session.Parameters>(
       store,
     })
   }
+  const serveWebSocket: session.Extensions['serveWebSocket'] = (options) =>
+    Ws.serve({
+      ...options,
+      onChargeCommitted: settleScheduled,
+      store,
+    })
   const bootstrapCharge = ChargeServer.charge({
     account,
     chainId: parameters.chainId,
@@ -385,7 +392,7 @@ export function session<const parameters extends session.Parameters>(
       unitType,
     }),
 
-    extensions: { settleScheduled },
+    extensions: { serveWebSocket },
 
     transport: deriveTransport<parameters>(transport),
 
@@ -513,9 +520,12 @@ export namespace session {
 
   /** Extensions attached to the Tempo session method handler. */
   export type Extensions = {
-    /** Applies the configured automatic settlement policy to a committed channel charge. */
-    settleScheduled: SettleChargedSessionChannel
+    /** Serves a WebSocket route from this handler using its configured store and settlement policy. */
+    serveWebSocket: (options: ServeWebSocketOptions) => Promise<void>
   }
+
+  /** WebSocket server options supplied after the session binds shared dependencies. */
+  export type ServeWebSocketOptions = Omit<Ws.serve.Options, 'onChargeCommitted' | 'store'>
 
   /** Request defaults inferred from the Tempo session method schema. */
   export type Defaults = LooseOmit<

--- a/src/tempo/session/server/Ws.ts
+++ b/src/tempo/session/server/Ws.ts
@@ -16,6 +16,7 @@ import {
 } from '../precompile/Protocol.js'
 import * as ChannelStore from './ChannelStore.js'
 import type { MeteredStreamOptions, SessionController } from './MeteredStream.js'
+import type { SettleChargedSessionChannel } from './Settlement.js'
 export type { SessionController } from './MeteredStream.js'
 export type { Socket } from './Transports.js'
 import { meterIterable } from './MeteredStream.js'
@@ -152,7 +153,7 @@ export async function serve(options: serve.Options): Promise<void> {
         channelId: context.channelId,
         tickCost: context.tickCost,
         generate,
-        onChargeCommitted: options.onChargeCommitted,
+        onChargeCommitted: options.onChargeCommitted ?? options.settleScheduled,
         pollIntervalMs,
         signal: abortController.signal,
         emitNeedVoucher: (message) => send(socket, message),
@@ -335,6 +336,8 @@ export declare namespace serve {
     route: SessionRoute
     /** Optional low-level hook invoked after each committed stream charge. */
     onChargeCommitted?: MeteredStreamOptions['onChargeCommitted']
+    /** @deprecated Use `onChargeCommitted`. */
+    settleScheduled?: SettleChargedSessionChannel | undefined
     socket: Socket
     store: ChannelStore.ChannelStore | import('../../../Store.js').Store
     url: string | URL

--- a/src/tempo/session/server/Ws.ts
+++ b/src/tempo/session/server/Ws.ts
@@ -15,8 +15,7 @@ import {
   type SessionReceipt,
 } from '../precompile/Protocol.js'
 import * as ChannelStore from './ChannelStore.js'
-import type { SessionController } from './MeteredStream.js'
-import type { SettleChargedSessionChannel } from './Settlement.js'
+import type { MeteredStreamOptions, SessionController } from './MeteredStream.js'
 export type { SessionController } from './MeteredStream.js'
 export type { Socket } from './Transports.js'
 import { meterIterable } from './MeteredStream.js'
@@ -153,7 +152,7 @@ export async function serve(options: serve.Options): Promise<void> {
         channelId: context.channelId,
         tickCost: context.tickCost,
         generate,
-        onChargeCommitted: options.settleScheduled,
+        onChargeCommitted: options.onChargeCommitted,
         pollIntervalMs,
         signal: abortController.signal,
         emitNeedVoucher: (message) => send(socket, message),
@@ -334,8 +333,8 @@ export declare namespace serve {
     /** Payment route handler. Receives synthetic `POST` requests with only
      *  the `Authorization` header — no cookies, bodies, or upgrade headers. */
     route: SessionRoute
-    /** Applies the session method's automatic settlement policy after each committed charge. */
-    settleScheduled?: SettleChargedSessionChannel | undefined
+    /** Optional low-level hook invoked after each committed stream charge. */
+    onChargeCommitted?: MeteredStreamOptions['onChargeCommitted']
     socket: Socket
     store: ChannelStore.ChannelStore | import('../../../Store.js').Store
     url: string | URL


### PR DESCRIPTION
## Motivation

WebSocket session servers should reuse the store and scheduled-settlement policy already configured on the session method instead of requiring callers to thread those dependencies through every route.

## Summary

- Added `mppx.session.serveWebSocket(...)` with the configured store and settlement callback bound automatically
- Kept the lower-level WebSocket server API available with a generic post-commit callback
- Updated the WebSocket example and documented HTTP, SSE, WebSocket, and mixed server configurations
- Added integration and type coverage for the bound helper

## Key design considerations

- The session method remains the single owner of shared session state and settlement policy
- The bound helper accepts only route-specific WebSocket options
- HTTP and SSE behavior remains unchanged