### PR TITLE
fix(tempo): require explicit custom session escrow

### DIFF
--- a/.changeset/secure-tempo-session-escrow.md
+++ b/.changeset/secure-tempo-session-escrow.md
@@ -2,4 +2,4 @@
 'mppx': patch
 ---
 
-Required server-advertised Tempo session escrows to match the canonical address or an explicit client override.
+Required server-advertised Tempo session escrows to match the canonical address unless clients enable `allowCustomEscrow`.

--- a/.changeset/secure-tempo-session-escrow.md
+++ b/.changeset/secure-tempo-session-escrow.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Required server-advertised Tempo session escrows to match the canonical address or an explicit client override.

--- a/README.md
+++ b/README.md
@@ -117,10 +117,19 @@ mppx sessions list
 mppx sessions view <channel-id>
 mppx sessions close <channel-id>
 mppx sessions close --all --yes
+
+# explicitly trust a custom session escrow advertised by the server
+mppx example.com -M allowCustomEscrow=true
 ```
 
 `--session auto` is the default. Pass `new` to open another channel or a channel ID to select one
 explicitly.
+
+Tempo session clients accept only the canonical escrow contract by default. A server may advertise
+its configured custom escrow in the payment challenge, but the client rejects it unless
+`-M allowCustomEscrow=true` is supplied. This opt-in trusts the server-selected address; clients
+that do not support custom escrows should leave it unset. See the
+[session escrow trust documentation](./src/tempo/session/README.md#escrow-configuration-and-trust).
 
 You can also install globally to use the `mppx` CLI from anywhere:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ overrides:
   path-to-regexp@<8.4.0: 8.4.0
   tar@<=7.5.20: 7.5.21
   postcss@<=8.5.22: 8.5.23
-  nanoid@<3.3.17: 3.3.17
+  nanoid@<3.3.18: 3.3.18
   '@modelcontextprotocol/sdk@>=1.10.0 <=1.25.3': 1.26.0
   '@modelcontextprotocol/server': 2.0.0-alpha.2
   qs@>=6.7.0 <=6.15.1: 6.15.2
@@ -3387,11 +3387,6 @@ packages:
 
   nan@2.28.0:
     resolution: {integrity: sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==}
-
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
 
   nanoid@3.3.18:
     resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
@@ -6894,8 +6889,6 @@ snapshots:
   nan@2.28.0:
     optional: true
 
-  nanoid@3.3.17: {}
-
   nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
@@ -7130,7 +7123,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,7 +23,7 @@ overrides:
   path-to-regexp@<8.4.0: '8.4.0'
   tar@<=7.5.20: '7.5.21'
   postcss@<=8.5.22: '8.5.23'
-  nanoid@<3.3.17: '3.3.17'
+  nanoid@<3.3.18: '3.3.18'
   '@modelcontextprotocol/sdk@>=1.10.0 <=1.25.3': '1.26.0'
   '@modelcontextprotocol/server': '2.0.0-alpha.2'
   qs@>=6.7.0 <=6.15.1: '6.15.2'
@@ -77,7 +77,7 @@ minimumReleaseAgeExclude:
   - hono@4.12.34
   - ip-address@10.3.1
   - js-yaml@4.3.1
-  - nanoid@3.3.17
+  - nanoid@3.3.18
   - ox@0.14.33
   - postcss@8.5.23
   - protobufjs@7.6.5

--- a/src/Challenge.test.ts
+++ b/src/Challenge.test.ts
@@ -660,7 +660,7 @@ describe('deserialize', () => {
 
       expect(Challenge.deserialize(header).id).toBe('abc123')
       expect(() => Challenge.deserialize(`${header}, ${name}="duplicate"`)).toThrow(
-        `Duplicate parameter: ${name}`,
+        `Duplicate parameter: ${name.toLowerCase()}`,
       )
     },
   )

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -1072,7 +1072,7 @@ describe('session multi-fetch (examples/session/multi-fetch)', () => {
       await fundAccount({ address: testAccount.address, token: Addresses.pathUsd })
       await fundAccount({ address: testAccount.address, token: asset })
 
-      const escrow = '0x0000000000000000000000000000000000000005' as Address
+      const escrow = tip20ChannelEscrow
       let openCredential: SessionCredentialPayload | undefined
 
       const httpServer = await Http.createServer(async (req, res) => {
@@ -1115,10 +1115,11 @@ describe('session multi-fetch (examples/session/multi-fetch)', () => {
       })
 
       try {
-        await serve(
+        const result = await serve(
           [httpServer.url, '--rpc-url', rpcUrl, '-s', '-M', 'deposit=10', '-M', `escrow=${escrow}`],
           { env: { MPPX_PRIVATE_KEY: testPrivateKey } },
         )
+        expect(result.exitCode, `${result.output}\n${result.stderr}`).toBeUndefined()
 
         expect(openCredential).toBeDefined()
         expect(openCredential?.action).toBe('open')

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -1066,7 +1066,7 @@ describe('session multi-fetch (examples/session/multi-fetch)', () => {
   })
 
   test(
-    'uses explicit escrow and server suggestedDeposit within CLI max deposit',
+    'accepts the escrow advertised by the server and its suggestedDeposit',
     { timeout: 120_000 },
     async () => {
       await fundAccount({ address: testAccount.address, token: Addresses.pathUsd })
@@ -1116,7 +1116,16 @@ describe('session multi-fetch (examples/session/multi-fetch)', () => {
 
       try {
         const result = await serve(
-          [httpServer.url, '--rpc-url', rpcUrl, '-s', '-M', 'deposit=10', '-M', `escrow=${escrow}`],
+          [
+            httpServer.url,
+            '--rpc-url',
+            rpcUrl,
+            '-s',
+            '-M',
+            'deposit=10',
+            '-M',
+            'allowCustomEscrow=true',
+          ],
           { env: { MPPX_PRIVATE_KEY: testPrivateKey } },
         )
         expect(result.exitCode, `${result.output}\n${result.stderr}`).toBeUndefined()

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -1065,80 +1065,85 @@ describe('session multi-fetch (examples/session/multi-fetch)', () => {
     }
   })
 
-  test('uses server suggestedDeposit within CLI max deposit', { timeout: 120_000 }, async () => {
-    await fundAccount({ address: testAccount.address, token: Addresses.pathUsd })
-    await fundAccount({ address: testAccount.address, token: asset })
+  test(
+    'uses explicit escrow and server suggestedDeposit within CLI max deposit',
+    { timeout: 120_000 },
+    async () => {
+      await fundAccount({ address: testAccount.address, token: Addresses.pathUsd })
+      await fundAccount({ address: testAccount.address, token: asset })
 
-    const escrow = tip20ChannelEscrow
-    let openCredential: SessionCredentialPayload | undefined
+      const escrow = '0x0000000000000000000000000000000000000005' as Address
+      let openCredential: SessionCredentialPayload | undefined
 
-    const httpServer = await Http.createServer(async (req, res) => {
-      const authHeader = req.headers.authorization
-      if (!authHeader) {
-        res.writeHead(402, {
-          'WWW-Authenticate': Challenge.serialize(
-            Challenge.from({
-              id: 'cli-deposit-override',
-              realm: 'cli-test-deposit-override',
-              method: 'tempo',
-              intent: 'session',
-              request: {
-                amount: '1000000',
-                currency: asset,
-                decimals: 6,
-                recipient: accounts[0].address,
-                suggestedDeposit: '7000000',
-                unitType: 'token',
-                methodDetails: {
-                  chainId: chain.id,
-                  escrowContract: escrow,
-                  sessionProtocol: Constants.SessionProtocols.v2,
+      const httpServer = await Http.createServer(async (req, res) => {
+        const authHeader = req.headers.authorization
+        if (!authHeader) {
+          res.writeHead(402, {
+            'WWW-Authenticate': Challenge.serialize(
+              Challenge.from({
+                id: 'cli-deposit-override',
+                realm: 'cli-test-deposit-override',
+                method: 'tempo',
+                intent: 'session',
+                request: {
+                  amount: '1000000',
+                  currency: asset,
+                  decimals: 6,
+                  recipient: accounts[0].address,
+                  suggestedDeposit: '7000000',
+                  unitType: 'token',
+                  methodDetails: {
+                    chainId: chain.id,
+                    escrowContract: escrow,
+                    sessionProtocol: Constants.SessionProtocols.v2,
+                  },
                 },
-              },
-            }),
-          ),
-        })
-        res.end()
-        return
-      }
+              }),
+            ),
+          })
+          res.end()
+          return
+        }
 
-      try {
-        const cred = Credential.deserialize<SessionCredentialPayload>(authHeader)
-        if (cred.payload.action === 'open') openCredential = cred.payload
-      } catch {}
+        try {
+          const cred = Credential.deserialize<SessionCredentialPayload>(authHeader)
+          if (cred.payload.action === 'open') openCredential = cred.payload
+        } catch {}
 
-      res.writeHead(200)
-      res.end('scraped-content')
-    })
-
-    try {
-      await serve([httpServer.url, '--rpc-url', rpcUrl, '-s', '-M', 'deposit=10'], {
-        env: { MPPX_PRIVATE_KEY: testPrivateKey },
+        res.writeHead(200)
+        res.end('scraped-content')
       })
 
-      expect(openCredential).toBeDefined()
-      expect(openCredential?.action).toBe('open')
-      if (!openCredential || openCredential.action !== 'open')
-        throw new Error('missing open credential')
+      try {
+        await serve(
+          [httpServer.url, '--rpc-url', rpcUrl, '-s', '-M', 'deposit=10', '-M', `escrow=${escrow}`],
+          { env: { MPPX_PRIVATE_KEY: testPrivateKey } },
+        )
 
-      const transaction = Transaction.deserialize(openCredential.transaction)
-      if (!('calls' in transaction)) throw new Error('unexpected transaction type')
-      const [openCall] = transaction.calls as readonly [{ to?: Address; data?: `0x${string}` }]
-      const open = decodeFunctionData({ abi: escrowAbi, data: openCall.data ?? '0x' })
-      const openArgs = open.args as readonly [Address, Address, Address, bigint, string, Address]
+        expect(openCredential).toBeDefined()
+        expect(openCredential?.action).toBe('open')
+        if (!openCredential || openCredential.action !== 'open')
+          throw new Error('missing open credential')
 
-      expect(openCall.to?.toLowerCase()).toBe(escrow.toLowerCase())
-      expect(open.functionName).toBe('open')
-      expect(openArgs[0].toLowerCase()).toBe(accounts[0].address.toLowerCase())
-      expect(openArgs[1]).toBe('0x0000000000000000000000000000000000000000')
-      expect(openArgs[2].toLowerCase()).toBe(asset.toLowerCase())
-      expect(openArgs[3]).toBe(7_000_000n)
-      expect(openArgs[4]).toEqual(expect.any(String))
-      expect(openArgs[5].toLowerCase()).toBe(testAccount.address.toLowerCase())
-    } finally {
-      httpServer.close()
-    }
-  })
+        const transaction = Transaction.deserialize(openCredential.transaction)
+        if (!('calls' in transaction)) throw new Error('unexpected transaction type')
+        const [openCall] = transaction.calls as readonly [{ to?: Address; data?: `0x${string}` }]
+        const open = decodeFunctionData({ abi: escrowAbi, data: openCall.data ?? '0x' })
+        const openArgs = open.args as readonly [Address, Address, Address, bigint, string, Address]
+
+        expect(openCall.to?.toLowerCase()).toBe(escrow.toLowerCase())
+        expect(open.functionName).toBe('open')
+        expect(openArgs[0].toLowerCase()).toBe(accounts[0].address.toLowerCase())
+        expect(openArgs[1]).toBe('0x0000000000000000000000000000000000000000')
+        expect(openArgs[2].toLowerCase()).toBe(asset.toLowerCase())
+        expect(openArgs[3]).toBe(7_000_000n)
+        expect(openArgs[4]).toEqual(expect.any(String))
+        expect(openArgs[5].toLowerCase()).toBe(testAccount.address.toLowerCase())
+      } finally {
+        httpServer.close()
+      }
+    },
+  )
 
   test(
     'selects retained non-SSE channels with auto, explicit, and new modes',

--- a/src/cli/plugins/tempo.ts
+++ b/src/cli/plugins/tempo.ts
@@ -51,6 +51,7 @@ const tempoOptionSchema = z.object({
   autoSwap: z.optional(booleanOption),
   channel: z.optional(z.coerce.string()),
   deposit: z.optional(z.union([z.string(), z.number()])),
+  escrow: z.optional(z.string().check(z.regex(/^0x[0-9a-fA-F]{40}$/, 'Invalid address'))),
   payWith: z.optional(z.string()),
   slippage: z.optional(z.coerce.number()),
   tokenIn: z.optional(z.string()),
@@ -59,6 +60,7 @@ const tempoOptionKeys = [
   'autoSwap',
   'channel',
   'deposit',
+  'escrow',
   'payWith',
   'slippage',
   'tokenIn',
@@ -251,6 +253,7 @@ export function tempo() {
         account,
         getClient: () => client!,
         ...(autoSwap !== undefined ? { autoSwap } : {}),
+        ...(tempoOpts.escrow !== undefined ? { escrow: tempoOpts.escrow as Address } : {}),
         maxDeposit: (() => {
           if (challenge.intent !== 'session') return undefined
           const suggestedDeposit = (challenge.request as Record<string, unknown>)

--- a/src/cli/plugins/tempo.ts
+++ b/src/cli/plugins/tempo.ts
@@ -48,19 +48,19 @@ async function writeResponseBody(response: Response) {
 }
 
 const tempoOptionSchema = z.object({
+  allowCustomEscrow: z.optional(booleanOption),
   autoSwap: z.optional(booleanOption),
   channel: z.optional(z.coerce.string()),
   deposit: z.optional(z.union([z.string(), z.number()])),
-  escrow: z.optional(z.string().check(z.regex(/^0x[0-9a-fA-F]{40}$/, 'Invalid address'))),
   payWith: z.optional(z.string()),
   slippage: z.optional(z.coerce.number()),
   tokenIn: z.optional(z.string()),
 })
 const tempoOptionKeys = [
+  'allowCustomEscrow',
   'autoSwap',
   'channel',
   'deposit',
-  'escrow',
   'payWith',
   'slippage',
   'tokenIn',
@@ -251,9 +251,11 @@ export function tempo() {
 
       const methods = tempoMethods({
         account,
+        ...(tempoOpts.allowCustomEscrow !== undefined
+          ? { allowCustomEscrow: tempoOpts.allowCustomEscrow }
+          : {}),
         getClient: () => client!,
         ...(autoSwap !== undefined ? { autoSwap } : {}),
-        ...(tempoOpts.escrow !== undefined ? { escrow: tempoOpts.escrow as Address } : {}),
         maxDeposit: (() => {
           if (challenge.intent !== 'session') return undefined
           const suggestedDeposit = (challenge.request as Record<string, unknown>)

--- a/src/cli/sessions/Manager.ts
+++ b/src/cli/sessions/Manager.ts
@@ -54,7 +54,7 @@ function assertCloseChallengeScope(challenge: TempoSessionChallenge, channel: Ch
     challenge.request.currency.toLowerCase() !== channel.descriptor.token.toLowerCase()
   )
     throw new Error('Close challenge changed the session token.')
-  if (resolveEscrow(challenge).toLowerCase() !== channel.escrow.toLowerCase())
+  if (resolveEscrow(challenge, channel.escrow).toLowerCase() !== channel.escrow.toLowerCase())
     throw new Error('Close challenge changed the session escrow.')
   const snapshot = getSessionSnapshot(challenge)
   if (snapshot && snapshot.channelId.toLowerCase() !== channel.channelId.toLowerCase())
@@ -84,6 +84,7 @@ export async function closeWithSessionManager(
   const manager = sessionManager({
     ...parameters.manager,
     bootstrap: false,
+    escrow: parameters.channel.escrow,
     fetch: validatedFetch,
   })
   getSessionManagerInternals(manager).rehydrate(parameters)

--- a/src/cli/sessions/request.test.ts
+++ b/src/cli/sessions/request.test.ts
@@ -2,7 +2,11 @@ import type { Hex } from 'viem'
 import { describe, expect, test } from 'vp/test'
 
 import type * as Challenge from '../../Challenge.js'
-import { resolveSessionMaxDeposit, resolveSessionSelection } from './request.js'
+import {
+  resolveSessionEscrowOverride,
+  resolveSessionMaxDeposit,
+  resolveSessionSelection,
+} from './request.js'
 
 const channelId = `0x${'12'.repeat(32)}` as Hex
 describe('resolveSessionSelection', () => {
@@ -22,6 +26,19 @@ describe('resolveSessionSelection', () => {
   test('rejects conflicting selectors', () => {
     expect(() => resolveSessionSelection('new', channelId)).toThrow(
       '--session and -M channel= select different sessions.',
+    )
+  })
+})
+
+describe('resolveSessionEscrowOverride', () => {
+  test('accepts an explicit escrow address', () => {
+    const escrow = '0x4444444444444444444444444444444444444444'
+    expect(resolveSessionEscrowOverride({ escrow })).toBe(escrow)
+  })
+
+  test('rejects an invalid escrow address', () => {
+    expect(() => resolveSessionEscrowOverride({ escrow: 'invalid' })).toThrow(
+      'Session escrow must be a 20-byte address.',
     )
   })
 })

--- a/src/cli/sessions/request.test.ts
+++ b/src/cli/sessions/request.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'vp/test'
 
 import type * as Challenge from '../../Challenge.js'
 import {
-  resolveSessionEscrowOverride,
+  resolveAllowCustomEscrow,
   resolveSessionMaxDeposit,
   resolveSessionSelection,
 } from './request.js'
@@ -30,15 +30,16 @@ describe('resolveSessionSelection', () => {
   })
 })
 
-describe('resolveSessionEscrowOverride', () => {
-  test('accepts an explicit escrow address', () => {
-    const escrow = '0x4444444444444444444444444444444444444444'
-    expect(resolveSessionEscrowOverride({ escrow })).toBe(escrow)
+describe('resolveAllowCustomEscrow', () => {
+  test('accepts boolean method options', () => {
+    expect(resolveAllowCustomEscrow({ allowCustomEscrow: 'true' })).toBe(true)
+    expect(resolveAllowCustomEscrow({ allowCustomEscrow: 'false' })).toBe(false)
+    expect(resolveAllowCustomEscrow({})).toBeUndefined()
   })
 
-  test('rejects an invalid escrow address', () => {
-    expect(() => resolveSessionEscrowOverride({ escrow: 'invalid' })).toThrow(
-      'Session escrow must be a 20-byte address.',
+  test('rejects an invalid boolean', () => {
+    expect(() => resolveAllowCustomEscrow({ allowCustomEscrow: 'yes' })).toThrow(
+      'allowCustomEscrow must be true or false.',
     )
   })
 })

--- a/src/cli/sessions/request.ts
+++ b/src/cli/sessions/request.ts
@@ -1,6 +1,6 @@
 import { Errors } from 'incur'
 import type { Hex } from 'ox'
-import { type Address, createClient, formatUnits, http, isAddress } from 'viem'
+import { createClient, formatUnits, http } from 'viem'
 
 import type * as Challenge from '../../Challenge.js'
 import {
@@ -84,16 +84,17 @@ function sessionDecimals(challenge: Challenge.Challenge): number {
   return typeof challenge.request.decimals === 'number' ? challenge.request.decimals : 6
 }
 
-/** @internal Resolves an explicitly trusted session escrow from CLI method options. */
-export function resolveSessionEscrowOverride(
+/** @internal Resolves whether the CLI accepts a server-advertised custom escrow. */
+export function resolveAllowCustomEscrow(
   methodOptions: Record<string, string>,
-): Address | undefined {
-  const escrow = methodOptions.escrow
-  if (escrow === undefined) return undefined
-  if (isAddress(escrow, { strict: false })) return escrow
+): boolean | undefined {
+  const value = methodOptions.allowCustomEscrow
+  if (value === undefined) return undefined
+  if (value === 'true') return true
+  if (value === 'false') return false
   throw new Errors.IncurError({
-    code: 'INVALID_SESSION_ESCROW',
-    message: 'Session escrow must be a 20-byte address.',
+    code: 'INVALID_ALLOW_CUSTOM_ESCROW',
+    message: 'allowCustomEscrow must be true or false.',
     exitCode: 2,
   })
 }
@@ -162,10 +163,10 @@ export async function runPersistentSessionRequest(
   const rpcUrl = resolveRpcUrl(options.rpcUrl, { network: options.network })
   const chain = await resolveChain({ network: options.network, rpcUrl })
   const client = createClient({ chain, transport: http(rpcUrl) })
-  const escrowOverride = resolveSessionEscrowOverride(parameters.methodOptions)
+  const allowCustomEscrow = resolveAllowCustomEscrow(parameters.methodOptions)
   const challengeContext = await resolveChallengeContext({
+    allowCustomEscrow,
     challenge: parameters.challenge,
-    escrowOverride,
     getClient: async () => client,
   })
   if (challengeContext.chainId !== chain.id)
@@ -269,11 +270,11 @@ export async function runPersistentSessionRequest(
     let replayPending = true
     const manager = sessionManager({
       account: resolvedAccount.account,
+      allowCustomEscrow,
       bootstrap: false,
       client,
       channelStore,
       decimals: sessionDecimals(parameters.challenge),
-      escrow: escrowOverride,
       maxDeposit: resolveSessionMaxDeposit(
         parameters.challenge,
         parameters.methodOptions,

--- a/src/cli/sessions/request.ts
+++ b/src/cli/sessions/request.ts
@@ -1,6 +1,6 @@
 import { Errors } from 'incur'
 import type { Hex } from 'ox'
-import { createClient, formatUnits, http } from 'viem'
+import { type Address, createClient, formatUnits, http, isAddress } from 'viem'
 
 import type * as Challenge from '../../Challenge.js'
 import {
@@ -84,6 +84,20 @@ function sessionDecimals(challenge: Challenge.Challenge): number {
   return typeof challenge.request.decimals === 'number' ? challenge.request.decimals : 6
 }
 
+/** @internal Resolves an explicitly trusted session escrow from CLI method options. */
+export function resolveSessionEscrowOverride(
+  methodOptions: Record<string, string>,
+): Address | undefined {
+  const escrow = methodOptions.escrow
+  if (escrow === undefined) return undefined
+  if (isAddress(escrow, { strict: false })) return escrow
+  throw new Errors.IncurError({
+    code: 'INVALID_SESSION_ESCROW',
+    message: 'Session escrow must be a 20-byte address.',
+    exitCode: 2,
+  })
+}
+
 /** @internal Resolves the manager deposit cap in human-readable token units. */
 export function resolveSessionMaxDeposit(
   challenge: Challenge.Challenge,
@@ -148,8 +162,10 @@ export async function runPersistentSessionRequest(
   const rpcUrl = resolveRpcUrl(options.rpcUrl, { network: options.network })
   const chain = await resolveChain({ network: options.network, rpcUrl })
   const client = createClient({ chain, transport: http(rpcUrl) })
+  const escrowOverride = resolveSessionEscrowOverride(parameters.methodOptions)
   const challengeContext = await resolveChallengeContext({
     challenge: parameters.challenge,
+    escrowOverride,
     getClient: async () => client,
   })
   if (challengeContext.chainId !== chain.id)
@@ -257,6 +273,7 @@ export async function runPersistentSessionRequest(
       client,
       channelStore,
       decimals: sessionDecimals(parameters.challenge),
+      escrow: escrowOverride,
       maxDeposit: resolveSessionMaxDeposit(
         parameters.challenge,
         parameters.methodOptions,

--- a/src/cli/sessions/store.ts
+++ b/src/cli/sessions/store.ts
@@ -757,7 +757,7 @@ function assertChallengeMatchesChannel(
     throw stateError(file, 'Session challenge payee does not match the channel.')
   if (token !== channel.descriptor.token.toLowerCase())
     throw stateError(file, 'Session challenge token does not match the channel.')
-  if (resolveEscrow(challenge).toLowerCase() !== channel.escrow.toLowerCase())
+  if (resolveEscrow(challenge, channel.escrow).toLowerCase() !== channel.escrow.toLowerCase())
     throw stateError(file, 'Session challenge escrow does not match the channel.')
   if (isObject(challenge.request.methodDetails)) {
     const methodDetails = challenge.request.methodDetails

--- a/src/tempo/legacy/client/ChannelOps.test.ts
+++ b/src/tempo/legacy/client/ChannelOps.test.ts
@@ -52,18 +52,40 @@ function makeChallenge(overrides?: Partial<Challenge>): Challenge {
 }
 
 describe('resolveEscrow', () => {
-  test('prefers escrowContractOverride over challenge.request.methodDetails.escrowContract', () => {
+  test('accepts a challenge escrow matching the client override', () => {
+    const override = '0xabcdef0000000000000000000000000000000005' as Address
     const challenge = {
-      request: { methodDetails: { escrowContract: '0xChallengeEscrow' } },
+      request: { methodDetails: { escrowContract: '0xABCDEF0000000000000000000000000000000005' } },
     }
-    const result = resolveEscrow(challenge, 42431, '0xOverride' as Address)
-    expect(result).toBe('0xOverride')
+    const result = resolveEscrow(challenge, 42431, override)
+    expect(result).toBe(override)
+  })
+
+  test('rejects a challenge escrow that does not match the client override', () => {
+    const challenge = {
+      request: {
+        methodDetails: { escrowContract: '0x0000000000000000000000000000000000000006' },
+      },
+    }
+    expect(() =>
+      resolveEscrow(challenge, 42431, '0x0000000000000000000000000000000000000005'),
+    ).toThrow('does not match client escrow')
+  })
+
+  test('rejects a noncanonical challenge escrow without a client override', () => {
+    const challenge = {
+      request: {
+        methodDetails: { escrowContract: '0x0000000000000000000000000000000000000006' },
+      },
+    }
+    expect(() => resolveEscrow(challenge, 42431)).toThrow('does not match client escrow')
   })
 
   test('falls back to escrowContractOverride', () => {
     const challenge = { request: { methodDetails: {} } }
-    const result = resolveEscrow(challenge, 42431, '0xOverride' as Address)
-    expect(result).toBe('0xOverride')
+    const override = '0x0000000000000000000000000000000000000005' as Address
+    const result = resolveEscrow(challenge, 42431, override)
+    expect(result).toBe(override)
   })
 
   test('falls back to defaults when no override', () => {
@@ -74,7 +96,7 @@ describe('resolveEscrow', () => {
 
   test('throws when no escrow available', () => {
     const challenge = { request: {} }
-    expect(() => resolveEscrow(challenge, 99999)).toThrow('No `escrowContract` available')
+    expect(() => resolveEscrow(challenge, 99999)).toThrow('No trusted `escrowContract` available')
   })
 
   test('falls back to defaults when methodDetails is undefined', () => {

--- a/src/tempo/legacy/client/ChannelOps.test.ts
+++ b/src/tempo/legacy/client/ChannelOps.test.ts
@@ -81,6 +81,15 @@ describe('resolveEscrow', () => {
     expect(() => resolveEscrow(challenge, 42431)).toThrow('does not match client escrow')
   })
 
+  test('accepts a server-advertised custom escrow when allowed', () => {
+    const challengeEscrow = '0x0000000000000000000000000000000000000006' as Address
+    const challenge = {
+      request: { methodDetails: { escrowContract: challengeEscrow } },
+    }
+    expect(resolveEscrow(challenge, 42431, undefined, true)).toBe(challengeEscrow)
+    expect(resolveEscrow(challenge, 99999, undefined, true)).toBe(challengeEscrow)
+  })
+
   test('falls back to escrowContractOverride', () => {
     const challenge = { request: { methodDetails: {} } }
     const override = '0x0000000000000000000000000000000000000005' as Address

--- a/src/tempo/legacy/client/ChannelOps.ts
+++ b/src/tempo/legacy/client/ChannelOps.ts
@@ -56,26 +56,34 @@ export function resolveChainId(challenge: Challenge): number {
   return md?.chainId ?? 0
 }
 
-/** Resolves the legacy escrow contract from a local override or chain default. */
+/** Resolves the server-advertised escrow against the client's trust policy. */
 export function resolveEscrow(
   challenge: { request: { methodDetails?: unknown } },
   chainId: number,
   escrowContractOverride?: Address,
+  allowCustomEscrow = false,
 ): Address {
   const challengeEscrow = (challenge.request.methodDetails as { escrowContract?: string })
     ?.escrowContract as Address | undefined
   const escrow =
     escrowContractOverride ??
     defaults.escrowContract[chainId as keyof typeof defaults.escrowContract]
-  if (!escrow)
+  if (!escrow && !(allowCustomEscrow && challengeEscrow))
     throw new Error(
       'No trusted `escrowContract` available. Provide it in client parameters or use a supported chain.',
     )
-  if (challengeEscrow && challengeEscrow.toLowerCase() !== escrow.toLowerCase())
+  if (
+    challengeEscrow &&
+    escrow &&
+    challengeEscrow.toLowerCase() !== escrow.toLowerCase() &&
+    (!allowCustomEscrow || escrowContractOverride !== undefined)
+  )
     throw new Error(
       `Tempo session escrow ${challengeEscrow} does not match client escrow ${escrow}.`,
     )
-  return escrow
+  if (challengeEscrow && (!escrow || challengeEscrow.toLowerCase() !== escrow.toLowerCase()))
+    return challengeEscrow
+  return escrow!
 }
 
 /** Serializes a legacy session credential with a payer DID source. */

--- a/src/tempo/legacy/client/ChannelOps.ts
+++ b/src/tempo/legacy/client/ChannelOps.ts
@@ -56,7 +56,7 @@ export function resolveChainId(challenge: Challenge): number {
   return md?.chainId ?? 0
 }
 
-/** Resolves the legacy escrow contract from local override, challenge hint, or defaults. */
+/** Resolves the legacy escrow contract from a local override or chain default. */
 export function resolveEscrow(
   challenge: { request: { methodDetails?: unknown } },
   chainId: number,
@@ -66,11 +66,14 @@ export function resolveEscrow(
     ?.escrowContract as Address | undefined
   const escrow =
     escrowContractOverride ??
-    challengeEscrow ??
     defaults.escrowContract[chainId as keyof typeof defaults.escrowContract]
   if (!escrow)
     throw new Error(
-      'No `escrowContract` available. Provide it in parameters or ensure the server challenge includes it.',
+      'No trusted `escrowContract` available. Provide it in client parameters or use a supported chain.',
+    )
+  if (challengeEscrow && challengeEscrow.toLowerCase() !== escrow.toLowerCase())
+    throw new Error(
+      `Tempo session escrow ${challengeEscrow} does not match client escrow ${escrow}.`,
     )
   return escrow
 }

--- a/src/tempo/legacy/client/Session.test.ts
+++ b/src/tempo/legacy/client/Session.test.ts
@@ -179,6 +179,30 @@ describe('session (pure)', () => {
       ).rejects.toThrow('cumulativeAmount required for close action')
     })
 
+    test('rejects a challenge escrow that differs from the cached channel escrow', async () => {
+      const method = session({ getClient: () => pureClient, account: pureAccount })
+      const context = {
+        action: 'topUp' as const,
+        additionalDeposit: '5',
+        channelId,
+        transaction: '0xabc',
+      }
+
+      await method.createCredential({ challenge: makeChallenge(), context })
+
+      await expect(
+        method.createCredential({
+          challenge: makeChallenge({
+            methodDetails: {
+              chainId: 42431,
+              escrowContract: '0x4444444444444444444444444444444444444444',
+            },
+          }),
+          context,
+        }),
+      ).rejects.toThrow('does not match client escrow')
+    })
+
     test('manual voucher produces valid credential', async () => {
       const method = session({ getClient: () => pureClient, account: pureAccount })
 

--- a/src/tempo/legacy/client/Session.test.ts
+++ b/src/tempo/legacy/client/Session.test.ts
@@ -1,15 +1,7 @@
 import { SignatureEnvelope } from 'ox/tempo'
-import {
-  type Address,
-  createClient,
-  custom,
-  decodeFunctionData,
-  erc20Abi,
-  type Hex,
-  http,
-} from 'viem'
+import { type Address, createClient, custom, type Hex, http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { Account as TempoAccount, Addresses, Transaction, WebCryptoP256 } from 'viem/tempo'
+import { Account as TempoAccount, Addresses, WebCryptoP256 } from 'viem/tempo'
 import { tempoModerato } from 'viem/tempo/chains'
 import { beforeAll, describe, expect, test } from 'vp/test'
 import { tempoNetwork } from '~test/config.js'
@@ -20,7 +12,6 @@ import * as Challenge from '../../../Challenge.js'
 import * as Constants from '../../../Constants.js'
 import * as Credential from '../../../Credential.js'
 import { chainId, escrowContract as escrowContractDefaults } from '../../internal/defaults.js'
-import { escrowAbi } from '../session/Chain.js'
 import type { LegacySessionCredentialPayload } from '../session/Types.js'
 import { verifyVoucher } from '../session/Voucher.js'
 import { session } from './Session.js'
@@ -579,7 +570,7 @@ describe.runIf(isLocalnet)('session (on-chain)', () => {
       }
     })
 
-    test('prefers local escrowContract and deposit over server challenge overrides', async () => {
+    test('rejects a server escrow that differs from the local override', async () => {
       const maliciousEscrow = '0x4444444444444444444444444444444444444444' as Address
       const method = session({
         getClient: () => client,
@@ -588,50 +579,18 @@ describe.runIf(isLocalnet)('session (on-chain)', () => {
         escrowContract,
       })
 
-      const result = await method.createCredential({
-        challenge: makeLiveChallenge({
-          suggestedDeposit: '7000000',
-          methodDetails: {
-            chainId: chain.id,
-            escrowContract: maliciousEscrow,
-          },
+      await expect(
+        method.createCredential({
+          challenge: makeLiveChallenge({
+            suggestedDeposit: '7000000',
+            methodDetails: {
+              chainId: chain.id,
+              escrowContract: maliciousEscrow,
+            },
+          }),
+          context: {},
         }),
-        context: {},
-      })
-
-      const cred = deserializePayload(result)
-      expect(cred.payload.action).toBe('open')
-      if (cred.payload.action !== 'open') throw new Error('unexpected action')
-
-      const transaction = Transaction.deserialize(cred.payload.transaction)
-      if (!('calls' in transaction)) throw new Error('unexpected transaction type')
-      const [approveCall, openCall] = transaction.calls as readonly [
-        { to?: Address; data?: Hex },
-        { to?: Address; data?: Hex },
-      ]
-      const approve = decodeFunctionData({
-        abi: erc20Abi,
-        data: approveCall.data ?? '0x',
-      })
-      const open = decodeFunctionData({
-        abi: escrowAbi,
-        data: openCall.data ?? '0x',
-      })
-      const approveArgs = approve.args as readonly [Address, bigint]
-      const openArgs = open.args as readonly [Address, Address, bigint, string, Address]
-
-      expect(approveCall.to).toBe(asset)
-      expect(approve.functionName).toBe('approve')
-      expect(approveArgs[0].toLowerCase()).toBe(escrowContract.toLowerCase())
-      expect(approveArgs[1]).toBe(10_000_000n)
-
-      expect(openCall.to?.toLowerCase()).toBe(escrowContract.toLowerCase())
-      expect(open.functionName).toBe('open')
-      expect(openArgs[0].toLowerCase()).toBe(payee.toLowerCase())
-      expect(openArgs[1].toLowerCase()).toBe(asset.toLowerCase())
-      expect(openArgs[2]).toBe(10_000_000n)
-      expect(openArgs[3]).toEqual(expect.any(String))
-      expect(openArgs[4].toLowerCase()).toBe(payer.address.toLowerCase())
+      ).rejects.toThrow('does not match client escrow')
     })
 
     test('maxDeposit alone', async () => {

--- a/src/tempo/legacy/client/Session.ts
+++ b/src/tempo/legacy/client/Session.ts
@@ -105,7 +105,7 @@ export function session(parameters: session.Parameters = {}) {
   ): Address {
     if (channelId) {
       const cached = escrowContractMap.get(channelId)
-      if (cached) return cached
+      if (cached) return resolveEscrow(challenge, chainId, cached)
     }
     return resolveEscrow(challenge, chainId, parameters.escrowContract)
   }
@@ -387,7 +387,7 @@ export declare namespace session {
       decimals?: number | undefined
       /** Initial deposit amount in human-readable units (e.g. "10" for 10 tokens). When set, the method handles the full channel lifecycle (open, voucher, cumulative tracking) automatically. */
       deposit?: string | undefined
-      /** Escrow contract address override. Derived from challenge or defaults if not provided. */
+      /** Escrow contract address override. Derived from chain defaults if not provided. */
       escrowContract?: Address | undefined
       /** Maximum deposit in human-readable units (e.g. "10"). Caps the server's `suggestedDeposit`. Enables auto-management like `deposit`. */
       maxDeposit?: string | undefined

--- a/src/tempo/legacy/client/Session.ts
+++ b/src/tempo/legacy/client/Session.ts
@@ -74,7 +74,7 @@ export type SessionContext = z.infer<typeof sessionContextSchema>
  * ```
  */
 export function session(parameters: session.Parameters = {}) {
-  const { decimals = defaults.decimals } = parameters
+  const { allowCustomEscrow = false, decimals = defaults.decimals } = parameters
 
   const getClient = Client.getResolver({
     chain: tempo_chain,
@@ -107,12 +107,7 @@ export function session(parameters: session.Parameters = {}) {
       const cached = escrowContractMap.get(channelId)
       if (cached) return resolveEscrow(challenge, chainId, cached)
     }
-    return resolveEscrow(
-      challenge,
-      chainId,
-      parameters.escrowContract,
-      parameters.allowCustomEscrow,
-    )
+    return resolveEscrow(challenge, chainId, parameters.escrowContract, allowCustomEscrow)
   }
 
   async function autoManageCredential(
@@ -386,7 +381,7 @@ export function session(parameters: session.Parameters = {}) {
 export declare namespace session {
   type Parameters = Account.getResolver.Parameters &
     Client.getResolver.Parameters & {
-      /** Accept a noncanonical escrow contract advertised by the server. */
+      /** Accept a noncanonical escrow contract advertised by the server. @default false */
       allowCustomEscrow?: boolean | undefined
       /** Account that signs voucher digests. Defaults to `account`; access-key accounts sign raw vouchers as their access-key address. */
       voucherSigner?: viem_Account | undefined

--- a/src/tempo/legacy/client/Session.ts
+++ b/src/tempo/legacy/client/Session.ts
@@ -107,7 +107,12 @@ export function session(parameters: session.Parameters = {}) {
       const cached = escrowContractMap.get(channelId)
       if (cached) return resolveEscrow(challenge, chainId, cached)
     }
-    return resolveEscrow(challenge, chainId, parameters.escrowContract)
+    return resolveEscrow(
+      challenge,
+      chainId,
+      parameters.escrowContract,
+      parameters.allowCustomEscrow,
+    )
   }
 
   async function autoManageCredential(
@@ -381,13 +386,15 @@ export function session(parameters: session.Parameters = {}) {
 export declare namespace session {
   type Parameters = Account.getResolver.Parameters &
     Client.getResolver.Parameters & {
+      /** Accept a noncanonical escrow contract advertised by the server. */
+      allowCustomEscrow?: boolean | undefined
       /** Account that signs voucher digests. Defaults to `account`; access-key accounts sign raw vouchers as their access-key address. */
       voucherSigner?: viem_Account | undefined
       /** Token decimals for parsing human-readable amounts (default: 6). */
       decimals?: number | undefined
       /** Initial deposit amount in human-readable units (e.g. "10" for 10 tokens). When set, the method handles the full channel lifecycle (open, voucher, cumulative tracking) automatically. */
       deposit?: string | undefined
-      /** Escrow contract address override. Derived from chain defaults if not provided. */
+      /** Exact escrow contract address pin. Takes precedence over `allowCustomEscrow`. */
       escrowContract?: Address | undefined
       /** Maximum deposit in human-readable units (e.g. "10"). Caps the server's `suggestedDeposit`. Enables auto-management like `deposit`. */
       maxDeposit?: string | undefined

--- a/src/tempo/legacy/client/SessionManager.test.ts
+++ b/src/tempo/legacy/client/SessionManager.test.ts
@@ -13,6 +13,7 @@ import { sessionManager } from './SessionManager.js'
 const channelId = '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex
 const challengeId = 'test-challenge-1'
 const realm = 'test.example.com'
+const escrowContract = '0x9d136eEa063eDE5418A6BC7bEafF009bBb6CFa70'
 
 function makeChallenge(overrides: Record<string, unknown> = {}): Challenge.Challenge {
   return Challenge.from({
@@ -26,7 +27,7 @@ function makeChallenge(overrides: Record<string, unknown> = {}): Challenge.Chall
       recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00',
       decimals: 6,
       methodDetails: {
-        escrowContract: '0x9d136eEa063eDE5418A6BC7bEafF009bBb6CFa70',
+        escrowContract,
         chainId: 4217,
       },
       ...overrides,
@@ -124,6 +125,7 @@ describe('Session', () => {
         const manager = sessionManagerWithMocks({
           account,
           client,
+          escrowContract,
           fetch: mockFetch as typeof globalThis.fetch,
           maxDeposit: '10',
           voucherSigner,
@@ -320,6 +322,7 @@ describe('Session', () => {
         const s = sessionManagerWithMocks({
           account,
           client,
+          escrowContract,
           fetch: mockFetch as typeof globalThis.fetch,
           maxDeposit: '10',
           voucherSigner,

--- a/src/tempo/legacy/client/SessionManager.ts
+++ b/src/tempo/legacy/client/SessionManager.ts
@@ -141,6 +141,7 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
 
   const method = sessionPlugin({
     account: parameters.account,
+    allowCustomEscrow: parameters.allowCustomEscrow,
     voucherSigner: parameters.voucherSigner,
     getClient: parameters.client ? () => parameters.client! : parameters.getClient,
     escrowContract: parameters.escrowContract,
@@ -882,13 +883,15 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
 export declare namespace sessionManager {
   type Parameters = Account.getResolver.Parameters &
     Client.getResolver.Parameters & {
+      /** Accept a noncanonical escrow contract advertised by the server. */
+      allowCustomEscrow?: boolean | undefined
       /** Account that signs voucher digests. Defaults to `account`; access-key accounts sign raw vouchers as their access-key address. */
       voucherSigner?: viem_Account | undefined
       /** Viem client instance. Shorthand for `getClient: () => client`. */
       client?: import('viem').Client | undefined
       /** Token decimals used to convert `maxDeposit` to raw units. Defaults to `6`. */
       decimals?: number | undefined
-      /** Escrow contract address. */
+      /** Exact escrow contract address pin. Takes precedence over `allowCustomEscrow`. */
       escrowContract?: Address | undefined
       fetch?: typeof globalThis.fetch | undefined
       /** Maximum deposit in human-readable units (e.g. `'10'` for 10 tokens). Converted to raw units via `decimals`. */

--- a/src/tempo/legacy/client/SessionManager.ts
+++ b/src/tempo/legacy/client/SessionManager.ts
@@ -115,6 +115,7 @@ export type PaymentResponse = Response & {
  * finalized, it resumes from the on-chain settled amount.
  */
 export function sessionManager(parameters: sessionManager.Parameters): SessionManager {
+  const allowCustomEscrow = parameters.allowCustomEscrow ?? false
   const fetchFn = parameters.fetch ?? globalThis.fetch
   const WebSocketImpl =
     parameters.webSocket ??
@@ -141,7 +142,7 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
 
   const method = sessionPlugin({
     account: parameters.account,
-    allowCustomEscrow: parameters.allowCustomEscrow,
+    allowCustomEscrow,
     voucherSigner: parameters.voucherSigner,
     getClient: parameters.client ? () => parameters.client! : parameters.getClient,
     escrowContract: parameters.escrowContract,
@@ -883,7 +884,7 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
 export declare namespace sessionManager {
   type Parameters = Account.getResolver.Parameters &
     Client.getResolver.Parameters & {
-      /** Accept a noncanonical escrow contract advertised by the server. */
+      /** Accept a noncanonical escrow contract advertised by the server. @default false */
       allowCustomEscrow?: boolean | undefined
       /** Account that signs voucher digests. Defaults to `account`; access-key accounts sign raw vouchers as their access-key address. */
       voucherSigner?: viem_Account | undefined

--- a/src/tempo/session/README.md
+++ b/src/tempo/session/README.md
@@ -47,6 +47,83 @@ flowchart LR
 | Client channel entry               | Latest locally usable channel descriptor, deposit, and cumulative authorization.      | Client `ChannelStore`; a cache.                                                     |
 | `SessionSnapshot`                  | Server-provided recovery hint.                                                        | Untrusted until client validation.                                                  |
 
+## Escrow configuration and trust
+
+The server owns escrow configuration. Its session method uses the canonical
+TIP20EscrowChannel address by default. The method-level `escrowContract` applies
+to all routes unless a route supplies its own value. The resolved address is
+included in each session challenge so clients can construct transactions,
+channel IDs, and voucher signatures for the same contract.
+
+```ts
+// Canonical escrow: no configuration required.
+const canonicalSession = tempo.session({ account, currency, getClient, store })
+
+// Custom deployment: the server advertises this address in its challenges.
+const customSession = tempo.session({
+  account,
+  currency,
+  escrowContract: customEscrow,
+  getClient,
+  store,
+})
+
+const customRoute = mppx.session({
+  amount: '0.01',
+  escrowContract: routeEscrow,
+  unitType: 'request',
+})
+```
+
+Receiving an address in a challenge does not make it trusted. Clients accept
+only the canonical escrow by default. A challenge advertising any other address
+is rejected before the client signs a transaction or voucher.
+
+Clients that intentionally support a server's custom deployment opt in with
+`allowCustomEscrow: true`:
+
+```ts
+import { tempo } from 'mppx/client'
+
+// Default: allowCustomEscrow is false.
+const canonicalOnly = tempo.session({ account })
+
+// Trust the custom escrow address advertised by the server.
+const customCompatible = tempo.session({
+  account,
+  allowCustomEscrow: true,
+})
+
+// The same option is available on the managed client.
+const manager = tempo.session.manager({
+  account,
+  allowCustomEscrow: true,
+})
+```
+
+`allowCustomEscrow` defaults to `false`; explicitly passing `false` has the same
+behavior as omitting it. Setting it to `true` trusts the server-selected escrow
+for a new channel. After resolution, persisted channel state remains bound to
+that exact address, so a later challenge cannot switch an existing channel to a
+different escrow.
+
+The pre-existing client `escrow` option (or legacy `escrowContract`) remains an
+exact-address pin for applications that need stronger policy. A pin takes
+precedence over `allowCustomEscrow`: the advertised address must match it.
+
+CLI clients use the same default and opt-in:
+
+```bash
+# Canonical escrow only (default)
+mppx https://api.example.com/paid
+
+# Accept the custom escrow advertised by this server
+mppx https://api.example.com/paid -M allowCustomEscrow=true
+```
+
+This is a client trust decision. Servers do not set `allowCustomEscrow`, and
+wallets or other clients may choose not to expose the opt-in at all.
+
 The amounts below have intentionally different meanings.
 
 | Amount                                        | Meaning                                      | Rule                                                     |

--- a/src/tempo/session/client/ChannelOps.test.ts
+++ b/src/tempo/session/client/ChannelOps.test.ts
@@ -46,22 +46,35 @@ const descriptor = {
 const channelId = Channel.computeId({ ...descriptor, chainId, escrow: tip20ChannelEscrow })
 
 describe('precompile client ChannelOps credential builders', () => {
-  test('resolves escrow from override, challenge hint, or canonical default', () => {
+  test('requires challenge escrow to match the canonical default or client override', () => {
     const override = '0x0000000000000000000000000000000000000005' as Address
     const hinted = '0x0000000000000000000000000000000000000006' as Address
 
     expect(
       ChannelOps.resolveEscrow(
-        { request: { methodDetails: { escrowContract: hinted } } },
+        { request: { methodDetails: { escrowContract: override } } },
         override,
       ),
     ).toBe(override)
-    expect(
+    expect(() =>
+      ChannelOps.resolveEscrow(
+        { request: { methodDetails: { escrowContract: hinted } } },
+        override,
+      ),
+    ).toThrow('does not match client escrow')
+    expect(() =>
       ChannelOps.resolveEscrow({ request: { methodDetails: { escrowContract: hinted } } }),
-    ).toBe(hinted)
-    expect(ChannelOps.resolveEscrow({ request: { methodDetails: { escrow: hinted } } })).toBe(
-      hinted,
-    )
+    ).toThrow('does not match client escrow')
+    expect(() =>
+      ChannelOps.resolveEscrow({ request: { methodDetails: { escrow: hinted } } }),
+    ).toThrow('does not match client escrow')
+    const canonicalMixedCase =
+      `${tip20ChannelEscrow.slice(0, 2)}${tip20ChannelEscrow.slice(2).toUpperCase()}` as Address
+    expect(
+      ChannelOps.resolveEscrow({
+        request: { methodDetails: { escrowContract: canonicalMixedCase } },
+      }),
+    ).toBe(tip20ChannelEscrow)
     expect(
       ChannelOps.resolveEscrow({
         request: { methodDetails: { escrowContract: 'not-an-address' } },

--- a/src/tempo/session/client/ChannelOps.test.ts
+++ b/src/tempo/session/client/ChannelOps.test.ts
@@ -46,7 +46,7 @@ const descriptor = {
 const channelId = Channel.computeId({ ...descriptor, chainId, escrow: tip20ChannelEscrow })
 
 describe('precompile client ChannelOps credential builders', () => {
-  test('requires challenge escrow to match the canonical default or client override', () => {
+  test('requires custom challenge escrows to be allowed or explicitly pinned', () => {
     const override = '0x0000000000000000000000000000000000000005' as Address
     const hinted = '0x0000000000000000000000000000000000000006' as Address
 
@@ -65,6 +65,13 @@ describe('precompile client ChannelOps credential builders', () => {
     expect(() =>
       ChannelOps.resolveEscrow({ request: { methodDetails: { escrowContract: hinted } } }),
     ).toThrow('does not match client escrow')
+    expect(
+      ChannelOps.resolveEscrow(
+        { request: { methodDetails: { escrowContract: hinted } } },
+        undefined,
+        true,
+      ),
+    ).toBe(hinted)
     expect(() =>
       ChannelOps.resolveEscrow({ request: { methodDetails: { escrow: hinted } } }),
     ).toThrow('does not match client escrow')

--- a/src/tempo/session/client/ChannelOps.ts
+++ b/src/tempo/session/client/ChannelOps.ts
@@ -110,7 +110,7 @@ async function signPreparedTempoTransaction(client: Client, prepared: unknown): 
   return (await signTransaction(client, prepared as never)) as Hex.Hex
 }
 
-/** Resolves the escrow precompile from local override, challenge hints, or canonical default. */
+/** Resolves the escrow precompile from a local override or canonical default. */
 export function resolveEscrow(
   challenge: {
     request: {
@@ -124,7 +124,12 @@ export function resolveEscrow(
     ? (readOptionalAddress(methodDetails.escrowContract) ??
       readOptionalAddress(methodDetails.escrow))
     : undefined
-  return escrowOverride ?? challengeEscrow ?? tip20ChannelEscrow
+  const expectedEscrow = escrowOverride ?? tip20ChannelEscrow
+  if (challengeEscrow && !isSameAddress(challengeEscrow, expectedEscrow))
+    throw new Error(
+      `Tempo session escrow ${challengeEscrow} does not match client escrow ${expectedEscrow}.`,
+    )
+  return expectedEscrow
 }
 
 /** Serializes a session credential with a DID source bound to the payer account. */

--- a/src/tempo/session/client/ChannelOps.ts
+++ b/src/tempo/session/client/ChannelOps.ts
@@ -110,7 +110,7 @@ async function signPreparedTempoTransaction(client: Client, prepared: unknown): 
   return (await signTransaction(client, prepared as never)) as Hex.Hex
 }
 
-/** Resolves the escrow precompile from a local override or canonical default. */
+/** Resolves the server-advertised escrow against the client's trust policy. */
 export function resolveEscrow(
   challenge: {
     request: {
@@ -118,6 +118,7 @@ export function resolveEscrow(
     }
   },
   escrowOverride?: Address | undefined,
+  allowCustomEscrow = false,
 ): Address {
   const methodDetails = challenge.request.methodDetails
   const challengeEscrow = isObject(methodDetails)
@@ -125,10 +126,15 @@ export function resolveEscrow(
       readOptionalAddress(methodDetails.escrow))
     : undefined
   const expectedEscrow = escrowOverride ?? tip20ChannelEscrow
-  if (challengeEscrow && !isSameAddress(challengeEscrow, expectedEscrow))
+  if (
+    challengeEscrow &&
+    !isSameAddress(challengeEscrow, expectedEscrow) &&
+    (!allowCustomEscrow || escrowOverride !== undefined)
+  )
     throw new Error(
       `Tempo session escrow ${challengeEscrow} does not match client escrow ${expectedEscrow}.`,
     )
+  if (challengeEscrow && !isSameAddress(challengeEscrow, expectedEscrow)) return challengeEscrow
   return expectedEscrow
 }
 

--- a/src/tempo/session/client/CredentialState.test.ts
+++ b/src/tempo/session/client/CredentialState.test.ts
@@ -373,7 +373,7 @@ describe('CredentialPlan', () => {
         amount: 10n,
         chainId: 42431,
         client,
-        escrow,
+        escrow: escrow.toLowerCase(),
         feePayer: true,
         payee,
         snapshot: snapshot(),

--- a/src/tempo/session/client/CredentialState.ts
+++ b/src/tempo/session/client/CredentialState.ts
@@ -212,6 +212,8 @@ export type ClientSessionMethodDetails = {
 
 /** Dependencies used to resolve a challenge into typed credential-planning data. */
 export type ResolveChallengeContextParameters = {
+  /** Whether to accept a noncanonical escrow advertised by the server. */
+  allowCustomEscrow?: boolean | undefined
   /** Challenge received from the 402 response. */
   challenge: Challenge.Challenge
   /** Optional local escrow override. */
@@ -421,13 +423,13 @@ function readSuggestedDeposit(value: unknown): string | undefined {
 export async function resolveChallengeContext(
   parameters: ResolveChallengeContextParameters,
 ): Promise<ChallengeContext> {
-  const { challenge, escrowOverride, getClient } = parameters
+  const { allowCustomEscrow, challenge, escrowOverride, getClient } = parameters
   const methodDetails = readMethodDetails(challenge)
   const client = await getClient({ chainId: methodDetails.chainId })
   const chainId = methodDetails.chainId ?? client.chain?.id
   if (!chainId) throw new Error('No chainId configured for TIP-1034 session challenge.')
 
-  const escrow = resolveEscrow(challenge, escrowOverride)
+  const escrow = resolveEscrow(challenge, escrowOverride, allowCustomEscrow)
   const payee = readAddress(challenge.request.recipient, 'recipient')
   const token = readAddress(challenge.request.currency, 'currency')
 

--- a/src/tempo/session/client/CredentialState.ts
+++ b/src/tempo/session/client/CredentialState.ts
@@ -212,7 +212,7 @@ export type ClientSessionMethodDetails = {
 
 /** Dependencies used to resolve a challenge into typed credential-planning data. */
 export type ResolveChallengeContextParameters = {
-  /** Whether to accept a noncanonical escrow advertised by the server. */
+  /** Whether to accept a noncanonical escrow advertised by the server. @default false */
   allowCustomEscrow?: boolean | undefined
   /** Challenge received from the 402 response. */
   challenge: Challenge.Challenge

--- a/src/tempo/session/client/Session.test.ts
+++ b/src/tempo/session/client/Session.test.ts
@@ -804,12 +804,12 @@ describe('precompile client session', () => {
     ).rejects.toThrow('opening deposit 50 below request amount 100')
   })
 
-  test('uses a matching client-configured escrow address for open transactions', async () => {
+  test('uses a server-configured custom escrow when allowed', async () => {
     const challengeEscrow = '0x0000000000000000000000000000000000000005' as Address
     const method = session({
       account,
+      allowCustomEscrow: true,
       decimals: 0,
-      escrow: challengeEscrow,
       getClient: () => client,
     })
     const payload = deserialize(

--- a/src/tempo/session/client/Session.test.ts
+++ b/src/tempo/session/client/Session.test.ts
@@ -831,6 +831,25 @@ describe('precompile client session', () => {
     )
   })
 
+  test.each([
+    ['omitted', {}],
+    ['false', { allowCustomEscrow: false }],
+  ] as const)('rejects a custom escrow when allowCustomEscrow is %s', async (_label, options) => {
+    const method = session({ account, decimals: 0, getClient: () => client, ...options })
+
+    await expect(
+      method.createCredential({
+        challenge: makeChallenge({
+          methodDetails: {
+            chainId,
+            escrowContract: '0x0000000000000000000000000000000000000005',
+          },
+        }),
+        context: {},
+      }),
+    ).rejects.toThrow('does not match client escrow')
+  })
+
   test('uses challenge-advertised operator for open transactions', async () => {
     const operator = '0x0000000000000000000000000000000000000006' as Address
     const method = session({ account, decimals: 0, getClient: () => client })

--- a/src/tempo/session/client/Session.test.ts
+++ b/src/tempo/session/client/Session.test.ts
@@ -804,9 +804,14 @@ describe('precompile client session', () => {
     ).rejects.toThrow('opening deposit 50 below request amount 100')
   })
 
-  test('uses resolved escrow address for open transactions', async () => {
+  test('uses a matching client-configured escrow address for open transactions', async () => {
     const challengeEscrow = '0x0000000000000000000000000000000000000005' as Address
-    const method = session({ account, decimals: 0, getClient: () => client })
+    const method = session({
+      account,
+      decimals: 0,
+      escrow: challengeEscrow,
+      getClient: () => client,
+    })
     const payload = deserialize(
       await method.createCredential({
         challenge: makeChallenge({

--- a/src/tempo/session/client/Session.ts
+++ b/src/tempo/session/client/Session.ts
@@ -119,7 +119,7 @@ function acknowledgesOpen(
 export function session(parameters: session.Parameters = {}) {
   const {
     account,
-    allowCustomEscrow,
+    allowCustomEscrow = false,
     autoSwap: autoSwapParameter,
     channelStore,
     decimals = defaults.decimals,
@@ -405,7 +405,7 @@ export declare namespace session {
 
   type Parameters = Account.getResolver.Parameters &
     Client.getResolver.Parameters & {
-      /** Accept a noncanonical escrow contract advertised by the server. */
+      /** Accept a noncanonical escrow contract advertised by the server. @default false */
       allowCustomEscrow?: boolean | undefined
       /** Automatically acquire the session currency from fallback stablecoins before open/top-up. */
       autoSwap?: AutoSwap.resolve.Value | undefined

--- a/src/tempo/session/client/Session.ts
+++ b/src/tempo/session/client/Session.ts
@@ -119,6 +119,7 @@ function acknowledgesOpen(
 export function session(parameters: session.Parameters = {}) {
   const {
     account,
+    allowCustomEscrow,
     autoSwap: autoSwapParameter,
     channelStore,
     decimals = defaults.decimals,
@@ -184,6 +185,7 @@ export function session(parameters: session.Parameters = {}) {
     async createCredential(parameters) {
       const { challenge, context } = parameters
       const resolved = await resolveChallengeContext({
+        allowCustomEscrow,
         challenge,
         escrowOverride,
         getClient,
@@ -311,7 +313,12 @@ export function session(parameters: session.Parameters = {}) {
     if (!isTip1034SessionChallenge(challenge)) return
     const sessionContext = context === undefined ? undefined : sessionContextSchema.parse(context)
     if (hasSessionAction(sessionContext)) return
-    const resolved = await resolveChallengeContext({ challenge, escrowOverride, getClient })
+    const resolved = await resolveChallengeContext({
+      allowCustomEscrow,
+      challenge,
+      escrowOverride,
+      getClient,
+    })
     const channel = await store.get(resolved.key)
     if (!channel?.opened) return
     const snapshot =
@@ -354,6 +361,7 @@ export function session(parameters: session.Parameters = {}) {
 
       const channelKey = (
         await resolveChallengeContext({
+          allowCustomEscrow,
           challenge,
           escrowOverride,
           getClient,
@@ -397,13 +405,15 @@ export declare namespace session {
 
   type Parameters = Account.getResolver.Parameters &
     Client.getResolver.Parameters & {
+      /** Accept a noncanonical escrow contract advertised by the server. */
+      allowCustomEscrow?: boolean | undefined
       /** Automatically acquire the session currency from fallback stablecoins before open/top-up. */
       autoSwap?: AutoSwap.resolve.Value | undefined
       /** Pluggable persistence for reusable channels. Defaults to an in-memory store. */
       channelStore?: ChannelStore | undefined
       /** Token decimals for parsing human-readable amounts (default: 6). */
       decimals?: number | undefined
-      /** TIP20EscrowChannel address override. */
+      /** Exact TIP20EscrowChannel address pin. Takes precedence over `allowCustomEscrow`. */
       escrow?: Address | undefined
       /** Maximum channel deposit in human-readable units. Caps server-suggested opens and automatic top-ups. */
       maxDeposit?: string | undefined

--- a/src/tempo/session/client/SessionManager.test.ts
+++ b/src/tempo/session/client/SessionManager.test.ts
@@ -293,6 +293,39 @@ describe('Session', () => {
   })
 
   describe('.fetch()', () => {
+    test('uses a server-advertised custom escrow when allowed', async () => {
+      const customEscrow = '0x0000000000000000000000000000000000000005' as Address
+      let openPayload: Extract<SessionCredentialPayload, { action: 'open' }> | undefined
+      const challenge = makeChallenge({
+        suggestedDeposit: '1000000',
+        methodDetails: {
+          chainId: 4217,
+          escrowContract: customEscrow,
+          sessionProtocol: Constants.SessionProtocols.v2,
+        },
+      })
+      const mockFetch = vi.fn().mockImplementation((_input, init?: RequestInit) => {
+        const authorization = new Headers(init?.headers).get(Constants.Headers.authorization)
+        if (!authorization) return Promise.resolve(make402Response(challenge))
+        const payload = Credential.deserialize<SessionCredentialPayload>(authorization).payload
+        if (payload.action === 'open') openPayload = payload
+        return Promise.resolve(makeOkResponse())
+      })
+      const s = sessionManager({
+        account,
+        allowCustomEscrow: true,
+        client,
+        fetch: mockFetch as typeof globalThis.fetch,
+        maxDeposit: '10',
+      })
+
+      expect((await s.fetch('https://api.example.com/data')).status).toBe(200)
+      if (!openPayload) throw new Error('expected open payload')
+      expect(openPayload.channelId).toBe(
+        Channel.computeId({ ...openPayload.descriptor, chainId: 4217, escrow: customEscrow }),
+      )
+    })
+
     test('passes through non-402 responses', async () => {
       const mockFetch = vi.fn().mockResolvedValue(makeOkResponse('hello'))
 

--- a/src/tempo/session/client/SessionManager.ts
+++ b/src/tempo/session/client/SessionManager.ts
@@ -189,6 +189,7 @@ function resolveSessionManagerConfig(parameters: sessionManager.Parameters): Ses
  * `channelStore` can persist reusable channels between manager instances.
  */
 export function sessionManager(parameters: sessionManager.Parameters): SessionManager {
+  const allowCustomEscrow = parameters.allowCustomEscrow ?? false
   const config = resolveSessionManagerConfig(parameters)
   const getClient = Client.getResolver({
     chain: tempo_chain,
@@ -319,7 +320,7 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
 
   const method = sessionPlugin({
     account: parameters.account,
-    allowCustomEscrow: parameters.allowCustomEscrow,
+    allowCustomEscrow,
     autoSwap: parameters.autoSwap,
     getClient: parameters.client ? () => parameters.client! : parameters.getClient,
     resolveAccount: parameters.resolveAccount,
@@ -973,7 +974,7 @@ export namespace sessionManager {
 
   export type Parameters = Account.getResolver.Parameters &
     Client.getResolver.Parameters & {
-      /** Accept a noncanonical escrow contract advertised by the server. */
+      /** Accept a noncanonical escrow contract advertised by the server. @default false */
       allowCustomEscrow?: boolean | undefined
       /** Automatically acquire the session currency from fallback stablecoins before open/top-up. */
       autoSwap?: sessionPlugin.Parameters['autoSwap']

--- a/src/tempo/session/client/SessionManager.ts
+++ b/src/tempo/session/client/SessionManager.ts
@@ -319,6 +319,7 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
 
   const method = sessionPlugin({
     account: parameters.account,
+    allowCustomEscrow: parameters.allowCustomEscrow,
     autoSwap: parameters.autoSwap,
     getClient: parameters.client ? () => parameters.client! : parameters.getClient,
     resolveAccount: parameters.resolveAccount,
@@ -972,6 +973,8 @@ export namespace sessionManager {
 
   export type Parameters = Account.getResolver.Parameters &
     Client.getResolver.Parameters & {
+      /** Accept a noncanonical escrow contract advertised by the server. */
+      allowCustomEscrow?: boolean | undefined
       /** Automatically acquire the session currency from fallback stablecoins before open/top-up. */
       autoSwap?: sessionPlugin.Parameters['autoSwap']
       /** Enables same-route HEAD bootstrap from a server session snapshot before opening a new channel. */
@@ -980,7 +983,7 @@ export namespace sessionManager {
       client?: import('viem').Client | undefined
       /** Token decimals used to convert `maxDeposit` to raw units. Defaults to `6`. */
       decimals?: number | undefined
-      /** TIP20EscrowChannel precompile address override. */
+      /** Exact TIP20EscrowChannel address pin. Takes precedence over `allowCustomEscrow`. */
       escrow?: Address | undefined
       /** Fetch implementation used for HTTP probes, management posts, and paid retries. */
       fetch?: typeof globalThis.fetch | undefined

--- a/src/tempo/session/server/Session.ts
+++ b/src/tempo/session/server/Session.ts
@@ -626,7 +626,7 @@ export namespace session {
     sse?: boolean | Transport.sse.Options | undefined
     /** Tempo chain ID used for TIP-1034 channel escrow challenges. Defaults to the resolved client chain ID. */
     chainId?: number | undefined
-    /** TIP20EscrowChannel precompile address override. */
+    /** Escrow contract advertised to clients. Defaults to the canonical TIP20EscrowChannel address. */
     escrowContract?: Address | undefined
     /** Callback invoked after any on-chain settlement or close transaction is confirmed. */
     onSessionSettlement?: OnSessionSettlement | undefined


### PR DESCRIPTION
## Motivation

Tempo session servers may use a custom escrow contract and advertise it in payment challenges. Clients should use the canonical Tempo escrow by default while allowing an explicit policy opt-in for servers with custom deployments.

## Summary

- Default Tempo session clients to the canonical escrow and reject noncanonical challenge addresses
- Add `allowCustomEscrow: true` for clients that intentionally trust the server-advertised escrow
- Expose the same opt-in in the CLI as `-M allowCustomEscrow=true`
- Keep existing exact-address client options as stronger pins for compatibility
- Validate cached and persisted channels against their resolved escrow
- Document server escrow configuration and client trust behavior

## Key design considerations

- Servers configure `escrowContract`; the resolved address is advertised in the challenge
- `allowCustomEscrow` defaults to `false`
- The opt-in is a client trust decision and does not require the client to know the custom address
- Exact-address pins take precedence over `allowCustomEscrow`
- Existing channels remain bound to their resolved escrow and cannot switch addresses
