### PR TITLE
fix: accept case-insensitive challenge auth parameters

### DIFF
--- a/.agents/friction-log/20260813082951-focused-tests-require/friction.md
+++ b/.agents/friction-log/20260813082951-focused-tests-require/friction.md
@@ -1,0 +1,24 @@
+---
+title: 'focused tests require an unavailable Tempo RPC'
+severity: 'minor'
+---
+
+## Expected Behavior
+
+Pure unit-test selection should run without requiring a Tempo RPC.
+
+## Current Behavior
+
+Running a unit-only `vp test` command executes the global Tempo setup and fails with ECONNREFUSED at localhost:18545 when no local RPC is running.
+
+## Possible Solution
+
+Document `VITE_TEMPO_NETWORK=none` for pure tests or skip global network setup when selected tests do not need it.
+
+## Minimal Reproducible Example
+
+Run `pnpm exec vp test run --project node --testNamePattern auth-param` without a Tempo RPC on port 18545.
+
+## Context
+
+This blocks focused parser unit tests until the network mode is explicitly disabled.

--- a/.changeset/fuzzy-bats-accept.md
+++ b/.changeset/fuzzy-bats-accept.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed deserialization of challenges with mixed-case auth-param names.

--- a/src/Challenge.test.ts
+++ b/src/Challenge.test.ts
@@ -565,6 +565,24 @@ describe('deserialize', () => {
     `)
   })
 
+  test.each([
+    {
+      name: 'uppercase',
+      header: paymentHeader.replace(/\b(id|realm|method|intent|request)=/g, (param) =>
+        param.toUpperCase(),
+      ),
+    },
+    {
+      name: 'mixed-case',
+      header: paymentHeader.replace(
+        /\b(id|realm|method|intent|request)=/g,
+        (param) => `${param[0]?.toUpperCase()}${param.slice(1)}`,
+      ),
+    },
+  ])('behavior: deserializes $name auth-param names', ({ header }) => {
+    expect(Challenge.deserialize(header)).toEqual(Challenge.deserialize(paymentHeader))
+  })
+
   test('behavior: roundtrips with optional fields', () => {
     const original = Challenge.from({
       id: 'abc123',
@@ -644,6 +662,11 @@ describe('deserialize', () => {
     {
       name: 'duplicate parameters',
       header: 'Payment id="a", realm="api", method="tempo", intent="charge", request="e30", id="b"',
+      error: 'Duplicate parameter: id',
+    },
+    {
+      name: 'case-insensitive duplicate parameters',
+      header: 'Payment id="a", realm="api", method="tempo", intent="charge", request="e30", ID="b"',
       error: 'Duplicate parameter: id',
     },
     {

--- a/src/Challenge.ts
+++ b/src/Challenge.ts
@@ -385,7 +385,7 @@ function parseAuthParams(input: string): Record<string, string> {
 
     const keyStart = i
     while (i < input.length && /[A-Za-z0-9_-]/.test(input[i] ?? '')) i++
-    const key = input.slice(keyStart, i)
+    const key = input.slice(keyStart, i).toLowerCase()
     if (!key) throw new Error('Malformed auth-param.')
 
     while (i < input.length && /\s/.test(input[i] ?? '')) i++


### PR DESCRIPTION
## Motivation

HTTP authentication parameter names are case-insensitive, but challenge deserialization only recognized lowercase names. Fixes #786.

## Summary

- Normalized auth-param names before challenge parsing
- Added coverage for uppercase, mixed-case, and case-variant duplicate parameters
- Added a patch changeset
- Recorded focused-test RPC setup friction

## Key design considerations

- Preserved lowercase serialized output while accepting spec-conformant input casing
- Applied normalization before duplicate detection so duplicates remain case-insensitive