### PR TITLE
feat(stripe): graceful degradation for defaultMethods()

### DIFF
--- a/.changeset/graceful-degradation.md
+++ b/.changeset/graceful-degradation.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+`stripe.create()`: `defaultMethods()` now returns sync SPT-only when no `depositAddresses` is provided, and uses `Promise.allSettled` in the function resolver path to gracefully degrade when individual networks fail.

--- a/src/stripe/server/Methods.test-d.ts
+++ b/src/stripe/server/Methods.test-d.ts
@@ -105,6 +105,19 @@ test('sync defaultMethods() with static depositAddresses returns SyncMethodsResu
   expectTypeOf(mppx.charge).not.toBeNullable()
 })
 
+test('no depositAddresses returns SyncMethodsResult', () => {
+  const mp = stripe.create({
+    client: {} as any,
+    networkId: 'profile_x',
+    livemode: false,
+  })
+  const methods = mp.defaultMethods()
+  expectTypeOf(methods).toHaveProperty('additional')
+
+  const mppx = Mppx.create({ methods, secretKey: 'test' })
+  expectTypeOf(mppx.charge).toBeFunction()
+})
+
 test('depositAddresses as resolver function returns DefaultMethodsBuilder', async () => {
   const mp = stripe.create({
     client: {} as any,

--- a/src/stripe/server/Methods.test.ts
+++ b/src/stripe/server/Methods.test.ts
@@ -23,10 +23,17 @@ function findMethod(methods: readonly AnyServer[], name: string, intent: string)
   return methods.find((m) => m.name === name && m.intent === intent)!
 }
 
+const mockResolver = async () => '0xabc'
+
 describe('stripe.create() defaultMethods', () => {
   test('returns tempo and spt methods', async () => {
     const client = createMockStripeClient()
-    const mp = stripe({ client, networkId: 'test-profile', livemode: false })
+    const mp = stripe({
+      client,
+      networkId: 'test-profile',
+      livemode: false,
+      depositAddresses: mockResolver,
+    })
 
     const methods = await mp.defaultMethods()
 
@@ -74,7 +81,12 @@ describe('stripe.create() defaultMethods', () => {
 
   test.each(['tempo', 'spt'] as const)('exclude removes %s', async (excluded) => {
     const client = createMockStripeClient()
-    const mp = stripe({ client, networkId: 'test-profile', livemode: false })
+    const mp = stripe({
+      client,
+      networkId: 'test-profile',
+      livemode: false,
+      depositAddresses: mockResolver,
+    })
 
     const methods = await mp.defaultMethods({ exclude: [excluded] })
     const expectedName = excluded === 'spt' ? 'stripe' : excluded
@@ -91,6 +103,7 @@ describe('stripe.create() PI recording', () => {
       client,
       networkId: 'test-profile',
       livemode: false,
+      depositAddresses: mockResolver,
     })
 
     const methods = await mp.defaultMethods()
@@ -113,6 +126,7 @@ describe('stripe.create() PI recording', () => {
       client,
       networkId: 'test-profile',
       livemode: false,
+      depositAddresses: mockResolver,
     })
 
     const methods = await mp.defaultMethods()
@@ -399,5 +413,46 @@ describe('stripe.create() canOffer composition with user hook', () => {
       solanaMethod.canOffer!({ input: new Request('http://x'), request: { amount: '5000' } }),
     ).toBe(false)
     expect(userCanOffer).not.toHaveBeenCalled()
+  })
+})
+
+describe('stripe.create() graceful degradation', () => {
+  test('partial resolver failure returns successful methods and warns', async () => {
+    const client = createMockStripeClient()
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const mp = stripe({
+      client,
+      networkId: 'test-profile',
+      livemode: false,
+      depositAddresses: async (network) => {
+        if (network === 'tempo') throw new Error('API unavailable')
+        return '0x1234567890abcdef1234567890abcdef12345678'
+      },
+    })
+
+    const methods = await mp.defaultMethods().additional({
+      base: {
+        x402: { facilitator: { verify: async () => ({}), settle: async () => ({}) } } as any,
+      },
+    })
+
+    expect(methods.find((m) => m.name === 'tempo')).toBeUndefined()
+    expect(findMethod(methods, 'evm', 'charge')).toBeDefined()
+    expect(findMethod(methods, 'stripe', 'charge')).toBeDefined()
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('tempo method excluded'))
+
+    warnSpy.mockRestore()
+  })
+
+  test('no depositAddresses returns sync SPT-only with .additional()', () => {
+    const client = createMockStripeClient()
+    const mp = stripe({ client, networkId: 'test-profile', livemode: false })
+
+    const methods = mp.defaultMethods()
+    expect(methods.additional).toBeTypeOf('function')
+
+    const withAdditional = methods.additional({})
+    expect(findMethod(withAdditional, 'stripe', 'charge')).toBeDefined()
   })
 })

--- a/src/stripe/server/Methods.ts
+++ b/src/stripe/server/Methods.ts
@@ -112,9 +112,9 @@ interface StripeMachinePayments<P extends stripe.Parameters = stripe.Parameters>
   ) => Promise<stripe.DepositAddress<N>>
   defaultMethods: (
     config?: DefaultMethodsConfig,
-  ) => P['depositAddresses'] extends Partial<Record<stripe.Network, string>>
-    ? SyncMethodsResult
-    : DefaultMethodsBuilder
+  ) => P['depositAddresses'] extends (network: stripe.Network) => Promise<string>
+    ? DefaultMethodsBuilder
+    : SyncMethodsResult
 }
 
 class DefaultMethodsBuilder implements PromiseLike<DefaultMethods> {
@@ -344,27 +344,37 @@ export function stripe<const P extends stripe.Parameters>(parameters: P): Stripe
   ): SyncMethodsResult | DefaultMethodsBuilder {
     const excluded = new Set(config?.exclude)
 
-    if (depositAddresses && typeof depositAddresses !== 'function') {
-      // Sync: static deposit addresses provided at stripe.create() time
-      const addresses = new Map(Object.entries(depositAddresses)) as Map<string, string>
-      return Object.assign(createMethodsFromAddresses(addresses, excluded), {
-        additional: (additional: AdditionalConfig) =>
-          createMethodsFromAddresses(addresses, excluded, additional),
-      }) as SyncMethodsResult
-    } else {
+    if (typeof depositAddresses === 'function') {
       // Async: resolve addresses dynamically
       return new DefaultMethodsBuilder(async (additional) => {
         const networks = neededNetworks(excluded, additional)
-        const results = await Promise.all(
+        const results = await Promise.allSettled(
           networks.map(async (network) => ({
             network,
             address: await resolveAddress(network),
           })),
         )
-        const addresses = new Map(results.map(({ network, address }) => [network, address]))
+        const addresses = new Map<string, string>()
+        for (const result of results) {
+          if (result.status === 'fulfilled') {
+            addresses.set(result.value.network, result.value.address)
+          } else {
+            const idx = results.indexOf(result)
+            console.warn(
+              `[stripe.create] ${networks[idx]} method excluded: ${(result.reason as Error)?.message ?? result.reason}`,
+            )
+          }
+        }
         return createMethodsFromAddresses(addresses, excluded, additional)
       })
     }
+
+    const addresses = new Map(Object.entries(depositAddresses ?? {})) as Map<string, string>
+
+    return Object.assign(createMethodsFromAddresses(addresses, excluded), {
+      additional: (additional: AdditionalConfig) =>
+        createMethodsFromAddresses(addresses, excluded, additional),
+    }) as SyncMethodsResult
   }
 
   return {
@@ -382,7 +392,7 @@ export function stripe<const P extends stripe.Parameters>(parameters: P): Stripe
 export namespace stripe {
   export const spt = charge_
 
-  /** @deprecated Use `stripe.spt()` instead. */
+  /** @deprecated Use `stripe.create({ ... }).spt.charge()` or `stripe.spt()` instead. */
   export const charge = charge_
 
   export const create = stripe


### PR DESCRIPTION
- `defaultMethods()` is now sync (SPT-only) when no `depositAddresses` is provided
- Function resolver path uses `Promise.allSettled` instead of `Promise.all` — failed networks are warned and excluded, successful ones still returned