### PR TITLE
fix: avoid missing workspace CLI links

### DIFF
--- a/.agents/friction-log/20260803161432-concurrent-html-builds/friction.md
+++ b/.agents/friction-log/20260803161432-concurrent-html-builds/friction.md
@@ -1,0 +1,24 @@
+---
+title: 'concurrent HTML builds share a temporary directory'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+Running pnpm build and pnpm check:types concurrently completes independently.
+
+## Current Behavior
+
+Both commands invoke the HTML builder against .tmp/html-build. One process removes the directory while the other still uses it, causing an ENOENT failure during cleanup.
+
+## Possible Solution
+
+Give each HTML build a unique temporary directory or make cleanup tolerate concurrent removal.
+
+## Minimal Reproducible Example
+
+Run pnpm build and pnpm check:types concurrently in the same worktree.
+
+## Context
+
+This prevents safely parallelizing independent validation commands.

--- a/.changeset/stable-workspace-bin.md
+++ b/.changeset/stable-workspace-bin.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added a stable CLI launcher for workspace dependency installation.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "build": "pnpm build:html && zile",
+    "build": "pnpm build:html && zile && node scripts/set-workspace-bin.js",
     "build:html": "node --import tsx scripts/build:html.ts",
     "changeset:publish:main": "zile publish:prepare && changeset publish --no-git-tag --tag main && zile publish:post",
     "changeset:publish": "zile publish:prepare && changeset publish && zile publish:post",
@@ -12,7 +12,7 @@
     "check:types:examples": "pnpm -r --filter './examples/**' run check:types",
     "deps": "pnpx taze -r --no-ignore-other-workspaces --ignore-paths node_modules",
     "deps:ci": "pnpx actions-up",
-    "dev": "zile dev",
+    "dev": "zile dev && node scripts/set-workspace-bin.js",
     "dev:example": "node scripts/dev:example.ts",
     "mppx": "node --import tsx src/bin.ts",
     "test": "vp test",
@@ -244,7 +244,7 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
-    "mppx": "./dist/bin.js",
+    "mppx": "./src/bin.js",
     "mppx.src": "./src/bin.ts"
   }
 }

--- a/scripts/set-workspace-bin.js
+++ b/scripts/set-workspace-bin.js
@@ -1,0 +1,8 @@
+import fs from 'node:fs/promises'
+
+const path = new URL('../package.json', import.meta.url)
+const packageJson = JSON.parse(await fs.readFile(path, 'utf8'))
+
+packageJson.bin.mppx = './src/bin.js'
+
+await fs.writeFile(path, `${JSON.stringify(packageJson, null, 2)}\n`)

--- a/src/bin.js
+++ b/src/bin.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import '../dist/bin.js'


### PR DESCRIPTION
## Motivation

Fresh worktrees linked the CLI before `dist/bin.js` existed, producing repeated missing-bin warnings during dependency installation. Fixes #752.

## Summary

- Added a stable source launcher for workspace CLI links.
- Restored the workspace bin mapping after build and development commands.
- Added a patch changeset.
- Recorded the concurrent HTML build temporary-directory collision.

## Key design considerations

- Published packages continue exposing the generated `dist/bin.js` entry.
- The workspace launcher delegates to the generated CLI once built.