### PR TITLE
fix(tempo): support machine-token relay settlement

### DIFF
--- a/.changeset/bright-pandas-trade.md
+++ b/.changeset/bright-pandas-trade.md
@@ -2,4 +2,4 @@
 'mppx': patch
 ---
 
-Added first-party machine-token payments for Tempo charges, including atomic push-mode and hosted fee-sponsored pull settlement.
+Added first-party machine-token payments for Tempo charges across push, pull, relay, and fee-sponsored settlement.

--- a/src/tempo/server/Charge.test.ts
+++ b/src/tempo/server/Charge.test.ts
@@ -1123,6 +1123,11 @@ describe('tempo', () => {
         testnet: true,
       })
       const machineTokenServer = Mppx_server.create({ methods: [method], realm, secretKey })
+      const relayServer = Mppx_server.create({
+        methods: [tempo_server.charge({ getClient: () => machineTokenClient })],
+        realm,
+        secretKey,
+      })
       const httpServer = await Http.createServer(async (req, res) => {
         const result = await Mppx_server.toNodeListener(
           machineTokenServer.charge({ amount: '1', decimals: 6, recipient: accounts[0].address }),
@@ -1143,11 +1148,8 @@ describe('tempo', () => {
         payload: { hash, type: 'hash' as const },
         source: `did:pkh:eip155:${defaults.chainId.testnet}:${accounts[1].address}`,
       })
-      const paid = await fetch(httpServer.url, {
-        headers: { Authorization: Credential.serialize(credential) },
-      })
-      expect(paid.status).toBe(200)
-      expect(Receipt.fromResponse(paid).reference).toBe(hash)
+      const receipt = await relayServer.verifyCredential(Credential.serialize(credential))
+      expect(receipt.reference).toBe(hash)
 
       httpServer.close()
     })
@@ -1203,6 +1205,16 @@ describe('tempo', () => {
         testnet: true,
       })
       const machineTokenServer = Mppx_server.create({ methods: [method], realm, secretKey })
+      const relayServer = Mppx_server.create({
+        methods: [
+          tempo_server.charge({
+            feePayer: feePayerServer.url,
+            getClient: () => machineTokenClient,
+          }),
+        ],
+        realm,
+        secretKey,
+      })
       const httpServer = await Http.createServer(async (req, res) => {
         const result = await Mppx_server.toNodeListener(
           machineTokenServer.charge({ amount: '1', decimals: 6, recipient: accounts[0].address }),
@@ -1245,12 +1257,9 @@ describe('tempo', () => {
         payload: { signature, type: 'transaction' as const },
         source: `did:pkh:eip155:${defaults.chainId.testnet}:${accounts[1].address}`,
       })
-      const paid = await fetch(httpServer.url, {
-        headers: { Authorization: Credential.serialize(credential) },
-      })
+      const receipt = await relayServer.verifyCredential(Credential.serialize(credential))
 
-      expect(paid.status).toBe(200)
-      expect(Receipt.fromResponse(paid).status).toBe('success')
+      expect(receipt.status).toBe('success')
       expect(feePayerMethods).toEqual(['eth_fillTransaction', 'eth_sendRawTransactionSync'])
 
       httpServer.close()

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -114,8 +114,6 @@ export function charge<const parameters extends charge.Parameters>(
   const { recipient, feePayer, feePayerUrl } = Account.resolve(parameters)
   if (configuredFeeToken && feePayerUrl)
     throw new Error('`feeToken` can only be configured for a local fee payer.')
-  if (machineTokenEnabled && relay)
-    throw new Error('`machineTokenEnabled` is not supported with a Tempo relay.')
 
   const getClient = Client.getResolver({
     chain: { ...tempo_chain, experimental_preconfirmationTime: 500 },
@@ -468,8 +466,6 @@ export function charge<const parameters extends charge.Parameters>(
       })()
       if (client.chain?.id !== chainId)
         throw new Error(`Client not configured with chainId ${chainId}.`)
-      if (request.machineTokenEnabled && relay)
-        throw new Error('`machineTokenEnabled` is not supported with a Tempo relay.')
       if (request.machineTokenEnabled && !MachineToken.isSupported(chainId))
         throw new Error(`Machine tokens are not supported on chainId ${chainId}.`)
 
@@ -850,8 +846,6 @@ export declare namespace charge {
      * credential as already broadcast and returns its receipt without sending
      * it again.
      *
-     * This option cannot be combined with `machineTokenEnabled` until the relay
-     * supports the first-party settlement route.
      */
     relay?: RelayOptions | undefined
     /**

--- a/src/tempo/server/Methods.ts
+++ b/src/tempo/server/Methods.ts
@@ -36,9 +36,9 @@ function createSessionMethod<const parameters extends tempo.Parameters>(
 /**
  * Creates the common Tempo `charge` and `session` methods from shared parameters.
  *
- * `machineTokenEnabled` and `relay` currently apply only to `charge` and cannot
- * be combined. The machine-token option is accepted globally so other Tempo
- * methods can adopt it without another provider-level configuration surface.
+ * `machineTokenEnabled` and `relay` currently apply only to `charge`. The
+ * machine-token option is accepted globally so other Tempo methods can adopt
+ * it without another provider-level configuration surface.
  *
  * @example
  * ```ts

--- a/src/tempo/server/Relay.test.ts
+++ b/src/tempo/server/Relay.test.ts
@@ -42,8 +42,10 @@ function mockRelay(handler: RelayHandler): typeof globalThis.fetch {
 function methods(fetch: typeof globalThis.fetch, url = apiBaseUrl) {
   return tempo({
     currency: '0x123',
+    machineTokenEnabled: true,
     recipient: '0x456',
     relay: { apiBaseUrl: url, apiKey: 'tempo_api_key', fetch },
+    testnet: true,
   })
 }
 
@@ -80,6 +82,7 @@ async function createPaymentServer(
   })
 
   return {
+    challenge,
     pay: () =>
       globalThis.fetch(server.url, {
         headers: { Authorization: Credential.serialize(paymentCredential) },
@@ -102,15 +105,6 @@ afterEach(() => {
 })
 
 describe('relay boundary', () => {
-  test('rejects machine-token settlement until the relay supports it', () => {
-    expect(() =>
-      tempo.charge({
-        machineTokenEnabled: true,
-        relay: { apiKey: 'tempo_api_key' },
-      }),
-    ).toThrow('`machineTokenEnabled` is not supported with a Tempo relay.')
-  })
-
   test('sends the complete credential to the configured validation endpoint', async () => {
     const fetch = mockRelay(() => Response.json({ success: true }))
     const [method, session] = methods(fetch)
@@ -499,9 +493,10 @@ describe('relay HTTP flow', () => {
         ? Response.json({ success: true })
         : successReceipt()
     })
-    const { pay, server } = await createPaymentServer(fetch)
+    const { challenge, pay, server } = await createPaymentServer(fetch)
 
     try {
+      expect(challenge.request.methodDetails).toMatchObject({ machineTokenEnabled: true })
       const response = await pay()
       expect(response.status).toBe(200)
       expect(response.headers.get('Payment-Receipt')).toBeTruthy()
@@ -519,9 +514,10 @@ describe('relay HTTP flow', () => {
         ? Response.json({ success: true })
         : successReceipt()
     })
-    const { pay, server } = await createPaymentServer(fetch, pushedPayload)
+    const { challenge, pay, server } = await createPaymentServer(fetch, pushedPayload)
 
     try {
+      expect(challenge.request.methodDetails).toMatchObject({ machineTokenEnabled: true })
       const response = await pay()
 
       expect(response.status).toBe(200)


### PR DESCRIPTION
## Why

Machine-token charges need to work through Tempo’s MPP relay across push, pull, and sponsored flows.

## What

- Allow `machineTokenEnabled` and `relay` on the same Tempo charge.
- Verify relay-side push and hosted fee-sponsored pull from the signed challenge hint.
- Replace the defensive relay rejection with positive end-to-end relay coverage.