### PR TITLE
feat(store): native tryClaim fast path for redis and upstash via setNx

### DIFF
--- a/.changeset/redis-upstash-setnx-tryclaim.md
+++ b/.changeset/redis-upstash-setnx-tryclaim.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added a native `Store.tryClaim` fast path to the `redis` and `upstash` adapters through an optional `setNx` primitive. When provided, a replay claim is a single atomic set-if-absent with an absolute expiry instead of the update-based read-modify-write fallback.

--- a/src/Store.test.ts
+++ b/src/Store.test.ts
@@ -237,6 +237,66 @@ describe('tryClaim', () => {
 
     expect(await Store.tryClaim(store, 'k', Date.now() + 60_000)).toBe(false)
   })
+
+  // A fake set-if-absent honoring an absolute-ms expiry, shared by the
+  // adapter fast-path tests.
+  function fakeSetNx(seen?: string[]) {
+    const claimed = new Map<string, number>()
+    return async (key: string, _value: string, expires: number) => {
+      seen?.push(key)
+      const existing = claimed.get(key)
+      if (existing !== undefined && existing > Date.now()) return false
+      claimed.set(key, expires)
+      return true
+    }
+  }
+
+  test('redis uses a native setNx fast path over the update fallback', async () => {
+    const kv = fakeStringKv()
+    let updateCalls = 0
+    const store = Store.redis({
+      get: kv.get,
+      set: kv.put,
+      del: kv.delete,
+      update: (key, fn) => {
+        updateCalls++
+        return kv.update(key, fn)
+      },
+      setNx: fakeSetNx(),
+    })
+    const expires = Date.now() + 60_000
+
+    expect(await Store.tryClaim(store, 'k', expires)).toBe(true)
+    expect(await Store.tryClaim(store, 'k', expires)).toBe(false)
+    // The native path is used, so the update fallback never runs.
+    expect(updateCalls).toBe(0)
+  })
+
+  test('upstash uses a native setNx fast path', async () => {
+    const store = Store.upstash({ ...fakeUnknownKv(), setNx: fakeSetNx() })
+    const expires = Date.now() + 60_000
+
+    expect(await Store.tryClaim(store, 'k', expires)).toBe(true)
+    expect(await Store.tryClaim(store, 'k', expires)).toBe(false)
+  })
+
+  test('setNx fast path is forwarded through a key prefix', async () => {
+    const kv = fakeStringKv()
+    const seen: string[] = []
+    const store = Store.redis(
+      {
+        get: kv.get,
+        set: kv.put,
+        del: kv.delete,
+        update: kv.update,
+        setNx: fakeSetNx(seen),
+      },
+      { keyPrefix: 'p:' },
+    )
+
+    expect(await Store.tryClaim(store, 'k', Date.now() + 60_000)).toBe(true)
+    expect(seen).toEqual(['p:k'])
+  })
 })
 
 describe('json roundtrip behavior', () => {

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -217,6 +217,29 @@ function wrapJsonUpdate(
   } satisfies AtomicActions
 }
 
+/**
+ * Builds a native {@link TryClaim} from an adapter's atomic set-if-absent
+ * primitive. `setNx` records the replay marker only when the key is absent and
+ * expires it at `expires`, so the claim needs a single round-trip instead of
+ * the {@link tryClaim} fallback's read-modify-write.
+ */
+function wrapSetNx(
+  setNx: ((key: string, value: string, expires: number) => Promise<boolean>) | undefined,
+): Pick<AtomicActions, 'tryClaim'> | {} {
+  if (!setNx) return {}
+  return {
+    tryClaim(key, expires) {
+      // The claim is the key's existence under its TTL; the NX path never reads
+      // this value back, so the marker is only a human-readable placeholder.
+      return setNx(
+        key,
+        Json.stringify({ expires, type: 'mppx:replay' } satisfies ReplayMarker),
+        expires,
+      )
+    },
+  } satisfies Pick<AtomicActions, 'tryClaim'>
+}
+
 /** Wraps a Cloudflare KV namespace. */
 export function cloudflare(
   kv: cloudflare.AtomicParameters,
@@ -324,6 +347,7 @@ export function redis(client: redis.Parameters, options?: redis.Options): Store 
         await client.del(key)
       },
       ...wrapJsonUpdate(client.update),
+      ...wrapSetNx(client.setNx),
     },
     options,
   )
@@ -343,6 +367,13 @@ export declare namespace redis {
       key: string,
       fn: (current: string | null) => Change<string, result>,
     ) => Promise<result>
+    /**
+     * Optional atomic set-if-absent with an absolute expiry, powering a native
+     * {@link TryClaim} fast path. `expires` is an absolute Unix-ms timestamp —
+     * map it to `SET … PXAT <expires> NX`, never a relative `PX`/TTL. Resolves
+     * `true` when this call recorded the key, `false` when it already existed.
+     */
+    setNx?: (key: string, value: string, expires: number) => Promise<boolean>
   }
 
   export type AtomicParameters = Omit<Parameters, 'update'> & {
@@ -370,6 +401,7 @@ export function upstash(redis: upstash.Parameters, options?: upstash.Options): S
             update: redis.update as Update,
           }
         : {}),
+      ...wrapSetNx(redis.setNx),
     },
     options,
   )
@@ -389,6 +421,14 @@ export declare namespace upstash {
       key: string,
       fn: (current: unknown | null) => Change<unknown, result>,
     ) => Promise<result>
+    /**
+     * Optional atomic set-if-absent with an absolute expiry, powering a native
+     * {@link TryClaim} fast path. `expires` is an absolute Unix-ms timestamp —
+     * map it to `set(key, value, { nx: true, pxat: expires })`, never a
+     * relative `px`/TTL. Resolves `true` when this call recorded the key,
+     * `false` when it already existed.
+     */
+    setNx?: (key: string, value: string, expires: number) => Promise<boolean>
   }
 
   export type AtomicParameters = Omit<Parameters, 'update'> & {


### PR DESCRIPTION
## What

Adds an optional `setNx(key, value, expires) => Promise<boolean>` to `redis.Parameters` and `upstash.Parameters`. When a caller provides it, the adapter exposes a native `Store.tryClaim` that maps to a single `SET … PXAT <expires> NX` (upstash: `set(key, value, { nx: true, pxat: expires })`).

This extends the exact extension point #765 created: today only `memory()` has a native `tryClaim`; `redis()` / `upstash()` / `cloudflare()` fall back to the `update`-based read-modify-write.

## Why

The value is not just performance, and it is not a bug fix (nothing regressed — these adapters only forward caller-supplied primitives). It is about which primitive a caller must supply to get an atomic replay claim:

- **Upstash REST — capability gap.** Upstash REST [does not support `WATCH`](https://upstash.com/docs/redis/features/restapi) and is stateless per request, so a correct optimistic-lock `update` (the CAS the `tryClaim` fallback needs) is **not implementable** there. `SET … NX` is the only atomic first-use primitive. `@upstash/redis` `set` supports both [`nx` and `pxat`](https://upstash.com/docs/redis/sdks/ts/commands/string/set).
- **Redis (ioredis / node-redis) — 1-RTT fast path.** A caller *can* write a correct WATCH/MULTI `update`; `SET NX PXAT` collapses that loop into one round-trip.

`cloudflare()` is intentionally left out: Workers KV is eventually consistent, last-write-wins, with [no conditional/atomic write](https://developers.cloudflare.com/kv/api/write-key-value-pairs/), so it cannot back an atomic set-if-absent. A Worker that needs atomic claims should use `Store.upstash()` / `Store.redis()` (Upstash REST works from Workers), or Cloudflare's own recommendation, Durable Objects.

## Details

- `expires` is an absolute Unix-ms timestamp, so it maps to `PXAT` / `pxat`, never a relative `PX`/TTL. The marker value is a placeholder — the claim is key-existence under the TTL, and the NX path never reads it back (noted in a comment).
- Additive and backward-compatible: existing callers passing `{ get, set, del, update? }` are unaffected. The key-prefix wrapper already forwards a native `tryClaim`, so prefixed stores inherit it.
- Both adapters share one code path (`wrapSetNx`).

Example callers:

```ts
// ioredis / Valkey
Store.redis({ get, set, del,
  setNx: async (k, v, expires) => (await client.set(k, v, 'PXAT', expires, 'NX')) === 'OK' })

// @upstash/redis
Store.upstash({ get, set, del,
  setNx: async (k, v, expires) => (await redis.set(k, v, { nx: true, pxat: expires })) === 'OK' })
```

## Test

Added runtime tests (redis and upstash use the native `setNx` path over the `update` fallback; the fast path is forwarded through a key prefix). `Store.test.ts` passes 41/41 and `tsgo -b` (incl. `Store.test-d.ts`) is clean. I could not run the full suite locally (its global setup needs a Tempo localnet RPC unrelated to this change).

## Open question

Right now `setNx` accelerates `tryClaim` on a store that is already an `AtomicStore` (provides `update`). Would you also want providing `setNx` alone to brand the store as claim-capable, so a caller who only needs replay protection does not have to implement a full `update` CAS? That touches the `AtomicActions` type model, so I left it out — happy to follow up whichever way you prefer.