### PR TITLE
chore: release unreleased changes as patch

### DIFF
--- a/.changeset/multi-method-intent-handler.md
+++ b/.changeset/multi-method-intent-handler.md
@@ -1,5 +1,5 @@
 ---
-'mppx': minor
+'mppx': patch
 ---
 
 Multi-method intent handler: `.charge()` now works when multiple methods share an intent, internally composing all matching methods into one handler that respects `selectOffers`.

--- a/.changeset/on-payment-success-hook.md
+++ b/.changeset/on-payment-success-hook.md
@@ -1,5 +1,5 @@
 ---
-'mppx': minor
+'mppx': patch
 ---
 
 Add per-method `onPaymentSuccess` hook to `ComposableHooks`. Routed through the server event dispatcher for error isolation.

--- a/.changeset/standardize-get-challenges.md
+++ b/.changeset/standardize-get-challenges.md
@@ -1,5 +1,5 @@
 ---
-'mppx': minor
+'mppx': patch
 ---
 
 Standardized client transports on `getChallenges` and removed the singular `getChallenge` hook.

--- a/.changeset/stripe-create-api.md
+++ b/.changeset/stripe-create-api.md
@@ -1,5 +1,5 @@
 ---
-'mppx': minor
+'mppx': patch
 ---
 
 Add `stripe.create()` machine payments API with auto deposit address resolution, PI recording, and unified `.charge()` handler.


### PR DESCRIPTION
## Motivation

Keep the next mppx release on the patch version line.

## Summary

- change all four unreleased minor changesets to patch changesets
- leave existing patch changesets unchanged

## Key design considerations

- changeset validation now resolves the complete unreleased set to a patch bump only