### PR TITLE
fix: use mpp idempotency prefix

### DIFF
--- a/.changeset/calm-keys-align.md
+++ b/.changeset/calm-keys-align.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Changed Stripe PaymentIntent idempotency keys to use the SDK-independent `mpp_` prefix.

--- a/src/stripe/server/Charge.test.ts
+++ b/src/stripe/server/Charge.test.ts
@@ -167,7 +167,7 @@ describe('stripe.charge with client', () => {
       allow_redirects: 'never',
       enabled: true,
     })
-    expect(options.idempotencyKey).toMatch(/^mppx_/)
+    expect(options.idempotencyKey).toBe(`mpp_${challenge.id}_spt_test_token`)
   })
 
   test('behavior: includes metadata in client call', async () => {

--- a/src/stripe/server/Charge.test.ts
+++ b/src/stripe/server/Charge.test.ts
@@ -313,6 +313,7 @@ describe('stripe.charge with client', () => {
     const [input, init] = fetchMock.mock.calls[0]!
     expect(input).toBe('https://api.stripe.com/v1/payment_intents')
     const headers = new Headers(init?.headers)
+    expect(headers.get('Idempotency-Key')).toBe(`mpp_${credential.challenge.id}_spt_test_token`)
     expect(headers.get('Stripe-Account')).toBe('acct_connected')
     const body = init?.body as URLSearchParams
     expect(body.get('application_fee_amount')).toBe('12')

--- a/src/stripe/server/Charge.ts
+++ b/src/stripe/server/Charge.ts
@@ -343,7 +343,7 @@ async function createWithClient(parameters: {
     }
     const paymentIntentOptions = {
       apiVersion: stripePreviewVersion,
-      idempotencyKey: `mppx_${challenge.id}_${spt}`,
+      idempotencyKey: `mpp_${challenge.id}_${spt}`,
       ...(settlement?.stripeAccount !== undefined && { stripeAccount: settlement.stripeAccount }),
     }
     const result = await client.paymentIntents.create(
@@ -396,7 +396,7 @@ async function createWithSecretKey(parameters: {
   const headers = {
     Authorization: `Basic ${btoa(`${secretKey}:`)}`,
     'Content-Type': 'application/x-www-form-urlencoded',
-    'Idempotency-Key': `mppx_${challenge.id}_${spt}`,
+    'Idempotency-Key': `mpp_${challenge.id}_${spt}`,
     'Stripe-Version': stripePreviewVersion,
     ...(settlement?.stripeAccount !== undefined && { 'Stripe-Account': settlement.stripeAccount }),
   }


### PR DESCRIPTION
## Why

Stripe idempotency keys currently encode the TypeScript SDK name in their prefix. The wire-visible namespace should identify MPP rather than a particular SDK.

## What

Changed Stripe PaymentIntent idempotency keys from `mppx_` to `mpp_` while preserving the challenge ID and SPT suffix. Added exact-key regression coverage for both Stripe execution paths and one patch changeset.

Retries that begin before the upgrade and continue after it will use a different key at the version boundary.