### PR TITLE
feat(tempo): support machine-token payments

### DIFF
--- a/.changeset/bright-pandas-trade.md
+++ b/.changeset/bright-pandas-trade.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added first-party machine-token payments for Tempo charges, including atomic push-mode and hosted fee-sponsored pull settlement.

--- a/src/server/Methods.test-d.ts
+++ b/src/server/Methods.test-d.ts
@@ -6,7 +6,6 @@ import type { StripeClient } from '../stripe/internal/types.js'
 test('accepts the machine-token option on Tempo charges and the global constructor', () => {
   expectTypeOf(tempo.charge({ machineTokenEnabled: true })).toHaveProperty('verify')
   expectTypeOf(tempo({ machineTokenEnabled: true })[0]).toHaveProperty('verify')
-  expectTypeOf(tempo({ machineTokenEnabled: true })[1]).toHaveProperty('verify')
 })
 
 test('all server method constructors expose typed canOffer hooks', () => {

--- a/src/server/Methods.test-d.ts
+++ b/src/server/Methods.test-d.ts
@@ -3,6 +3,12 @@ import { expectTypeOf, test } from 'vp/test'
 
 import type { StripeClient } from '../stripe/internal/types.js'
 
+test('accepts the machine-token option on Tempo charges and the global constructor', () => {
+  expectTypeOf(tempo.charge({ machineTokenEnabled: true })).toHaveProperty('verify')
+  expectTypeOf(tempo({ machineTokenEnabled: true })[0]).toHaveProperty('verify')
+  expectTypeOf(tempo({ machineTokenEnabled: true })[1]).toHaveProperty('verify')
+})
+
 test('all server method constructors expose typed canOffer hooks', () => {
   tempo.charge({
     canOffer({ input, request }) {

--- a/src/server/Methods.test.ts
+++ b/src/server/Methods.test.ts
@@ -5,6 +5,16 @@ import { accounts } from '~test/tempo/viem.js'
 
 const recipient = '0x0000000000000000000000000000000000000001'
 
+describe('Tempo machine token', () => {
+  test('preserves the option on direct and global charge methods', () => {
+    const direct = tempo.charge({ machineTokenEnabled: true })
+    const [global] = tempo({ machineTokenEnabled: true })
+
+    expect((direct.defaults as { machineTokenEnabled?: boolean }).machineTokenEnabled).toBe(true)
+    expect((global.defaults as { machineTokenEnabled?: boolean }).machineTokenEnabled).toBe(true)
+  })
+})
+
 describe('composable method hooks', () => {
   test('all server method constructors forward canOffer', () => {
     const canOffer = vi.fn(() => true)

--- a/src/server/Methods.test.ts
+++ b/src/server/Methods.test.ts
@@ -8,10 +8,11 @@ const recipient = '0x0000000000000000000000000000000000000001'
 describe('Tempo machine token', () => {
   test('preserves the option on direct and global charge methods', () => {
     const direct = tempo.charge({ machineTokenEnabled: true })
-    const [global] = tempo({ machineTokenEnabled: true })
+    const [global, session] = tempo({ machineTokenEnabled: true })
 
     expect((direct.defaults as { machineTokenEnabled?: boolean }).machineTokenEnabled).toBe(true)
     expect((global.defaults as { machineTokenEnabled?: boolean }).machineTokenEnabled).toBe(true)
+    expect(session.defaults).not.toHaveProperty('machineTokenEnabled')
   })
 })
 

--- a/src/tempo/Methods.test.ts
+++ b/src/tempo/Methods.test.ts
@@ -55,6 +55,20 @@ describe('charge', () => {
     expect(result.data.methodDetails?.supportedModes).toEqual(['pull'])
   })
 
+  test('schema: serializes the machine-token hint into methodDetails', () => {
+    const result = Methods.charge.schema.request.safeParse({
+      machineTokenEnabled: true,
+      amount: '1',
+      currency: '0x20c0000000000000000000000000000000000001',
+      decimals: 6,
+      recipient: '0x1234567890abcdef1234567890abcdef12345678',
+    })
+    expect(result.success).toBe(true)
+    if (!result.success) return
+
+    expect(result.data.methodDetails?.machineTokenEnabled).toBe(true)
+  })
+
   test('schema: rejects empty supportedModes', () => {
     const result = Methods.charge.schema.request.safeParse({
       amount: '1',

--- a/src/tempo/Methods.ts
+++ b/src/tempo/Methods.ts
@@ -119,6 +119,7 @@ export const charge = Method.from({
     request: z.pipe(
       z
         .object({
+          machineTokenEnabled: z.optional(z.boolean()),
           amount: z.amount(),
           chainId: z.optional(z.number()),
           currency: z.string(),
@@ -153,16 +154,28 @@ export const charge = Method.from({
           }, 'Invalid splits'),
         ),
       z.transform(
-        ({ amount, chainId, decimals, feePayer, memo, splits, supportedModes, ...rest }) => ({
+        ({
+          machineTokenEnabled,
+          amount,
+          chainId,
+          decimals,
+          feePayer,
+          memo,
+          splits,
+          supportedModes,
+          ...rest
+        }) => ({
           ...rest,
           amount: parseUnits(amount, decimals).toString(),
-          ...(chainId !== undefined ||
+          ...(machineTokenEnabled !== undefined ||
+          chainId !== undefined ||
           feePayer !== undefined ||
           memo !== undefined ||
           splits !== undefined ||
           supportedModes !== undefined
             ? {
                 methodDetails: {
+                  ...(machineTokenEnabled !== undefined && { machineTokenEnabled }),
                   ...(chainId !== undefined && { chainId }),
                   ...(feePayer !== undefined && { feePayer }),
                   ...(memo !== undefined && { memo }),

--- a/src/tempo/client/Charge.test.ts
+++ b/src/tempo/client/Charge.test.ts
@@ -256,6 +256,166 @@ describe('tempo.charge client', () => {
     }
   })
 
+  test('tries the enabled machine token before direct balance and auto-swap', async () => {
+    vi.resetModules()
+    const chainId = 42431
+    const machineTokenCalls = [{ data: '0x1234', to: '0x4444444444444444444444444444444444444444' }]
+    const autoSwapCalls = [{ data: '0x5678', to: '0x5555555555555555555555555555555555555555' }]
+    let hasMachineTokens = true
+    const findMachineTokenCalls = vi.fn(async (_client: unknown, _parameters: unknown) =>
+      hasMachineTokens ? machineTokenCalls : undefined,
+    )
+    const findAutoSwapCalls = vi.fn(async () => autoSwapCalls)
+    const prepareTransactionRequest = vi.fn(
+      async (_client: unknown, _parameters: { calls: readonly unknown[] }) => ({}),
+    )
+    const signTransaction = vi.fn(async () => '0xdeadbeef')
+    vi.doMock('viem/actions', () => ({
+      prepareTransactionRequest,
+      sendCallsSync: vi.fn(),
+      signTransaction,
+      signTypedData: vi.fn(),
+    }))
+    vi.doMock('../internal/machine-token.js', () => ({
+      findCalls: findMachineTokenCalls,
+    }))
+    vi.doMock('../internal/auto-swap.js', () => ({
+      defaultCurrencies: [currency],
+      findCalls: findAutoSwapCalls,
+      resolve: vi.fn(() => ({ tokenIn: [currency], slippage: 1 })),
+    }))
+
+    try {
+      const { charge: chargeWithMockedFunding } = await import('./Charge.js')
+      const client = createClient({
+        account,
+        chain: tempoLocalnet,
+        transport: http('http://127.0.0.1'),
+      })
+      const method = chargeWithMockedFunding({
+        account,
+        autoSwap: true,
+        getClient: () => client,
+      })
+
+      const credential = Credential.deserialize(
+        await method.createCredential({
+          challenge: createChallenge({
+            amount: '1',
+            chainId,
+            feePayer: true,
+            machineTokenEnabled: true,
+            supportedModes: ['pull', 'push'],
+          }),
+          context: {},
+        }),
+      )
+
+      expect(findMachineTokenCalls).toHaveBeenCalledOnce()
+      expect(findMachineTokenCalls.mock.calls[0]?.[1]).toMatchObject({
+        account: account.address,
+        chainId,
+        currency,
+      })
+      expect(findAutoSwapCalls).not.toHaveBeenCalled()
+      expect(prepareTransactionRequest.mock.calls[0]?.[1]).toMatchObject({
+        calls: machineTokenCalls,
+      })
+      expect(signTransaction).toHaveBeenCalledWith(
+        client,
+        expect.objectContaining({ feePayer: true }),
+      )
+      expect(credential.payload).toEqual({ signature: '0xdeadbeef', type: 'transaction' })
+
+      hasMachineTokens = false
+      await method.createCredential({
+        challenge: createChallenge({
+          amount: '1',
+          chainId,
+          feePayer: true,
+          machineTokenEnabled: true,
+          supportedModes: ['pull', 'push'],
+        }),
+        context: {},
+      })
+      expect(findAutoSwapCalls).toHaveBeenCalledOnce()
+      expect(prepareTransactionRequest.mock.calls[1]?.[1].calls).toEqual([
+        ...autoSwapCalls,
+        expect.objectContaining({ address: currency, functionName: 'transferWithMemo' }),
+      ])
+    } finally {
+      vi.doUnmock('viem/actions')
+      vi.doUnmock('../internal/machine-token.js')
+      vi.doUnmock('../internal/auto-swap.js')
+      vi.resetModules()
+    }
+  })
+
+  test('broadcasts local machine-token calls as one Tempo transaction', async () => {
+    vi.resetModules()
+    const chainId = 4217
+    const hash = `0x${'ab'.repeat(32)}`
+    const machineTokenCalls = [
+      { data: '0x1234', to: '0x4444444444444444444444444444444444444444' },
+      { data: '0x5678', to: '0x5555555555555555555555555555555555555555' },
+    ]
+    const sendCallsSync = vi.fn()
+    const sendTransactionSync = vi.fn(async () => ({ transactionHash: hash }))
+    vi.doMock('viem/actions', () => ({
+      prepareTransactionRequest: vi.fn(),
+      sendCallsSync,
+      sendTransactionSync,
+      signTransaction: vi.fn(),
+      signTypedData: vi.fn(),
+    }))
+    vi.doMock('../internal/machine-token.js', () => ({
+      findCalls: vi.fn(async () => machineTokenCalls),
+    }))
+
+    try {
+      const { charge: chargeWithMockedActions } = await import('./Charge.js')
+      const client = createClient({
+        account,
+        chain: tempoLocalnet,
+        transport: http('http://127.0.0.1'),
+      })
+      const method = chargeWithMockedActions({
+        account,
+        getClient: () => client,
+        mode: 'push',
+      })
+
+      const credential = Credential.deserialize(
+        await method.createCredential({
+          challenge: createChallenge({
+            amount: '1',
+            chainId,
+            feePayer: true,
+            machineTokenEnabled: true,
+            supportedModes: ['push'],
+          }),
+          context: {},
+        }),
+      )
+
+      expect(sendTransactionSync).toHaveBeenCalledWith(
+        client,
+        expect.objectContaining({
+          account,
+          calls: machineTokenCalls,
+          nonceKey: 'expiring',
+        }),
+      )
+      expect((sendTransactionSync as any).mock.calls[0]?.[1]).not.toHaveProperty('feePayer')
+      expect(sendCallsSync).not.toHaveBeenCalled()
+      expect(credential.payload).toEqual({ hash, type: 'hash' })
+    } finally {
+      vi.doUnmock('viem/actions')
+      vi.doUnmock('../internal/machine-token.js')
+      vi.resetModules()
+    }
+  })
+
   test('zero-amount proof binds to the root payer for an access-key account', async () => {
     vi.resetModules()
     // Capture the typed data so we can assert what the proof commits to.

--- a/src/tempo/client/Charge.test.ts
+++ b/src/tempo/client/Charge.test.ts
@@ -262,8 +262,8 @@ describe('tempo.charge client', () => {
     const machineTokenCalls = [{ data: '0x1234', to: '0x4444444444444444444444444444444444444444' }]
     const autoSwapCalls = [{ data: '0x5678', to: '0x5555555555555555555555555555555555555555' }]
     let hasMachineTokens = true
-    const findMachineTokenCalls = vi.fn(async (_client: unknown, _parameters: unknown) =>
-      hasMachineTokens ? machineTokenCalls : undefined,
+    const findMachineTokenRoute = vi.fn(async (_client: unknown, _parameters: unknown) =>
+      hasMachineTokens ? { calls: machineTokenCalls } : undefined,
     )
     const findAutoSwapCalls = vi.fn(async () => autoSwapCalls)
     const prepareTransactionRequest = vi.fn(
@@ -277,7 +277,7 @@ describe('tempo.charge client', () => {
       signTypedData: vi.fn(),
     }))
     vi.doMock('../internal/machine-token.js', () => ({
-      findCalls: findMachineTokenCalls,
+      findRoute: findMachineTokenRoute,
     }))
     vi.doMock('../internal/auto-swap.js', () => ({
       defaultCurrencies: [currency],
@@ -311,8 +311,8 @@ describe('tempo.charge client', () => {
         }),
       )
 
-      expect(findMachineTokenCalls).toHaveBeenCalledOnce()
-      expect(findMachineTokenCalls.mock.calls[0]?.[1]).toMatchObject({
+      expect(findMachineTokenRoute).toHaveBeenCalledOnce()
+      expect(findMachineTokenRoute.mock.calls[0]?.[1]).toMatchObject({
         account: account.address,
         chainId,
         currency,
@@ -369,7 +369,7 @@ describe('tempo.charge client', () => {
       signTypedData: vi.fn(),
     }))
     vi.doMock('../internal/machine-token.js', () => ({
-      findCalls: vi.fn(async () => machineTokenCalls),
+      findRoute: vi.fn(async () => ({ calls: machineTokenCalls })),
     }))
 
     try {

--- a/src/tempo/client/Charge.ts
+++ b/src/tempo/client/Charge.ts
@@ -3,6 +3,7 @@ import type { Address } from 'viem'
 import {
   prepareTransactionRequest,
   sendCallsSync,
+  sendTransactionSync,
   signTypedData,
   signTransaction,
 } from 'viem/actions'
@@ -18,6 +19,7 @@ import * as Attribution from '../Attribution.js'
 import * as AutoSwap from '../internal/auto-swap.js'
 import * as Charge_internal from '../internal/charge.js'
 import * as defaults from '../internal/defaults.js'
+import * as MachineToken from '../internal/machine-token.js'
 import * as Proof from '../internal/proof.js'
 import * as Methods from '../Methods.js'
 import type * as AccountResolution from './ResolveAccount.js'
@@ -141,6 +143,7 @@ export function charge(parameters: charge.Parameters = {}) {
         context?.autoSwap ?? parameters.autoSwap,
         AutoSwap.defaultCurrencies,
       )
+      const machineTokenEnabled = methodDetails?.machineTokenEnabled === true
 
       const account =
         (await parameters.resolveAccount?.({
@@ -148,7 +151,7 @@ export function charge(parameters: charge.Parameters = {}) {
           chainId,
           operation: {
             kind: 'executeCalls',
-            ...(autoSwap ? {} : { calls: transferCalls }),
+            ...(autoSwap || machineTokenEnabled ? {} : { calls: transferCalls }),
           },
         })) ?? defaultAccount
 
@@ -165,17 +168,27 @@ export function charge(parameters: charge.Parameters = {}) {
         return supportedModes[0]!
       })()
 
-      const swapCalls = autoSwap
-        ? await AutoSwap.findCalls(client, {
+      const machineTokenCalls = machineTokenEnabled
+        ? await MachineToken.findCalls(client, {
             account: account.address,
-            amountOut: BigInt(amount),
-            tokenOut: currency,
-            tokenIn: autoSwap.tokenIn,
-            slippage: autoSwap.slippage,
+            chainId,
+            currency,
+            transfers,
           })
         : undefined
 
-      const calls = [...(swapCalls ?? []), ...transferCalls]
+      const swapCalls =
+        !machineTokenCalls && autoSwap
+          ? await AutoSwap.findCalls(client, {
+              account: account.address,
+              amountOut: BigInt(amount),
+              tokenOut: currency,
+              tokenIn: autoSwap.tokenIn,
+              slippage: autoSwap.slippage,
+            })
+          : undefined
+
+      const calls = machineTokenCalls ?? [...(swapCalls ?? []), ...transferCalls]
 
       const validBefore = (() => {
         const defaultExpiry = Math.floor(Date.now() / 1000) + 25
@@ -185,11 +198,24 @@ export function charge(parameters: charge.Parameters = {}) {
       })()
 
       if (mode === 'push') {
-        const { receipts } = await sendCallsSync(client, {
-          account,
-          calls: calls as never,
-          experimental_fallback: true,
-        })
+        const { receipts } =
+          account.type === 'local'
+            ? {
+                receipts: [
+                  await sendTransactionSync(client, {
+                    account,
+                    calls,
+                    nonceKey: 'expiring',
+                    validBefore,
+                  } as never),
+                ],
+              }
+            : await sendCallsSync(client, {
+                account,
+                calls: calls as never,
+                experimental_fallback: calls.length === 1,
+                forceAtomic: calls.length > 1,
+              })
         const hash = receipts?.[0]?.transactionHash
         if (!hash) throw new Error('No transaction receipt returned.')
         return Credential.serialize({

--- a/src/tempo/client/Charge.ts
+++ b/src/tempo/client/Charge.ts
@@ -168,8 +168,8 @@ export function charge(parameters: charge.Parameters = {}) {
         return supportedModes[0]!
       })()
 
-      const machineTokenCalls = machineTokenEnabled
-        ? await MachineToken.findCalls(client, {
+      const machineTokenRoute = machineTokenEnabled
+        ? await MachineToken.findRoute(client, {
             account: account.address,
             chainId,
             currency,
@@ -178,7 +178,7 @@ export function charge(parameters: charge.Parameters = {}) {
         : undefined
 
       const swapCalls =
-        !machineTokenCalls && autoSwap
+        !machineTokenRoute && autoSwap
           ? await AutoSwap.findCalls(client, {
               account: account.address,
               amountOut: BigInt(amount),
@@ -188,7 +188,7 @@ export function charge(parameters: charge.Parameters = {}) {
             })
           : undefined
 
-      const calls = machineTokenCalls ?? [...(swapCalls ?? []), ...transferCalls]
+      const calls = machineTokenRoute?.calls ?? [...(swapCalls ?? []), ...transferCalls]
 
       const validBefore = (() => {
         const defaultExpiry = Math.floor(Date.now() / 1000) + 25

--- a/src/tempo/internal/defaults.ts
+++ b/src/tempo/internal/defaults.ts
@@ -20,6 +20,18 @@ export const currency = {
   [chainId.testnet]: tokens.pathUsd,
 } as const satisfies Record<ChainId, string>
 
+/** First-party machine-token swap deployments. */
+export const machineToken = {
+  [chainId.mainnet]: {
+    swap: '0xC6D32f013E0fA3e83B63Dc680E99826761595732',
+    token: '0x20C0000000000000000000003793c39601711f19',
+  },
+  [chainId.testnet]: {
+    swap: '0x07f1FE0467Ae01DE340024aa4b7DD9729b1c169b',
+    token: '0x20c000000000000000000000f85bbCa724044De0',
+  },
+} as const satisfies Partial<Record<ChainId, { swap: `0x${string}`; token: `0x${string}` }>>
+
 /**
  * Default token decimals for TIP-20 stablecoins (e.g. pathUSD, USDC).
  *

--- a/src/tempo/internal/machine-token.test.ts
+++ b/src/tempo/internal/machine-token.test.ts
@@ -26,26 +26,31 @@ describe('Tempo machine token', () => {
 
     try {
       const MachineToken = await import('./machine-token.js')
-      const calls = await MachineToken.findCalls(client, {
+      const route = await MachineToken.findRoute(client, {
         account: payer,
         chainId,
         currency: targetToken,
         transfers,
       })
 
-      expect(calls).toHaveLength(2)
+      expect(route?.calls).toHaveLength(2)
       expect(
-        MachineToken.validateCalls({ calls: calls!, chainId, currency: targetToken, transfers }),
+        MachineToken.matchRoute({
+          calls: route!.calls,
+          chainId,
+          currency: targetToken,
+          transfers,
+        })?.transfers,
       ).toEqual(transfers)
       expect(
-        MachineToken.validateCalls({
-          calls: calls!,
+        MachineToken.matchRoute({
+          calls: route!.calls,
           chainId,
           currency: targetToken,
           transfers: [{ amount: transfers[0]!.amount, recipient }],
-        }),
+        })?.transfers,
       ).toEqual(transfers)
-      expect(MachineToken.isSwap({ address: deployment.swap, chainId })).toBe(true)
+      expect(route?.settlementSender).toBe(deployment.swap)
     } finally {
       vi.doUnmock('viem/actions')
       vi.resetModules()
@@ -62,7 +67,7 @@ describe('Tempo machine token', () => {
     try {
       const MachineToken = await import('./machine-token.js')
       await expect(
-        MachineToken.findCalls(client, {
+        MachineToken.findRoute(client, {
           account: payer,
           chainId,
           currency: targetToken,
@@ -87,7 +92,7 @@ describe('Tempo machine token', () => {
     try {
       const MachineToken = await import('./machine-token.js')
       await expect(
-        MachineToken.findCalls(client, {
+        MachineToken.findRoute(client, {
           account: payer,
           chainId,
           currency: targetToken,
@@ -109,7 +114,7 @@ describe('Tempo machine token', () => {
 
     try {
       const MachineToken = await import('./machine-token.js')
-      const calls = await MachineToken.findCalls(client, {
+      const route = await MachineToken.findRoute(client, {
         account: payer,
         chainId,
         currency: targetToken,
@@ -117,19 +122,19 @@ describe('Tempo machine token', () => {
       })
 
       expect(
-        MachineToken.validateCalls({
-          calls: [...calls!, calls![0]!],
+        MachineToken.matchRoute({
+          calls: [...route!.calls, route!.calls[0]!],
           chainId,
           currency: targetToken,
           transfers,
         }),
-      ).toBe(false)
+      ).toBeUndefined()
       expect(
-        MachineToken.validateCalls({
+        MachineToken.matchRoute({
           calls: [
-            calls![0]!,
+            route!.calls[0]!,
             {
-              ...calls![1],
+              ...route!.calls[1],
               data: encodeFunctionData({
                 abi: Abis.tip20,
                 functionName: 'transfer',
@@ -141,7 +146,7 @@ describe('Tempo machine token', () => {
           currency: targetToken,
           transfers,
         }),
-      ).toBe(false)
+      ).toBeUndefined()
     } finally {
       vi.doUnmock('viem/actions')
       vi.resetModules()
@@ -151,13 +156,24 @@ describe('Tempo machine token', () => {
   test('does not use unconfigured chains', async () => {
     const MachineToken = await import('./machine-token.js')
     await expect(
-      MachineToken.findCalls(client, {
+      MachineToken.findRoute(client, {
         account: payer,
         chainId: 69420,
         currency: targetToken,
         transfers,
       }),
     ).resolves.toBeUndefined()
-    expect(MachineToken.isSwap({ address: deployment.swap, chainId: 69420 })).toBe(false)
+    expect(MachineToken.getSettlementSender(69420)).toBeUndefined()
+  })
+
+  test('falls back for split charges', async () => {
+    const MachineToken = await import('./machine-token.js')
+    expect(
+      MachineToken.getRoute({
+        chainId,
+        currency: targetToken,
+        transfers: [...transfers, transfers[0]!],
+      }),
+    ).toBeUndefined()
   })
 })

--- a/src/tempo/internal/machine-token.test.ts
+++ b/src/tempo/internal/machine-token.test.ts
@@ -1,0 +1,163 @@
+import { createClient, custom, encodeFunctionData } from 'viem'
+import { Abis } from 'viem/tempo'
+import { describe, expect, test, vi } from 'vp/test'
+
+import * as defaults from './defaults.js'
+import type { Transfer } from './machine-token.js'
+
+const chainId = defaults.chainId.testnet
+const deployment = defaults.machineToken[chainId]
+const targetToken = '0x20c0000000000000000000000000000000000001'
+const recipient = '0x2222222222222222222222222222222222222222'
+const payer = '0x1111111111111111111111111111111111111111'
+const memo = `0x${'ab'.repeat(32)}` as const
+const client = createClient({
+  transport: custom({ request: async () => undefined as never }),
+})
+const transfers = [{ amount: 1_000_000n, memo, recipient }] satisfies readonly Transfer[]
+
+describe('Tempo machine token', () => {
+  test('builds and validates the exact first-party approve + swapTo calls', async () => {
+    vi.resetModules()
+    vi.doMock('viem/actions', () => ({
+      call: vi.fn(),
+      readContract: vi.fn(async () => 1_000_000n),
+    }))
+
+    try {
+      const MachineToken = await import('./machine-token.js')
+      const calls = await MachineToken.findCalls(client, {
+        account: payer,
+        chainId,
+        currency: targetToken,
+        transfers,
+      })
+
+      expect(calls).toHaveLength(2)
+      expect(
+        MachineToken.validateCalls({ calls: calls!, chainId, currency: targetToken, transfers }),
+      ).toEqual(transfers)
+      expect(
+        MachineToken.validateCalls({
+          calls: calls!,
+          chainId,
+          currency: targetToken,
+          transfers: [{ amount: transfers[0]!.amount, recipient }],
+        }),
+      ).toEqual(transfers)
+      expect(MachineToken.isSwap({ address: deployment.swap, chainId })).toBe(true)
+    } finally {
+      vi.doUnmock('viem/actions')
+      vi.resetModules()
+    }
+  })
+
+  test('falls back when the payer lacks sufficient machine tokens', async () => {
+    vi.resetModules()
+    vi.doMock('viem/actions', () => ({
+      call: vi.fn(),
+      readContract: vi.fn(async () => 999_999n),
+    }))
+
+    try {
+      const MachineToken = await import('./machine-token.js')
+      await expect(
+        MachineToken.findCalls(client, {
+          account: payer,
+          chainId,
+          currency: targetToken,
+          transfers,
+        }),
+      ).resolves.toBeUndefined()
+    } finally {
+      vi.doUnmock('viem/actions')
+      vi.resetModules()
+    }
+  })
+
+  test('falls back when the swap cannot be simulated', async () => {
+    vi.resetModules()
+    vi.doMock('viem/actions', () => ({
+      call: vi.fn(async () => {
+        throw new Error('merchant is not allowlisted')
+      }),
+      readContract: vi.fn(async () => 1_000_000n),
+    }))
+
+    try {
+      const MachineToken = await import('./machine-token.js')
+      await expect(
+        MachineToken.findCalls(client, {
+          account: payer,
+          chainId,
+          currency: targetToken,
+          transfers,
+        }),
+      ).resolves.toBeUndefined()
+    } finally {
+      vi.doUnmock('viem/actions')
+      vi.resetModules()
+    }
+  })
+
+  test('rejects extra calls and any mismatch in the owned swap', async () => {
+    vi.resetModules()
+    vi.doMock('viem/actions', () => ({
+      call: vi.fn(),
+      readContract: vi.fn(async () => 1_000_000n),
+    }))
+
+    try {
+      const MachineToken = await import('./machine-token.js')
+      const calls = await MachineToken.findCalls(client, {
+        account: payer,
+        chainId,
+        currency: targetToken,
+        transfers,
+      })
+
+      expect(
+        MachineToken.validateCalls({
+          calls: [...calls!, calls![0]!],
+          chainId,
+          currency: targetToken,
+          transfers,
+        }),
+      ).toBe(false)
+      expect(
+        MachineToken.validateCalls({
+          calls: [
+            calls![0]!,
+            {
+              ...calls![1],
+              data: encodeFunctionData({
+                abi: Abis.tip20,
+                functionName: 'transfer',
+                args: [recipient, transfers[0]!.amount],
+              }),
+            },
+          ],
+          chainId,
+          currency: targetToken,
+          transfers,
+        }),
+      ).toBe(false)
+    } finally {
+      vi.doUnmock('viem/actions')
+      vi.resetModules()
+    }
+  })
+
+  test('does not use unconfigured chains', async () => {
+    const MachineToken = await import('./machine-token.js')
+    await expect(
+      MachineToken.findCalls(client, {
+        account: payer,
+        chainId: 69420,
+        currency: targetToken,
+        transfers,
+      }),
+    ).resolves.toBeUndefined()
+    expect(MachineToken.isSwap({ address: deployment.swap, chainId: 69420 })).toBe(false)
+  })
+})

--- a/src/tempo/internal/machine-token.ts
+++ b/src/tempo/internal/machine-token.ts
@@ -40,8 +40,8 @@ type RouteCall = {
 
 type Route = {
   calls: readonly [RouteCall, RouteCall]
-  token: Address
-  transfer: { amount: bigint; memo: Hex.Hex; recipient: Address }
+  settlementSender: Address
+  transfers: readonly [{ amount: bigint; memo: Hex.Hex; recipient: Address }]
 }
 
 export type Transfer = {
@@ -66,7 +66,7 @@ export function isSupported(chainId: number | undefined): boolean {
   return !!getDeployment(chainId)
 }
 
-/** Resolves the canonical first-party machine-token settlement route. */
+/** Resolves the canonical first-party settlement route for a compatible charge. */
 export function getRoute(parameters: {
   chainId: number | undefined
   currency: Address
@@ -97,13 +97,13 @@ export function getRoute(parameters: {
         to: deployment.swap,
       },
     ],
-    token: deployment.token,
-    transfer: { amount, memo, recipient: transfer.recipient },
+    settlementSender: deployment.swap,
+    transfers: [{ amount, memo, recipient: transfer.recipient }],
   }
 }
 
-/** Builds and simulates the first-party machine-token settlement calls. */
-export async function findCalls(
+/** Builds and simulates the first-party settlement route. */
+export async function findRoute(
   client: Client,
   parameters: {
     account: Address
@@ -111,7 +111,7 @@ export async function findCalls(
     currency: Address
     transfers: readonly Transfer[]
   },
-): Promise<readonly Call[] | undefined> {
+): Promise<Route | undefined> {
   const route = getRoute(parameters)
   if (!route) return undefined
 
@@ -120,28 +120,28 @@ export async function findCalls(
       client,
       Actions.token.getBalance.call(client, {
         account: parameters.account,
-        token: route.token,
+        token: route.calls[0].to,
       }) as never,
     )
-    if ((balance as bigint) < route.transfer.amount) return undefined
+    if ((balance as bigint) < route.transfers[0].amount) return undefined
 
     await call(client, { account: parameters.account, calls: route.calls } as never)
-    return route.calls
+    return route
   } catch {
     return undefined
   }
 }
 
-/** Validates the exact first-party machine-token settlement route. */
-export function validateCalls(parameters: {
+/** Matches an exact first-party settlement route. */
+export function matchRoute(parameters: {
   calls: readonly Call[]
   chainId: number | undefined
   currency: Address
   transfers: readonly Transfer[]
-}): readonly Transfer[] | false {
+}): Route | undefined {
   const transfer = parameters.transfers.length === 1 ? parameters.transfers[0] : undefined
   const swap = parameters.calls[1]
-  if (!transfer || parameters.calls.length !== 2 || !swap?.data) return false
+  if (!transfer || parameters.calls.length !== 2 || !swap?.data) return undefined
 
   try {
     const decoded = decodeFunctionData({ abi: swapAbi, data: swap.data })
@@ -149,7 +149,7 @@ export function validateCalls(parameters: {
       ...parameters,
       transfers: [{ ...transfer, memo: transfer.memo ?? decoded.args[4] }],
     })
-    if (!route) return false
+    if (!route) return undefined
     if (
       parameters.calls.some((call, index) => {
         const expected = route.calls[index]
@@ -163,16 +163,15 @@ export function validateCalls(parameters: {
         )
       })
     )
-      return false
+      return undefined
 
-    return [route.transfer]
+    return route
   } catch {
-    return false
+    return undefined
   }
 }
 
-/** Returns whether an address is the first-party machine-token swap. */
-export function isSwap(parameters: { address: Address; chainId: number | undefined }): boolean {
-  const deployment = getDeployment(parameters.chainId)
-  return !!deployment && isAddressEqual(parameters.address, deployment.swap)
+/** Returns the trusted sender that settles the configured route on a chain. */
+export function getSettlementSender(chainId: number | undefined): Address | undefined {
+  return getDeployment(chainId)?.swap
 }

--- a/src/tempo/internal/machine-token.ts
+++ b/src/tempo/internal/machine-token.ts
@@ -1,0 +1,178 @@
+import type * as Hex from 'ox/Hex'
+import {
+  decodeFunctionData,
+  encodeFunctionData,
+  isAddressEqual,
+  type Address,
+  type Client,
+} from 'viem'
+import { call, readContract } from 'viem/actions'
+import { Abis, Actions } from 'viem/tempo'
+
+import * as defaults from './defaults.js'
+
+const swapAbi = [
+  {
+    inputs: [
+      { name: 'inputToken', type: 'address' },
+      { name: 'amount', type: 'uint256' },
+      { name: 'targetToken', type: 'address' },
+      { name: 'recipient', type: 'address' },
+      { name: 'memo', type: 'bytes32' },
+    ],
+    name: 'swapTo',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+] as const
+
+export type Call = {
+  data?: Hex.Hex | undefined
+  to?: Address | undefined
+  value?: bigint | undefined
+}
+
+type RouteCall = {
+  data: Hex.Hex
+  to: Address
+}
+
+type Route = {
+  calls: readonly [RouteCall, RouteCall]
+  token: Address
+  transfer: { amount: bigint; memo: Hex.Hex; recipient: Address }
+}
+
+export type Transfer = {
+  amount: bigint | string
+  memo?: string | undefined
+  recipient: Address
+}
+
+/** Shared first-party machine-token configuration for Tempo methods. */
+export type Options = {
+  /** Enables first-party machine-token settlement for supported Tempo methods. */
+  machineTokenEnabled?: boolean | undefined
+}
+
+function getDeployment(chainId: number | undefined) {
+  if (chainId === undefined) return undefined
+  return defaults.machineToken[chainId as keyof typeof defaults.machineToken]
+}
+
+/** Returns whether a first-party machine-token route is deployed on a chain. */
+export function isSupported(chainId: number | undefined): boolean {
+  return !!getDeployment(chainId)
+}
+
+/** Resolves the canonical first-party machine-token settlement route. */
+export function getRoute(parameters: {
+  chainId: number | undefined
+  currency: Address
+  transfers: readonly Transfer[]
+}): Route | undefined {
+  const deployment = getDeployment(parameters.chainId)
+  const transfer = parameters.transfers.length === 1 ? parameters.transfers[0] : undefined
+  if (!deployment || !transfer?.memo) return undefined
+  const amount = BigInt(transfer.amount)
+  const memo = transfer.memo as Hex.Hex
+
+  return {
+    calls: [
+      {
+        data: encodeFunctionData({
+          abi: Abis.tip20,
+          functionName: 'approve',
+          args: [deployment.swap, amount],
+        }),
+        to: deployment.token,
+      },
+      {
+        data: encodeFunctionData({
+          abi: swapAbi,
+          functionName: 'swapTo',
+          args: [deployment.token, amount, parameters.currency, transfer.recipient, memo],
+        }),
+        to: deployment.swap,
+      },
+    ],
+    token: deployment.token,
+    transfer: { amount, memo, recipient: transfer.recipient },
+  }
+}
+
+/** Builds and simulates the first-party machine-token settlement calls. */
+export async function findCalls(
+  client: Client,
+  parameters: {
+    account: Address
+    chainId: number
+    currency: Address
+    transfers: readonly Transfer[]
+  },
+): Promise<readonly Call[] | undefined> {
+  const route = getRoute(parameters)
+  if (!route) return undefined
+
+  try {
+    const balance = await readContract(
+      client,
+      Actions.token.getBalance.call(client, {
+        account: parameters.account,
+        token: route.token,
+      }) as never,
+    )
+    if ((balance as bigint) < route.transfer.amount) return undefined
+
+    await call(client, { account: parameters.account, calls: route.calls } as never)
+    return route.calls
+  } catch {
+    return undefined
+  }
+}
+
+/** Validates the exact first-party machine-token settlement route. */
+export function validateCalls(parameters: {
+  calls: readonly Call[]
+  chainId: number | undefined
+  currency: Address
+  transfers: readonly Transfer[]
+}): readonly Transfer[] | false {
+  const transfer = parameters.transfers.length === 1 ? parameters.transfers[0] : undefined
+  const swap = parameters.calls[1]
+  if (!transfer || parameters.calls.length !== 2 || !swap?.data) return false
+
+  try {
+    const decoded = decodeFunctionData({ abi: swapAbi, data: swap.data })
+    const route = getRoute({
+      ...parameters,
+      transfers: [{ ...transfer, memo: transfer.memo ?? decoded.args[4] }],
+    })
+    if (!route) return false
+    if (
+      parameters.calls.some((call, index) => {
+        const expected = route.calls[index]
+        return (
+          !call.data ||
+          !call.to ||
+          !expected ||
+          (call.value ?? 0n) !== 0n ||
+          !isAddressEqual(call.to, expected.to) ||
+          call.data.toLowerCase() !== expected.data.toLowerCase()
+        )
+      })
+    )
+      return false
+
+    return [route.transfer]
+  } catch {
+    return false
+  }
+}
+
+/** Returns whether an address is the first-party machine-token swap. */
+export function isSwap(parameters: { address: Address; chainId: number | undefined }): boolean {
+  const deployment = getDeployment(parameters.chainId)
+  return !!deployment && isAddressEqual(parameters.address, deployment.swap)
+}

--- a/src/tempo/server/Charge.test.ts
+++ b/src/tempo/server/Charge.test.ts
@@ -3,7 +3,14 @@ import { Mppx as Mppx_client, tempo as tempo_client } from 'mppx/client'
 import { Mppx as Mppx_server, tempo as tempo_server } from 'mppx/server'
 import { P256, type Hex, WebAuthnP256 } from 'ox'
 import { SignatureEnvelope, TxEnvelopeTempo } from 'ox/tempo'
-import { createClient, custom, encodeFunctionData, parseSignature, parseUnits } from 'viem'
+import {
+  createClient,
+  custom,
+  encodeFunctionData,
+  maxUint256,
+  parseSignature,
+  parseUnits,
+} from 'viem'
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts'
 import {
   getTransactionReceipt,
@@ -21,6 +28,7 @@ import { accounts, asset, chain, client, fundAccount, http } from '~test/tempo/v
 import * as Store from '../../Store.js'
 import * as Attribution from '../Attribution.js'
 import * as defaults from '../internal/defaults.js'
+import * as MachineToken from '../internal/machine-token.js'
 import * as Proof from '../internal/proof.js'
 
 const realm = 'api.example.com'
@@ -999,6 +1007,82 @@ describe('tempo', () => {
   })
 
   describe('intent: charge; type: transaction; via Mppx', () => {
+    test('behavior: advertises the machine-token hint and validates owned calls', async () => {
+      const machineTokenClient = createClient({
+        account: accounts[1],
+        chain: { ...chain, id: defaults.chainId.testnet },
+        transport: custom({
+          async request({ method }) {
+            if (method === 'eth_chainId') return `0x${defaults.chainId.testnet.toString(16)}`
+            if (method === 'eth_call') return '0x'
+            throw new Error(`Unexpected machine-token test RPC method: ${method}`)
+          },
+        }),
+      })
+      const [method] = tempo_server({
+        machineTokenEnabled: true,
+        account: accounts[0],
+        currency: asset,
+        feePayer: true,
+        getClient: () => machineTokenClient,
+        memo: `0x${'ab'.repeat(32)}`,
+        supportedModes: ['pull', 'push'],
+        testnet: true,
+      })
+      const machineTokenServer = Mppx_server.create({ methods: [method], realm, secretKey })
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await Mppx_server.toNodeListener(
+          machineTokenServer.charge({ amount: '1', decimals: 6, recipient: accounts[0].address }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
+      })
+
+      const response = await fetch(httpServer.url)
+      const challenge = Challenge.fromResponse(response, {
+        methods: [tempo_client.charge()],
+      })
+      expect(challenge.request.methodDetails?.machineTokenEnabled).toBe(true)
+      expect(challenge.request.methodDetails).toMatchObject({
+        feePayer: true,
+        supportedModes: ['pull', 'push'],
+      })
+
+      const amount = BigInt(challenge.request.amount)
+      const memo = challenge.request.methodDetails!.memo as Hex.Hex
+      const calls = MachineToken.getRoute({
+        chainId: defaults.chainId.testnet,
+        currency: asset,
+        transfers: [{ amount, memo, recipient: accounts[0].address }],
+      })!.calls
+      const signature = await signTransaction(machineTokenClient, {
+        account: accounts[1],
+        calls,
+        gas: 100_000n,
+        maxFeePerGas: 1_000_000_000n,
+        maxPriorityFeePerGas: 1_000_000_000n,
+        nonce: 0,
+        nonceKey: maxUint256,
+        feePayer: true,
+        validBefore: Math.floor(Date.now() / 1_000) + 25,
+      } as never)
+      const credential = Credential.from({
+        challenge,
+        payload: { signature, type: 'transaction' as const },
+        source: `did:pkh:eip155:${defaults.chainId.testnet}:${accounts[1].address}`,
+      })
+      await expect(
+        method.validate?.({
+          credential: credential as never,
+          request: credential.challenge.request as never,
+        }),
+      ).resolves.toMatchObject({
+        details: { mode: 'pull', sender: accounts[1].address.toLowerCase() },
+      })
+
+      httpServer.close()
+    })
+
     test('behavior: rejects pull then push replay of the same transaction hash', async () => {
       const dedupServer = Mppx_server.create({
         methods: [
@@ -2297,6 +2381,15 @@ describe('tempo', () => {
         for await (const chunk of req) requestBody += chunk
         const request = JSON.parse(requestBody)
         feePayerRequests.push(request)
+
+        if (request.method === 'eth_sendRawTransactionSync') {
+          sequence.push('relay-broadcast')
+          const result = await client.request(request)
+          res.setHeader('content-type', 'application/json')
+          res.end(JSON.stringify({ id: request.id, jsonrpc: '2.0', result }))
+          return
+        }
+
         sequence.push('complete')
 
         const transaction = request.params[0]
@@ -2387,8 +2480,11 @@ describe('tempo', () => {
 
       const response = await mppx.fetch(httpServer.url)
       expect(response.status).toBe(200)
-      expect(feePayerRequests.map(({ method }) => method)).toEqual(['eth_fillTransaction'])
-      expect(sequence).toEqual(['simulate', 'complete', 'simulate', 'broadcast'])
+      expect(feePayerRequests.map(({ method }) => method)).toEqual([
+        'eth_fillTransaction',
+        'eth_sendRawTransactionSync',
+      ])
+      expect(sequence).toEqual(['simulate', 'complete', 'simulate', 'relay-broadcast'])
 
       const receipt = Receipt.fromResponse(response)
       expect(receipt.status).toBe('success')
@@ -2404,9 +2500,9 @@ describe('tempo', () => {
       const rejected = await mppx.fetch(httpServer.url)
 
       expect(rejected.status).not.toBe(200)
-      expect(feePayerRequests).toHaveLength(2)
+      expect(feePayerRequests).toHaveLength(3)
       expect(sequence.slice(0, 2)).toEqual(['simulate', 'complete'])
-      expect(sequence).not.toContain('broadcast')
+      expect(sequence).not.toContain('relay-broadcast')
 
       httpServer.close()
       feePayerServer.close()

--- a/src/tempo/server/Charge.test.ts
+++ b/src/tempo/server/Charge.test.ts
@@ -6,7 +6,10 @@ import { SignatureEnvelope, TxEnvelopeTempo } from 'ox/tempo'
 import {
   createClient,
   custom,
+  encodeAbiParameters,
+  encodeEventTopics,
   encodeFunctionData,
+  keccak256,
   maxUint256,
   parseSignature,
   parseUnits,
@@ -62,6 +65,88 @@ function sponsoredFeeExposure(credential: string) {
 
 function tokenTransferCall(parameters: viem_token.transfer.Args) {
   return Actions.token.transfer.call(client, parameters)
+}
+
+async function fillHostedFeePayer(transaction: any, chainId: number) {
+  const quantity = (value: unknown) =>
+    value === undefined ? undefined : BigInt(value as string | number | bigint | boolean)
+  const envelope = TxEnvelopeTempo.from({
+    accessList: transaction.accessList,
+    calls: transaction.calls.map(({ value, ...call }: any) => ({
+      ...call,
+      ...(value && value !== '0x' ? { value: BigInt(value) } : {}),
+    })),
+    chainId,
+    feeToken: defaults.tokens.pathUsd,
+    from: transaction.from,
+    ...(quantity(transaction.gas) !== undefined ? { gas: quantity(transaction.gas) } : {}),
+    ...(quantity(transaction.maxFeePerGas) !== undefined
+      ? { maxFeePerGas: quantity(transaction.maxFeePerGas) }
+      : {}),
+    ...(quantity(transaction.maxPriorityFeePerGas) !== undefined
+      ? { maxPriorityFeePerGas: quantity(transaction.maxPriorityFeePerGas) }
+      : {}),
+    ...(quantity(transaction.nonce) !== undefined ? { nonce: quantity(transaction.nonce) } : {}),
+    ...(quantity(transaction.nonceKey) !== undefined
+      ? { nonceKey: quantity(transaction.nonceKey) }
+      : {}),
+    type: 'tempo',
+    ...(transaction.validAfter ? { validAfter: Number(BigInt(transaction.validAfter)) } : {}),
+    ...(transaction.validBefore ? { validBefore: Number(BigInt(transaction.validBefore)) } : {}),
+  })
+  const hash = TxEnvelopeTempo.getFeePayerSignPayload(envelope, { sender: transaction.from })
+  const { r, s, yParity } = parseSignature(await accounts[0].sign!({ hash }))
+  return {
+    feePayerSignature: { r, s, yParity },
+    feeToken: defaults.tokens.pathUsd,
+  }
+}
+
+function machineTokenReceipt(parameters: {
+  amount: bigint
+  from: Hex.Hex
+  hash: Hex.Hex
+  memo: Hex.Hex
+  recipient: Hex.Hex
+}) {
+  const settlementSender = defaults.machineToken[defaults.chainId.testnet].swap
+  const blockHash = `0x${'ef'.repeat(32)}` as const
+  return {
+    blockHash,
+    blockNumber: '0x1',
+    contractAddress: null,
+    cumulativeGasUsed: '0x1',
+    effectiveGasPrice: '0x1',
+    from: parameters.from,
+    gasUsed: '0x1',
+    logs: [
+      {
+        address: asset,
+        blockHash,
+        blockNumber: '0x1',
+        data: encodeAbiParameters([{ type: 'uint256' }], [parameters.amount]),
+        logIndex: '0x0',
+        removed: false,
+        topics: encodeEventTopics({
+          abi: Abis.tip20,
+          args: {
+            from: settlementSender,
+            memo: parameters.memo,
+            to: parameters.recipient,
+          },
+          eventName: 'TransferWithMemo',
+        }),
+        transactionHash: parameters.hash,
+        transactionIndex: '0x0',
+      },
+    ],
+    logsBloom: `0x${'00'.repeat(256)}`,
+    status: '0x1',
+    to: settlementSender,
+    transactionHash: parameters.hash,
+    transactionIndex: '0x0',
+    type: '0x76',
+  }
 }
 
 type ProofAccessKeyContext = {
@@ -1007,14 +1092,23 @@ describe('tempo', () => {
   })
 
   describe('intent: charge; type: transaction; via Mppx', () => {
-    test('behavior: advertises the machine-token hint and validates owned calls', async () => {
+    test('behavior: accepts a pushed machine-token settlement', async () => {
+      const hash = `0x${'12'.repeat(32)}` as Hex.Hex
+      const memo = `0x${'ab'.repeat(32)}` as Hex.Hex
+      let challenge: Challenge.Challenge | undefined
       const machineTokenClient = createClient({
-        account: accounts[1],
         chain: { ...chain, id: defaults.chainId.testnet },
         transport: custom({
           async request({ method }) {
             if (method === 'eth_chainId') return `0x${defaults.chainId.testnet.toString(16)}`
-            if (method === 'eth_call') return '0x'
+            if (method === 'eth_getTransactionReceipt' && challenge)
+              return machineTokenReceipt({
+                amount: BigInt(String(challenge.request.amount)),
+                from: accounts[1].address,
+                hash,
+                memo,
+                recipient: accounts[0].address,
+              })
             throw new Error(`Unexpected machine-token test RPC method: ${method}`)
           },
         }),
@@ -1023,10 +1117,9 @@ describe('tempo', () => {
         machineTokenEnabled: true,
         account: accounts[0],
         currency: asset,
-        feePayer: true,
         getClient: () => machineTokenClient,
-        memo: `0x${'ab'.repeat(32)}`,
-        supportedModes: ['pull', 'push'],
+        memo,
+        supportedModes: ['push'],
         testnet: true,
       })
       const machineTokenServer = Mppx_server.create({ methods: [method], realm, secretKey })
@@ -1039,31 +1132,112 @@ describe('tempo', () => {
       })
 
       const response = await fetch(httpServer.url)
-      const challenge = Challenge.fromResponse(response, {
+      challenge = Challenge.fromResponse(response, {
         methods: [tempo_client.charge()],
       })
-      expect(challenge.request.methodDetails?.machineTokenEnabled).toBe(true)
-      expect(challenge.request.methodDetails).toMatchObject({
-        feePayer: true,
-        supportedModes: ['pull', 'push'],
+      expect(
+        (challenge.request.methodDetails as { machineTokenEnabled?: boolean })?.machineTokenEnabled,
+      ).toBe(true)
+      const credential = Credential.from({
+        challenge,
+        payload: { hash, type: 'hash' as const },
+        source: `did:pkh:eip155:${defaults.chainId.testnet}:${accounts[1].address}`,
+      })
+      const paid = await fetch(httpServer.url, {
+        headers: { Authorization: Credential.serialize(credential) },
+      })
+      expect(paid.status).toBe(200)
+      expect(Receipt.fromResponse(paid).reference).toBe(hash)
+
+      httpServer.close()
+    })
+
+    test('behavior: broadcasts a hosted fee-sponsored machine-token settlement', async () => {
+      const memo = `0x${'ab'.repeat(32)}` as Hex.Hex
+      let challenge: Challenge.Challenge | undefined
+      const feePayerMethods: string[] = []
+      const feePayerServer = await Http.createServer(async (req, res) => {
+        let body = ''
+        for await (const chunk of req) body += chunk
+        const request = JSON.parse(body)
+        feePayerMethods.push(request.method)
+        const result = await (async () => {
+          if (request.method === 'eth_fillTransaction')
+            return {
+              tx: await fillHostedFeePayer(request.params[0], defaults.chainId.testnet),
+            }
+          if (request.method === 'eth_sendRawTransactionSync' && challenge) {
+            const hash = keccak256(request.params[0] as Hex.Hex)
+            return machineTokenReceipt({
+              amount: BigInt(String(challenge.request.amount)),
+              from: accounts[1].address,
+              hash,
+              memo,
+              recipient: accounts[0].address,
+            })
+          }
+          throw new Error(`Unexpected hosted fee-payer method: ${request.method}`)
+        })()
+        res.setHeader('content-type', 'application/json')
+        res.end(JSON.stringify({ id: request.id, jsonrpc: '2.0', result }))
+      })
+      const machineTokenClient = createClient({
+        account: accounts[1],
+        chain: { ...chain, id: defaults.chainId.testnet },
+        transport: custom({
+          async request({ method }) {
+            if (method === 'eth_chainId') return `0x${defaults.chainId.testnet.toString(16)}`
+            if (method === 'eth_call') return '0x'
+            throw new Error(`Unexpected machine-token test RPC method: ${method}`)
+          },
+        }),
+      })
+      const method = tempo_server.charge({
+        machineTokenEnabled: true,
+        account: accounts[0],
+        currency: asset,
+        feePayer: feePayerServer.url,
+        getClient: () => machineTokenClient,
+        memo,
+        supportedModes: ['pull'],
+        testnet: true,
+      })
+      const machineTokenServer = Mppx_server.create({ methods: [method], realm, secretKey })
+      const httpServer = await Http.createServer(async (req, res) => {
+        const result = await Mppx_server.toNodeListener(
+          machineTokenServer.charge({ amount: '1', decimals: 6, recipient: accounts[0].address }),
+        )(req, res)
+        if (result.status === 402) return
+        res.end('OK')
       })
 
-      const amount = BigInt(challenge.request.amount)
-      const memo = challenge.request.methodDetails!.memo as Hex.Hex
+      const response = await fetch(httpServer.url)
+      challenge = Challenge.fromResponse(response, { methods: [tempo_client.charge()] })
+      expect(challenge.request.methodDetails).toMatchObject({
+        feePayer: true,
+        machineTokenEnabled: true,
+        supportedModes: ['pull'],
+      })
       const calls = MachineToken.getRoute({
         chainId: defaults.chainId.testnet,
         currency: asset,
-        transfers: [{ amount, memo, recipient: accounts[0].address }],
+        transfers: [
+          {
+            amount: BigInt(String(challenge.request.amount)),
+            memo,
+            recipient: accounts[0].address,
+          },
+        ],
       })!.calls
       const signature = await signTransaction(machineTokenClient, {
         account: accounts[1],
         calls,
+        feePayer: true,
         gas: 100_000n,
         maxFeePerGas: 1_000_000_000n,
         maxPriorityFeePerGas: 1_000_000_000n,
         nonce: 0,
         nonceKey: maxUint256,
-        feePayer: true,
         validBefore: Math.floor(Date.now() / 1_000) + 25,
       } as never)
       const credential = Credential.from({
@@ -1071,16 +1245,16 @@ describe('tempo', () => {
         payload: { signature, type: 'transaction' as const },
         source: `did:pkh:eip155:${defaults.chainId.testnet}:${accounts[1].address}`,
       })
-      await expect(
-        method.validate?.({
-          credential: credential as never,
-          request: credential.challenge.request as never,
-        }),
-      ).resolves.toMatchObject({
-        details: { mode: 'pull', sender: accounts[1].address.toLowerCase() },
+      const paid = await fetch(httpServer.url, {
+        headers: { Authorization: Credential.serialize(credential) },
       })
 
+      expect(paid.status).toBe(200)
+      expect(Receipt.fromResponse(paid).status).toBe('success')
+      expect(feePayerMethods).toEqual(['eth_fillTransaction', 'eth_sendRawTransactionSync'])
+
       httpServer.close()
+      feePayerServer.close()
     })
 
     test('behavior: rejects pull then push replay of the same transaction hash', async () => {
@@ -2392,53 +2566,13 @@ describe('tempo', () => {
 
         sequence.push('complete')
 
-        const transaction = request.params[0]
-        const quantity = (value: unknown) =>
-          value === undefined ? undefined : BigInt(value as string | number | bigint | boolean)
-        const envelope = TxEnvelopeTempo.from({
-          accessList: transaction.accessList,
-          calls: transaction.calls.map(({ value, ...call }: any) => ({
-            ...call,
-            ...(value && value !== '0x' ? { value: BigInt(value) } : {}),
-          })),
-          chainId: chain.id,
-          feeToken: defaults.tokens.pathUsd,
-          from: transaction.from,
-          ...(quantity(transaction.gas) !== undefined ? { gas: quantity(transaction.gas) } : {}),
-          ...(quantity(transaction.maxFeePerGas) !== undefined
-            ? { maxFeePerGas: quantity(transaction.maxFeePerGas) }
-            : {}),
-          ...(quantity(transaction.maxPriorityFeePerGas) !== undefined
-            ? { maxPriorityFeePerGas: quantity(transaction.maxPriorityFeePerGas) }
-            : {}),
-          ...(quantity(transaction.nonce) !== undefined
-            ? { nonce: quantity(transaction.nonce) }
-            : {}),
-          ...(quantity(transaction.nonceKey) !== undefined
-            ? { nonceKey: quantity(transaction.nonceKey) }
-            : {}),
-          type: 'tempo',
-          ...(transaction.validAfter ? { validAfter: Number(BigInt(transaction.validAfter)) } : {}),
-          ...(transaction.validBefore
-            ? { validBefore: Number(BigInt(transaction.validBefore)) }
-            : {}),
-        })
-        const hash = TxEnvelopeTempo.getFeePayerSignPayload(envelope, {
-          sender: transaction.from,
-        })
-        const { r, s, yParity } = parseSignature(await accounts[0].sign!({ hash }))
-        const feePayerSignature = { r, s, yParity }
-
         res.setHeader('content-type', 'application/json')
         res.end(
           JSON.stringify({
             id: request.id,
             jsonrpc: '2.0',
             result: {
-              tx: {
-                feePayerSignature,
-                feeToken: defaults.tokens.pathUsd,
-              },
+              tx: await fillHostedFeePayer(request.params[0], chain.id),
             },
           }),
         )

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -1,7 +1,9 @@
 import * as SignatureEnvelope from 'ox/tempo/SignatureEnvelope'
 import {
+  createClient,
   decodeFunctionData,
   formatUnits,
+  http,
   keccak256,
   parseEventLogs,
   type TransactionReceipt,
@@ -32,6 +34,7 @@ import * as Charge_internal from '../internal/charge.js'
 import * as defaults from '../internal/defaults.js'
 import * as FeePayer from '../internal/fee-payer.js'
 import { resolveFeeToken } from '../internal/fee-token.js'
+import * as MachineToken from '../internal/machine-token.js'
 import * as Proof from '../internal/proof.js'
 import * as Selectors from '../internal/selectors.js'
 import type * as types from '../internal/types.js'
@@ -57,6 +60,7 @@ export function charge<const parameters extends charge.Parameters>(
   >,
 ): Method.Server<typeof Methods.charge, charge.DeriveDefaults<parameters>> {
   const {
+    machineTokenEnabled,
     amount,
     currency = defaults.resolveCurrency(parameters),
     decimals = defaults.decimals,
@@ -143,6 +147,7 @@ export function charge<const parameters extends charge.Parameters>(
     const currency = resolvedRequest.currency as `0x${string}`
     const recipient = resolvedRequest.recipient as `0x${string}`
     const memo = methodDetails?.memo as `0x${string}` | undefined
+    const machineTokenEnabled = methodDetails?.machineTokenEnabled === true
     const isZeroAmount = BigInt(amount) === 0n
 
     Expires.assert(challenge.expires, challenge.id)
@@ -152,6 +157,7 @@ export function charge<const parameters extends charge.Parameters>(
 
     return {
       amount,
+      machineTokenEnabled,
       chainId,
       challenge,
       client: await getClient({ chainId }),
@@ -179,6 +185,7 @@ export function charge<const parameters extends charge.Parameters>(
     context: CredentialContext,
   ) {
     const {
+      machineTokenEnabled,
       amount,
       chainId,
       challenge,
@@ -202,6 +209,8 @@ export function charge<const parameters extends charge.Parameters>(
     })
     const sender = source?.address ?? receipt.from
     const matchedLogs = await assertTransferLogs(receipt, {
+      machineTokenEnabled,
+      chainId: chainId ?? client.chain?.id,
       currency,
       sender,
       source,
@@ -266,6 +275,7 @@ export function charge<const parameters extends charge.Parameters>(
     context: CredentialContext,
   ) {
     const {
+      machineTokenEnabled,
       amount,
       chainId,
       challenge,
@@ -296,11 +306,21 @@ export function charge<const parameters extends charge.Parameters>(
       requestAllowsFeePayer &&
       !!(typeof request.feePayer === 'object' ? request.feePayer : feePayer || feePayerUrl)
     const transfers = getExpectedTransfers({ amount, memo, methodDetails, recipient })
-    const matchedCalls = assertTransferCalls(transaction.calls ?? [], {
-      currency,
-      exactCount: isFeePayerTx,
-      transfers,
-    })
+    const machineTokenTransfers = machineTokenEnabled
+      ? MachineToken.validateCalls({
+          calls: (transaction.calls ?? []) as readonly MachineToken.Call[],
+          chainId: chainId ?? client.chain?.id,
+          currency,
+          transfers,
+        })
+      : false
+    const matchedCalls =
+      machineTokenTransfers ||
+      assertTransferCalls(transaction.calls ?? [], {
+        currency,
+        exactCount: isFeePayerTx,
+        transfers,
+      })
     if (!memo)
       assertChallengeBoundCallMemo(matchedCalls, {
         challengeId: challenge.id,
@@ -308,11 +328,12 @@ export function charge<const parameters extends charge.Parameters>(
       })
 
     if (isFeePayerTx) {
-      FeePayer.validateCalls(
-        transaction.calls,
-        { amount, currency, recipient },
-        { currency, expectedTransfers: transfers },
-      )
+      if (!machineTokenTransfers)
+        FeePayer.validateCalls(
+          transaction.calls,
+          { amount, currency, recipient },
+          { currency, expectedTransfers: transfers },
+        )
       FeePayer.assertAllowedFeeToken(transaction, FeePayer.defaultAllowedFeeTokens(chainId))
     } else {
       await viem_call(
@@ -321,7 +342,13 @@ export function charge<const parameters extends charge.Parameters>(
       )
     }
 
-    return { isFeePayerTx, serializedTransaction, transaction, transfers }
+    return {
+      isFeePayerTx,
+      serializedTransaction,
+      transaction,
+      transfers,
+      usesMachineToken: !!machineTokenTransfers,
+    }
   }
 
   async function validateCredential(
@@ -350,7 +377,7 @@ export function charge<const parameters extends charge.Parameters>(
       }
 
       case 'transaction': {
-        const { isFeePayerTx, serializedTransaction, transaction, transfers } =
+        const { isFeePayerTx, serializedTransaction, transaction, transfers, usesMachineToken } =
           await validateTransactionCredential(credential, context.payload, request, context)
         return {
           details: {
@@ -364,6 +391,7 @@ export function charge<const parameters extends charge.Parameters>(
           transaction,
           transfers,
           type: 'transaction' as const,
+          usesMachineToken,
         }
       }
     }
@@ -374,6 +402,7 @@ export function charge<const parameters extends charge.Parameters>(
     canOffer: parameters.canOffer,
     onPaymentSuccess: parameters.onPaymentSuccess,
     defaults: {
+      machineTokenEnabled,
       amount,
       currency,
       decimals,
@@ -434,6 +463,8 @@ export function charge<const parameters extends charge.Parameters>(
       })()
       if (client.chain?.id !== chainId)
         throw new Error(`Client not configured with chainId ${chainId}.`)
+      if (request.machineTokenEnabled && !MachineToken.isSupported(chainId))
+        throw new Error(`Machine tokens are not supported on chainId ${chainId}.`)
 
       const resolvedFeePayer = (() => {
         if (request.feePayer === false) return credential ? false : undefined
@@ -446,6 +477,7 @@ export function charge<const parameters extends charge.Parameters>(
 
       return {
         ...request,
+        machineTokenEnabled: request.machineTokenEnabled || undefined,
         chainId,
         feePayer: resolvedFeePayer,
         memo: request.memo || undefined,
@@ -518,7 +550,8 @@ export function charge<const parameters extends charge.Parameters>(
         }
 
         case 'transaction': {
-          const { isFeePayerTx, serializedTransaction, transaction, transfers } = validated
+          const { isFeePayerTx, serializedTransaction, transaction, transfers, usesMachineToken } =
+            validated
 
           // Pre-broadcast dedup: catch exact byte-for-byte replays early.
           const hash = keccak256(serializedTransaction)
@@ -533,6 +566,10 @@ export function charge<const parameters extends charge.Parameters>(
           let reservation: SponsorBudget.Handle | undefined
 
           try {
+            const broadcastClient =
+              feePayerUrl && isFeePayerTx
+                ? createClient({ chain: client.chain!, transport: http(feePayerUrl) })
+                : client
             const allowedFeeTokens = FeePayer.defaultAllowedFeeTokens(chainId)
             if (isFeePayerTx) FeePayer.assertAllowedFeeToken(transaction, allowedFeeTokens)
             const selectableFeeTokens = allowedFeeTokens as readonly `0x${string}`[]
@@ -664,11 +701,13 @@ export function charge<const parameters extends charge.Parameters>(
 
             broadcastAttempted = true
             if (waitForConfirmation) {
-              const receipt = await sendRawTransactionSync(client, {
+              const receipt = await sendRawTransactionSync(broadcastClient, {
                 serializedTransaction: serializedTransaction_final,
               })
               if (reservation) await SponsorBudget.release(sponsorBudgetStore!, reservation)
               const matchedLogs = await assertTransferLogs(receipt, {
+                machineTokenEnabled: usesMachineToken,
+                chainId: chainId ?? client.chain?.id,
                 currency,
                 sender: transaction.from! as `0x${string}`,
                 transfers,
@@ -688,7 +727,7 @@ export function charge<const parameters extends charge.Parameters>(
             // Optimistic path: broadcast without waiting for confirmation
             // (simulation above already ran). The returned receipt assumes
             // success — callers opt in via waitForConfirmation: false.
-            const reference = await sendRawTransaction(client, {
+            const reference = await sendRawTransaction(broadcastClient, {
               serializedTransaction: serializedTransaction_final,
             })
             if (reference.toLowerCase() !== finalHash.toLowerCase())
@@ -749,7 +788,7 @@ export declare namespace charge {
     source?: { address: `0x${string}`; chainId: number } | undefined
   }
 
-  type Parameters = {
+  type Parameters = MachineToken.Options & {
     /** Render payment page when Accept header is text/html (e.g. in browsers) */
     html?: boolean | Html.Config | undefined
     /**
@@ -875,12 +914,20 @@ function chargeBinding(request: ChargeRequest) {
     request
   requestRest satisfies Record<string, never>
 
-  const { chainId, feePayer, memo, splits, supportedModes, ...methodDetailsRest } =
-    methodDetails ?? {}
+  const {
+    chainId,
+    feePayer,
+    machineTokenEnabled,
+    memo,
+    splits,
+    supportedModes,
+    ...methodDetailsRest
+  } = methodDetails ?? {}
   methodDetailsRest satisfies Record<string, never>
   void feePayer
 
   return {
+    machineTokenEnabled,
     amount,
     chainId,
     currency,
@@ -1038,6 +1085,8 @@ type TransferLog =
 async function assertTransferLogs(
   receipt: TransactionReceipt,
   parameters: {
+    machineTokenEnabled?: boolean | undefined
+    chainId?: number | undefined
     currency: `0x${string}`
     sender: `0x${string}`
     source?: { address: `0x${string}`; chainId: number } | undefined
@@ -1073,9 +1122,12 @@ async function assertTransferLogs(
       if (!memoMatches) continue
       if (
         !(await isValidTransferSender({
+          machineTokenEnabled: parameters.machineTokenEnabled,
+          chainId: parameters.chainId,
           expectedSender: parameters.sender,
           sender: log.args.from,
           source: parameters.source,
+          transactionSender: receipt.from,
           validateSender: parameters.validateSender,
         }))
       )
@@ -1181,12 +1233,21 @@ function isSameTransferLog(a: ParsedTransferLog, b: ParsedTransferLog): boolean 
 }
 
 async function isValidTransferSender(parameters: {
+  machineTokenEnabled?: boolean | undefined
+  chainId?: number | undefined
   expectedSender: `0x${string}`
   sender: `0x${string}`
   source?: { address: `0x${string}`; chainId: number } | undefined
+  transactionSender: `0x${string}`
   validateSender?: charge.ValidateSender | undefined
 }): Promise<boolean> {
   if (TempoAddress.isEqual(parameters.sender, parameters.expectedSender)) return true
+  if (
+    parameters.machineTokenEnabled &&
+    TempoAddress.isEqual(parameters.transactionSender, parameters.expectedSender) &&
+    MachineToken.isSwap({ address: parameters.sender, chainId: parameters.chainId })
+  )
+    return true
   if (!parameters.validateSender) return false
   return parameters.validateSender({
     expectedSender: parameters.expectedSender,
@@ -1345,7 +1406,7 @@ function assertChallengeBoundMemo(
 }
 
 function assertChallengeBoundCallMemo(
-  matchedCalls: readonly Charge_internal.Transfer[],
+  matchedCalls: readonly { memo?: string | undefined }[],
   parameters: { challengeId: string; realm: string },
 ) {
   const bound = matchedCalls.some((call) => {

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -114,6 +114,8 @@ export function charge<const parameters extends charge.Parameters>(
   const { recipient, feePayer, feePayerUrl } = Account.resolve(parameters)
   if (configuredFeeToken && feePayerUrl)
     throw new Error('`feeToken` can only be configured for a local fee payer.')
+  if (machineTokenEnabled && relay)
+    throw new Error('`machineTokenEnabled` is not supported with a Tempo relay.')
 
   const getClient = Client.getResolver({
     chain: { ...tempo_chain, experimental_preconfirmationTime: 500 },
@@ -148,6 +150,9 @@ export function charge<const parameters extends charge.Parameters>(
     const recipient = resolvedRequest.recipient as `0x${string}`
     const memo = methodDetails?.memo as `0x${string}` | undefined
     const machineTokenEnabled = methodDetails?.machineTokenEnabled === true
+    const settlementSender = machineTokenEnabled
+      ? MachineToken.getSettlementSender(chainId)
+      : undefined
     const isZeroAmount = BigInt(amount) === 0n
 
     Expires.assert(challenge.expires, challenge.id)
@@ -169,6 +174,7 @@ export function charge<const parameters extends charge.Parameters>(
       recipient,
       requestAllowsFeePayer: request.feePayer !== false,
       resolvedRequest,
+      settlementSenders: settlementSender ? [settlementSender] : [],
       supportedModes,
     }
   }
@@ -185,7 +191,6 @@ export function charge<const parameters extends charge.Parameters>(
     context: CredentialContext,
   ) {
     const {
-      machineTokenEnabled,
       amount,
       chainId,
       challenge,
@@ -194,6 +199,7 @@ export function charge<const parameters extends charge.Parameters>(
       memo,
       methodDetails,
       recipient,
+      settlementSenders,
       supportedModes,
     } = context
     if (supportedModes && !supportedModes.includes('push'))
@@ -209,10 +215,9 @@ export function charge<const parameters extends charge.Parameters>(
     })
     const sender = source?.address ?? receipt.from
     const matchedLogs = await assertTransferLogs(receipt, {
-      machineTokenEnabled,
-      chainId: chainId ?? client.chain?.id,
       currency,
       sender,
+      settlementSenders,
       source,
       transfers,
       validateSender,
@@ -306,16 +311,16 @@ export function charge<const parameters extends charge.Parameters>(
       requestAllowsFeePayer &&
       !!(typeof request.feePayer === 'object' ? request.feePayer : feePayer || feePayerUrl)
     const transfers = getExpectedTransfers({ amount, memo, methodDetails, recipient })
-    const machineTokenTransfers = machineTokenEnabled
-      ? MachineToken.validateCalls({
+    const machineTokenRoute = machineTokenEnabled
+      ? MachineToken.matchRoute({
           calls: (transaction.calls ?? []) as readonly MachineToken.Call[],
           chainId: chainId ?? client.chain?.id,
           currency,
           transfers,
         })
-      : false
+      : undefined
     const matchedCalls =
-      machineTokenTransfers ||
+      machineTokenRoute?.transfers ??
       assertTransferCalls(transaction.calls ?? [], {
         currency,
         exactCount: isFeePayerTx,
@@ -328,7 +333,7 @@ export function charge<const parameters extends charge.Parameters>(
       })
 
     if (isFeePayerTx) {
-      if (!machineTokenTransfers)
+      if (!machineTokenRoute)
         FeePayer.validateCalls(
           transaction.calls,
           { amount, currency, recipient },
@@ -345,9 +350,9 @@ export function charge<const parameters extends charge.Parameters>(
     return {
       isFeePayerTx,
       serializedTransaction,
+      settlementSenders: machineTokenRoute ? [machineTokenRoute.settlementSender] : [],
       transaction,
       transfers,
-      usesMachineToken: !!machineTokenTransfers,
     }
   }
 
@@ -377,7 +382,7 @@ export function charge<const parameters extends charge.Parameters>(
       }
 
       case 'transaction': {
-        const { isFeePayerTx, serializedTransaction, transaction, transfers, usesMachineToken } =
+        const { isFeePayerTx, serializedTransaction, settlementSenders, transaction, transfers } =
           await validateTransactionCredential(credential, context.payload, request, context)
         return {
           details: {
@@ -388,10 +393,10 @@ export function charge<const parameters extends charge.Parameters>(
           },
           isFeePayerTx,
           serializedTransaction,
+          settlementSenders,
           transaction,
           transfers,
           type: 'transaction' as const,
-          usesMachineToken,
         }
       }
     }
@@ -463,6 +468,8 @@ export function charge<const parameters extends charge.Parameters>(
       })()
       if (client.chain?.id !== chainId)
         throw new Error(`Client not configured with chainId ${chainId}.`)
+      if (request.machineTokenEnabled && relay)
+        throw new Error('`machineTokenEnabled` is not supported with a Tempo relay.')
       if (request.machineTokenEnabled && !MachineToken.isSupported(chainId))
         throw new Error(`Machine tokens are not supported on chainId ${chainId}.`)
 
@@ -550,7 +557,7 @@ export function charge<const parameters extends charge.Parameters>(
         }
 
         case 'transaction': {
-          const { isFeePayerTx, serializedTransaction, transaction, transfers, usesMachineToken } =
+          const { isFeePayerTx, serializedTransaction, settlementSenders, transaction, transfers } =
             validated
 
           // Pre-broadcast dedup: catch exact byte-for-byte replays early.
@@ -706,10 +713,9 @@ export function charge<const parameters extends charge.Parameters>(
               })
               if (reservation) await SponsorBudget.release(sponsorBudgetStore!, reservation)
               const matchedLogs = await assertTransferLogs(receipt, {
-                machineTokenEnabled: usesMachineToken,
-                chainId: chainId ?? client.chain?.id,
                 currency,
                 sender: transaction.from! as `0x${string}`,
+                settlementSenders,
                 transfers,
               })
               if (!memo)
@@ -843,6 +849,9 @@ export declare namespace charge {
      * relay broadcasts pull credentials, while it recognizes a push
      * credential as already broadcast and returns its receipt without sending
      * it again.
+     *
+     * This option cannot be combined with `machineTokenEnabled` until the relay
+     * supports the first-party settlement route.
      */
     relay?: RelayOptions | undefined
     /**
@@ -1085,10 +1094,9 @@ type TransferLog =
 async function assertTransferLogs(
   receipt: TransactionReceipt,
   parameters: {
-    machineTokenEnabled?: boolean | undefined
-    chainId?: number | undefined
     currency: `0x${string}`
     sender: `0x${string}`
+    settlementSenders?: readonly `0x${string}`[] | undefined
     source?: { address: `0x${string}`; chainId: number } | undefined
     transfers: readonly ExpectedTransfer[]
     validateSender?: charge.ValidateSender | undefined
@@ -1122,10 +1130,9 @@ async function assertTransferLogs(
       if (!memoMatches) continue
       if (
         !(await isValidTransferSender({
-          machineTokenEnabled: parameters.machineTokenEnabled,
-          chainId: parameters.chainId,
           expectedSender: parameters.sender,
           sender: log.args.from,
+          settlementSenders: parameters.settlementSenders,
           source: parameters.source,
           transactionSender: receipt.from,
           validateSender: parameters.validateSender,
@@ -1233,19 +1240,17 @@ function isSameTransferLog(a: ParsedTransferLog, b: ParsedTransferLog): boolean 
 }
 
 async function isValidTransferSender(parameters: {
-  machineTokenEnabled?: boolean | undefined
-  chainId?: number | undefined
   expectedSender: `0x${string}`
   sender: `0x${string}`
+  settlementSenders?: readonly `0x${string}`[] | undefined
   source?: { address: `0x${string}`; chainId: number } | undefined
   transactionSender: `0x${string}`
   validateSender?: charge.ValidateSender | undefined
 }): Promise<boolean> {
   if (TempoAddress.isEqual(parameters.sender, parameters.expectedSender)) return true
   if (
-    parameters.machineTokenEnabled &&
     TempoAddress.isEqual(parameters.transactionSender, parameters.expectedSender) &&
-    MachineToken.isSwap({ address: parameters.sender, chainId: parameters.chainId })
+    parameters.settlementSenders?.some((sender) => TempoAddress.isEqual(parameters.sender, sender))
   )
     return true
   if (!parameters.validateSender) return false

--- a/src/tempo/server/Methods.ts
+++ b/src/tempo/server/Methods.ts
@@ -36,16 +36,20 @@ function createSessionMethod<const parameters extends tempo.Parameters>(
 /**
  * Creates the common Tempo `charge` and `session` methods from shared parameters.
  *
- * When configured, `relay` applies to the `charge` method. Session vouchers
- * remain local state transitions and session relay delegation will be added
- * with its action-specific lifecycle support.
+ * When configured, `machineTokenEnabled` and `relay` apply to the `charge`
+ * method. The machine-token option is global so other Tempo methods can adopt
+ * it without introducing another provider-level configuration surface.
  *
  * @example
  * ```ts
  * import { Mppx, tempo } from 'mppx/server'
  *
  * const mppx = Mppx.create({
- *   methods: [tempo.common({ currency: '0x...', recipient: '0x...' })],
+ *   methods: tempo({
+ *     currency: '0x...',
+ *     machineTokenEnabled: true,
+ *     recipient: '0x...',
+ *   }),
  * })
  * ```
  */

--- a/src/tempo/server/Methods.ts
+++ b/src/tempo/server/Methods.ts
@@ -36,9 +36,9 @@ function createSessionMethod<const parameters extends tempo.Parameters>(
 /**
  * Creates the common Tempo `charge` and `session` methods from shared parameters.
  *
- * When configured, `machineTokenEnabled` and `relay` apply to the `charge`
- * method. The machine-token option is global so other Tempo methods can adopt
- * it without introducing another provider-level configuration surface.
+ * `machineTokenEnabled` and `relay` currently apply only to `charge` and cannot
+ * be combined. The machine-token option is accepted globally so other Tempo
+ * methods can adopt it without another provider-level configuration surface.
  *
  * @example
  * ```ts

--- a/src/tempo/server/Relay.test.ts
+++ b/src/tempo/server/Relay.test.ts
@@ -102,6 +102,15 @@ afterEach(() => {
 })
 
 describe('relay boundary', () => {
+  test('rejects machine-token settlement until the relay supports it', () => {
+    expect(() =>
+      tempo.charge({
+        machineTokenEnabled: true,
+        relay: { apiKey: 'tempo_api_key' },
+      }),
+    ).toThrow('`machineTokenEnabled` is not supported with a Tempo relay.')
+  })
+
   test('sends the complete credential to the configured validation endpoint', async () => {
     const fetch = mockRelay(() => Response.json({ success: true }))
     const [method, session] = methods(fetch)


### PR DESCRIPTION
## Why

MPP clients should prefer an MPP-owned machine token when a Tempo payment method enables it, while merchants continue to price and settle in their normal currency. The same interface should extend to other Tempo methods without exposing token-specific details.

## What

- add `machineTokenEnabled` to `tempo.charge` and the global `tempo` constructor
- resolve one canonical first-party token-to-currency swap route for client construction and server validation
- try the machine-token route before existing funding behavior
- support atomic client-broadcast push and server-broadcast pull, including local and hosted fee sponsorship