### PR TITLE
Add stripe.create() higher-level interface

### DIFF
--- a/.changeset/stripe-create-api.md
+++ b/.changeset/stripe-create-api.md
@@ -1,0 +1,5 @@
+---
+'mppx': minor
+---
+
+Add `stripe.create()` machine payments API with auto deposit address resolution, PI recording, and unified `.charge()` handler.

--- a/src/server/Methods.test-d.ts
+++ b/src/server/Methods.test-d.ts
@@ -68,7 +68,7 @@ test('provider convenience constructors forward canOffer', () => {
     settle: async () => ({ reference: '0x01' }),
   })
 
-  stripe({
+  stripe.charge({
     canOffer({ request }) {
       expectTypeOf(request.methodDetails.networkId).toEqualTypeOf<string>()
       return true

--- a/src/server/Methods.test.ts
+++ b/src/server/Methods.test.ts
@@ -47,7 +47,7 @@ describe('composable method hooks', () => {
     expect(evmCharge.canOffer).toBe(evmCanOffer)
 
     const stripeCanOffer = vi.fn(() => true)
-    const [stripeCharge] = stripe({
+    const stripeCharge = stripe.charge({
       canOffer: stripeCanOffer,
       client: {} as never,
       networkId: 'internal',

--- a/src/stripe/internal/constants.ts
+++ b/src/stripe/internal/constants.ts
@@ -4,4 +4,4 @@
  * Required for `shared_payment_granted_token` (SPTs are in private preview).
  * Bump this when upgrading to a newer Stripe API version.
  */
-export const stripePreviewVersion = '2026-02-25.preview'
+export const stripePreviewVersion = '2026-07-29.preview'

--- a/src/stripe/internal/types.ts
+++ b/src/stripe/internal/types.ts
@@ -14,6 +14,7 @@ export type StripeClient = {
       lastResponse?: { headers?: Record<string, string> }
     }>
   }
+  rawRequest?(method: string, path: string, params?: any, options?: any): Promise<any>
 }
 
 /**

--- a/src/stripe/server/Charge.ts
+++ b/src/stripe/server/Charge.ts
@@ -91,6 +91,7 @@ export function charge<const parameters extends charge.Parameters>(parameters: p
   const {
     amount,
     canOffer,
+    onPaymentSuccess,
     currency,
     decimals,
     description,
@@ -146,6 +147,8 @@ export function charge<const parameters extends charge.Parameters>(parameters: p
       if (minimum !== undefined && BigInt(context.request.amount) < minimum) return false
       return (await canOffer?.(context)) ?? true
     },
+
+    onPaymentSuccess,
 
     async verify({ credential, envelope, request }) {
       const { challenge } = credential

--- a/src/stripe/server/Methods.test-d.ts
+++ b/src/stripe/server/Methods.test-d.ts
@@ -1,0 +1,157 @@
+import type { Client } from 'viem'
+import { expectTypeOf, test } from 'vp/test'
+
+import * as Mppx from '../../server/Mppx.js'
+import type { AtomicStore } from '../../Store.js'
+import { stripe } from './Methods.js'
+
+test('async defaultMethods() produces types compose can use', async () => {
+  const mp = stripe.create({ client: {} as any, networkId: 'profile_x', livemode: false })
+  const methods = await mp.defaultMethods()
+  const mppx = Mppx.create({ methods, secretKey: 'test' })
+
+  const result = await mppx.compose(
+    ['tempo/charge', { amount: '0.01', description: 'test' }],
+    ['stripe/charge', { amount: '0.50', currency: 'usd', decimals: 2, description: 'test' }],
+  )(new Request('http://localhost'))
+
+  expectTypeOf(result.status).toEqualTypeOf<200 | 402>()
+})
+
+test('tempo.session() accepts getClient, feePayer, store without casts', () => {
+  const mp = stripe.create({ client: {} as any, networkId: 'profile_x', livemode: false })
+  const addr = '' as stripe.DepositAddress<'tempo'>
+
+  const session = mp.tempo.session({
+    recipient: addr,
+    getClient: () => ({}) as Client,
+    feePayer: 'https://api.tempo.xyz/rpc/sponsor?key=test',
+    store: {} as AtomicStore,
+    sse: true,
+    settlementSchedule: { amount: '0.01' },
+    onSessionSettlement: async () => {},
+  })
+
+  expectTypeOf(session).toHaveProperty('name')
+  expectTypeOf(session).toHaveProperty('intent')
+})
+
+test('.charge() works with multiple charge methods (implicit compose)', async () => {
+  const mp = stripe.create({ client: {} as any, networkId: 'profile_x', livemode: false })
+  const methods = await mp.defaultMethods()
+  const mppx = Mppx.create({ methods, secretKey: 'test' })
+
+  expectTypeOf(mppx.charge).toBeFunction()
+  expectTypeOf(mppx.charge).not.toBeNullable()
+
+  // Note: MultiMethodFn options are permissive (UnionToIntersection of any-based schemas).
+  // Negative assertions for .charge() options require concrete method schemas to be useful.
+})
+
+test('stripe.create() rejects invalid parameters', () => {
+  // @ts-expect-error - livemode is required
+  stripe.create({ client: {} as any, networkId: 'x' })
+  // @ts-expect-error - networkId is required
+  stripe.create({ client: {} as any, livemode: true })
+  stripe.create({
+    client: {} as any,
+    networkId: 'x',
+    livemode: true,
+    // @ts-expect-error - unsupported network key
+    depositAddresses: { ethereum: '0x' },
+  })
+})
+
+test('additional() rejects unsupported network keys', async () => {
+  const mp = stripe.create({ client: {} as any, networkId: 'profile_x', livemode: false })
+  // @ts-expect-error - 'arbitrum' is not a supported custom rail network
+  await mp.defaultMethods().additional({ arbitrum: (_addr) => ({}) as any })
+})
+
+test('additional() accepts tempo.session and base with full params', async () => {
+  const mp = stripe.create({ client: {} as any, networkId: 'profile_x', livemode: false })
+  const methods = await mp.defaultMethods().additional({
+    base: {
+      x402: { facilitator: { verify: async () => ({}) as any, settle: async () => ({}) as any } },
+    },
+    tempo: {
+      session: {
+        store: {} as AtomicStore,
+        sse: true,
+        settlementSchedule: { amount: '0.01' },
+        onSessionSettlement: async () => {},
+        getClient: () => ({}) as Client,
+      },
+    },
+  })
+
+  const mppx = Mppx.create({ methods, secretKey: 'test' })
+  expectTypeOf(mppx.charge).toBeFunction()
+  expectTypeOf(mppx.charge).not.toBeNullable()
+})
+
+test('sync defaultMethods() with static depositAddresses returns SyncMethodsResult', () => {
+  const mp = stripe.create({
+    client: {} as any,
+    networkId: 'profile_x',
+    livemode: false,
+    depositAddresses: { tempo: '0x123' },
+  })
+  const methods = mp.defaultMethods()
+  expectTypeOf(methods).toHaveProperty('additional')
+
+  const mppx = Mppx.create({ methods, secretKey: 'test' })
+  expectTypeOf(mppx.charge).toBeFunction()
+  expectTypeOf(mppx.charge).not.toBeNullable()
+})
+
+test('depositAddresses as resolver function returns DefaultMethodsBuilder', async () => {
+  const mp = stripe.create({
+    client: {} as any,
+    networkId: 'profile_x',
+    livemode: false,
+    depositAddresses: async (_network) => '0xaddr',
+  })
+  const methods = await mp.defaultMethods()
+  const mppx = Mppx.create({ methods, secretKey: 'test' })
+  expectTypeOf(mppx.charge).toBeFunction()
+})
+
+test('connect config with stripeAccount passes to Mppx.create', async () => {
+  const mp = stripe.create({
+    client: {} as any,
+    networkId: 'profile_x',
+    livemode: true,
+    connect: { stripeAccount: 'acct_123', applicationFeeAmount: 100 },
+  })
+  const methods = await mp.defaultMethods()
+  const mppx = Mppx.create({ methods, secretKey: 'test' })
+  expectTypeOf(mppx.charge).toBeFunction()
+})
+
+test('additional() with custom rail (solana) works via compose', async () => {
+  const mp = stripe.create({ client: {} as any, networkId: 'profile_x', livemode: false })
+  const methods = await mp.defaultMethods().additional({
+    base: {
+      x402: { facilitator: { verify: async () => ({}) as any, settle: async () => ({}) as any } },
+    },
+    solana: (_address) => ({
+      name: 'solana' as const,
+      intent: 'charge' as const,
+      schema: { credential: { payload: {} as any }, request: {} as any },
+      verify: async () =>
+        ({ method: 'solana', status: 'success', reference: '0x', timestamp: '' }) as const,
+    }),
+  })
+
+  const mppx = Mppx.create({ methods, secretKey: 'test' })
+
+  const result = await mppx.compose(
+    ['tempo/charge', { amount: '0.01', description: 'test' }],
+    ['evm/charge', { amount: '0.01', description: 'test' }],
+    ['solana/charge', { amount: '10000', description: 'test' }] as any,
+    ['stripe/charge', { amount: '0.50', currency: 'usd', decimals: 2, description: 'test' }],
+  )(new Request('http://localhost'))
+
+  expectTypeOf(result.status).toEqualTypeOf<200 | 402>()
+})

--- a/src/stripe/server/Methods.test.ts
+++ b/src/stripe/server/Methods.test.ts
@@ -1,0 +1,193 @@
+import { stripe } from 'mppx/server'
+import { describe, expect, test, vi } from 'vp/test'
+
+import type { AnyServer } from '../../Method.js'
+import type { StripeClient } from '../internal/types.js'
+
+function createMockStripeClient(): StripeClient {
+  return {
+    paymentIntents: {
+      create: vi.fn(async () => ({ id: 'pi_mock', status: 'succeeded' })),
+    },
+    rawRequest: vi.fn(async (_method: string, path: string) => {
+      if (path.includes('deposit_addresses')) {
+        if (path.includes('limit=1')) return { data: [{ address: '0xabc' }] }
+        return { address: '0xnew' }
+      }
+      return {}
+    }),
+  }
+}
+
+function findMethod(methods: readonly AnyServer[], name: string, intent: string) {
+  return methods.find((m) => m.name === name && m.intent === intent)!
+}
+
+describe('stripe.create() defaultMethods', () => {
+  test('returns tempo and spt methods', async () => {
+    const client = createMockStripeClient()
+    const mp = stripe({ client, networkId: 'test-profile', livemode: false })
+
+    const methods = await mp.defaultMethods()
+
+    expect(findMethod(methods, 'tempo', 'charge')).toBeDefined()
+    expect(findMethod(methods, 'stripe', 'charge')).toBeDefined()
+  })
+
+  test.each(['tempo', 'spt'] as const)('exclude removes %s', async (excluded) => {
+    const client = createMockStripeClient()
+    const mp = stripe({ client, networkId: 'test-profile', livemode: false })
+
+    const methods = await mp.defaultMethods({ exclude: [excluded] })
+    const expectedName = excluded === 'spt' ? 'stripe' : excluded
+
+    expect(methods.find((m) => m.name === expectedName && m.intent === 'charge')).toBeUndefined()
+    expect(methods.length).toBeGreaterThan(0)
+  })
+})
+
+describe('stripe.create() PI recording', () => {
+  test('onPaymentSuccess handler returns a Promise', async () => {
+    const client = createMockStripeClient()
+    const mp = stripe({
+      client,
+      networkId: 'test-profile',
+      livemode: false,
+    })
+
+    const methods = await mp.defaultMethods()
+    const tempoMethod = findMethod(methods, 'tempo', 'charge')
+    expect(tempoMethod.onPaymentSuccess).toBeTypeOf('function')
+
+    const result = tempoMethod.onPaymentSuccess!({
+      receipt: { reference: '0xtx123' },
+      request: { amount: '500000' },
+    })
+
+    expect(result).toBeInstanceOf(Promise)
+    await result
+    expect(client.paymentIntents.create).toHaveBeenCalledOnce()
+  })
+
+  test('onPaymentSuccess returns undefined when receipt has no reference', async () => {
+    const client = createMockStripeClient()
+    const mp = stripe({
+      client,
+      networkId: 'test-profile',
+      livemode: false,
+    })
+
+    const methods = await mp.defaultMethods()
+    const tempoMethod = findMethod(methods, 'tempo', 'charge')
+
+    const result = tempoMethod.onPaymentSuccess!({
+      receipt: {},
+      request: { amount: '500000' },
+    })
+
+    expect(result).toBeUndefined()
+    expect(client.paymentIntents.create).not.toHaveBeenCalled()
+  })
+})
+
+describe('stripe.create() custom hook composition', () => {
+  test('composes user hook with PI recorder for custom rails', async () => {
+    const client = createMockStripeClient()
+    const userHookCalls: unknown[] = []
+
+    const mp = stripe({
+      client,
+      networkId: 'test-profile',
+      livemode: false,
+      depositAddresses: { tempo: '0xtempoaddr', solana: 'SOLaddr' },
+    })
+
+    const methods = mp.defaultMethods().additional({
+      solana: (_address) => ({
+        name: 'solana',
+        intent: 'charge',
+        schema: {
+          request: { parse: (x: unknown) => x },
+          response: { parse: (x: unknown) => x },
+        } as AnyServer['schema'],
+        onPaymentSuccess: (params: unknown) => {
+          userHookCalls.push(params)
+        },
+      }),
+    })
+
+    const solanaMethod = findMethod(methods, 'solana', 'charge')
+
+    const params = { receipt: { reference: '0xsolhash' }, request: { amount: '10000' } }
+    const result = solanaMethod.onPaymentSuccess!(params)
+    expect(result).toBeInstanceOf(Promise)
+    await result
+
+    expect(userHookCalls).toHaveLength(1)
+    expect(userHookCalls[0]).toBe(params)
+    expect(client.paymentIntents.create).toHaveBeenCalledOnce()
+  })
+
+  test('uses recorder alone when custom rail has no user hook', async () => {
+    const client = createMockStripeClient()
+
+    const mp = stripe({
+      client,
+      networkId: 'test-profile',
+      livemode: false,
+      depositAddresses: { tempo: '0xtempoaddr', solana: 'SOLaddr' },
+    })
+
+    const methods = mp.defaultMethods().additional({
+      solana: (_address) => ({
+        name: 'solana',
+        intent: 'charge',
+        schema: {
+          request: { parse: (x: unknown) => x },
+          response: { parse: (x: unknown) => x },
+        } as AnyServer['schema'],
+      }),
+    })
+
+    const solanaMethod = findMethod(methods, 'solana', 'charge')
+
+    await solanaMethod.onPaymentSuccess!({
+      receipt: { reference: '0xsolhash' },
+      request: { amount: '10000' },
+    })
+
+    expect(client.paymentIntents.create).toHaveBeenCalledOnce()
+  })
+})
+
+describe('stripe.create() deposit address cache isolation', () => {
+  test('different clients do not share cached addresses', async () => {
+    const client1 = createMockStripeClient()
+    const client2: StripeClient = {
+      paymentIntents: { create: vi.fn(async () => ({ id: 'pi_2', status: 'succeeded' })) },
+      rawRequest: vi.fn(async () => ({ data: [{ address: '0xdifferent' }] })),
+    }
+
+    const mp1 = stripe({ client: client1, networkId: 'profile1', livemode: false })
+    const mp2 = stripe({ client: client2, networkId: 'profile2', livemode: true })
+
+    const addr1 = await mp1.findOrCreateDepositAddress('tempo')
+    const addr2 = await mp2.findOrCreateDepositAddress('tempo')
+
+    expect(addr1).toBe('0xabc')
+    expect(addr2).toBe('0xdifferent')
+    expect(client1.rawRequest).toHaveBeenCalledOnce()
+    expect(client2.rawRequest).toHaveBeenCalledOnce()
+  })
+
+  test('same client reuses cached address', async () => {
+    const client = createMockStripeClient()
+    const mp = stripe({ client, networkId: 'profile', livemode: false })
+
+    const addr1 = await mp.findOrCreateDepositAddress('tempo')
+    const addr2 = await mp.findOrCreateDepositAddress('tempo')
+
+    expect(addr1).toBe(addr2)
+    expect(client.rawRequest).toHaveBeenCalledOnce()
+  })
+})

--- a/src/stripe/server/Methods.ts
+++ b/src/stripe/server/Methods.ts
@@ -66,8 +66,11 @@ type DefaultMethodsWithAdditional<C extends AdditionalConfig> = readonly [
   ...(C extends { tempo: { session: any } } ? [TempoSessionServer] : []),
 ]
 
-const defaultMethodNames = ['tempo', 'spt'] as const
-type DefaultMethodName = (typeof defaultMethodNames)[number]
+type DefaultMethodName = 'tempo' | 'spt'
+const defaultMethodNames: readonly DefaultMethodName[] = ['tempo', 'spt']
+
+type AdditionalBuiltinKey = 'base' | 'tempo'
+const additionalBuiltinKeys: readonly AdditionalBuiltinKey[] = ['base', 'tempo']
 
 type DefaultMethodsConfig = {
   exclude?: DefaultMethodName[]
@@ -247,8 +250,6 @@ export function stripe<const P extends stripe.Parameters>(parameters: P): Stripe
     spt: () => makeSptCharge(),
   }
 
-  type AdditionalBuiltinKey = 'base' | 'tempo'
-
   const additionalBuilders: Record<
     AdditionalBuiltinKey,
     (addresses: Map<string, string>, config: AdditionalConfig) => Method.AnyServer | null
@@ -354,13 +355,12 @@ export namespace stripe {
   export const findOrCreateDepositAddress = _findOrCreateDepositAddress
 }
 
-function neededNetworks(excluded: Set<string>, additional?: AdditionalConfig): string[] {
-  const networks: string[] = []
+function neededNetworks(excluded: Set<string>, additional?: AdditionalConfig): stripe.Network[] {
+  const networks: stripe.Network[] = []
   if (!excluded.has('tempo') || additional?.tempo?.session) networks.push('tempo')
   if (additional?.base) networks.push('base')
-  for (const [network, value] of Object.entries(additional ?? {})) {
-    if (network === 'base' || network === 'tempo') continue
-    if (typeof value === 'function') networks.push(network)
+  for (const [network] of customRails(additional)) {
+    networks.push(network as stripe.Network)
   }
   return networks
 }
@@ -381,7 +381,7 @@ function customRails(additional?: AdditionalConfig): [string, CustomRailFactory]
   if (!additional) return []
   return Object.entries(additional).filter((entry): entry is [string, CustomRailFactory] => {
     const [k, v] = entry
-    return k !== 'base' && k !== 'tempo' && typeof v === 'function'
+    return !(additionalBuiltinKeys as readonly string[]).includes(k) && typeof v === 'function'
   })
 }
 

--- a/src/stripe/server/Methods.ts
+++ b/src/stripe/server/Methods.ts
@@ -1,24 +1,404 @@
+import * as EvmAssets from '../../evm/Assets.js'
+import { charge as evmCharge } from '../../evm/server/Charge.js'
+import type * as Method from '../../Method.js'
+import * as tempoDefaults from '../../tempo/internal/defaults.js'
+import { charge as tempoCharge } from '../../tempo/server/Charge.js'
+import { session as tempoSession } from '../../tempo/session/server/Session.js'
+import type { StripeClient } from '../internal/types.js'
 import { charge as charge_ } from './Charge.js'
+import { findOrCreateDepositAddress as _findOrCreateDepositAddress } from './internal/deposit-address.js'
+import { recordCryptoPayment } from './internal/record-payment.js'
+import { type ConnectConfig } from './internal/request.js'
+
+// --- Public types ---
+
+export declare namespace stripe {
+  type Network = 'tempo' | 'base' | 'solana'
+
+  type DepositAddress<N extends Network = Network> = string & {
+    readonly __brand: 'StripeDepositAddress'
+    readonly __network: N
+  }
+
+  // TODO: make networkId and livemode also accept dynamic resolvers (fetched from
+  // GET /v2/network/business_profiles/me which returns { id, livemode, ... }).
+  // This would allow `stripe.create({ secretKey })` with no other params.
+  type Parameters = {
+    client: StripeClient
+    networkId: string
+    livemode: boolean
+    connect?: ConnectConfig
+    depositAddresses?: Partial<Record<Network, string>> | ((network: Network) => Promise<string>)
+  }
+}
+
+// --- Internal types ---
+
+type CustomRailFactory = (address: string) => Method.AnyServer | readonly Method.AnyServer[]
+
+type ServerOf<N extends string, I extends string> = Omit<Method.AnyServer, 'name' | 'intent'> & {
+  name: N
+  intent: I
+}
+
+type TempoServer = ServerOf<'tempo', 'charge'>
+type TempoSessionServer = ServerOf<'tempo', 'session'>
+type SptServer = ServerOf<'stripe', 'charge'>
+type EvmServer = ServerOf<'evm', 'charge'>
+
+type BaseConfig = {
+  x402: NonNullable<Parameters<typeof evmCharge>[0]['x402']>
+} & Partial<Omit<Parameters<typeof evmCharge>[0], 'currency' | 'recipient' | 'x402'>>
+
+type CustomRailNetwork = Exclude<stripe.Network, 'tempo' | 'base'>
+
+type AdditionalConfig = {
+  base?: BaseConfig
+  tempo?: { session: Omit<tempoSession.Parameters, 'currency' | 'recipient'> }
+} & { [K in CustomRailNetwork]?: CustomRailFactory }
+
+type DefaultMethods = readonly [TempoServer, SptServer]
+
+type DefaultMethodsWithAdditional<C extends AdditionalConfig> = readonly [
+  TempoServer,
+  SptServer,
+  ...(C extends { base: object } ? [EvmServer] : []),
+  ...(C extends { tempo: { session: any } } ? [TempoSessionServer] : []),
+]
+
+const defaultMethodNames = ['tempo', 'spt'] as const
+type DefaultMethodName = (typeof defaultMethodNames)[number]
+
+type DefaultMethodsConfig = {
+  exclude?: DefaultMethodName[]
+}
+
+type SyncMethodsResult = DefaultMethods & {
+  additional<C extends AdditionalConfig>(config: C): DefaultMethodsWithAdditional<C>
+}
+
+interface StripeMachinePayments<P extends stripe.Parameters = stripe.Parameters> {
+  spt: {
+    charge: (params?: { paymentMethodTypes?: string[] }) => SptServer
+  }
+  tempo: {
+    charge: (
+      params: { recipient: stripe.DepositAddress<'tempo'> } & Partial<
+        Omit<Parameters<typeof tempoCharge>[0], 'currency' | 'recipient'>
+      >,
+    ) => TempoServer
+    session: (
+      params: { recipient: stripe.DepositAddress<'tempo'> } & Omit<
+        tempoSession.Parameters,
+        'currency' | 'recipient'
+      >,
+    ) => TempoSessionServer
+  }
+  base: {
+    charge: (params: { recipient: stripe.DepositAddress<'base'> } & BaseConfig) => EvmServer
+  }
+  findOrCreateDepositAddress: <N extends stripe.Network>(
+    network: N,
+  ) => Promise<stripe.DepositAddress<N>>
+  defaultMethods: (
+    config?: DefaultMethodsConfig,
+  ) => P['depositAddresses'] extends Partial<Record<stripe.Network, string>>
+    ? SyncMethodsResult
+    : DefaultMethodsBuilder
+}
+
+class DefaultMethodsBuilder implements PromiseLike<DefaultMethods> {
+  readonly #resolve: (additional?: AdditionalConfig) => Promise<any>
+  #additional: AdditionalConfig | undefined
+
+  constructor(resolve: (additional?: AdditionalConfig) => Promise<any>) {
+    this.#resolve = resolve
+  }
+
+  additional<C extends AdditionalConfig>(config: C): PromiseLike<DefaultMethodsWithAdditional<C>> {
+    this.#additional = config
+    return this as unknown as PromiseLike<DefaultMethodsWithAdditional<C>>
+  }
+
+  then<T = DefaultMethods, U = never>(
+    onfulfilled?: ((value: DefaultMethods) => T | PromiseLike<T>) | null,
+    onrejected?: ((reason: unknown) => U | PromiseLike<U>) | null,
+  ): Promise<T | U> {
+    return this.#resolve(this.#additional).then(onfulfilled, onrejected)
+  }
+}
 
 /**
- * Creates a Stripe `charge` method for usage on the server.
+ * Creates a configured Stripe machine payments instance.
  *
  * @example
  * ```ts
  * import { Mppx, stripe } from 'mppx/server'
  *
+ * const machinePayments = stripe.create({
+ *   client: stripeClient,
+ *   networkId: process.env.STRIPE_PROFILE_ID!,
+ *   livemode: !process.env.STRIPE_SECRET_KEY!.includes('_test_'),
+ * })
+ *
+ * // Async: deposit addresses resolved from Stripe API
  * const mppx = Mppx.create({
- *   methods: [stripe({ secretKey: 'sk_...' })],
+ *   methods: await machinePayments.defaultMethods(),
+ *   secretKey: mppSecretKey,
+ * })
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Sync: deposit addresses provided statically
+ * const machinePayments = stripe.create({
+ *   client: stripeClient,
+ *   networkId: process.env.STRIPE_PROFILE_ID!,
+ *   livemode: !process.env.STRIPE_SECRET_KEY!.includes('_test_'),
+ *   depositAddresses: { tempo: process.env.TEMPO_DEPOSIT_ADDRESS! },
+ * })
+ *
+ * const mppx = Mppx.create({
+ *   methods: machinePayments.defaultMethods(),
+ *   secretKey: mppSecretKey,
+ * })
+ * ```
+ *
+ * @example
+ * ```ts
+ * // With additional custom rails
+ * const mppx = Mppx.create({
+ *   methods: await machinePayments.defaultMethods().additional({
+ *     base: { x402: { facilitator } },
+ *     solana: (address) => solana.charge({ recipient: address, currency: USDC, decimals: 6 }),
+ *   }),
+ *   secretKey: mppSecretKey,
  * })
  * ```
  */
-export function stripe<const parameters extends stripe.Parameters>(parameters: parameters) {
-  return [stripe.charge(parameters)] as const
+export function stripe<const P extends stripe.Parameters>(parameters: P): StripeMachinePayments<P> {
+  const { client, networkId, livemode, connect, depositAddresses } = parameters
+  if (!client.rawRequest)
+    throw new Error('stripe.create() requires a Stripe SDK client with rawRequest() (v15+)')
+  const tempoCurrency = (
+    livemode ? tempoDefaults.tokens.usdc : tempoDefaults.tokens.pathUsd
+  ) as `0x${string}`
+  const tempoPaymentHandler = createPaymentSuccessHandler(client, 'tempo', connect)
+  const basePaymentHandler = createPaymentSuccessHandler(client, 'base', connect)
+
+  function makeSptCharge(params?: { paymentMethodTypes?: string[] }): Method.AnyServer {
+    return charge_({
+      client,
+      networkId,
+      currency: 'usd',
+      decimals: 2,
+      paymentMethodTypes: params?.paymentMethodTypes ?? ['card', 'link'],
+      ...(connect && { connect }),
+    } as Parameters<typeof charge_>[0]) as Method.AnyServer
+  }
+
+  function makeTempoCharge(
+    params: { recipient: `0x${string}` } & Partial<
+      Omit<Parameters<typeof tempoCharge>[0], 'currency' | 'recipient'>
+    >,
+  ): Method.AnyServer {
+    const { recipient, ...rest } = params
+    return tempoCharge({
+      currency: tempoCurrency,
+      recipient,
+      ...(!livemode && { testnet: true }),
+      onPaymentSuccess: tempoPaymentHandler,
+      ...rest,
+    }) as Method.AnyServer
+  }
+
+  function makeTempoSession(
+    params: { recipient: `0x${string}` } & Omit<tempoSession.Parameters, 'currency' | 'recipient'>,
+  ): Method.AnyServer {
+    const { recipient, ...rest } = params
+    return tempoSession({
+      currency: tempoCurrency,
+      recipient,
+      ...(!livemode && { testnet: true }),
+      ...rest,
+    } as tempoSession.Parameters) as Method.AnyServer
+  }
+
+  function makeBaseCharge(params: { recipient: `0x${string}` } & BaseConfig): Method.AnyServer {
+    const { recipient, x402, ...rest } = params
+    return evmCharge({
+      currency: livemode ? EvmAssets.base.USDC : EvmAssets.baseSepolia.USDC,
+      recipient,
+      x402,
+      onPaymentSuccess: basePaymentHandler,
+      ...rest,
+    }) as Method.AnyServer
+  }
+
+  const defaultMethodBuilders: Record<
+    DefaultMethodName,
+    (addresses: Map<string, string>) => Method.AnyServer | null
+  > = {
+    tempo: (addresses) => {
+      const address = addresses.get('tempo')
+      if (!address) return null
+      return makeTempoCharge({ recipient: address as `0x${string}` })
+    },
+    spt: () => makeSptCharge(),
+  }
+
+  type AdditionalBuiltinKey = 'base' | 'tempo'
+
+  const additionalBuilders: Record<
+    AdditionalBuiltinKey,
+    (addresses: Map<string, string>, config: AdditionalConfig) => Method.AnyServer | null
+  > = {
+    base: (addresses, config) => {
+      if (!config.base) return null
+      const address = addresses.get('base')
+      if (!address) return null
+      return makeBaseCharge({ recipient: address as `0x${string}`, ...config.base })
+    },
+    tempo: (addresses, config) => {
+      if (!config.tempo?.session) return null
+      const address = addresses.get('tempo')
+      if (!address) return null
+      return makeTempoSession({ recipient: address as `0x${string}`, ...config.tempo.session })
+    },
+  }
+
+  function createMethodsFromAddresses(
+    addresses: Map<string, string>,
+    excluded: Set<string>,
+    additional?: AdditionalConfig,
+  ): DefaultMethods {
+    const result: Method.AnyServer[] = []
+
+    for (const name of defaultMethodNames) {
+      if (excluded.has(name)) continue
+      const method = defaultMethodBuilders[name](addresses)
+      if (method) result.push(method)
+    }
+
+    if (additional) {
+      for (const key of Object.keys(additionalBuilders) as AdditionalBuiltinKey[]) {
+        const method = additionalBuilders[key](addresses, additional)
+        if (method) result.push(method)
+      }
+
+      for (const [network, factory] of customRails(additional)) {
+        const address = requireAddress(addresses, network)
+        const handler = createPaymentSuccessHandler(client, network as stripe.Network, connect)
+        for (const m of toArray(factory(address))) {
+          result.push({ ...m, onPaymentSuccess: m.onPaymentSuccess ?? handler } as Method.AnyServer)
+        }
+      }
+    }
+
+    return result as unknown as DefaultMethods
+  }
+
+  function resolveAddress(network: string): Promise<string> {
+    if (typeof depositAddresses === 'function') return depositAddresses(network as stripe.Network)
+    return _findOrCreateDepositAddress(client, network, connect ? { connect } : undefined)
+  }
+
+  function defaultMethods(
+    config?: DefaultMethodsConfig,
+  ): SyncMethodsResult | DefaultMethodsBuilder {
+    const excluded = new Set(config?.exclude)
+
+    if (depositAddresses && typeof depositAddresses !== 'function') {
+      // Sync: static deposit addresses provided at stripe.create() time
+      const addresses = new Map(Object.entries(depositAddresses)) as Map<string, string>
+      return Object.assign(createMethodsFromAddresses(addresses, excluded), {
+        additional: (additional: AdditionalConfig) =>
+          createMethodsFromAddresses(addresses, excluded, additional),
+      }) as SyncMethodsResult
+    } else {
+      // Async: resolve addresses dynamically
+      return new DefaultMethodsBuilder(async (additional) => {
+        const networks = neededNetworks(excluded, additional)
+        const results = await Promise.all(
+          networks.map(async (network) => ({
+            network,
+            address: await resolveAddress(network),
+          })),
+        )
+        const addresses = new Map(results.map(({ network, address }) => [network, address]))
+        return createMethodsFromAddresses(addresses, excluded, additional)
+      })
+    }
+  }
+
+  return {
+    spt: { charge: makeSptCharge },
+    tempo: { charge: makeTempoCharge, session: makeTempoSession },
+    base: { charge: makeBaseCharge },
+    findOrCreateDepositAddress: async <N extends stripe.Network>(network: N) => {
+      const address = await resolveAddress(network)
+      return address as stripe.DepositAddress<N>
+    },
+    defaultMethods,
+  } as StripeMachinePayments
 }
 
 export namespace stripe {
-  export type Parameters = charge_.Parameters
+  export const spt = charge_
 
-  /** Creates a Stripe `charge` method for SPT-based payments. */
+  /** @deprecated Use `stripe.spt()` instead. */
   export const charge = charge_
+
+  export const create = stripe
+
+  export const findOrCreateDepositAddress = _findOrCreateDepositAddress
+}
+
+function neededNetworks(excluded: Set<string>, additional?: AdditionalConfig): string[] {
+  const networks: string[] = []
+  if (!excluded.has('tempo') || additional?.tempo?.session) networks.push('tempo')
+  if (additional?.base) networks.push('base')
+  for (const [network, value] of Object.entries(additional ?? {})) {
+    if (network === 'base' || network === 'tempo') continue
+    if (typeof value === 'function') networks.push(network)
+  }
+  return networks
+}
+
+function requireAddress(addresses: Map<string, string>, network: string): string {
+  const address = addresses.get(network)
+  if (!address) throw new Error(`stripe: missing deposit address for ${network}`)
+  return address
+}
+
+function toArray(
+  value: Method.AnyServer | readonly Method.AnyServer[],
+): readonly Method.AnyServer[] {
+  return Array.isArray(value) ? value : [value]
+}
+
+function customRails(additional?: AdditionalConfig): [string, CustomRailFactory][] {
+  if (!additional) return []
+  return Object.entries(additional).filter((entry): entry is [string, CustomRailFactory] => {
+    const [k, v] = entry
+    return k !== 'base' && k !== 'tempo' && typeof v === 'function'
+  })
+}
+
+function createPaymentSuccessHandler(
+  client: StripeClient,
+  network: stripe.Network,
+  connect?: ConnectConfig,
+) {
+  return (params: { receipt: any; request: any }) => {
+    const { receipt, request } = params
+    if (receipt?.reference && request?.amount) {
+      recordCryptoPayment(client, {
+        network,
+        reference: receipt.reference,
+        amount: String(request.amount),
+        ...(connect && { connect }),
+      })
+    }
+  }
 }

--- a/src/stripe/server/Methods.ts
+++ b/src/stripe/server/Methods.ts
@@ -289,9 +289,13 @@ export function stripe<const P extends stripe.Parameters>(parameters: P): Stripe
 
       for (const [network, factory] of customRails(additional)) {
         const address = requireAddress(addresses, network)
-        const handler = createPaymentSuccessHandler(client, network as stripe.Network, connect)
+        const recorder = createPaymentSuccessHandler(client, network as stripe.Network, connect)
         for (const m of toArray(factory(address))) {
-          result.push({ ...m, onPaymentSuccess: m.onPaymentSuccess ?? handler } as Method.AnyServer)
+          const onPaymentSuccess = m.onPaymentSuccess
+            ? (params: any) =>
+                Promise.all([m.onPaymentSuccess!(params), recorder(params)]).then(() => {})
+            : recorder
+          result.push({ ...m, onPaymentSuccess } as Method.AnyServer)
         }
       }
     }
@@ -393,7 +397,7 @@ function createPaymentSuccessHandler(
   return (params: { receipt: any; request: any }) => {
     const { receipt, request } = params
     if (receipt?.reference && request?.amount) {
-      recordCryptoPayment(client, {
+      return recordCryptoPayment(client, {
         network,
         reference: receipt.reference,
         amount: String(request.amount),

--- a/src/stripe/server/internal/deposit-address.ts
+++ b/src/stripe/server/internal/deposit-address.ts
@@ -1,0 +1,52 @@
+import type { StripeClient } from '../../internal/types.js'
+import { stripeRequest, type ConnectConfig } from './request.js'
+
+export type DepositAddressResolver = (
+  client: StripeClient,
+  network: string,
+  options?: { connect?: ConnectConfig },
+) => Promise<string>
+
+const cache = new Map<string, string>()
+
+/**
+ * Finds an existing deposit address or creates a new one for the given network.
+ * Cached per network+stripeAccount for the process lifetime.
+ */
+export async function findOrCreateDepositAddress(
+  client: StripeClient,
+  network: string,
+  options?: { connect?: ConnectConfig },
+): Promise<string> {
+  const key = options?.connect?.stripeAccount
+    ? `${options.connect.stripeAccount}:${network}`
+    : network
+  const cached = cache.get(key)
+  if (cached) return cached
+
+  const list = (await stripeRequest(
+    client,
+    'GET',
+    `/v1/crypto/deposit_addresses?network=${network}&limit=1`,
+    undefined,
+    options,
+  )) as {
+    data?: { address: string }[]
+  }
+  if (list.data && list.data.length > 0) {
+    cache.set(key, list.data[0]!.address)
+    return list.data[0]!.address
+  }
+
+  const created = (await stripeRequest(
+    client,
+    'POST',
+    '/v1/crypto/deposit_addresses',
+    { network },
+    options,
+  )) as {
+    address: string
+  }
+  cache.set(key, created.address)
+  return created.address
+}

--- a/src/stripe/server/internal/deposit-address.ts
+++ b/src/stripe/server/internal/deposit-address.ts
@@ -7,21 +7,26 @@ export type DepositAddressResolver = (
   options?: { connect?: ConnectConfig },
 ) => Promise<string>
 
-const cache = new Map<string, string>()
+const cache = new WeakMap<StripeClient, Map<string, string>>()
 
 /**
  * Finds an existing deposit address or creates a new one for the given network.
- * Cached per network+stripeAccount for the process lifetime.
+ * Cached per client+network+stripeAccount for the process lifetime.
  */
 export async function findOrCreateDepositAddress(
   client: StripeClient,
   network: string,
   options?: { connect?: ConnectConfig },
 ): Promise<string> {
+  let clientCache = cache.get(client)
+  if (!clientCache) {
+    clientCache = new Map()
+    cache.set(client, clientCache)
+  }
   const key = options?.connect?.stripeAccount
     ? `${options.connect.stripeAccount}:${network}`
     : network
-  const cached = cache.get(key)
+  const cached = clientCache.get(key)
   if (cached) return cached
 
   const list = (await stripeRequest(
@@ -34,7 +39,7 @@ export async function findOrCreateDepositAddress(
     data?: { address: string }[]
   }
   if (list.data && list.data.length > 0) {
-    cache.set(key, list.data[0]!.address)
+    clientCache.set(key, list.data[0]!.address)
     return list.data[0]!.address
   }
 
@@ -47,6 +52,6 @@ export async function findOrCreateDepositAddress(
   )) as {
     address: string
   }
-  cache.set(key, created.address)
+  clientCache.set(key, created.address)
   return created.address
 }

--- a/src/stripe/server/internal/record-payment.ts
+++ b/src/stripe/server/internal/record-payment.ts
@@ -1,0 +1,60 @@
+import type { StripeClient } from '../../internal/types.js'
+import type { stripe } from '../Methods.js'
+import { createPaymentIntent, type ConnectConfig } from './request.js'
+
+const NETWORK_CONFIG: Record<stripe.Network, { stripeNetworkName: string; tokenDecimals: number }> =
+  {
+    tempo: { stripeNetworkName: 'tempo', tokenDecimals: 6 },
+    base: { stripeNetworkName: 'base', tokenDecimals: 6 },
+    solana: { stripeNetworkName: 'solana', tokenDecimals: 6 },
+  }
+
+/**
+ * Records a crypto payment as a Stripe PaymentIntent using transaction_verification mode.
+ * Fire-and-forget: errors are logged but never thrown.
+ */
+export function recordCryptoPayment(
+  client: StripeClient,
+  parameters: {
+    network: stripe.Network
+    reference: string
+    amount: string
+    connect?: ConnectConfig
+  },
+): void {
+  const { network, reference, amount, connect } = parameters
+  const { stripeNetworkName, tokenDecimals } = NETWORK_CONFIG[network]
+
+  const amountCents = Math.round(Number(amount) / 10 ** (tokenDecimals - 2))
+  if (amountCents < 1) {
+    throw new Error(
+      `[stripe] sub-cent crypto payment: ${amount} raw units on ${network} = ${amountCents} cents`,
+    )
+  }
+
+  createPaymentIntent(
+    client,
+    {
+      amount: amountCents,
+      currency: 'usd',
+      confirm: true,
+      payment_method_data: { type: 'crypto' },
+      payment_method_types: ['crypto'],
+      payment_method_options: {
+        crypto: {
+          mode: 'transaction_verification',
+          transaction_verification_options: {
+            network: stripeNetworkName,
+            transaction_hash: reference,
+          },
+        },
+      },
+    },
+    {
+      idempotencyKey: reference,
+      ...(connect && { connect }),
+    },
+  ).catch((err) => {
+    console.error('[stripe] failed to record crypto payment:', err)
+  })
+}

--- a/src/stripe/server/internal/record-payment.ts
+++ b/src/stripe/server/internal/record-payment.ts
@@ -11,7 +11,7 @@ const NETWORK_CONFIG: Record<stripe.Network, { stripeNetworkName: string; tokenD
 
 /**
  * Records a crypto payment as a Stripe PaymentIntent using transaction_verification mode.
- * Fire-and-forget: errors are logged but never thrown.
+ * Errors are logged but never thrown (the returned Promise always resolves).
  */
 export function recordCryptoPayment(
   client: StripeClient,
@@ -21,18 +21,19 @@ export function recordCryptoPayment(
     amount: string
     connect?: ConnectConfig
   },
-): void {
+): Promise<void> {
   const { network, reference, amount, connect } = parameters
   const { stripeNetworkName, tokenDecimals } = NETWORK_CONFIG[network]
 
   const amountCents = Math.round(Number(amount) / 10 ** (tokenDecimals - 2))
   if (amountCents < 1) {
-    throw new Error(
-      `[stripe] sub-cent crypto payment: ${amount} raw units on ${network} = ${amountCents} cents`,
+    console.warn(
+      `[stripe] skipping PI recording: ${amount} raw units on ${network} rounds to ${amountCents} cents (below Stripe minimum)`,
     )
+    return Promise.resolve()
   }
 
-  createPaymentIntent(
+  return createPaymentIntent(
     client,
     {
       amount: amountCents,
@@ -54,7 +55,10 @@ export function recordCryptoPayment(
       idempotencyKey: reference,
       ...(connect && { connect }),
     },
-  ).catch((err) => {
-    console.error('[stripe] failed to record crypto payment:', err)
-  })
+  ).then(
+    () => {},
+    (err) => {
+      console.error('[stripe] failed to record crypto payment:', err)
+    },
+  )
 }

--- a/src/stripe/server/internal/request.ts
+++ b/src/stripe/server/internal/request.ts
@@ -1,0 +1,49 @@
+import { stripePreviewVersion } from '../../internal/constants.js'
+import type { StripeClient } from '../../internal/types.js'
+
+export type ConnectConfig = {
+  stripeAccount: string
+  applicationFeeAmount?: number
+  onBehalfOf?: string
+  transferData?: { amount?: number; destination: string }
+  transferGroup?: string
+}
+
+/** Creates a Stripe PaymentIntent using the SDK client. Handles Connect param mapping. */
+export async function createPaymentIntent(
+  client: StripeClient,
+  params: Record<string, unknown>,
+  options?: { idempotencyKey?: string; connect?: ConnectConfig },
+): Promise<{ id: string; status: string; replayed: boolean }> {
+  const connect = options?.connect
+  const fullParams = {
+    ...params,
+    ...(connect && {
+      application_fee_amount: connect.applicationFeeAmount,
+      on_behalf_of: connect.onBehalfOf,
+      transfer_data: connect.transferData,
+      transfer_group: connect.transferGroup,
+    }),
+  }
+  const result = await client.paymentIntents.create(fullParams as any, {
+    apiVersion: stripePreviewVersion,
+    idempotencyKey: options?.idempotencyKey,
+    stripeAccount: connect?.stripeAccount,
+  })
+  const replayed = result.lastResponse?.headers?.['idempotent-replayed'] === 'true'
+  return { id: result.id, status: result.status, replayed }
+}
+
+/** Makes a raw Stripe API request using the SDK client. */
+export async function stripeRequest(
+  client: StripeClient,
+  method: 'GET' | 'POST',
+  path: string,
+  params?: Record<string, unknown>,
+  options?: { connect?: ConnectConfig },
+): Promise<unknown> {
+  return client.rawRequest!(method, path, method === 'GET' ? undefined : params, {
+    apiVersion: stripePreviewVersion,
+    stripeAccount: options?.connect?.stripeAccount,
+  })
+}


### PR DESCRIPTION
## Motivation

Setting up MPP integrations with mppx on top of Stripe requires ~100 lines of boilerplate: resolving deposit addresses, configuring each method with test/live tokens, recording crypto payments as PaymentIntents, and wiring up the right amount conversions. 

This PR adds a higher level interface that encapsulates much more of this complexity, allowing integrations to write much less code (example PRs: https://github.com/stripe-wpp/machine-payments-examples/pull/48 https://github.com/sandlerben/starlink-payment-api/pull/6).

### Goals (h/t @brendanjryan)
- Single interface to configure stripe + MPP (users should only need to config once) 
- Users can configure manually + choose payment methods if they want
- Users can compose stripe methods with non-stripe methods (e.g. cards on Stripe, solana off Stripe)
- Automatic configuration of new payment methods / destinations supported on stripe
- Support for both x402 and MPP
- Support methods supported by Stripe but which run through external MPP sdks (e.g. Solana)

## Summary

- Add `stripe.create()` factory that configures Stripe machine payments methods from `{ client, networkId, livemode }`
- `defaultMethods()` returns pre-configured tempo + SPT methods; sync with static addresses, async with API resolution (cached)
- `.additional()` for EVM (base), tempo sessions, and custom rails (solana); custom rail keys restricted to `stripe.Network` at compile time
- Crypto payments automatically recorded as Stripe PaymentIntents via per-method `onPaymentSuccess` hooks
- Normalize charge amounts so `.charge()` works with human-readable dollar amounts across all built-in methods
- Declarative builders with exhaustive `Record` types for defaults and additional methods
- `ConnectConfig` bundles `stripeAccount` with PI-specific params

## Examples

Async (deposit addresses resolved from Stripe API):

```ts
import { Mppx, stripe } from 'mppx/server'

const stripeMachinePayments = stripe.create({
  client: stripeClient,
  networkId: process.env.STRIPE_PROFILE_ID!,
  livemode: !process.env.STRIPE_SECRET_KEY!.includes('_test_'),
})

const mppx = Mppx.create({
  methods: await stripeMachinePayments.defaultMethods(),
  secretKey: mppSecretKey,
})
```

Sync (static deposit addresses, no API call):

```ts
const stripeMachinePayments = stripe.create({
  client: stripeClient,
  networkId: process.env.STRIPE_PROFILE_ID!,
  livemode: !process.env.STRIPE_SECRET_KEY!.includes('_test_'),
  depositAddresses: { tempo: process.env.TEMPO_DEPOSIT_ADDRESS! },
})

const mppx = Mppx.create({
  methods: stripeMachinePayments.defaultMethods(),
  secretKey: mppSecretKey,
})
```

With additional custom rails:

```ts
const mppx = Mppx.create({
  methods: await stripeMachinePayments.defaultMethods().additional({
    base: { x402: { facilitator } },
    solana: (address) => solana.charge({ recipient: address, currency: USDC, decimals: 6 }),
  }),
  secretKey: mppSecretKey,
})
```

Unified `.charge()` (all methods get the same human-readable amount):

```ts
const result = await mppx.charge({ amount: '0.50', description: 'Payment' })(request)
if (result.status === 402) return result.challenge
return result.withReceipt(Response.json({ ok: true }))
```
