### PR TITLE
feat: add ThaiChain support (chain ID 7)

### DIFF
--- a/.changeset/add-thaichain-support.md
+++ b/.changeset/add-thaichain-support.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added support for ThaiChain (chain ID 7) with TCH token.

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -1,10 +1,21 @@
 import * as readline from 'node:readline'
 
 import type { Chain } from 'viem'
-import { type Address, createClient, http } from 'viem'
+import { type Address, createClient, http, defineChain } from 'viem'
 import { tempo as tempoMainnet, tempoModerato } from 'viem/tempo/chains'
 
 import * as defaults from '../tempo/internal/defaults.js'
+
+// Define ThaiChain
+const thaiChain = defineChain({
+  id: 7,
+  name: 'ThaiChain',
+  nativeCurrency: { name: 'TCH', symbol: 'TCH', decimals: 6 },
+  rpcUrls: { default: { http: ['https://rpc.thaichain.org'] } },
+  blockExplorers: {
+    default: { name: 'ThaiChain Explorer', url: 'https://exp.thaichain.org' },
+  },
+})
 
 // Inlined from https://github.com/alexeyraspopov/picocolors (ISC License)
 export const pc = (() => {
@@ -270,7 +281,8 @@ export async function resolveChain(
   const { getChainId } = await import('viem/actions')
   const chainId = await getChainId(createClient({ transport: http(rpcUrl) }))
   const allExports = Object.values(await import('viem/tempo/chains')) as unknown[]
-  const candidates = allExports.filter(
+  // Add ThaiChain to candidates
+  const candidates = [...allExports, thaiChain].filter(
     (c): c is Chain =>
       typeof c === 'object' && c !== null && 'id' in c && (c as Chain).id === chainId,
   )
@@ -283,6 +295,7 @@ export function chainName(chain: { id: number; name: string }) {
   const chainNames: Record<number, string> = {
     [tempoMainnet.id]: 'mainnet',
     [tempoModerato.id]: 'testnet',
+    [thaiChain.id]: 'thaichain',
   }
   return chainNames[chain.id] ?? chain.name
 }

--- a/src/tempo/internal/defaults.ts
+++ b/src/tempo/internal/defaults.ts
@@ -3,6 +3,7 @@ import type { ValueOf } from '../../internal/types.js'
 export const chainId = {
   mainnet: 4217,
   testnet: 42431,
+  thaichain: 7,
 } as const
 export type ChainId = ValueOf<typeof chainId>
 
@@ -12,12 +13,15 @@ export const tokens = {
   usdc: '0x20C000000000000000000000b9537d11c60E8b50',
   /** pathUSD token address. */
   pathUsd: '0x20c0000000000000000000000000000000000000',
+  /** TCH token address on ThaiChain. */
+  tch: '0x20C0000000000000000000000000000000000000',
 } as const
 
 /** Chain ID → default currency. */
 export const currency = {
   [chainId.mainnet]: tokens.usdc,
   [chainId.testnet]: tokens.pathUsd,
+  [chainId.thaichain]: tokens.tch,
 } as const satisfies Record<ChainId, string>
 
 /**
@@ -33,12 +37,14 @@ export const decimals = 6
 export const escrowContract = {
   [chainId.mainnet]: '0x33b901018174DDabE4841042ab76ba85D4e24f25',
   [chainId.testnet]: '0xe1c4d3dce17bc111181ddf716f75bae49e61a336',
+  [chainId.thaichain]: '0x0000000000000000000000000000000000000000', // Not used for charge intent
 } as const satisfies Record<ChainId, string>
 
 /** Default RPC URLs for each Tempo chain. */
 export const rpcUrl = {
   [chainId.mainnet]: 'https://rpc.tempo.xyz',
   [chainId.testnet]: 'https://rpc.moderato.tempo.xyz',
+  [chainId.thaichain]: 'https://rpc.thaichain.org',
 } as const satisfies Record<ChainId, string>
 
 /** Resolves the default currency. */

--- a/src/tempo/internal/fee-payer.ts
+++ b/src/tempo/internal/fee-payer.ts
@@ -365,6 +365,8 @@ const policyByChainId = {
     ...defaultPolicy,
     maxPriorityFeePerGas: 50_000_000_000n,
   },
+  // ThaiChain uses the same policy as mainnet
+  [defaults.chainId.thaichain]: defaultPolicy,
 } as const satisfies Record<defaults.ChainId, Policy>
 
 function getPolicy(chainId: number, overrides: Partial<Policy> | undefined): Policy {


### PR DESCRIPTION
## Summary

This PR adds support for ThaiChain, a Tempo-based blockchain with chain ID 7.

## Changes

- **src/tempo/internal/defaults.ts**: Added ThaiChain configuration
  - Chain ID: 7
  - TCH token address: 0x20C0000000000000000000000000000000000000
  - RPC URL: https://rpc.thaichain.org
  - Explorer URL: https://exp.thaichain.org

- **src/tempo/internal/fee-payer.ts**: Added ThaiChain fee policy
  - Uses default policy (same as mainnet)

- **src/cli/utils.ts**: Added ThaiChain definition
  - Added thaiChain to resolveChain function
  - Added ThaiChain to chainName mapping

- **.changeset/add-thaichain-support.md**: Added changeset for patch version bump

## Testing

Tested with real ThaiChain MPP gateway:

```bash
mppx https://mpp.thaichain.org/api/v1/market   --rpc-url https://rpc.thaichain.org
```

Successfully paid 0.01 TCH and received market data response.

## Related

- ThaiChain: https://thaichain.org
- MPP Gateway: https://mpp.thaichain.org
- Explorer: https://exp.thaichain.org