### PR TITLE
fix: ignore quoted Payment text in multi-challenge headers

### DIFF
--- a/.changeset/fuzzy-mice-parse.md
+++ b/.changeset/fuzzy-mice-parse.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed multi-challenge parsing when quoted parameter values contained the Payment scheme name.

--- a/src/Challenge.fuzz.test.ts
+++ b/src/Challenge.fuzz.test.ts
@@ -3,14 +3,16 @@ import { Challenge } from 'mppx'
 import { describe, expect, test } from 'vp/test'
 
 describe('parseAuthParams robustness', () => {
-  test('deserialize never throws unhandled exception on arbitrary input', () => {
+  test('deserializers never throw unhandled exceptions on arbitrary input', () => {
     fc.assert(
       fc.property(fc.string(), (input) => {
-        try {
-          Challenge.deserialize(input)
-        } catch (e) {
-          if (!(e instanceof Error)) throw e
-          if (e instanceof TypeError || e instanceof RangeError) throw e
+        for (const deserialize of [Challenge.deserialize, Challenge.deserializeList]) {
+          try {
+            deserialize(input)
+          } catch (e) {
+            if (!(e instanceof Error)) throw e
+            if (e instanceof TypeError || e instanceof RangeError) throw e
+          }
         }
       }),
       { numRuns: 10_000 },
@@ -53,20 +55,43 @@ describe('adversarial header strings', () => {
   })
 })
 
-describe('serialize/deserialize roundtrip', () => {
-  const challengeArb = fc.record({
-    id: fc.string({ minLength: 1 }).filter((s) => /^[A-Za-z0-9_-]+$/.test(s)),
-    realm: fc.string({ minLength: 1 }).filter((s) => /^[A-Za-z0-9._-]+$/.test(s)),
-    method: fc.string({ minLength: 1 }).filter((s) => /^[a-z][a-z0-9:_-]*$/.test(s)),
-    intent: fc.string({ minLength: 1 }).filter((s) => /^[a-z][a-z0-9_-]*$/.test(s)),
-    request: fc.dictionary(
-      fc
-        .string({ minLength: 1 })
-        .filter((s) => /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(s) && s !== '__proto__'),
-      fc.oneof(fc.string(), fc.integer().map(String), fc.boolean().map(String)),
-    ),
-  })
+const authParamTextArb = fc.string().filter((value) => !/[\r\n]/.test(value))
+const schemeLikeTextArb = fc
+  .tuple(
+    authParamTextArb,
+    fc.constantFrom('Payment ', 'payment ', 'PAYMENT\t', 'pAyMeNt  '),
+    authParamTextArb,
+  )
+  .map(([prefix, token, suffix]) => `${prefix}${token}${suffix}`)
+const quotedFieldTextArb = fc.oneof(
+  authParamTextArb.filter((value) => value.length > 0),
+  schemeLikeTextArb,
+)
+const optionalQuotedFieldTextArb = fc.option(quotedFieldTextArb, { nil: undefined })
+const challengeArb = fc.record({
+  description: optionalQuotedFieldTextArb,
+  id: quotedFieldTextArb,
+  realm: quotedFieldTextArb,
+  method: fc.string({ minLength: 1 }).filter((s) => /^[a-z][a-z0-9:_-]*$/.test(s)),
+  intent: quotedFieldTextArb,
+  opaque: optionalQuotedFieldTextArb,
+  request: fc.dictionary(
+    fc
+      .string({ minLength: 1 })
+      .filter((s) => /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(s) && s !== '__proto__'),
+    fc.oneof(fc.string(), fc.integer().map(String), fc.boolean().map(String)),
+  ),
+})
 
+function escapeAuthParam(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+}
+
+const decoySchemeArb = fc
+  .tuple(fc.constantFrom('Basic', 'Bearer', 'Digest'), schemeLikeTextArb)
+  .map(([scheme, value]) => `${scheme} realm="${escapeAuthParam(value)}"`)
+
+describe('serialize/deserialize roundtrip', () => {
   test('serialize then deserialize produces equivalent challenge', () => {
     fc.assert(
       fc.property(challengeArb, (input) => {
@@ -78,44 +103,52 @@ describe('serialize/deserialize roundtrip', () => {
         expect(deserialized.method).toBe(input.method)
         expect(deserialized.intent).toBe(input.intent)
         expect(deserialized.request).toEqual(input.request)
+        expect(deserialized.description).toBe(input.description)
+        expect(deserialized.opaque).toBe(input.opaque)
       }),
-      { numRuns: 1_000 },
+      { numRuns: 5_000 },
     )
   })
 })
 
 describe('deserializeList roundtrip', () => {
-  const challengeArb = fc.record({
-    id: fc.string({ minLength: 1 }).filter((s) => /^[A-Za-z0-9_-]+$/.test(s)),
-    realm: fc.string({ minLength: 1 }).filter((s) => /^[A-Za-z0-9._-]+$/.test(s)),
-    method: fc.string({ minLength: 1 }).filter((s) => /^[a-z][a-z0-9:_-]*$/.test(s)),
-    intent: fc.string({ minLength: 1 }).filter((s) => /^[a-z][a-z0-9_-]*$/.test(s)),
-    request: fc.dictionary(
-      fc
-        .string({ minLength: 1 })
-        .filter((s) => /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(s) && s !== '__proto__'),
-      fc.oneof(fc.string(), fc.integer().map(String), fc.boolean().map(String)),
-    ),
+  const entryArb = fc.record({
+    challenge: challengeArb,
+    decoy: fc.option(decoySchemeArb, { nil: undefined }),
+    scheme: fc.constantFrom('Payment ', 'payment ', 'PAYMENT  ', 'pAyMeNt\t'),
   })
 
-  test('serialize multiple then deserializeList returns all challenges', () => {
+  test('finds only real challenges among quoted decoys and mixed auth schemes', () => {
     fc.assert(
-      fc.property(fc.array(challengeArb, { minLength: 1, maxLength: 3 }), (challenges) => {
-        const header = challenges
-          .map((c) => Challenge.serialize(c as Challenge.Challenge))
-          .join(', ')
-        const result = Challenge.deserializeList(header)
+      fc.property(
+        fc.array(entryArb, { minLength: 1, maxLength: 5 }),
+        fc.option(decoySchemeArb, { nil: undefined }),
+        (entries, trailingDecoy) => {
+          const parts: string[] = []
+          for (const { challenge, decoy, scheme } of entries) {
+            if (decoy) parts.push(decoy)
+            parts.push(
+              Challenge.serialize(challenge as Challenge.Challenge).replace(/^Payment /, scheme),
+            )
+          }
+          if (trailingDecoy) parts.push(trailingDecoy)
 
-        expect(result).toHaveLength(challenges.length)
-        for (let i = 0; i < challenges.length; i++) {
-          expect(result[i]!.id).toBe(challenges[i]!.id)
-          expect(result[i]!.realm).toBe(challenges[i]!.realm)
-          expect(result[i]!.method).toBe(challenges[i]!.method)
-          expect(result[i]!.intent).toBe(challenges[i]!.intent)
-          expect(result[i]!.request).toEqual(challenges[i]!.request)
-        }
-      }),
-      { numRuns: 1_000 },
+          const result = Challenge.deserializeList(parts.join(', '))
+
+          expect(result).toHaveLength(entries.length)
+          for (let i = 0; i < entries.length; i++) {
+            const expected = entries[i]!.challenge
+            expect(result[i]!.id).toBe(expected.id)
+            expect(result[i]!.realm).toBe(expected.realm)
+            expect(result[i]!.method).toBe(expected.method)
+            expect(result[i]!.intent).toBe(expected.intent)
+            expect(result[i]!.request).toEqual(expected.request)
+            expect(result[i]!.description).toBe(expected.description)
+            expect(result[i]!.opaque).toBe(expected.opaque)
+          }
+        },
+      ),
+      { numRuns: 10_000 },
     )
   })
 })

--- a/src/Challenge.test.ts
+++ b/src/Challenge.test.ts
@@ -692,6 +692,71 @@ describe('deserialize', () => {
   })
 })
 
+describe('deserializeList', () => {
+  const baseChallenge = {
+    id: 'first',
+    realm: 'api.example.com',
+    method: 'stripe',
+    intent: 'charge',
+    request: { amount: '50', currency: 'usd' },
+  } satisfies Challenge.Challenge
+  const secondHeader = Challenge.serialize({
+    id: 'second',
+    realm: 'api.example.com',
+    method: 'tempo',
+    intent: 'charge',
+    request: { amount: '1000000', currency: 'USD' },
+  })
+
+  test('behavior: parses the reported Stripe and Tempo header with payment in description', () => {
+    const stripeHeader =
+      'Payment id="k3fGx9QpLmZ2vT8sWyR4nB6cD1eH5jA7uN0iO2aS9dU", realm="example.com", method="stripe", intent="charge", request="eyJhbW91bnQiOiI1MCIsImN1cnJlbmN5IjoidXNkIiwiZXh0ZXJuYWxJZCI6Im9yZGVyLTEyMyIsIm1ldGhvZERldGFpbHMiOnsibmV0d29ya0lkIjoicHJvZmlsZV8wMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwIiwicGF5bWVudE1ldGhvZFR5cGVzIjpbImNhcmQiLCJsaW5rIl19fQ", description="Agentcash card payment test", expires="2026-09-01T00:00:00.000Z", opaque="eyJfbXBweF9zY29wZSI6ImNvZmZlZXNob3A6b3JkZXI6b3JkZXItMTIzOnBheSJ9"'
+
+    const challenges = Challenge.deserializeList(`${stripeHeader}, ${secondHeader}`)
+
+    expect(challenges).toHaveLength(2)
+    expect(challenges[0]).toMatchObject({
+      id: 'k3fGx9QpLmZ2vT8sWyR4nB6cD1eH5jA7uN0iO2aS9dU',
+      method: 'stripe',
+      description: 'Agentcash card payment test',
+    })
+    expect(challenges[1]).toMatchObject({ id: 'second', method: 'tempo' })
+  })
+
+  test.each([
+    ['description', 'Agentcash card payment test'],
+    ['description', 'Payment at the start'],
+    ['description', 'Use "Payment now", then retry \\'],
+    ['description', 'comma, Payment fake challenge'],
+    ['id', 'id with Payment text'],
+    ['intent', 'payment plan'],
+    ['realm', 'Payment realm'],
+    ['opaque', 'opaque Payment value'],
+  ] as const)('behavior: ignores scheme-like text in the %s parameter', (field, value) => {
+    const firstHeader = Challenge.serialize({ ...baseChallenge, [field]: value })
+    const challenges = Challenge.deserializeList(`${firstHeader}, ${secondHeader}`)
+
+    expect(challenges).toHaveLength(2)
+    expect(challenges[0]?.[field]).toBe(value)
+    expect(challenges[1]).toMatchObject({ id: 'second', method: 'tempo' })
+  })
+
+  test('behavior: finds case-insensitive Payment schemes among other auth schemes', () => {
+    const firstHeader = Challenge.serialize(baseChallenge)
+    const header =
+      `Bearer error_description="use Payment challenge", ${firstHeader}, ` +
+      `Digest realm="fallback Payment realm", ${secondHeader.replace(/^Payment /, 'pAyMeNt\t')}`
+
+    expect(Challenge.deserializeList(header).map(({ id }) => id)).toEqual(['first', 'second'])
+  })
+
+  test('error: quoted Payment text is not treated as a challenge', () => {
+    const header = 'Bearer error_description="use Payment challenge"'
+
+    expect(() => Challenge.deserializeList(header)).toThrow('No Payment schemes found.')
+  })
+})
+
 describe('fromHeaders', () => {
   test('behavior: extracts challenge from Headers object', () => {
     const original = Challenge.from({

--- a/src/Challenge.ts
+++ b/src/Challenge.ts
@@ -366,35 +366,12 @@ export function deserialize<const methods extends readonly Method.Method[] | und
 /** @internal Extracts the `Payment` scheme from a WWW-Authenticate value that may contain multiple schemes. */
 function extractPaymentAuthParams(header: string): string | null {
   const token = Constants.Schemes.payment
-  let inQuotes = false
-  let escaped = false
+  const [start] = findSchemeStarts(header, token)
+  if (start === undefined) return null
 
-  for (let i = 0; i < header.length; i++) {
-    const char = header[i]
-
-    if (inQuotes) {
-      if (escaped) escaped = false
-      else if (char === '\\') escaped = true
-      else if (char === '"') inQuotes = false
-      continue
-    }
-
-    if (char === '"') {
-      inQuotes = true
-      continue
-    }
-
-    if (!startsWithSchemeToken(header, i, token)) continue
-
-    const prefix = header.slice(0, i)
-    if (prefix.trim() && !prefix.trimEnd().endsWith(',')) continue
-
-    let paramsStart = i + token.length
-    while (paramsStart < header.length && /\s/.test(header[paramsStart] ?? '')) paramsStart++
-    return header.slice(paramsStart)
-  }
-
-  return null
+  let paramsStart = start + token.length
+  while (paramsStart < header.length && /\s/.test(header[paramsStart] ?? '')) paramsStart++
+  return header.slice(paramsStart)
 }
 
 /** @internal Parses auth-params with support for escaped quoted-string values. */
@@ -481,9 +458,41 @@ function readQuotedAuthParamValue(
 
 /** @internal */
 function startsWithSchemeToken(value: string, index: number, token: string): boolean {
-  if (!value.slice(index).toLowerCase().startsWith(token.toLowerCase())) return false
+  if (value.slice(index, index + token.length).toLowerCase() !== token.toLowerCase()) return false
   const next = value[index + token.length]
   return Boolean(next && /\s/.test(next))
+}
+
+/** @internal Finds auth scheme boundaries while ignoring quoted-string contents. */
+function findSchemeStarts(value: string, token: string): number[] {
+  const starts: number[] = []
+  let inQuotes = false
+  let escaped = false
+
+  for (let i = 0; i < value.length; i++) {
+    const char = value[i]
+
+    if (inQuotes) {
+      if (escaped) escaped = false
+      else if (char === '\\') escaped = true
+      else if (char === '"') inQuotes = false
+      continue
+    }
+
+    if (char === '"') {
+      inQuotes = true
+      continue
+    }
+
+    if (!startsWithSchemeToken(value, i, token)) continue
+
+    let boundary = i - 1
+    while (boundary >= 0 && /\s/.test(value[boundary] ?? '')) boundary--
+    if (boundary >= 0 && value[boundary] !== ',') continue
+    starts.push(i)
+  }
+
+  return starts
 }
 
 /**
@@ -594,12 +603,7 @@ export function fromHeadersList<
 export function deserializeList<
   const methods extends readonly Method.Method[] | undefined = undefined,
 >(value: string, options?: from.Options<methods>): from.ReturnType<from.Parameters, methods>[] {
-  // Find the start index of each `Payment ` scheme prefix.
-  const starts: number[] = []
-  const schemePattern = new RegExp(`${Constants.Schemes.payment}\\s+`, 'gi')
-  for (const match of value.matchAll(schemePattern)) {
-    starts.push(match.index!)
-  }
+  const starts = findSchemeStarts(value, Constants.Schemes.payment)
   if (starts.length === 0) throw new Error('No Payment schemes found.')
 
   // Slice each scheme from its `Payment ` prefix up to the next scheme boundary,


### PR DESCRIPTION
## Motivation

Multi-challenge headers were split on any case-insensitive Payment substring, including quoted parameter values. This caused valid combined Stripe and Tempo challenges to fail parsing.

## Summary

- Replaced regex-based scheme detection with quote- and escape-aware boundary scanning
- Added the reported Stripe and Tempo regression case plus quoted-field edge cases
- Expanded fast-check coverage for malformed headers, mixed auth schemes, and scheme-like quoted text
- Added a patch changeset

## Key design considerations

- Treats Payment as a challenge only at the start of the header or after a top-level comma
- Shares scheme-boundary detection between single- and multi-challenge parsing