### PR TITLE
fix: handle prototype-named auth parameters

### DIFF
--- a/.changeset/parse-auth-param-prototype.md
+++ b/.changeset/parse-auth-param-prototype.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed challenge parsing for extension parameters named after `Object.prototype` properties.

--- a/src/Challenge.test.ts
+++ b/src/Challenge.test.ts
@@ -635,6 +635,18 @@ describe('deserialize', () => {
     expect(challenge.description).toBe(expected)
   })
 
+  test.each(['constructor', 'toString', 'valueOf', 'hasOwnProperty', '__proto__'])(
+    'behavior: accepts extension parameter named %s',
+    (name) => {
+      const header = `${paymentHeader}, ${name}="value"`
+
+      expect(Challenge.deserialize(header).id).toBe('abc123')
+      expect(() => Challenge.deserialize(`${header}, ${name}="duplicate"`)).toThrow(
+        `Duplicate parameter: ${name}`,
+      )
+    },
+  )
+
   test.each([
     {
       name: 'missing Payment scheme',

--- a/src/Challenge.ts
+++ b/src/Challenge.ts
@@ -376,7 +376,7 @@ function extractPaymentAuthParams(header: string): string | null {
 
 /** @internal Parses auth-params with support for escaped quoted-string values. */
 function parseAuthParams(input: string): Record<string, string> {
-  const result: Record<string, string> = {}
+  const result: Record<string, string> = Object.create(null)
   let i = 0
 
   while (i < input.length) {


### PR DESCRIPTION
## Motivation

Challenge parsing incorrectly rejected extension auth parameters whose names exist on Object.prototype. Fixes #787.

## Summary

- Store parsed auth parameters in a null-prototype object.
- Cover prototype-named parameters while preserving duplicate rejection.
- Add a patch changeset.

## Key design considerations

- Retain the existing indexed lookup and duplicate detection without prototype collisions.
- Ensure __proto__ is stored as ordinary parameter data.