### PR TITLE
feat(server): multi-method intent handler with implicit compose

### DIFF
--- a/.changeset/multi-method-intent-handler.md
+++ b/.changeset/multi-method-intent-handler.md
@@ -1,0 +1,5 @@
+---
+'mppx': minor
+---
+
+Multi-method intent handler: `.charge()` now works when multiple methods share an intent, internally composing all matching methods into one handler that respects `selectOffers`.

--- a/src/server/Mppx.test-d.ts
+++ b/src/server/Mppx.test-d.ts
@@ -130,6 +130,13 @@ describe('Mppx type tests', () => {
     expectTypeOf(mppx.compose).toBeFunction()
   })
 
+  test('multi-method intent handler is callable and non-nullable', () => {
+    const mppx = Mppx.create({ methods: [alphaMethod, betaMethod], realm, secretKey })
+
+    expectTypeOf(mppx.charge).toBeFunction()
+    expectTypeOf(mppx.charge).not.toBeNullable()
+  })
+
   test('compose accepts method reference tuples', () => {
     const mppx = Mppx.create({ methods: [alphaMethod, betaMethod], realm, secretKey })
 

--- a/src/server/Mppx.test.ts
+++ b/src/server/Mppx.test.ts
@@ -59,6 +59,82 @@ describe('create', () => {
   })
 })
 
+describe('multi-method intent handler', () => {
+  test('composes all methods sharing an intent into a single handler', async () => {
+    const schema = {
+      credential: { payload: z.object({ sig: z.string() }) },
+      request: z.object({ amount: z.string(), currency: z.string() }),
+    }
+
+    const method1 = Method.toServer(Method.from({ name: 'foo', intent: 'charge', schema }), {
+      defaults: { currency: 'usd' },
+      verify: async () => ({
+        method: 'foo',
+        status: 'success' as const,
+        reference: '0x1',
+        timestamp: new Date().toISOString(),
+      }),
+    })
+    const method2 = Method.toServer(Method.from({ name: 'bar', intent: 'charge', schema }), {
+      defaults: { currency: 'eur' },
+      verify: async () => ({
+        method: 'bar',
+        status: 'success' as const,
+        reference: '0x2',
+        timestamp: new Date().toISOString(),
+      }),
+    })
+
+    const mppx = Mppx.create({ methods: [method1, method2], secretKey, realm })
+
+    expect(typeof mppx.charge).toBe('function')
+
+    const result = await (mppx as any).charge({ amount: '100' })(new Request('http://localhost'))
+    expect(result.status).toBe(402)
+
+    const wwwAuth = result.challenge.headers.get('www-authenticate')
+    expect(wwwAuth).toContain('method="foo"')
+    expect(wwwAuth).toContain('method="bar"')
+  })
+
+  test('single method with unique intent gets direct handler', async () => {
+    const schema = {
+      credential: { payload: z.object({ sig: z.string() }) },
+      request: z.object({ amount: z.string(), currency: z.string() }),
+    }
+
+    const method1 = Method.toServer(Method.from({ name: 'foo', intent: 'charge', schema }), {
+      defaults: { currency: 'usd' },
+      verify: async () => ({
+        method: 'foo',
+        status: 'success' as const,
+        reference: '0x1',
+        timestamp: new Date().toISOString(),
+      }),
+    })
+    const method2 = Method.toServer(Method.from({ name: 'bar', intent: 'session', schema }), {
+      defaults: { currency: 'usd' },
+      verify: async () => ({
+        method: 'bar',
+        status: 'success' as const,
+        reference: '0x2',
+        timestamp: new Date().toISOString(),
+      }),
+    })
+
+    const mppx = Mppx.create({ methods: [method1, method2], secretKey, realm })
+
+    const result = await (mppx as any).charge({ amount: '100', currency: 'usd' })(
+      new Request('http://localhost'),
+    )
+    expect(result.status).toBe(402)
+
+    const wwwAuth = result.challenge.headers.get('www-authenticate')
+    expect(wwwAuth).toContain('method="foo"')
+    expect(wwwAuth).not.toContain('method="bar"')
+  })
+})
+
 describe('request handler', () => {
   test('returns 402 when no Authorization header', async () => {
     const handler = Mppx.create({ methods: [method], realm, secretKey })

--- a/src/server/Mppx.ts
+++ b/src/server/Mppx.ts
@@ -374,22 +374,37 @@ type IsUniqueIntent<methods extends readonly Method.AnyServer[], intent extends 
       : never
     : never
 
-/** Only includes shorthand intent keys when the intent is unique across methods. */
-type UniqueIntentHandlers<
+/** Shorthand intent handlers. Single-method intents get direct handlers;
+ *  multi-method intents get an implicit compose wrapper. */
+type IntentHandlers<
   methods extends readonly Method.AnyServer[],
   transport extends Transport.AnyTransport,
 > = {
-  [method_name in methods[number]['intent'] as IsUniqueIntent<methods, method_name> extends true
-    ? method_name extends ReservedKey
-      ? never
-      : method_name
-    : never]: MethodFn<
-    Extract<methods[number], { intent: method_name }>,
-    EffectiveTransportOf<Extract<methods[number], { intent: method_name }>, transport>,
-    NonNullable<Extract<methods[number], { intent: method_name }>['defaults']>
-  > &
-    MethodExtensions<Extract<methods[number], { intent: method_name }>>
+  [intent in methods[number]['intent'] as intent extends ReservedKey
+    ? never
+    : intent]: IsUniqueIntent<methods, intent> extends true
+    ? MethodFn<
+        Extract<methods[number], { intent: intent }>,
+        EffectiveTransportOf<Extract<methods[number], { intent: intent }>, transport>,
+        NonNullable<Extract<methods[number], { intent: intent }>['defaults']>
+      > &
+        MethodExtensions<Extract<methods[number], { intent: intent }>>
+    : MultiMethodFn<Extract<methods[number], { intent: intent }>, transport>
 }
+
+/** Handler for an intent with multiple methods - takes the intersection of all methods' options. */
+type MultiMethodFn<methods extends Method.AnyServer, transport extends Transport.AnyTransport> = (
+  options: UnionToIntersection<MultiMethodFnDistribute<methods>>,
+) => (input: Transport.InputOf<transport>) => Promise<MethodFn.Response<transport>>
+
+type MultiMethodFnDistribute<M> =
+  M extends Method.Server<infer method, infer defaults, any, any, any>
+    ? MethodFn.Options<method, NonNullable<defaults>>
+    : never
+
+type UnionToIntersection<U> = (U extends any ? (x: U) => void : never) extends (x: infer I) => void
+  ? I
+  : never
 
 /** Nested handlers: `mppx.tempo.charge(...)`, grouped by method name then intent. */
 type PublicAlias<method extends Method.AnyServer> = method extends {
@@ -434,7 +449,7 @@ type Handlers<
     NonNullable<mi['defaults']>
   > &
     MethodExtensions<mi>
-} & UniqueIntentHandlers<methods, transport> &
+} & IntentHandlers<methods, transport> &
   NestedHandlers<methods, transport> & {
     [mi in methods[number] as PublicAlias<mi> extends string
       ? `${mi['name']}/${PublicAlias<mi>}`
@@ -539,9 +554,32 @@ export function create<
     if (aliasKey) handlers[aliasKey] = fn
   }
 
-  // Also set shorthand intent key when there's no collision
+  // Set shorthand intent key: single method gets direct handler,
+  // multiple methods get an implicit compose wrapper.
+  const processedIntents = new Set<string>()
   for (const mi of methods) {
-    if (intentCount[mi.intent] === 1) handlers[mi.intent] = handlers[`${mi.name}/${mi.intent}`]
+    if (processedIntents.has(mi.intent)) continue
+    processedIntents.add(mi.intent)
+
+    if (intentCount[mi.intent] === 1) {
+      handlers[mi.intent] = handlers[`${mi.name}/${mi.intent}`]
+    } else {
+      const intentMethods = (methods as readonly Method.AnyServer[]).filter(
+        (m) => m.intent === mi.intent,
+      )
+      handlers[mi.intent] = (options: Record<string, unknown>) => {
+        const configured = intentMethods.map((m) => {
+          const key = `${m.name}/${m.intent}`
+          const handlerFn = handlers[key] as AnyMethodFn
+          return handlerFn(options)
+        })
+        return composeHandlers(
+          configured as ConfiguredHandler[],
+          undefined,
+          selectOffers as SelectOffers<readonly Method.AnyServer[]> | undefined,
+        )
+      }
+    }
   }
 
   // Build nested handlers: mppx.tempo.charge(...)


### PR DESCRIPTION
## Motivation

When multiple methods share an intent (e.g. tempo/charge + stripe/charge), the shorthand `mppx.charge(...)` previously did not work; you had to instead use `mppx.compose(["tempo/charge", ...], ["stripe/charge", ...])`. This makes the common multi-method case verbose.

## Summary

- Replace `UniqueIntentHandlers` (only exposed shorthand for single-method intents) with `IntentHandlers` (exposes shorthand for all intents)
- Single-method intent: direct handler (unchanged behavior)
- Multi-method intent: implicit compose wrapper that fans out the same options to all matching methods
- Uses `composeHandlers` with `selectOffers` so the implicit compose respects server-level offer filtering
- Add `MultiMethodFn` type that accepts the intersection of all matching methods' options. If methods have incompatible required fields that can't be satisfied by a single options object, the call won't typecheck.

```ts
// Before: required explicit compose
const result = await mppx.compose(
  ['tempo/charge', { amount: '0.50' }],
  ['stripe/charge', { amount: '0.50', currency: 'usd', decimals: 2 }],
)(request)

// After: shorthand works for shared intents
const result = await mppx.charge({ amount: '0.50' })(request)
```