### PR TITLE
examples: add missing secretKey to charge, subscription, and multi-fetch servers

### DIFF
--- a/examples/charge/src/server.ts
+++ b/examples/charge/src/server.ts
@@ -6,7 +6,13 @@ import { Actions, Chain } from 'viem/tempo'
 const account = privateKeyToAccount(generatePrivateKey())
 const currency = '0x20c0000000000000000000000000000000000000' as const // pathUSD
 
+// `Mppx.create()` requires a secret key so challenge IDs can be verified
+// statelessly. The example ships with a default demo key so it works
+// out of the box, but still allows override via `MPP_SECRET_KEY`.
+const secretKey = process.env.MPP_SECRET_KEY ?? 'mppx-demo-charge-secret-key-minimum-32'
+
 const mppx = Mppx.create({
+  secretKey,
   methods: [
     tempo({
       account,

--- a/examples/session/multi-fetch/src/server.ts
+++ b/examples/session/multi-fetch/src/server.ts
@@ -82,7 +82,14 @@ const client = createClient({
 //     If you omit the account from the client, channel opens will work (the
 //     client's signed tx is broadcast) but closes will silently fail — the
 //     server can't sign the settle tx without a key.
+//
+// `Mppx.create()` requires a secret key so challenge IDs can be verified
+// statelessly. The example ships with a default demo key so it works
+// out of the box, but still allows override via `MPP_SECRET_KEY`.
+const secretKey = process.env.MPP_SECRET_KEY ?? 'mppx-demo-multi-fetch-secret-key-32'
+
 const mppx = Mppx.create({
+  secretKey,
   methods: [
     tempo.session({
       account,

--- a/examples/subscription/src/server.ts
+++ b/examples/subscription/src/server.ts
@@ -20,7 +20,13 @@ function subscriptionKey(source: { address: string; chainId: number }) {
   return `news:eip155:${source.chainId}:${source.address.toLowerCase()}:${planId}`
 }
 
+// `Mppx.create()` requires a secret key so challenge IDs can be verified
+// statelessly. The example ships with a default demo key so it works
+// out of the box, but still allows override via `MPP_SECRET_KEY`.
+const secretKey = process.env.MPP_SECRET_KEY ?? 'mppx-demo-subscription-secret-key-32'
+
 const mppx = Mppx.create({
+  secretKey,
   methods: [
     tempo.subscription({
       amount: pricePerPeriod,


### PR DESCRIPTION
Three example servers call `Mppx.create` without a `secretKey` and with no `MPP_SECRET_KEY` source anywhere in the example, so they throw at module load:

```
Error: Missing secret key. Set the MPP_SECRET_KEY environment variable or pass `secretKey` to Mppx.create().
```

- `examples/charge/src/server.ts`
- `examples/subscription/src/server.ts`
- `examples/session/multi-fetch/src/server.ts`

The sse and ws session examples already handle this with a demo-key fallback plus `MPP_SECRET_KEY` override, so this just applies the same pattern (and the same explanatory comment) to the other three. Verified by running the multi-fetch example before and after: the original fails on first request with the error above, the fixed one serves. `pnpm check:types:examples` passes.

No changeset since this only touches examples, happy to add one if you'd prefer.

FWIW the docs examples have the same gap - the pay-as-you-go and one-time-payments session snippets on mpp.dev / tempo.xyz omit `secretKey` from `Mppx.create` (the one-time ones use a `crypto.randomBytes` fallback, the session ones nothing at all), which is how I hit this in the first place (via tempoxyz/mpp-irl#10). Can open a PR against the docs repo too if that's useful.