### PR TITLE
fix(deps): align package.json versions with pnpm workspace overrides

### DIFF
--- a/.changeset/spicy-words-count.md
+++ b/.changeset/spicy-words-count.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Align package.json dependency versions with pnpm-workspace.yaml overrides.

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -48,6 +48,9 @@ jobs:
             echo "✓ No pnpm.overrides in package.json"
           fi
 
+      - name: Ensure package.json versions match workspace overrides
+        run: pnpm exec tsx scripts/check-override-drift.ts
+
       - name: Audit dependencies
         # npm's legacy audit endpoint is returning 410 Gone. Keep the audit
         # check enabled, but don't fail CI on registry-level audit outages.

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "eslint-plugin-compat": "^7.0.2",
     "express": "^5.2.1",
     "fast-check": "^4.9.0",
-    "file-type": "22.0.1",
+    "file-type": "21.3.2",
     "frog": "^1.0.15",
     "hono": "4.12.32",
     "isows": "^1.0.7",
@@ -53,7 +53,7 @@
     "tempo.ts": "^0.14.2",
     "testcontainers": "^12.0.4",
     "tsx": "^4.23.1",
-    "typescript": "~7.0.2",
+    "typescript": "~5.9.3",
     "viem": "2.55.10",
     "vite": "^8.1.5",
     "vp": "npm:vite-plus@~0.1.24",
@@ -233,7 +233,7 @@
     "@stripe/stripe-js": "9.12.0",
     "eventsource-parser": "3.1.0",
     "incur": "^0.4.19",
-    "ox": "1.0.5",
+    "ox": "0.14.33",
     "zod": "^4.4.3"
   },
   "repository": {

--- a/scripts/check-override-drift.ts
+++ b/scripts/check-override-drift.ts
@@ -1,0 +1,85 @@
+#!/usr/bin/env tsx
+// Validates that package.json dependency versions don't conflict with
+// pnpm-workspace.yaml overrides. If a workspace override pins a package
+// to a specific version, the matching entry in package.json must declare
+// the same version — otherwise the declared version is misleading since
+// pnpm will always resolve to the override.
+//
+// This catches dependabot PRs that bump overridden packages, since
+// dependabot does not read pnpm workspace overrides.
+
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const root = resolve(import.meta.dirname, '..')
+const pkg = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'))
+const workspaceRaw = readFileSync(resolve(root, 'pnpm-workspace.yaml'), 'utf8')
+
+// Minimal YAML parser for the overrides map (avoids adding a dependency).
+// Handles lines like:   package-name: '1.2.3'
+//                       '@scoped/pkg': "1.2.3"
+//                       package-name: 1.2.3  # with optional comment
+function parseOverrides(yaml: string): Record<string, string> {
+  const overrides: Record<string, string> = {}
+  let inOverrides = false
+  for (const line of yaml.split('\n')) {
+    if (/^overrides:\s*$/.test(line)) {
+      inOverrides = true
+      continue
+    }
+    if (inOverrides) {
+      if (/^\S/.test(line)) break // new top-level key
+      const m = line.match(/^\s+['"]?([\w@/._^<>=! -]+)['"]?:\s*['"]?([^'"#]+)['"]?\s*(?:#.*)?$/)
+      if (m) overrides[m[1].trim()] = m[2].trim()
+    }
+  }
+  return overrides
+}
+
+interface Mismatch {
+  name: string
+  pkgVersion: string
+  overrideVersion: string
+}
+
+const overrides = parseOverrides(workspaceRaw)
+// Only check dependencies and devDependencies. peerDependencies express
+// consumer compatibility ranges and are not resolved locally.
+const allDeps: Record<string, string> = {
+  ...pkg.dependencies,
+  ...pkg.devDependencies,
+}
+
+const mismatches: Mismatch[] = []
+for (const [name, pkgVersion] of Object.entries(allDeps)) {
+  // Only check simple overrides (no range selectors like "pkg@<2.0.0")
+  if (!(name in overrides)) continue
+  const overrideVersion = overrides[name]
+  // Skip non-version overrides (workspace:*, npm:..., https://...)
+  if (/^(workspace:|npm:|https?:)/.test(overrideVersion)) continue
+  // Normalize: strip leading ^ and ~ for comparison
+  const cleanPkg = pkgVersion.replace(/^[~^]/, '')
+  const cleanOverride = overrideVersion.replace(/^[~^]/, '')
+  if (cleanPkg !== cleanOverride) {
+    mismatches.push({ name, pkgVersion, overrideVersion })
+  }
+}
+
+if (mismatches.length > 0) {
+  console.error(
+    'package.json declares versions that conflict with pnpm-workspace.yaml overrides:\n',
+  )
+  for (const { name, pkgVersion, overrideVersion } of mismatches) {
+    console.error(`  ${name}`)
+    console.error(`    package.json:          ${pkgVersion}`)
+    console.error(`    workspace override:    ${overrideVersion}`)
+    console.error()
+  }
+  console.error('The workspace override wins at install time, making package.json misleading.')
+  console.error(
+    'Either update package.json to match the override, or remove/update the override.\n',
+  )
+  process.exit(1)
+}
+
+console.log('✓ All package.json versions are consistent with workspace overrides')


### PR DESCRIPTION
## Summary
- Dependabot PR #737 bumped `ox`, `typescript`, and `file-type` in `package.json` but the `pnpm-workspace.yaml` overrides continued pinning the old versions, causing a silent mismatch where declared deps differed from what was actually installed.
- Reverts `package.json` to match the workspace overrides until these pins can be lifted together with their dependents (e.g., `ox` is pinned for `viem@2.55.10` compatibility).

**We can alternatively get rid of the overrides in pnpm-workspace.yaml if preferred! Not sure if that would cause churn for existing MPP integrations?**

| Package | package.json (was) | Actually installed (override) |
|---------|-------------------|-------------------------------|
| ox | 1.0.5 | 0.14.33 |
| typescript | ~7.0.2 | ~5.9.3 |
| file-type | 22.0.1 | 21.3.2 |

## Test plan
- [x] `pnpm install` reports "Already up to date" (lockfile unchanged)
- [x] `pnpm run check:types` passes