### PR TITLE
feat(tempo): bound optimistic charge exposure

### DIFF
--- a/.changeset/bounded-optimistic-credit.md
+++ b/.changeset/bounded-optimistic-credit.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added bounded per-payer credit accounting for optimistic Tempo charges, with confirmed fallback when pending charges and reverted-payment debt reach the configured exposure limit.

--- a/src/tempo/server/Charge.test.ts
+++ b/src/tempo/server/Charge.test.ts
@@ -3048,6 +3048,115 @@ describe('tempo', () => {
     })
   })
 
+  describe('intent: charge; bounded optimistic credit', () => {
+    test('retains an under-cap charge as pending payee exposure', async () => {
+      const creditStore = Store.memory()
+      const scope = 'test-usd'
+      const creditServer = Mppx_server.create({
+        methods: [
+          tempo_server.charge({
+            getClient() {
+              return client
+            },
+            currency: asset,
+            account: accounts[0],
+            optimistic: { maxExposure: 1_000_000n, scope },
+            store: creditStore,
+          }),
+        ],
+        realm,
+        secretKey,
+      })
+      const mppx = Mppx_client.create({
+        polyfill: false,
+        methods: [
+          tempo_client({
+            account: accounts[1],
+            getClient() {
+              return client
+            },
+          }),
+        ],
+      })
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await Mppx_server.toNodeListener(
+          creditServer.charge({ amount: '1', currency: asset }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
+      })
+
+      const response = await mppx.fetch(httpServer.url)
+      expect(response.status).toBe(200)
+      const receipt = Receipt.fromResponse(response)
+      const creditKey =
+        `mppx:charge:credit:${chain.id}:${scope}:${accounts[1].address.toLowerCase()}` as const
+      expect(await creditStore.get(creditKey)).toMatchObject({
+        debt: '0',
+        reservations: {
+          [receipt.reference]: {
+            amount: '1000000',
+            phase: 'pending',
+            transactionHash: receipt.reference,
+          },
+        },
+        version: 1,
+      })
+
+      httpServer.close()
+    })
+
+    test('falls back to confirmed settlement above the payer cap', async () => {
+      const creditStore = Store.memory()
+      const scope = 'test-usd'
+      const creditServer = Mppx_server.create({
+        methods: [
+          tempo_server.charge({
+            getClient() {
+              return client
+            },
+            currency: asset,
+            account: accounts[0],
+            optimistic: { maxExposure: 999_999n, scope },
+            store: creditStore,
+          }),
+        ],
+        realm,
+        secretKey,
+      })
+      const mppx = Mppx_client.create({
+        polyfill: false,
+        methods: [
+          tempo_client({
+            account: accounts[1],
+            getClient() {
+              return client
+            },
+          }),
+        ],
+      })
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await Mppx_server.toNodeListener(
+          creditServer.charge({ amount: '1', currency: asset }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
+      })
+
+      const response = await mppx.fetch(httpServer.url)
+      expect(response.status).toBe(200)
+      const receipt = Receipt.fromResponse(response)
+      await expect(
+        getTransactionReceipt(client, { hash: receipt.reference as `0x${string}` }),
+      ).resolves.toMatchObject({ status: 'success' })
+      const creditKey =
+        `mppx:charge:credit:${chain.id}:${scope}:${accounts[1].address.toLowerCase()}` as const
+      expect(await creditStore.get(creditKey)).toBeNull()
+
+      httpServer.close()
+    })
+  })
+
   describe('intent: charge; type: proof (zero-dollar auth)', () => {
     test('default: end-to-end zero-dollar auth via SDK', async () => {
       const mppx = Mppx_client.create({

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -36,6 +36,7 @@ import * as Proof from '../internal/proof.js'
 import * as Selectors from '../internal/selectors.js'
 import type * as types from '../internal/types.js'
 import * as Methods from '../Methods.js'
+import * as CreditBudget from './CreditBudget.js'
 import { html as htmlContent } from './internal/html.gen.js'
 import * as Relay from './Relay.js'
 import * as SponsorBudget from './SponsorBudget.js'
@@ -66,12 +67,22 @@ export function charge<const parameters extends charge.Parameters>(
     feePayerPolicy,
     html,
     memo,
+    optimistic,
     relay,
     splits,
     supportedModes,
     validateSender,
-    waitForConfirmation = true,
+    waitForConfirmation: waitForConfirmation_parameter,
   } = parameters
+  if (optimistic && parameters.waitForConfirmation !== undefined)
+    throw new Error('`optimistic` cannot be combined with `waitForConfirmation`.')
+  if (optimistic && relay)
+    throw new Error('`optimistic` cannot be combined with delegated relay settlement.')
+  if (optimistic && !parameters.store)
+    throw new Error('`optimistic` requires a shared atomic `store`.')
+  if (optimistic && optimistic.maxExposure <= 0n)
+    throw new Error('`optimistic.maxExposure` must be greater than zero.')
+  const waitForConfirmation = waitForConfirmation_parameter ?? !optimistic
   const storeKeyPrefix = parameters.storeKeyPrefix ?? ''
   const rawStore = (parameters.store ?? Store.memory()) as Store.AtomicStore<charge.StoreItemMap>
   const store = Store.from(rawStore, { keyPrefix: storeKeyPrefix })
@@ -80,6 +91,9 @@ export function charge<const parameters extends charge.Parameters>(
   // atomic sponsor-wide budget.
   const sponsorBudgetStore = Store.from(rawStore) as Store.AtomicStore<{
     [key: `mppx:charge:sponsor-budget:${string}`]: SponsorBudget.State
+  }>
+  const creditBudgetStore = Store.from(rawStore) as Store.AtomicStore<{
+    [key: `mppx:charge:credit:${string}`]: CreditBudget.State
   }>
   const {
     maxInFlightReservations = 100,
@@ -514,6 +528,7 @@ export function charge<const parameters extends charge.Parameters>(
           }
 
           let broadcastAttempted = false
+          let creditReservation: CreditBudget.Handle | undefined
           let finalHash: `0x${string}` | undefined
           let reservation: SponsorBudget.Handle | undefined
 
@@ -638,6 +653,64 @@ export function charge<const parameters extends charge.Parameters>(
                 FeePayer.simulationTransaction(transaction, { feePayer: false }) as never,
               )
 
+            if (optimistic) {
+              const payer = transaction.from! as `0x${string}`
+              const scope =
+                optimistic.scope ?? `${currency.toLowerCase()}:${recipient.toLowerCase()}`
+              const expiresAt = transaction.validBefore
+                ? Number(transaction.validBefore) * 1_000
+                : challenge.expires
+                  ? Date.parse(challenge.expires)
+                  : Number.MAX_SAFE_INTEGER
+              creditReservation =
+                (await CreditBudget.reserve(creditBudgetStore, {
+                  amount: BigInt(amount),
+                  chainId: chainId ?? client.chain!.id,
+                  expiresAt,
+                  async getOutcome(pending) {
+                    let receipt: TransactionReceipt
+                    try {
+                      receipt = await getTransactionReceipt(client, {
+                        hash: pending.transactionHash,
+                      })
+                    } catch {
+                      return 'pending'
+                    }
+                    if (receipt.status !== 'success') return 'failed'
+                    try {
+                      const matchedLogs = await assertTransferLogs(receipt, {
+                        currency: pending.currency,
+                        sender: pending.sender,
+                        transfers: pending.transfers,
+                        validateSender,
+                      })
+                      if (pending.challengeBoundMemo)
+                        assertChallengeBoundMemo(matchedLogs, {
+                          challengeId: pending.challengeId,
+                          realm: pending.realm,
+                        })
+                      return 'success'
+                    } catch {
+                      return 'failed'
+                    }
+                  },
+                  id: finalHash.toLowerCase(),
+                  maxExposure: optimistic.maxExposure,
+                  owner: globalThis.crypto.randomUUID(),
+                  payer,
+                  payment: {
+                    challengeBoundMemo: !memo,
+                    challengeId: challenge.id,
+                    currency,
+                    realm: challenge.realm,
+                    sender: payer,
+                    transactionHash: finalHash,
+                    transfers,
+                  },
+                  scope,
+                })) ?? undefined
+            }
+
             if (
               reservation &&
               !(await SponsorBudget.transition(sponsorBudgetStore, reservation, 'broadcasting'))
@@ -645,9 +718,16 @@ export function charge<const parameters extends charge.Parameters>(
               throw new VerificationFailedError({
                 reason: 'Sponsor budget reservation ownership was lost before broadcast',
               })
+            if (
+              creditReservation &&
+              !(await CreditBudget.transition(creditBudgetStore, creditReservation, 'broadcasting'))
+            )
+              throw new VerificationFailedError({
+                reason: 'Charge credit reservation ownership was lost before broadcast',
+              })
 
             broadcastAttempted = true
-            if (waitForConfirmation) {
+            if (waitForConfirmation || (optimistic && !creditReservation)) {
               const receipt = await sendRawTransactionSync(client, {
                 serializedTransaction: serializedTransaction_final,
               })
@@ -656,6 +736,7 @@ export function charge<const parameters extends charge.Parameters>(
                 currency,
                 sender: transaction.from! as `0x${string}`,
                 transfers,
+                validateSender,
               })
               if (!memo)
                 assertChallengeBoundMemo(matchedLogs, {
@@ -686,6 +767,13 @@ export function charge<const parameters extends charge.Parameters>(
               throw new VerificationFailedError({
                 reason: 'Sponsor budget reservation ownership was lost after broadcast',
               })
+            if (
+              creditReservation &&
+              !(await CreditBudget.transition(creditBudgetStore, creditReservation, 'pending'))
+            )
+              throw new VerificationFailedError({
+                reason: 'Charge credit reservation ownership was lost after broadcast',
+              })
             return {
               method: 'tempo',
               status: 'success',
@@ -694,6 +782,8 @@ export function charge<const parameters extends charge.Parameters>(
             } as const
           } catch (error) {
             if (!broadcastAttempted) {
+              if (creditReservation)
+                await CreditBudget.release(creditBudgetStore, creditReservation)
               if (reservation) await SponsorBudget.release(sponsorBudgetStore, reservation)
               if (finalHash && finalHash.toLowerCase() !== hash.toLowerCase())
                 await releaseHashUse(store, finalHash)
@@ -710,7 +800,7 @@ export function charge<const parameters extends charge.Parameters>(
 
 export declare namespace charge {
   type StoreItemMap = {
-    [key: `mppx:charge:${string}`]: number | SponsorBudget.State
+    [key: `mppx:charge:${string}`]: CreditBudget.State | number | SponsorBudget.State
   }
 
   type Defaults = LooseOmit<Method.RequestDefaults<typeof Methods.charge>, 'feePayer' | 'recipient'>
@@ -807,6 +897,17 @@ export declare namespace charge {
      * the failure.
      */
     waitForConfirmation?: boolean | undefined
+    /**
+     * Serves transaction charges after simulation and broadcast while bounding
+     * the payee's unconfirmed exposure per payer. Explicitly reverted charges
+     * become debt and consume the configured capacity; charges above remaining
+     * capacity wait for confirmation instead.
+     *
+     * Requires a shared atomic {@link Store.AtomicStore}. The optional scope can
+     * aggregate economically interchangeable charge methods that use the same
+     * raw unit (for example, six-decimal USD stablecoins).
+     */
+    optimistic?: OptimisticCredit | undefined
   } & Client.getResolver.Parameters &
     Account.resolve.Parameters &
     Defaults
@@ -829,6 +930,13 @@ export declare namespace charge {
      * @default `maxTotalFee * 10`
      */
     maxInFlightTotalFee?: bigint | undefined
+  }
+
+  type OptimisticCredit = {
+    /** Maximum aggregate debt plus pending charge amount in raw token units. */
+    maxExposure: bigint
+    /** Caller-owned accounting scope. Defaults to the configured currency and recipient. */
+    scope?: string | undefined
   }
 
   /** Tempo API relay configuration for server-side charges. */

--- a/src/tempo/server/CreditBudget.test.ts
+++ b/src/tempo/server/CreditBudget.test.ts
@@ -1,0 +1,159 @@
+import { Store } from 'mppx'
+import { describe, expect, test } from 'vp/test'
+
+import * as CreditBudget from './CreditBudget.js'
+
+const payer = `0x${'11'.repeat(20)}` as const
+const currency = `0x${'22'.repeat(20)}` as const
+const recipient = `0x${'33'.repeat(20)}` as const
+const sender = payer
+
+function parameters(overrides: Record<string, unknown> = {}) {
+  const transactionHash = `0x${'44'.repeat(32)}` as const
+  return {
+    amount: 60n,
+    chainId: 4217,
+    expiresAt: Date.now() + 60_000,
+    getOutcome: async () => 'pending' as const,
+    id: transactionHash,
+    maxExposure: 100n,
+    owner: 'owner-1',
+    payer,
+    payment: {
+      challengeBoundMemo: true,
+      challengeId: 'challenge-1',
+      currency,
+      realm: 'api.example.com',
+      sender,
+      transactionHash,
+      transfers: [{ amount: '60', recipient }],
+    },
+    scope: 'usd',
+    ...overrides,
+  }
+}
+
+function createStore() {
+  return Store.memory() as Store.AtomicStore<CreditBudget.ItemMap>
+}
+
+describe('CreditBudget', () => {
+  test('falls back to confirmation when pending exposure would exceed the cap', async () => {
+    const store = createStore()
+    const first = parameters()
+    const handle = await CreditBudget.reserve(store, first)
+    expect(handle).not.toBeNull()
+    await CreditBudget.transition(store, handle!, 'broadcasting')
+    await CreditBudget.transition(store, handle!, 'pending')
+
+    const second = await CreditBudget.reserve(
+      store,
+      parameters({
+        amount: 50n,
+        id: `0x${'55'.repeat(32)}`,
+        owner: 'owner-2',
+        payment: {
+          ...first.payment,
+          transactionHash: `0x${'55'.repeat(32)}`,
+        },
+      }),
+    )
+
+    expect(second).toBeNull()
+  })
+
+  test('releases successful charges for reuse', async () => {
+    const store = createStore()
+    const first = parameters()
+    const handle = await CreditBudget.reserve(store, first)
+    await CreditBudget.transition(store, handle!, 'pending')
+
+    const second = await CreditBudget.reserve(
+      store,
+      parameters({
+        getOutcome: async () => 'success' as const,
+        id: `0x${'55'.repeat(32)}`,
+        owner: 'owner-2',
+        payment: {
+          ...first.payment,
+          transactionHash: `0x${'55'.repeat(32)}`,
+        },
+      }),
+    )
+
+    expect(second).not.toBeNull()
+    expect((await CreditBudget.getState(store, first))?.debt).toBe('0')
+  })
+
+  test('converts reverted optimistic charges into durable debt', async () => {
+    const store = createStore()
+    const first = parameters()
+    const handle = await CreditBudget.reserve(store, first)
+    await CreditBudget.transition(store, handle!, 'pending')
+
+    const second = await CreditBudget.reserve(
+      store,
+      parameters({
+        amount: 50n,
+        getOutcome: async () => 'failed' as const,
+        id: `0x${'55'.repeat(32)}`,
+        owner: 'owner-2',
+        payment: {
+          ...first.payment,
+          transactionHash: `0x${'55'.repeat(32)}`,
+        },
+      }),
+    )
+
+    expect(second).toBeNull()
+    expect(await CreditBudget.getState(store, first)).toMatchObject({
+      debt: '60',
+      reservations: {},
+    })
+  })
+
+  test('isolates exposure by payer', async () => {
+    const store = createStore()
+    const first = parameters({ amount: 100n })
+    const handle = await CreditBudget.reserve(store, first)
+    await CreditBudget.transition(store, handle!, 'pending')
+
+    const otherPayer = `0x${'66'.repeat(20)}` as const
+    const other = await CreditBudget.reserve(
+      store,
+      parameters({
+        amount: 100n,
+        id: `0x${'77'.repeat(32)}`,
+        owner: 'owner-2',
+        payer: otherPayer,
+        payment: {
+          ...first.payment,
+          sender: otherPayer,
+          transactionHash: `0x${'77'.repeat(32)}`,
+        },
+      }),
+    )
+
+    expect(other).not.toBeNull()
+  })
+
+  test('atomically admits only one of two charges that exceed the cap together', async () => {
+    const store = createStore()
+    const first = parameters()
+    const second = parameters({
+      id: `0x${'55'.repeat(32)}`,
+      owner: 'owner-2',
+      payment: {
+        ...first.payment,
+        transactionHash: `0x${'55'.repeat(32)}`,
+      },
+    })
+
+    const reservations = await Promise.all([
+      CreditBudget.reserve(store, first),
+      CreditBudget.reserve(store, second),
+    ])
+
+    expect(reservations.filter(Boolean)).toHaveLength(1)
+  })
+})

--- a/src/tempo/server/CreditBudget.ts
+++ b/src/tempo/server/CreditBudget.ts
@@ -1,0 +1,248 @@
+import type { Hex } from 'viem'
+
+import type * as Store from '../../Store.js'
+
+export type Phase = 'broadcasting' | 'pending' | 'prepared'
+
+export type ExpectedTransfer = {
+  amount: string
+  allowAnyMemo?: boolean | undefined
+  memo?: Hex | undefined
+  recipient: Hex
+}
+
+export type Reservation = {
+  amount: string
+  challengeBoundMemo: boolean
+  challengeId: string
+  currency: Hex
+  expiresAt: number
+  leaseUntil: number
+  owner: string
+  phase: Phase
+  realm: string
+  sender: Hex
+  transactionHash: Hex
+  transfers: readonly ExpectedTransfer[]
+}
+
+export type State = {
+  debt: string
+  reservations: Record<string, Reservation>
+  version: 1
+}
+
+export type Handle = {
+  chainId: number
+  id: string
+  owner: string
+  payer: Hex
+  scope: string
+}
+
+export type Outcome = 'failed' | 'pending' | 'success'
+
+export type ItemMap = {
+  [key: `mppx:charge:credit:${string}`]: State
+}
+
+type ReserveParameters = Handle & {
+  amount: bigint
+  expiresAt: number
+  getOutcome: (reservation: Reservation) => Promise<Outcome>
+  maxExposure: bigint
+  payment: Pick<
+    Reservation,
+    | 'challengeBoundMemo'
+    | 'challengeId'
+    | 'currency'
+    | 'realm'
+    | 'sender'
+    | 'transactionHash'
+    | 'transfers'
+  >
+}
+
+const preparedLeaseMs = 30_000
+
+function key(parameters: Pick<Handle, 'chainId' | 'payer' | 'scope'>) {
+  return `mppx:charge:credit:${parameters.chainId}:${parameters.scope}:${parameters.payer.toLowerCase()}` as const
+}
+
+function isState(value: State | null): value is State {
+  return (
+    value?.version === 1 && typeof value.debt === 'string' && typeof value.reservations === 'object'
+  )
+}
+
+function exposure(state: State) {
+  return Object.values(state.reservations).reduce(
+    (total, reservation) => total + BigInt(reservation.amount),
+    BigInt(state.debt),
+  )
+}
+
+async function mutateOwned(
+  store: Store.AtomicStore<ItemMap>,
+  handle: Handle,
+  mutate: (reservation: Reservation, state: State) => State | null,
+) {
+  return store.update(key(handle), (current) => {
+    if (!isState(current)) return { op: 'noop', result: false }
+    const reservation = current.reservations[handle.id]
+    if (!reservation || reservation.owner !== handle.owner) return { op: 'noop', result: false }
+
+    const next = mutate(reservation, current)
+    if (!next || (next.debt === '0' && Object.keys(next.reservations).length === 0))
+      return { op: 'delete', result: true }
+    return { op: 'set', value: next, result: true }
+  })
+}
+
+async function resolve(
+  store: Store.AtomicStore<ItemMap>,
+  handle: Handle,
+  reservation: Reservation,
+  outcome: Exclude<Outcome, 'pending'>,
+) {
+  return store.update(key(handle), (current) => {
+    if (!isState(current)) return { op: 'noop', result: false }
+    const latest = current.reservations[handle.id]
+    if (
+      !latest ||
+      latest.owner !== reservation.owner ||
+      latest.phase !== 'pending' ||
+      latest.transactionHash.toLowerCase() !== reservation.transactionHash.toLowerCase()
+    )
+      return { op: 'noop', result: false }
+
+    const reservations = { ...current.reservations }
+    delete reservations[handle.id]
+    const debt =
+      outcome === 'failed'
+        ? (BigInt(current.debt) + BigInt(reservation.amount)).toString()
+        : current.debt
+    if (debt === '0' && Object.keys(reservations).length === 0)
+      return { op: 'delete', result: true }
+    return {
+      op: 'set',
+      value: { debt, reservations, version: 1 },
+      result: true,
+    }
+  })
+}
+
+/** Reconciles terminal optimistic charges before making another credit decision. */
+export async function reconcile(
+  store: Store.AtomicStore<ItemMap>,
+  parameters: Pick<ReserveParameters, 'chainId' | 'getOutcome' | 'payer' | 'scope'>,
+) {
+  const state = await store.get(key(parameters))
+  if (!isState(state)) return
+
+  const now = Date.now()
+  await Promise.all(
+    Object.entries(state.reservations).map(async ([id, reservation]) => {
+      const handle = {
+        chainId: parameters.chainId,
+        id,
+        owner: reservation.owner,
+        payer: parameters.payer,
+        scope: parameters.scope,
+      }
+      if (
+        (reservation.phase === 'prepared' && reservation.leaseUntil <= now) ||
+        (reservation.phase === 'broadcasting' && reservation.expiresAt <= now)
+      ) {
+        await release(store, handle)
+        return
+      }
+      if (reservation.phase !== 'pending') return
+
+      const outcome = await parameters.getOutcome(reservation)
+      if (outcome !== 'pending') await resolve(store, handle, reservation, outcome)
+    }),
+  )
+}
+
+/**
+ * Reserves bounded payee exposure for an optimistic charge.
+ *
+ * A `null` result means the caller must confirm the charge before serving the
+ * resource. Explicitly failed optimistic charges remain as debt and consume
+ * capacity; successful charges release their reservation during reconciliation.
+ *
+ * @internal
+ */
+export async function reserve(
+  store: Store.AtomicStore<ItemMap>,
+  parameters: ReserveParameters,
+): Promise<Handle | null> {
+  await reconcile(store, parameters)
+  const now = Date.now()
+  const result = await store.update(key(parameters), (current) => {
+    if (current !== null && !isState(current)) return { op: 'noop', result: 'invalid' as const }
+
+    const state = current ?? { debt: '0', reservations: {}, version: 1 as const }
+    if (state.reservations[parameters.id]) return { op: 'noop', result: 'duplicate' as const }
+    if (exposure(state) + parameters.amount > parameters.maxExposure)
+      return { op: 'noop', result: 'confirm' as const }
+
+    return {
+      op: 'set',
+      value: {
+        ...state,
+        reservations: {
+          ...state.reservations,
+          [parameters.id]: {
+            amount: parameters.amount.toString(),
+            expiresAt: parameters.expiresAt,
+            leaseUntil: Math.min(parameters.expiresAt, now + preparedLeaseMs),
+            owner: parameters.owner,
+            phase: 'prepared' as const,
+            ...parameters.payment,
+          },
+        },
+      },
+      result: 'reserved' as const,
+    }
+  })
+
+  if (result === 'reserved') return parameters
+  if (result === 'confirm') return null
+  if (result === 'invalid') throw new Error('Charge credit store contains incompatible state')
+  throw new Error('Charge already has a credit reservation')
+}
+
+/** Advances an owned reservation around the transaction broadcast. @internal */
+export async function transition(
+  store: Store.AtomicStore<ItemMap>,
+  handle: Handle,
+  phase: Exclude<Phase, 'prepared'>,
+): Promise<boolean> {
+  return mutateOwned(store, handle, (reservation, state) => ({
+    ...state,
+    reservations: {
+      ...state.reservations,
+      [handle.id]: { ...reservation, phase },
+    },
+  }))
+}
+
+/** Releases an owned reservation when no resource was served. @internal */
+export async function release(store: Store.AtomicStore<ItemMap>, handle: Handle): Promise<boolean> {
+  return mutateOwned(store, handle, (_reservation, state) => {
+    const reservations = { ...state.reservations }
+    delete reservations[handle.id]
+    return { ...state, reservations }
+  })
+}
+
+/** Returns the current bounded-credit state for diagnostics and tests. @internal */
+export async function getState(
+  store: Store.AtomicStore<ItemMap>,
+  parameters: Pick<Handle, 'chainId' | 'payer' | 'scope'>,
+): Promise<State | null> {
+  const state = await store.get(key(parameters))
+  return isState(state) ? state : null
+}


### PR DESCRIPTION
## Summary

- add atomic per-payer accounting for optimistic Tempo charge exposure
- reconcile pending receipts using the existing exact transfer, sender, and challenge-bound memo verification
- retain reverted optimistic payments as debt and fall back to confirmed settlement when debt plus pending charges reaches the configured cap
- support caller-owned scopes for aggregating economically interchangeable currencies with the same raw unit

## Motivation

An optimistic MPP charge can be broadcast successfully while later reverting onchain. The observed [SpendingLimitExceeded transaction](https://explore.tempo.xyz/tx/0x0770a9c00e85825986dc9e55fb34bfaf126fa994d75bd1460107005499a24fa5) produced an application success path before its receipt was known, which leaves unlimited optimistic mode open to unbounded unpaid service. Waiting for every confirmation closes that hole but adds settlement latency to every request.

This adds a bounded fast path:

```
debt + pending exposure + new charge <= cap => serve optimistically
otherwise                                    => wait for confirmation
```

Successful receipts release capacity. Explicit failures become durable debt and continue consuming the payer credit line. Confirmed fallback payments cover the current request; they do not silently forgive existing debt.

The cap is per payer and intentionally does not replace an application-level global breaker or Sybil policy.

## Validation

- `pnpm exec vp test --run --project node src/tempo/server/CreditBudget.test.ts` — 5 passed
- `pnpm exec vp test --run --project node src/tempo/server/Charge.test.ts` — 125 passed
- `pnpm check:types`
- `pnpm check:ci`
- `git diff --check origin/main...HEAD`
