### PR TITLE
feat(stripe): reject sub-cent amounts and add new tests

### DIFF
--- a/.changeset/stripe-crypto-min-amount.md
+++ b/.changeset/stripe-crypto-min-amount.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Reject sub-cent amounts via `canOffer` before issuing 402 challenge on stripe-managed crypto rails. Add `metadata` parameter to `stripe.create()` for forwarding key-value pairs to Stripe PaymentIntents.

--- a/src/stripe/server/Methods.test.ts
+++ b/src/stripe/server/Methods.test.ts
@@ -34,6 +34,44 @@ describe('stripe.create() defaultMethods', () => {
     expect(findMethod(methods, 'stripe', 'charge')).toBeDefined()
   })
 
+  test('forwards metadata to SPT method defaults', () => {
+    const client = createMockStripeClient()
+    const mp = stripe({
+      client,
+      networkId: 'test-profile',
+      livemode: false,
+      depositAddresses: { tempo: '0xtempoaddr' },
+      metadata: { agent_id: 'test-agent' },
+    })
+    const methods = mp.defaultMethods()
+    const sptMethod = findMethod(methods, 'stripe', 'charge')
+
+    expect((sptMethod as any).defaults?.metadata).toEqual({ agent_id: 'test-agent' })
+  })
+
+  test('forwards metadata to crypto PI recording', async () => {
+    const client = createMockStripeClient()
+    const mp = stripe({
+      client,
+      networkId: 'test-profile',
+      livemode: false,
+      depositAddresses: { tempo: '0xtempoaddr' },
+      metadata: { agent_id: 'test-agent' },
+    })
+    const methods = mp.defaultMethods()
+    const tempoMethod = findMethod(methods, 'tempo', 'charge')
+
+    await tempoMethod.onPaymentSuccess!({
+      receipt: { reference: '0xtx123' },
+      request: { amount: '500000' },
+    })
+
+    expect(client.paymentIntents.create).toHaveBeenCalledWith(
+      expect.objectContaining({ metadata: { agent_id: 'test-agent' } }),
+      expect.anything(),
+    )
+  })
+
   test.each(['tempo', 'spt'] as const)('exclude removes %s', async (excluded) => {
     const client = createMockStripeClient()
     const mp = stripe({ client, networkId: 'test-profile', livemode: false })
@@ -87,6 +125,55 @@ describe('stripe.create() PI recording', () => {
 
     expect(result).toBeUndefined()
     expect(client.paymentIntents.create).not.toHaveBeenCalled()
+  })
+})
+
+describe('stripe.create() canOffer minimum amount', () => {
+  test('tempo rejects amounts below 1 cent', () => {
+    const client = createMockStripeClient()
+    const mp = stripe({
+      client,
+      networkId: 'test-profile',
+      livemode: false,
+      depositAddresses: { tempo: '0xtempoaddr' },
+    })
+    const methods = mp.defaultMethods()
+    const tempoMethod = findMethod(methods, 'tempo', 'charge')
+
+    expect(
+      tempoMethod.canOffer!({ input: new Request('http://x'), request: { amount: '9999' } }),
+    ).toBe(false)
+    expect(
+      tempoMethod.canOffer!({ input: new Request('http://x'), request: { amount: '10000' } }),
+    ).toBe(true)
+  })
+
+  test('custom rail inherits minimum amount check', () => {
+    const client = createMockStripeClient()
+    const mp = stripe({
+      client,
+      networkId: 'test-profile',
+      livemode: false,
+      depositAddresses: { tempo: '0xtempoaddr', solana: 'SOLaddr' },
+    })
+    const methods = mp.defaultMethods().additional({
+      solana: (_address) => ({
+        name: 'solana',
+        intent: 'charge',
+        schema: {
+          request: { parse: (x: unknown) => x },
+          response: { parse: (x: unknown) => x },
+        } as AnyServer['schema'],
+      }),
+    })
+    const solanaMethod = findMethod(methods, 'solana', 'charge')
+
+    expect(
+      solanaMethod.canOffer!({ input: new Request('http://x'), request: { amount: '5000' } }),
+    ).toBe(false)
+    expect(
+      solanaMethod.canOffer!({ input: new Request('http://x'), request: { amount: '10000' } }),
+    ).toBe(true)
   })
 })
 
@@ -189,5 +276,128 @@ describe('stripe.create() deposit address cache isolation', () => {
 
     expect(addr1).toBe(addr2)
     expect(client.rawRequest).toHaveBeenCalledOnce()
+  })
+})
+
+describe('stripe methods composed with non-stripe methods', () => {
+  function makeIndependentMethod(): AnyServer {
+    return {
+      name: 'solana',
+      intent: 'charge',
+      schema: {
+        request: { parse: (x: unknown) => x },
+        response: { parse: (x: unknown) => x },
+      } as AnyServer['schema'],
+      onPaymentSuccess: vi.fn(),
+    } as unknown as AnyServer
+  }
+
+  test('independent methods are not modified by stripe factory', () => {
+    const client = createMockStripeClient()
+    const mp = stripe({
+      client,
+      networkId: 'test-profile',
+      livemode: false,
+      depositAddresses: { tempo: '0xtempoaddr' },
+    })
+    const stripeMethods = mp.defaultMethods()
+    const independent = makeIndependentMethod()
+    const originalHook = independent.onPaymentSuccess
+
+    const allMethods = [...stripeMethods, independent]
+    const solana = allMethods.find((m) => m.name === 'solana')!
+
+    expect(solana.onPaymentSuccess).toBe(originalHook)
+    expect(solana.canOffer).toBeUndefined()
+  })
+
+  test('stripe PI recording does not fire for independent methods', async () => {
+    const client = createMockStripeClient()
+    const mp = stripe({
+      client,
+      networkId: 'test-profile',
+      livemode: false,
+      depositAddresses: { tempo: '0xtempoaddr' },
+    })
+    const stripeMethods = mp.defaultMethods()
+    const independent = makeIndependentMethod()
+
+    // Stripe tempo's hook records a PI
+    const tempoMethod = findMethod(stripeMethods, 'tempo', 'charge')
+    await tempoMethod.onPaymentSuccess!({
+      receipt: { reference: '0xtx1' },
+      request: { amount: '500000' },
+    })
+    expect(client.paymentIntents.create).toHaveBeenCalledOnce()
+
+    // Independent method's hook does NOT touch stripe
+    independent.onPaymentSuccess!({
+      receipt: { reference: '0xtx2' },
+      request: { amount: '500000' },
+    })
+    expect(client.paymentIntents.create).toHaveBeenCalledOnce()
+    expect(independent.onPaymentSuccess).toHaveBeenCalledOnce()
+  })
+})
+
+describe('stripe.create() canOffer composition with user hook', () => {
+  test('user canOffer is checked after minimum amount passes', () => {
+    const client = createMockStripeClient()
+    const userCanOffer = vi.fn(() => false)
+
+    const mp = stripe({
+      client,
+      networkId: 'test-profile',
+      livemode: false,
+      depositAddresses: { tempo: '0xtempoaddr', solana: 'SOLaddr' },
+    })
+    const methods = mp.defaultMethods().additional({
+      solana: (_address) => ({
+        name: 'solana',
+        intent: 'charge',
+        schema: {
+          request: { parse: (x: unknown) => x },
+          response: { parse: (x: unknown) => x },
+        } as AnyServer['schema'],
+        canOffer: userCanOffer,
+      }),
+    })
+    const solanaMethod = findMethod(methods, 'solana', 'charge')
+
+    // Amount passes minimum but user rejects
+    expect(
+      solanaMethod.canOffer!({ input: new Request('http://x'), request: { amount: '50000' } }),
+    ).toBe(false)
+    expect(userCanOffer).toHaveBeenCalledOnce()
+  })
+
+  test('user canOffer is not called when amount is below minimum', () => {
+    const client = createMockStripeClient()
+    const userCanOffer = vi.fn(() => true)
+
+    const mp = stripe({
+      client,
+      networkId: 'test-profile',
+      livemode: false,
+      depositAddresses: { tempo: '0xtempoaddr', solana: 'SOLaddr' },
+    })
+    const methods = mp.defaultMethods().additional({
+      solana: (_address) => ({
+        name: 'solana',
+        intent: 'charge',
+        schema: {
+          request: { parse: (x: unknown) => x },
+          response: { parse: (x: unknown) => x },
+        } as AnyServer['schema'],
+        canOffer: userCanOffer,
+      }),
+    })
+    const solanaMethod = findMethod(methods, 'solana', 'charge')
+
+    // Amount below minimum - short-circuits, user hook never called
+    expect(
+      solanaMethod.canOffer!({ input: new Request('http://x'), request: { amount: '5000' } }),
+    ).toBe(false)
+    expect(userCanOffer).not.toHaveBeenCalled()
   })
 })

--- a/src/stripe/server/Methods.ts
+++ b/src/stripe/server/Methods.ts
@@ -29,6 +29,7 @@ export declare namespace stripe {
     livemode: boolean
     connect?: ConnectConfig
     depositAddresses?: Partial<Record<Network, string>> | ((network: Network) => Promise<string>)
+    metadata?: Record<string, string> | undefined
   }
 }
 
@@ -86,9 +87,10 @@ interface StripeMachinePayments<P extends stripe.Parameters = stripe.Parameters>
   }
   tempo: {
     charge: (
-      params: { recipient: stripe.DepositAddress<'tempo'> } & Partial<
-        Omit<Parameters<typeof tempoCharge>[0], 'currency' | 'recipient'>
-      >,
+      params: {
+        recipient: stripe.DepositAddress<'tempo'>
+        metadata?: Record<string, string>
+      } & Partial<Omit<Parameters<typeof tempoCharge>[0], 'currency' | 'recipient'>>,
     ) => TempoServer
     session: (
       params: { recipient: stripe.DepositAddress<'tempo'> } & Omit<
@@ -98,7 +100,12 @@ interface StripeMachinePayments<P extends stripe.Parameters = stripe.Parameters>
     ) => TempoSessionServer
   }
   base: {
-    charge: (params: { recipient: stripe.DepositAddress<'base'> } & BaseConfig) => EvmServer
+    charge: (
+      params: {
+        recipient: stripe.DepositAddress<'base'>
+        metadata?: Record<string, string>
+      } & BaseConfig,
+    ) => EvmServer
   }
   findOrCreateDepositAddress: <N extends stripe.Network>(
     network: N,
@@ -180,14 +187,19 @@ class DefaultMethodsBuilder implements PromiseLike<DefaultMethods> {
  * ```
  */
 export function stripe<const P extends stripe.Parameters>(parameters: P): StripeMachinePayments<P> {
-  const { client, networkId, livemode, connect, depositAddresses } = parameters
+  const { client, networkId, livemode, connect, depositAddresses, metadata } = parameters
   if (!client.rawRequest)
     throw new Error('stripe.create() requires a Stripe SDK client with rawRequest() (v15+)')
   const tempoCurrency = (
     livemode ? tempoDefaults.tokens.usdc : tempoDefaults.tokens.pathUsd
   ) as `0x${string}`
-  const tempoPaymentHandler = createPaymentSuccessHandler(client, 'tempo', connect)
-  const basePaymentHandler = createPaymentSuccessHandler(client, 'base', connect)
+  const tempoPaymentHandler = createPaymentSuccessHandler(client, 'tempo', connect, metadata)
+  const basePaymentHandler = createPaymentSuccessHandler(client, 'base', connect, metadata)
+
+  // All stripe-managed crypto rails use 6-decimal stablecoins. Reject amounts
+  // below 1 cent since Stripe cannot record them.
+  const cryptoCanOffer = ({ request }: { request: { amount: string } }) =>
+    Number(request.amount) >= 10_000
 
   function makeSptCharge(params?: { paymentMethodTypes?: string[] }): Method.AnyServer {
     return charge_({
@@ -197,20 +209,25 @@ export function stripe<const P extends stripe.Parameters>(parameters: P): Stripe
       decimals: 2,
       paymentMethodTypes: params?.paymentMethodTypes ?? ['card', 'link'],
       ...(connect && { connect }),
+      ...(metadata && { metadata }),
     } as Parameters<typeof charge_>[0]) as Method.AnyServer
   }
 
   function makeTempoCharge(
-    params: { recipient: `0x${string}` } & Partial<
+    params: { recipient: `0x${string}`; metadata?: Record<string, string> } & Partial<
       Omit<Parameters<typeof tempoCharge>[0], 'currency' | 'recipient'>
     >,
   ): Method.AnyServer {
-    const { recipient, ...rest } = params
+    const { recipient, metadata: callMetadata, ...rest } = params
+    const handler = callMetadata
+      ? createPaymentSuccessHandler(client, 'tempo', connect, { ...metadata, ...callMetadata })
+      : tempoPaymentHandler
     return tempoCharge({
       currency: tempoCurrency,
       recipient,
       ...(!livemode && { testnet: true }),
-      onPaymentSuccess: tempoPaymentHandler,
+      canOffer: cryptoCanOffer,
+      onPaymentSuccess: handler,
       ...rest,
     }) as Method.AnyServer
   }
@@ -227,13 +244,19 @@ export function stripe<const P extends stripe.Parameters>(parameters: P): Stripe
     } as tempoSession.Parameters) as Method.AnyServer
   }
 
-  function makeBaseCharge(params: { recipient: `0x${string}` } & BaseConfig): Method.AnyServer {
-    const { recipient, x402, ...rest } = params
+  function makeBaseCharge(
+    params: { recipient: `0x${string}`; metadata?: Record<string, string> } & BaseConfig,
+  ): Method.AnyServer {
+    const { recipient, x402, metadata: callMetadata, ...rest } = params
+    const handler = callMetadata
+      ? createPaymentSuccessHandler(client, 'base', connect, { ...metadata, ...callMetadata })
+      : basePaymentHandler
     return evmCharge({
       currency: livemode ? EvmAssets.base.USDC : EvmAssets.baseSepolia.USDC,
       recipient,
       x402,
-      onPaymentSuccess: basePaymentHandler,
+      canOffer: cryptoCanOffer,
+      onPaymentSuccess: handler,
       ...rest,
     }) as Method.AnyServer
   }
@@ -289,13 +312,21 @@ export function stripe<const P extends stripe.Parameters>(parameters: P): Stripe
 
       for (const [network, factory] of customRails(additional)) {
         const address = requireAddress(addresses, network)
-        const recorder = createPaymentSuccessHandler(client, network as stripe.Network, connect)
+        const recorder = createPaymentSuccessHandler(
+          client,
+          network as stripe.Network,
+          connect,
+          metadata,
+        )
         for (const m of toArray(factory(address))) {
           const onPaymentSuccess = m.onPaymentSuccess
             ? (params: any) =>
                 Promise.all([m.onPaymentSuccess!(params), recorder(params)]).then(() => {})
             : recorder
-          result.push({ ...m, onPaymentSuccess } as Method.AnyServer)
+          const canOffer = m.canOffer
+            ? (params: any) => cryptoCanOffer(params) && m.canOffer!(params)
+            : cryptoCanOffer
+          result.push({ ...m, canOffer, onPaymentSuccess } as Method.AnyServer)
         }
       }
     }
@@ -393,6 +424,7 @@ function createPaymentSuccessHandler(
   client: StripeClient,
   network: stripe.Network,
   connect?: ConnectConfig,
+  metadata?: Record<string, string>,
 ) {
   return (params: { receipt: any; request: any }) => {
     const { receipt, request } = params
@@ -402,6 +434,7 @@ function createPaymentSuccessHandler(
         reference: receipt.reference,
         amount: String(request.amount),
         ...(connect && { connect }),
+        ...(metadata && { metadata }),
       })
     }
   }

--- a/src/stripe/server/internal/record-payment.ts
+++ b/src/stripe/server/internal/record-payment.ts
@@ -20,9 +20,10 @@ export function recordCryptoPayment(
     reference: string
     amount: string
     connect?: ConnectConfig
+    metadata?: Record<string, string>
   },
 ): Promise<void> {
-  const { network, reference, amount, connect } = parameters
+  const { network, reference, amount, connect, metadata } = parameters
   const { stripeNetworkName, tokenDecimals } = NETWORK_CONFIG[network]
 
   const amountCents = Math.round(Number(amount) / 10 ** (tokenDecimals - 2))
@@ -50,6 +51,7 @@ export function recordCryptoPayment(
           },
         },
       },
+      ...(metadata && { metadata }),
     },
     {
       idempotencyKey: reference,


### PR DESCRIPTION
A few minor follow-ups from #764:

- Add `canOffer` for Stripe-wrapped crypto payment methods that filter out below 1 cent.
- Forward `metadata` to `PaymentIntent` creation for all methods
- Add tests ensuring that Stripe and non-Stripe methods can compose together.