### PR TITLE
fix(tempo): use mpp relay idempotency prefix

### DIFF
--- a/.changeset/tidy-relays-wave.md
+++ b/.changeset/tidy-relays-wave.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Changed Tempo relay idempotency keys to use the `mpp_` prefix.

--- a/examples/charge-relay/src/server.ts
+++ b/examples/charge-relay/src/server.ts
@@ -43,7 +43,7 @@ const payments = Mppx.create({
       async broadcast(parameters: Parameters<NonNullable<typeof method.broadcast>>[0]) {
         const { credential } = parameters
         const receipt = await relay('/v1/mpp/broadcast', credential, {
-          'idempotency-key': `mppx_${credential.challenge.id}`,
+          'idempotency-key': `mpp_${credential.challenge.id}`,
         })
         return Receipt.from({ ...receipt, status: 'success' })
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   path-to-regexp@<8.4.0: 8.4.0
   tar@<=7.5.20: 7.5.21
   postcss@<=8.5.22: 8.5.23
+  nanoid@<3.3.17: 3.3.17
   '@modelcontextprotocol/sdk@>=1.10.0 <=1.25.3': 1.26.0
   '@modelcontextprotocol/server': 2.0.0-alpha.2
   qs@>=6.7.0 <=6.15.1: 6.15.2
@@ -3404,8 +3405,8 @@ packages:
   nan@2.28.0:
     resolution: {integrity: sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -6944,7 +6945,7 @@ snapshots:
   nan@2.28.0:
     optional: true
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   natural-compare@1.4.0: {}
 
@@ -7178,7 +7179,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,6 +23,7 @@ overrides:
   path-to-regexp@<8.4.0: '8.4.0'
   tar@<=7.5.20: '7.5.21'
   postcss@<=8.5.22: '8.5.23'
+  nanoid@<3.3.17: '3.3.17'
   '@modelcontextprotocol/sdk@>=1.10.0 <=1.25.3': '1.26.0'
   '@modelcontextprotocol/server': '2.0.0-alpha.2'
   qs@>=6.7.0 <=6.15.1: '6.15.2'
@@ -76,6 +77,7 @@ minimumReleaseAgeExclude:
   - hono@4.12.34
   - ip-address@10.3.1
   - js-yaml@4.3.1
+  - nanoid@3.3.17
   - ox@0.14.33
   - postcss@8.5.23
   - protobufjs@7.6.5

--- a/src/tempo/server/Relay.test.ts
+++ b/src/tempo/server/Relay.test.ts
@@ -196,7 +196,7 @@ describe('relay boundary', () => {
           headers: expect.objectContaining({
             Accept: 'application/json',
             'content-type': 'application/json',
-            'idempotency-key': expect.stringMatching(/^mppx_0x/),
+            'idempotency-key': expect.stringMatching(/^mpp_0x/),
             'tempo-api-key': 'tempo_api_key',
           }),
           method: 'POST',
@@ -282,9 +282,9 @@ describe('relay boundary', () => {
 
     const keys = calls.map((init) => (init.headers as Record<string, string>)['idempotency-key'])
     expect(keys).toEqual([
-      `mppx_${Hash.keccak256(Hex.toBytes(credential.payload.signature), { as: 'Hex' })}`,
-      `mppx_${Hash.keccak256(Hex.toBytes(credential.payload.signature), { as: 'Hex' })}`,
-      `mppx_${Hash.keccak256(Hex.toBytes('0x5678'), { as: 'Hex' })}`,
+      `mpp_${Hash.keccak256(Hex.toBytes(credential.payload.signature), { as: 'Hex' })}`,
+      `mpp_${Hash.keccak256(Hex.toBytes(credential.payload.signature), { as: 'Hex' })}`,
+      `mpp_${Hash.keccak256(Hex.toBytes('0x5678'), { as: 'Hex' })}`,
     ])
   })
 
@@ -316,7 +316,7 @@ describe('relay boundary', () => {
       ),
       { as: 'Hex' },
     )
-    expect(headers['idempotency-key']).toBe(`mppx_${expected}`)
+    expect(headers['idempotency-key']).toBe(`mpp_${expected}`)
   })
 
   test('preserves the legacy combined verify hook', async () => {

--- a/src/tempo/server/Relay.ts
+++ b/src/tempo/server/Relay.ts
@@ -232,11 +232,11 @@ function idempotencyKey(input: RelayInput): string {
     Hex.validate(payload.signature)
   ) {
     const transactionHash = Hash.keccak256(Hex.toBytes(payload.signature), { as: 'Hex' })
-    return `mppx_${transactionHash}`
+    return `mpp_${transactionHash}`
   }
 
   const hash = Hash.sha256(Bytes.fromString(Json.canonicalize(input)), { as: 'Hex' })
-  return `mppx_${hash}`
+  return `mpp_${hash}`
 }
 
 function failure(value?: unknown) {


### PR DESCRIPTION
## Motivation

Use the protocol namespace for Tempo relay idempotency keys instead of the TypeScript package namespace.

## Summary

- Changed generated Tempo relay idempotency keys from `mppx_` to `mpp_`.
- Updated relay coverage and the charge relay example.
- Added a patch changeset.

## Key design considerations

- Preserved the deterministic transaction and credential hash suffixes.
- Left Stripe idempotency keys unchanged because they are outside the Tempo relay integration.