### PR TITLE
test: verify override drift check catches existing mismatches

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -48,6 +48,9 @@ jobs:
             echo "✓ No pnpm.overrides in package.json"
           fi
 
+      - name: Ensure package.json versions match workspace overrides
+        run: pnpm exec tsx scripts/check-override-drift.ts
+
       - name: Audit dependencies
         # npm's legacy audit endpoint is returning 410 Gone. Keep the audit
         # check enabled, but don't fail CI on registry-level audit outages.

--- a/scripts/check-override-drift.ts
+++ b/scripts/check-override-drift.ts
@@ -1,0 +1,92 @@
+#!/usr/bin/env tsx
+// Validates that package.json dependency versions don't conflict with
+// pnpm-workspace.yaml overrides. If a workspace override pins a package
+// to a specific version, the matching entry in package.json must declare
+// the same version — otherwise the declared version is misleading since
+// pnpm will always resolve to the override.
+//
+// This catches dependabot PRs that bump overridden packages, since
+// dependabot does not read pnpm workspace overrides.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const root = resolve(import.meta.dirname, "..");
+const pkg = JSON.parse(readFileSync(resolve(root, "package.json"), "utf8"));
+const workspaceRaw = readFileSync(
+  resolve(root, "pnpm-workspace.yaml"),
+  "utf8",
+);
+
+// Minimal YAML parser for the overrides map (avoids adding a dependency).
+// Handles lines like:   package-name: '1.2.3'
+//                       package-name: "1.2.3"
+//                       package-name: 1.2.3
+function parseOverrides(yaml: string): Record<string, string> {
+  const overrides: Record<string, string> = {};
+  let inOverrides = false;
+  for (const line of yaml.split("\n")) {
+    if (/^overrides:\s*$/.test(line)) {
+      inOverrides = true;
+      continue;
+    }
+    if (inOverrides) {
+      if (/^\S/.test(line)) break; // new top-level key
+      const m = line.match(
+        /^\s+([\w@/._^<>=! -]+):\s*['"]?([^'"]+)['"]?\s*$/,
+      );
+      if (m) overrides[m[1].trim()] = m[2].trim();
+    }
+  }
+  return overrides;
+}
+
+interface Mismatch {
+  name: string;
+  pkgVersion: string;
+  overrideVersion: string;
+}
+
+const overrides = parseOverrides(workspaceRaw);
+const allDeps: Record<string, string> = {
+  ...pkg.dependencies,
+  ...pkg.devDependencies,
+};
+
+const mismatches: Mismatch[] = [];
+for (const [name, pkgVersion] of Object.entries(allDeps)) {
+  // Only check simple overrides (no range selectors like "pkg@<2.0.0")
+  if (!(name in overrides)) continue;
+  const overrideVersion = overrides[name];
+  // Skip non-version overrides (workspace:*, npm:..., https://...)
+  if (/^(workspace:|npm:|https?:)/.test(overrideVersion)) continue;
+  // Normalize: strip leading ^ and ~ for comparison
+  const cleanPkg = pkgVersion.replace(/^[~^]/, "");
+  const cleanOverride = overrideVersion.replace(/^[~^]/, "");
+  if (cleanPkg !== cleanOverride) {
+    mismatches.push({ name, pkgVersion, overrideVersion });
+  }
+}
+
+if (mismatches.length > 0) {
+  console.error(
+    "package.json declares versions that conflict with pnpm-workspace.yaml overrides:\n",
+  );
+  for (const { name, pkgVersion, overrideVersion } of mismatches) {
+    console.error(`  ${name}`);
+    console.error(`    package.json:          ${pkgVersion}`);
+    console.error(`    workspace override:    ${overrideVersion}`);
+    console.error();
+  }
+  console.error(
+    "The workspace override wins at install time, making package.json misleading.",
+  );
+  console.error(
+    "Either update package.json to match the override, or remove/update the override.\n",
+  );
+  process.exit(1);
+}
+
+console.log(
+  "✓ All package.json versions are consistent with workspace overrides",
+);


### PR DESCRIPTION
## Purpose

This draft PR deliberately keeps the mismatched package.json versions (ox 1.0.5, typescript ~7.0.2, file-type 22.0.1) while adding the new `scripts/check-override-drift.ts` CI check.

**This PR is expected to FAIL CI** at the "Ensure package.json versions match workspace overrides" step, demonstrating that the check would have caught PR #737's drift before merge.

See companion PR #755 for the actual fix.

Do not merge — close after CI runs.