### PR TITLE
fix: close sessions with stale receipt spend

### DIFF
--- a/.changeset/tidy-clocks-close.md
+++ b/.changeset/tidy-clocks-close.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed Tempo session fallback closes when locally persisted receipt spend was stale.

--- a/.changeset/tidy-clocks-close.md
+++ b/.changeset/tidy-clocks-close.md
@@ -2,4 +2,4 @@
 'mppx': patch
 ---
 
-Fixed Tempo session fallback closes when locally persisted receipt spend was stale.
+Fixed Tempo session fallback closes with stale receipts and rejected invalid close accounting.

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -1301,7 +1301,12 @@ describe('session multi-fetch (examples/session/multi-fetch)', () => {
 
       const listed = await serve(['sessions', 'list', '--json'], { env })
       expect(JSON.parse(listed.output).sessions).toEqual([
-        expect.objectContaining({ channelId, status: 'open' }),
+        expect.objectContaining({
+          channelId,
+          confirmedSpend: '1000',
+          status: 'open',
+          units: 1,
+        }),
       ])
 
       const closed = await serve(['sessions', 'close', channelId!, '--rpc-url', rpcUrl, '--json'], {

--- a/src/cli/sessions/Manager.test.ts
+++ b/src/cli/sessions/Manager.test.ts
@@ -143,6 +143,47 @@ function managerParameters(store: ChannelStore) {
 }
 
 describe('CLI session manager adapter', () => {
+  test('closes at cumulative authorization when receipt-confirmed spend is stale', async () => {
+    const { challenge } = challengeResponse()
+    const entry = channelEntry()
+    entry.cumulativeAmount = 5n
+    const { remove, store } = channelStore(entry)
+    const closeAmounts: string[] = []
+    const fetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const payload = credentialPayload(init)
+      if (payload?.action !== 'close') throw new Error('expected close credential')
+      closeAmounts.push(payload.cumulativeAmount)
+      if (BigInt(payload.cumulativeAmount) < 4n)
+        throw new Error('close voucher amount must be >= 4 (spent)')
+      return new Response(null, {
+        headers: {
+          [Constants.Headers.paymentReceipt]: serializeSessionReceipt(
+            createSessionReceipt({
+              acceptedCumulative: 5n,
+              challengeId: challenge.id,
+              channelId,
+              spent: 4n,
+              txHash: `0x${'aa'.repeat(32)}` as Hex,
+            }),
+          ),
+        },
+      })
+    })
+
+    const result = await closeWithSessionManager({
+      channel: entry,
+      challenge,
+      fetch,
+      input: 'https://api.example.test/resource',
+      manager: managerParameters(store),
+      spent: 0n,
+    })
+
+    expect(result.receipt).toMatchObject({ channelId, spent: '4' })
+    expect(closeAmounts).toEqual(['5'])
+    expect(remove).toHaveBeenCalledOnce()
+  })
+
   test('rehydrates durable context and closes at receipt-confirmed spend', async () => {
     const { challenge } = challengeResponse(
       'challenge-1',

--- a/src/tempo/session/client/Runtime.test.ts
+++ b/src/tempo/session/client/Runtime.test.ts
@@ -750,6 +750,22 @@ describe('CloseAuthorization', () => {
           spent: 80n,
         }),
       ).toThrow('close-ready spent exceeds local voucher state')
+
+      expect(() =>
+        assertCloseReadyWithinLocalState({
+          cumulativeAmount: 100n,
+          readySpent: 79n,
+          spent: 80n,
+        }),
+      ).toThrow('close-ready spent is below locally confirmed spend')
+
+      expect(() =>
+        assertCloseReadyWithinLocalState({
+          cumulativeAmount: 100n,
+          readySpent: -1n,
+          spent: 0n,
+        }),
+      ).toThrow('close-ready spent is not a uint96 amount')
     })
 
     test('matches final close receipts with spend bounded by the signed amount', () => {
@@ -766,6 +782,7 @@ describe('CloseAuthorization', () => {
           challengeId: 'challenge-1',
           channelId,
           expectedCloseAmount: '80',
+          minimumSpent: 70n,
           receipt,
         }),
       ).toBe(true)
@@ -774,6 +791,7 @@ describe('CloseAuthorization', () => {
           challengeId: 'challenge-1',
           channelId,
           expectedCloseAmount: '81',
+          minimumSpent: 70n,
           receipt,
         }),
       ).toBe(false)
@@ -783,6 +801,7 @@ describe('CloseAuthorization', () => {
           challengeId: 'challenge-1',
           channelId,
           expectedCloseAmount: '80',
+          minimumSpent: 70n,
           receipt: { ...receipt, spent: '70' },
         }),
       ).toBe(true)
@@ -792,10 +811,34 @@ describe('CloseAuthorization', () => {
           challengeId: 'challenge-1',
           channelId,
           expectedCloseAmount: '80',
+          minimumSpent: 70n,
           receipt: { ...receipt, spent: '81' },
         }),
       ).toBe(false)
     })
+
+    test.each(['69', '-1', 'not-an-amount', (2n ** 96n).toString()])(
+      'rejects invalid or regressed close receipt spend %s',
+      (spent) => {
+        const receipt = createSessionReceipt({
+          acceptedCumulative: 80n,
+          challengeId: 'challenge-1',
+          channelId,
+          spent: 80n,
+          txHash: '0x1234',
+        })
+
+        expect(
+          isExpectedCloseReceipt({
+            challengeId: 'challenge-1',
+            channelId,
+            expectedCloseAmount: '80',
+            minimumSpent: 70n,
+            receipt: { ...receipt, spent },
+          }),
+        ).toBe(false)
+      },
+    )
   })
 })
 

--- a/src/tempo/session/client/Runtime.test.ts
+++ b/src/tempo/session/client/Runtime.test.ts
@@ -752,7 +752,7 @@ describe('CloseAuthorization', () => {
       ).toThrow('close-ready spent exceeds local voucher state')
     })
 
-    test('matches only final close receipts with txHash and exact amounts', () => {
+    test('matches final close receipts with spend bounded by the signed amount', () => {
       const receipt = createSessionReceipt({
         acceptedCumulative: 80n,
         challengeId: 'challenge-1',
@@ -775,6 +775,24 @@ describe('CloseAuthorization', () => {
           channelId,
           expectedCloseAmount: '81',
           receipt,
+        }),
+      ).toBe(false)
+
+      expect(
+        isExpectedCloseReceipt({
+          challengeId: 'challenge-1',
+          channelId,
+          expectedCloseAmount: '80',
+          receipt: { ...receipt, spent: '70' },
+        }),
+      ).toBe(true)
+
+      expect(
+        isExpectedCloseReceipt({
+          challengeId: 'challenge-1',
+          channelId,
+          expectedCloseAmount: '80',
+          receipt: { ...receipt, spent: '81' },
         }),
       ).toBe(false)
     })

--- a/src/tempo/session/client/Runtime.ts
+++ b/src/tempo/session/client/Runtime.ts
@@ -657,7 +657,7 @@ export function isExpectedCloseReceipt(parameters: ExpectedCloseReceiptParameter
     receipt.challengeId === challengeId &&
     receipt.channelId === channelId &&
     receipt.acceptedCumulative === expectedCloseAmount &&
-    receipt.spent === expectedCloseAmount
+    BigInt(receipt.spent) <= BigInt(expectedCloseAmount)
   )
 }
 
@@ -842,7 +842,7 @@ export function closedStateFromReceipt(receipt: SessionReceipt, entry: ChannelEn
  * Priority:
  * 1. Matching close-ready receipt spend.
  * 2. Matching socket delivery estimate (`deliveredChunks * tickCost`) clamped by cumulative.
- * 3. Latest receipt-tracked spend for HTTP/SSE.
+ * 3. Highest local cumulative authorization for HTTP/SSE.
  */
 export function computeFallbackCloseAmount(parameters: FallbackCloseAmountParameters): bigint {
   const {
@@ -871,7 +871,7 @@ export function computeFallbackCloseAmount(parameters: FallbackCloseAmountParame
     return bestSpent > cumulativeAmount ? cumulativeAmount : bestSpent
   }
 
-  return spent
+  return cumulativeAmount
 }
 
 /**

--- a/src/tempo/session/client/Runtime.ts
+++ b/src/tempo/session/client/Runtime.ts
@@ -605,8 +605,10 @@ export type ExpectedCloseReceiptParameters = {
   challengeId: string
   /** Channel ID being closed. */
   channelId: Hex
-  /** Expected final cumulative/spent amount. */
+  /** Expected final cumulative authorization. */
   expectedCloseAmount: string
+  /** Lowest cumulative spend already confirmed by the client. */
+  minimumSpent?: bigint | undefined
   /** Receipt to test. */
   receipt: SessionReceipt
 }
@@ -644,6 +646,8 @@ export function localCloseSpendLimit(parameters: Omit<CloseReadySpendParameters,
 /** Throws when a close-ready receipt asks the client to sign beyond local state. */
 export function assertCloseReadyWithinLocalState(parameters: CloseReadySpendParameters): void {
   const { cumulativeAmount, readySpent, spent } = parameters
+  if (!Ws.isUint96(readySpent)) throw new Error('close-ready spent is not a uint96 amount')
+  if (readySpent < spent) throw new Error('close-ready spent is below locally confirmed spend')
   if (readySpent > localCloseSpendLimit({ cumulativeAmount, spent })) {
     throw new Error('close-ready spent exceeds local voucher state')
   }
@@ -651,13 +655,18 @@ export function assertCloseReadyWithinLocalState(parameters: CloseReadySpendPara
 
 /** Returns whether a receipt is the expected final close settlement receipt. */
 export function isExpectedCloseReceipt(parameters: ExpectedCloseReceiptParameters): boolean {
-  const { challengeId, channelId, expectedCloseAmount, receipt } = parameters
+  const { challengeId, channelId, expectedCloseAmount, minimumSpent = 0n, receipt } = parameters
+  const expected = Ws.parseUint96Amount(expectedCloseAmount)
+  const receiptSpent = Ws.parseUint96Amount(receipt.spent)
+  if (expected === undefined || receiptSpent === undefined || !Ws.isUint96(minimumSpent))
+    return false
   return (
     Boolean(receipt.txHash) &&
     receipt.challengeId === challengeId &&
     receipt.channelId === channelId &&
     receipt.acceptedCumulative === expectedCloseAmount &&
-    BigInt(receipt.spent) <= BigInt(expectedCloseAmount)
+    receiptSpent >= minimumSpent &&
+    receiptSpent <= expected
   )
 }
 
@@ -842,7 +851,7 @@ export function closedStateFromReceipt(receipt: SessionReceipt, entry: ChannelEn
  * Priority:
  * 1. Matching close-ready receipt spend.
  * 2. Matching socket delivery estimate (`deliveredChunks * tickCost`) clamped by cumulative.
- * 3. Highest local cumulative authorization for HTTP/SSE.
+ * 3. Local cumulative authorization high-water mark for HTTP/SSE.
  */
 export function computeFallbackCloseAmount(parameters: FallbackCloseAmountParameters): bigint {
   const {
@@ -857,12 +866,18 @@ export function computeFallbackCloseAmount(parameters: FallbackCloseAmountParame
     tickCost = 0n,
   } = parameters
 
+  if (spent > cumulativeAmount) {
+    throw new Error('locally confirmed spend exceeds local voucher state')
+  }
+
   if (
     closeReadyReceipt &&
     closeReadyReceipt.challengeId === challengeId &&
     closeReadyReceipt.channelId === channelId
   ) {
-    return BigInt(closeReadyReceipt.spent)
+    const closeReadySpent = Ws.parseUint96Amount(closeReadyReceipt.spent)
+    if (closeReadySpent === undefined) throw new Error('close-ready spent is not a uint96 amount')
+    return closeReadySpent > spent ? closeReadySpent : spent
   }
 
   if (socketChallengeId === challengeId && socketChannelId === channelId && tickCost > 0n) {
@@ -994,6 +1009,7 @@ export async function closeSocketSession(
         challengeId: target.challenge.id,
         channelId: target.channelId,
         expectedCloseAmount,
+        minimumSpent: readySpent,
         receipt,
       }),
     )

--- a/src/tempo/session/client/SessionManager.test.ts
+++ b/src/tempo/session/client/SessionManager.test.ts
@@ -209,6 +209,25 @@ describe('Session', () => {
       ).toBe(80n)
     })
 
+    test('keeps locally confirmed spend when the close-ready receipt is stale', () => {
+      const receipt = createSessionReceipt({
+        acceptedCumulative: 100n,
+        challengeId,
+        channelId,
+        spent: 40n,
+      })
+
+      expect(
+        computeFallbackCloseAmount({
+          challengeId,
+          channelId,
+          closeReadyReceipt: receipt,
+          cumulativeAmount: 100n,
+          spent: 50n,
+        }),
+      ).toBe(50n)
+    })
+
     test('uses matching socket delivery estimate clamped to cumulative authorization', () => {
       expect(
         computeFallbackCloseAmount({

--- a/src/tempo/session/client/SessionManager.test.ts
+++ b/src/tempo/session/client/SessionManager.test.ts
@@ -224,7 +224,7 @@ describe('Session', () => {
       ).toBe(90n)
     })
 
-    test('uses receipt-tracked spend when no socket estimate applies', () => {
+    test('uses local cumulative authorization when no socket estimate applies', () => {
       expect(
         computeFallbackCloseAmount({
           challengeId,
@@ -236,7 +236,7 @@ describe('Session', () => {
           spent: 40n,
           tickCost: 10n,
         }),
-      ).toBe(40n)
+      ).toBe(100n)
     })
   })
 

--- a/src/tempo/session/client/SessionManager.ts
+++ b/src/tempo/session/client/SessionManager.ts
@@ -759,6 +759,7 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
     const receipt = await closeHttpSession({
       createSessionCredential,
       fetch: config.fetch,
+      getMinimumSpent: () => runtime.spent,
       lastUrl: runtime.lastUrl,
       resolveSignedCloseAmount: (challenge) =>
         getValidatedFallbackCloseAmount(target, challenge, true),

--- a/src/tempo/session/client/SessionManager.ts
+++ b/src/tempo/session/client/SessionManager.ts
@@ -531,6 +531,7 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
       throw new Error('close snapshot accepted cumulative is below locally confirmed spend')
     }
     if (spent > runtime.spent) runtime.spent = spent
+    return snapshot
   }
 
   function getValidatedFallbackCloseAmount(
@@ -538,8 +539,11 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
     challenge: TempoSessionChallenge = target.challenge,
     applySnapshot = false,
   ) {
-    if (applySnapshot) applyCloseSnapshot(target, challenge)
-    const closeAmount = getFallbackCloseAmount(challenge, target.channelId)
+    const snapshot = applySnapshot
+      ? applyCloseSnapshot(target, challenge)
+      : validateCloseSnapshot(target.channel, challenge)
+    const closeAmount =
+      snapshot?.acceptedCumulative ?? getFallbackCloseAmount(challenge, target.channelId)
     if (closeAmount > target.channel.cumulativeAmount) {
       throw new Error('fallback close amount exceeds local voucher state')
     }

--- a/src/tempo/session/client/Transports.test.ts
+++ b/src/tempo/session/client/Transports.test.ts
@@ -402,6 +402,22 @@ describe('HttpManagement', () => {
       expect(authorizationHeader(fetch.mock.calls[1]?.[1])).toBe('close-challenge-2')
     })
 
+    test('closeHttpSession rejects spend below the locally confirmed high-water mark', async () => {
+      await expect(
+        closeHttpSession({
+          createSessionCredential: async () => 'close-credential',
+          fetch: async () =>
+            new Response(null, {
+              headers: { [Constants.Headers.paymentReceipt]: receiptHeader(5n, 3n) },
+            }),
+          getMinimumSpent: () => 4n,
+          lastUrl: 'https://example.test/resource',
+          signedCloseAmount: '5',
+          target: { challenge: challenge(), channel: channel(), channelId },
+        }),
+      ).rejects.toThrow('Session close response included a mismatched payment receipt.')
+    })
+
     test('closeHttpSession rejects a receipt without settlement proof', async () => {
       const receipt = serializeSessionReceipt(
         createSessionReceipt({
@@ -1027,6 +1043,15 @@ describe('WsDriver', () => {
           receipt: receipt(),
         }),
       ).toBe('received payment-close-ready beyond local voucher state')
+
+      expect(
+        validateSocketCloseReadyReceipt({
+          challengeId: 'challenge-1',
+          channelId,
+          cumulativeAmount: 80n,
+          receipt: receipt({ spent: -1n }),
+        }),
+      ).toBe('received invalid payment-close-ready spend')
     })
 
     test('validates final close receipts when a close amount is expected', () => {
@@ -1045,6 +1070,15 @@ describe('WsDriver', () => {
           channelId,
           expectedCloseAmount: '81',
           receipt: receipt({ txHash: '0x1234' }),
+        }),
+      ).toBe('received mismatched payment-close receipt frame')
+
+      expect(
+        validateSocketPaymentReceipt({
+          challengeId: 'challenge-1',
+          channelId,
+          expectedCloseAmount: '80',
+          receipt: receipt({ spent: 79n, txHash: '0x1234' }),
         }),
       ).toBe('received mismatched payment-close receipt frame')
     })

--- a/src/tempo/session/client/Transports.ts
+++ b/src/tempo/session/client/Transports.ts
@@ -516,6 +516,8 @@ export type CloseHttpSessionParameters = {
   fetch: typeof globalThis.fetch
   /** Last paid resource URL; used as the management endpoint base. */
   lastUrl: RequestInfo | URL | null
+  /** Returns the latest cumulative spend already confirmed by the client. */
+  getMinimumSpent?: (() => bigint) | undefined
   /** Resolves the close amount again when the server refreshes the challenge. */
   resolveSignedCloseAmount?: ((challenge: TempoSessionChallenge) => string) | undefined
   /** Final cumulative amount the client is willing to sign. */
@@ -790,6 +792,7 @@ export async function closeHttpSession(
       challengeId: closeChallenge.id,
       channelId: parameters.target.channelId,
       expectedCloseAmount: signedCloseAmount,
+      minimumSpent: parameters.getMinimumSpent?.() ?? 0n,
       receipt,
     })
   )
@@ -1303,7 +1306,9 @@ export function validateSocketCloseReadyReceipt(
   parameters: ValidateSocketCloseReadyReceiptParameters,
 ): string | undefined {
   if (!isExpectedSocketReceipt(parameters)) return 'received mismatched payment-close-ready frame'
-  if (BigInt(parameters.receipt.spent) > parameters.cumulativeAmount) {
+  const spent = Ws.parseUint96Amount(parameters.receipt.spent)
+  if (spent === undefined) return 'received invalid payment-close-ready spend'
+  if (spent > parameters.cumulativeAmount) {
     return 'received payment-close-ready beyond local voucher state'
   }
   return undefined
@@ -1318,7 +1323,13 @@ export function validateSocketPaymentReceipt(
   if (
     expectedCloseAmount !== null &&
     Boolean(receipt.txHash) &&
-    !isExpectedCloseReceipt({ challengeId, channelId, expectedCloseAmount, receipt })
+    !isExpectedCloseReceipt({
+      challengeId,
+      channelId,
+      expectedCloseAmount,
+      minimumSpent: BigInt(expectedCloseAmount),
+      receipt,
+    })
   ) {
     return 'received mismatched payment-close receipt frame'
   }

--- a/src/tempo/session/precompile/Protocol.test.ts
+++ b/src/tempo/session/precompile/Protocol.test.ts
@@ -47,6 +47,18 @@ describe('precompile Uint96', () => {
     expect(Types.isUint96(maxUint96 + 1n)).toBe(false)
   })
 
+  test.each(['-1', '1.5', '0x1', '', '1'.repeat(30), (maxUint96 + 1n).toString()])(
+    'rejects invalid uint96 amount string %s',
+    (value) => {
+      expect(Types.parseUint96Amount(value)).toBeUndefined()
+    },
+  )
+
+  test('parses decimal strings within uint96 bounds', () => {
+    expect(Types.parseUint96Amount('0')).toBe(0n)
+    expect(Types.parseUint96Amount(maxUint96.toString())).toBe(maxUint96)
+  })
+
   test('assertUint96 validates valid values and throws for invalid values', () => {
     const amount: bigint = 1n
     Types.assertUint96(amount)

--- a/src/tempo/session/precompile/Protocol.ts
+++ b/src/tempo/session/precompile/Protocol.ts
@@ -16,6 +16,13 @@ export function isUint96(value: bigint): value is Uint96 {
   return value >= 0n && value <= maxUint96
 }
 
+/** Parses an unsigned decimal raw amount when it fits TIP-1034's `uint96` range. */
+export function parseUint96Amount(value: RawAmountString): Uint96 | undefined {
+  if (!/^\d{1,29}$/.test(value)) return undefined
+  const amount = BigInt(value)
+  return isUint96(amount) ? amount : undefined
+}
+
 /** Converts a bigint into a TIP20EscrowChannel `uint96` amount after validating bounds. */
 export function uint96(value: bigint): Uint96 {
   assertUint96(value)


### PR DESCRIPTION
## Motivation

Persistent Tempo sessions can retain stale receipt spend after the server has charged content. Cooperative close then signs below server-recorded spend and is rejected.

## Summary

- Close HTTP/SSE fallback sessions at the highest locally authorized cumulative amount.
- Prefer refreshed server snapshot authorization when available.
- Accept close receipts whose captured spend is bounded by the signed close voucher.
- Add regression coverage for stale persisted spend and durable CLI accounting.

## Key design considerations

- Never signs above the client’s existing cumulative authorization.
- Preserves close-ready and socket delivery estimates for streaming sessions.
- Keeps snapshot validation bounded by local voucher state.