### PR TITLE
feat(server): add per-method onPaymentSuccess hook

### DIFF
--- a/.changeset/on-payment-success-hook.md
+++ b/.changeset/on-payment-success-hook.md
@@ -1,0 +1,5 @@
+---
+'mppx': minor
+---
+
+Add per-method `onPaymentSuccess` hook to `ComposableHooks`. Routed through the server event dispatcher for error isolation.

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ coverage
 test-results/
 .cursor
 _/foundry/
+.worktrees

--- a/src/Method.ts
+++ b/src/Method.ts
@@ -237,9 +237,7 @@ export type CanOfferFn<method extends Method> = (parameters: {
  * Optional per-method hook invoked after a payment succeeds.
  *
  * Called after verification completes successfully. Use this for side-effects
- * like recording the payment in an external system (e.g. creating a Stripe
- * PaymentIntent for on-chain transactions). Routed through the server event
- * dispatcher so errors are isolated and do not affect the response.
+ * like recording the payment in an external system.
  */
 export type OnPaymentSuccessFn<method extends Method> = (parameters: {
   input?: globalThis.Request

--- a/src/Method.ts
+++ b/src/Method.ts
@@ -233,9 +233,25 @@ export type CanOfferFn<method extends Method> = (parameters: {
 }) => MaybePromise<boolean>
 
 /** Hooks supported by every composable server method constructor. */
+/**
+ * Optional per-method hook invoked after a payment succeeds.
+ *
+ * Called after verification completes successfully. Use this for side-effects
+ * like recording the payment in an external system (e.g. creating a Stripe
+ * PaymentIntent for on-chain transactions). Routed through the server event
+ * dispatcher so errors are isolated and do not affect the response.
+ */
+export type OnPaymentSuccessFn<method extends Method> = (parameters: {
+  input?: globalThis.Request
+  receipt: DeepReadonly<Receipt.Receipt>
+  request: DeepReadonly<z.output<method['schema']['request']>>
+}) => MaybePromise<void>
+
 export type ComposableHooks<method extends Method> = {
   /** Decides whether this method's configured offer is available for an HTTP request. */
   canOffer?: CanOfferFn<method> | undefined
+  /** Invoked after a successful payment on this method. */
+  onPaymentSuccess?: OnPaymentSuccessFn<method> | undefined
 }
 
 /** Credential creation function for a single method. */

--- a/src/evm/server/Charge.ts
+++ b/src/evm/server/Charge.ts
@@ -25,6 +25,7 @@ export function charge(parameters: charge.NativeConfig): Method.AnyServer {
 
   return Method.toServer<typeof Methods.charge, charge.Defaults, typeof transport>(Methods.charge, {
     canOffer: parameters.canOffer,
+    onPaymentSuccess: parameters.onPaymentSuccess,
     defaults: {
       chainId: config.chainId,
       currency: config.currency,

--- a/src/server/Mppx.test.ts
+++ b/src/server/Mppx.test.ts
@@ -1465,6 +1465,59 @@ describe('server events', () => {
     expect(events).toEqual(['success:tx-standalone:undefined:/standalone'])
   })
 
+  test('per-method onPaymentSuccess hook fires on successful payment', async () => {
+    const hookCalls: { receipt: string; amount: string }[] = []
+    const serverMethod = Method.toServer(eventCharge, {
+      onPaymentSuccess: async ({ receipt, request }) => {
+        hookCalls.push({ receipt: receipt.reference, amount: (request as any).amount })
+      },
+      async verify() {
+        return receipt('tx-hook')
+      },
+    })
+    const handler = Mppx.create({ methods: [serverMethod], realm, secretKey })
+
+    const first = await handler.charge(options())(new Request('https://example.com/resource'))
+    expect(first.status).toBe(402)
+    if (first.status !== 402) throw new Error()
+
+    await handler.verifyCredential(
+      Credential.from({
+        challenge: Challenge.fromResponse(first.challenge),
+        payload: { token: 'valid' },
+      }),
+      { request: options() },
+    )
+
+    expect(hookCalls).toEqual([{ receipt: 'tx-hook', amount: '1000' }])
+  })
+
+  test('per-method onPaymentSuccess hook errors do not propagate', async () => {
+    const serverMethod = Method.toServer(eventCharge, {
+      onPaymentSuccess: async () => {
+        throw new Error('hook failure')
+      },
+      async verify() {
+        return receipt('tx-error')
+      },
+    })
+    const handler = Mppx.create({ methods: [serverMethod], realm, secretKey })
+
+    const first = await handler.charge(options())(new Request('https://example.com/resource'))
+    expect(first.status).toBe(402)
+    if (first.status !== 402) throw new Error()
+
+    const result = await handler.verifyCredential(
+      Credential.from({
+        challenge: Challenge.fromResponse(first.challenge),
+        payload: { token: 'valid' },
+      }),
+      { request: options() },
+    )
+
+    expect(result.reference).toBe('tx-error')
+  })
+
   test('emits payment failure from standalone verifyCredential failures', async () => {
     const events: string[] = []
     const capturedRequest = {

--- a/src/server/Mppx.test.ts
+++ b/src/server/Mppx.test.ts
@@ -1466,10 +1466,10 @@ describe('server events', () => {
   })
 
   test('per-method onPaymentSuccess hook fires on successful payment', async () => {
-    const hookCalls: { receipt: string; amount: string }[] = []
+    const calls: string[] = []
     const serverMethod = Method.toServer(eventCharge, {
-      onPaymentSuccess: async ({ receipt, request }) => {
-        hookCalls.push({ receipt: receipt.reference, amount: (request as any).amount })
+      onPaymentSuccess: async ({ receipt }) => {
+        calls.push(receipt.reference)
       },
       async verify() {
         return receipt('tx-hook')
@@ -1477,19 +1477,91 @@ describe('server events', () => {
     })
     const handler = Mppx.create({ methods: [serverMethod], realm, secretKey })
 
-    const first = await handler.charge(options())(new Request('https://example.com/resource'))
-    expect(first.status).toBe(402)
-    if (first.status !== 402) throw new Error()
-
+    const challenge = await handler.charge(options())(new Request('https://example.com/resource'))
+    if (challenge.status !== 402) throw new Error()
     await handler.verifyCredential(
       Credential.from({
-        challenge: Challenge.fromResponse(first.challenge),
+        challenge: Challenge.fromResponse(challenge.challenge),
         payload: { token: 'valid' },
       }),
       { request: options() },
     )
 
-    expect(hookCalls).toEqual([{ receipt: 'tx-hook', amount: '1000' }])
+    expect(calls).toEqual(['tx-hook'])
+  })
+
+  test('onPaymentSuccess does not fire for a different method name', async () => {
+    const hookCalls: string[] = []
+
+    const methodWithHook = Method.toServer(eventCharge, {
+      onPaymentSuccess: async ({ receipt }) => {
+        hookCalls.push(receipt.reference)
+      },
+      async verify() {
+        return receipt('tx-a')
+      },
+    })
+    const otherName = Method.from({ name: 'other', intent: 'charge', schema: eventCharge.schema })
+    const methodWithoutHook = Method.toServer(otherName, {
+      async verify() {
+        return receipt('tx-b')
+      },
+    })
+
+    const handler = Mppx.create({ methods: [methodWithHook, methodWithoutHook], realm, secretKey })
+
+    // Pay the method WITHOUT the hook
+    const challenge = await handler.compose(['other/charge', options()])(
+      new Request('https://example.com'),
+    )
+    if (challenge.status !== 402) throw new Error()
+    await handler.verifyCredential(
+      Credential.from({
+        challenge: Challenge.fromResponse(challenge.challenge),
+        payload: { token: 'valid' },
+      }),
+      { request: options() },
+    )
+
+    expect(hookCalls).toEqual([])
+  })
+
+  test('onPaymentSuccess does not fire for a different intent', async () => {
+    const hookCalls: string[] = []
+
+    const chargeMethod = Method.toServer(eventCharge, {
+      onPaymentSuccess: async ({ receipt }) => {
+        hookCalls.push(receipt.reference)
+      },
+      async verify() {
+        return receipt('tx-charge')
+      },
+    })
+    const sessionSchema = Method.from({
+      name: 'mock',
+      intent: 'session',
+      schema: eventCharge.schema,
+    })
+    const sessionMethod = Method.toServer(sessionSchema, {
+      async verify() {
+        return receipt('tx-session')
+      },
+    })
+
+    const handler = Mppx.create({ methods: [chargeMethod, sessionMethod], realm, secretKey })
+
+    // Pay the session method - charge hook should NOT fire
+    const challenge = await handler.session(options())(new Request('https://example.com'))
+    if (challenge.status !== 402) throw new Error()
+    await handler.verifyCredential(
+      Credential.from({
+        challenge: Challenge.fromResponse(challenge.challenge),
+        payload: { token: 'valid' },
+      }),
+      { request: options() },
+    )
+
+    expect(hookCalls).toEqual([])
   })
 
   test('per-method onPaymentSuccess hook errors do not propagate', async () => {

--- a/src/server/Mppx.ts
+++ b/src/server/Mppx.ts
@@ -511,6 +511,17 @@ export function create<
 
   for (const mi of methods) {
     intentCount[mi.intent] = (intentCount[mi.intent] ?? 0) + 1
+    if (mi.onPaymentSuccess) {
+      serverEvents.on('payment.success', (async (ctx: PaymentSuccessContext) => {
+        if (ctx.method.name === mi.name && ctx.method.intent === mi.intent) {
+          await mi.onPaymentSuccess({
+            input: ctx.input,
+            receipt: ctx.receipt,
+            request: ctx.request,
+          })
+        }
+      }) as never)
+    }
   }
   assertNoReservedMppxKeys(methods as readonly Method.AnyServer[])
 

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -361,6 +361,7 @@ export function charge<const parameters extends charge.Parameters>(
   type Defaults = charge.DeriveDefaults<parameters>
   const method = Method.toServer<typeof Methods.charge, Defaults>(Methods.charge, {
     canOffer: parameters.canOffer,
+    onPaymentSuccess: parameters.onPaymentSuccess,
     defaults: {
       amount,
       currency,

--- a/src/tempo/server/Subscription.ts
+++ b/src/tempo/server/Subscription.ts
@@ -95,6 +95,7 @@ export function subscription<const parameters extends subscription.Parameters>(
     subscription.Extensions
   >(Methods.subscription, {
     canOffer: parameters.canOffer,
+    onPaymentSuccess: parameters.onPaymentSuccess,
     defaults: {
       amount,
       currency,

--- a/src/tempo/session/server/Session.ts
+++ b/src/tempo/session/server/Session.ts
@@ -482,6 +482,7 @@ export function session<const parameters extends session.Parameters>(
     session.Extensions
   >(Methods.session, {
     canOffer: parameters.canOffer,
+    onPaymentSuccess: parameters.onPaymentSuccess,
     defaults: deriveServerDefaults<parameters>({
       amount,
       currency,


### PR DESCRIPTION
## Motivation

Enable per-method side-effects after successful payment verification without requiring consumers to manually filter server-level `payment.success` events by method name/intent. 

## Summary

- Add `onPaymentSuccess` to `ComposableHooks` (alongside existing `canOffer`)
- Auto-register per-method hooks as filtered `payment.success` event listeners in `Mppx.create()`
- All method constructors (tempo charge, tempo session, tempo subscription, evm charge) pass through the new parameter

```ts
import { tempo } from 'mppx/server'

const charge = tempo.charge({
  currency: USDC,
  recipient: '0x...',
  onPaymentSuccess: async ({ receipt, request }) => {
    await recordPayment(receipt.reference, request.amount)
  },
})
```

The hook receives the same `PaymentSuccessContext` shape as the server event (`receipt`, `request`, `input`), scoped to the specific method it was configured on.