### PR TITLE
fix(deps): centralize workspace dependency pins

### DIFF
--- a/.changeset/calm-catalog-pins.md
+++ b/.changeset/calm-catalog-pins.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Aligned published and workspace dependency versions with shared pnpm catalog pins.

--- a/examples/charge-relay/package.json
+++ b/examples/charge-relay/package.json
@@ -13,7 +13,7 @@
     "hono": "4.12.32",
     "mppx": "latest",
     "tsx": "^4.23.1",
-    "typescript": "~7.0.2",
+    "typescript": "catalog:",
     "viem": "^2.54.4"
   }
 }

--- a/examples/charge-wagmi/package.json
+++ b/examples/charge-wagmi/package.json
@@ -24,7 +24,7 @@
     "@types/react-dom": "^19.2.3",
     "@typescript/native-preview": "^7.0.0-dev.20260707.2",
     "@vitejs/plugin-react": "^6.0.4",
-    "typescript": "~7.0.2",
+    "typescript": "catalog:",
     "vite": "^8.1.5"
   }
 }

--- a/examples/charge/package.json
+++ b/examples/charge/package.json
@@ -14,7 +14,7 @@
     "@typescript/native-preview": "^7.0.0-dev.20260707.2",
     "bun": "^1.3.14",
     "mppx": "latest",
-    "typescript": "~7.0.2",
+    "typescript": "catalog:",
     "viem": "^2.54.4",
     "vite": "^8.1.5"
   }

--- a/examples/session/multi-fetch/package.json
+++ b/examples/session/multi-fetch/package.json
@@ -13,7 +13,7 @@
     "@typescript/native-preview": "latest",
     "mppx": "latest",
     "tsx": "latest",
-    "typescript": "latest",
+    "typescript": "catalog:",
     "viem": "^2.54.4",
     "vite": "^8.1.5"
   }

--- a/examples/session/sse/package.json
+++ b/examples/session/sse/package.json
@@ -13,7 +13,7 @@
     "@typescript/native-preview": "latest",
     "mppx": "latest",
     "tsx": "latest",
-    "typescript": "latest",
+    "typescript": "catalog:",
     "viem": "^2.54.4",
     "vite": "^8.1.5"
   }

--- a/examples/session/ws/package.json
+++ b/examples/session/ws/package.json
@@ -15,7 +15,7 @@
     "isows": "^1.0.7",
     "mppx": "workspace:*",
     "tsx": "^4.23.1",
-    "typescript": "~7.0.2",
+    "typescript": "catalog:",
     "viem": "^2.54.4",
     "vite": "^8.1.5",
     "ws": "^8.21.1"

--- a/examples/stripe/package.json
+++ b/examples/stripe/package.json
@@ -16,7 +16,7 @@
     "@typescript/native-preview": "^7.0.0-dev.20260707.2",
     "mppx": "latest",
     "stripe": "^17.7.0",
-    "typescript": "~7.0.2",
+    "typescript": "catalog:",
     "vite": "^8.1.5"
   }
 }

--- a/examples/subscription/package.json
+++ b/examples/subscription/package.json
@@ -13,7 +13,7 @@
     "@typescript/native-preview": "7.0.0-dev.20260707.2",
     "mppx": "workspace:*",
     "tsx": "^4.23.1",
-    "typescript": "~7.0.2",
+    "typescript": "catalog:",
     "viem": "^2.54.4",
     "vite": "^8.1.5"
   }

--- a/examples/x402-mpp/package.json
+++ b/examples/x402-mpp/package.json
@@ -13,7 +13,7 @@
     "hono": "4.12.32",
     "mppx": "latest",
     "tsx": "4.23.1",
-    "typescript": "~7.0.2",
+    "typescript": "catalog:",
     "viem": "2.54.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "eslint-plugin-compat": "^7.0.2",
     "express": "^5.2.1",
     "fast-check": "^4.9.0",
-    "file-type": "22.0.1",
+    "file-type": "catalog:",
     "frog": "^1.0.15",
     "hono": "4.12.32",
     "isows": "^1.0.7",
@@ -53,7 +53,7 @@
     "tempo.ts": "^0.14.2",
     "testcontainers": "^12.0.4",
     "tsx": "^4.23.1",
-    "typescript": "~7.0.2",
+    "typescript": "catalog:",
     "viem": "2.55.10",
     "vite": "^8.1.5",
     "vp": "npm:vite-plus@~0.1.24",
@@ -233,7 +233,7 @@
     "@stripe/stripe-js": "9.12.0",
     "eventsource-parser": "3.1.0",
     "incur": "^0.4.19",
-    "ox": "1.0.5",
+    "ox": "catalog:",
     "zod": "^4.4.3"
   },
   "repository": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,11 +9,16 @@ blockExoticSubdeps: true
 minimumReleaseAge: 1440
 trustPolicy: no-downgrade
 
+catalog:
+  file-type: '21.3.2'
+  ox: '0.14.33'
+  typescript: '~5.9.3'
+
 overrides:
   mppx: 'workspace:*'
   vitest: 'npm:@voidzero-dev/vite-plus-test@~0.1.24'
-  typescript: '~5.9.3'
-  ox: '0.14.33'
+  typescript: 'catalog:'
+  ox: 'catalog:'
   viem: '2.55.10'
   path-to-regexp@<8.4.0: '8.4.0'
   tar@<=7.5.20: '7.5.21'
@@ -28,7 +33,7 @@ overrides:
   rollup@>=4.0.0 <4.59.0: '4.59.0'
   ajv@>=7.0.0-alpha.0 <8.18.0: '8.18.0'
   elysia@<1.4.26: '1.4.26'
-  file-type: '21.3.2'
+  file-type: 'catalog:'
   flatted@<=3.4.1: '>=3.4.2'
   follow-redirects@<=1.15.11: '1.16.0'
   fast-uri@<3.1.5: '3.1.5'


### PR DESCRIPTION
## Motivation

Workspace-wide overrides masked newer dependency declarations in package manifests, so local builds and published metadata could resolve different versions.

## Summary

- Added a pnpm catalog for the pinned Ox, TypeScript, and file-type versions.
- Referenced the catalog from root and example manifests and workspace overrides.
- Added a patch changeset for the published dependency correction.

## Key design considerations

- Retained the existing versions until their major upgrades can be validated independently.
- Used pnpm's publish-time catalog resolution so consumers receive concrete dependency versions.
- Kept the lockfile unchanged because effective installed versions did not change.