### PR TITLE
fix(subscription): resume a commit a crash interrupted instead of locking the lookup forever

### DIFF
--- a/.changeset/resume-interrupted-subscription-commit.md
+++ b/.changeset/resume-interrupted-subscription-commit.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Resumed a subscription activation whose commit a crash interrupted, instead of locking the lookup key forever. The created subscription is now persisted with the `committingAt` marker, and once the marker is older than a new `activationRecoveryTimeoutMs` (default 15m) a later activation finishes the commit from the stored record without re-running `create()`, so the period is not charged twice.

--- a/src/tempo/subscription/Store.test.ts
+++ b/src/tempo/subscription/Store.test.ts
@@ -100,6 +100,48 @@ describe('tempo subscription store', () => {
     ).toEqual({ status: 'replayed' })
   })
 
+  test('resumes a commit interrupted after the subscription was persisted', async () => {
+    const base = Store.memory()
+    let crashArmed = true
+    const store = fromStore(
+      {
+        ...base,
+        async put(key: string, value: unknown) {
+          // Crash after `committingAt` is written (via update) but before the
+          // subscription record lands.
+          if (crashArmed && key.includes(subscriptionId))
+            throw new Error('simulated crash before commit')
+          return base.put(key, value)
+        },
+      },
+      { activationRecoveryTimeoutMs: 0 },
+    )
+
+    let creates = 0
+    const create = async () => {
+      creates++
+      return { subscription: createRecord() }
+    }
+
+    await expect(
+      store.activate({ challengeId: 'c1', create, lookupKey: 'user-1:plan:pro' }),
+    ).rejects.toThrow('simulated crash before commit')
+    expect(creates).toBe(1)
+
+    // A fresh challenge must resume the interrupted commit, not re-run create()
+    // (which would charge the first period again) or lock the lookup forever.
+    crashArmed = false
+    const retry = await store.activate({
+      challengeId: 'c2',
+      create,
+      lookupKey: 'user-1:plan:pro',
+    })
+
+    expect(retry.status).toBe('existing')
+    expect(creates).toBe(1)
+    expect((await store.get(subscriptionId))?.subscriptionId).toBe(subscriptionId)
+  })
+
   test('tracks a resolved lookup key activation until committed', async () => {
     const store = fromStore(Store.memory())
     let finishActivation!: () => void

--- a/src/tempo/subscription/Store.ts
+++ b/src/tempo/subscription/Store.ts
@@ -10,6 +10,7 @@ const defaultActivationPrefix = 'tempo:subscription:activation:'
 const defaultAccessKeyPrefix = 'tempo:subscription:access-key:'
 const defaultCredentialPrefix = 'tempo:subscription:credential:'
 const defaultActivationTimeoutMs = 15 * 60 * 1_000
+const defaultActivationRecoveryTimeoutMs = 15 * 60 * 1_000
 const defaultRenewalTimeoutMs = 15 * 60 * 1_000
 
 /** Subscription-aware wrapper around a generic key-value store. */
@@ -73,6 +74,12 @@ type ActivationMarker = {
   challengeId?: string
   committingAt?: string
   startedAt?: string
+  /**
+   * The created subscription, persisted alongside `committingAt` so a commit
+   * interrupted after `create()` (and its settlement) can be resumed from the
+   * durable record instead of re-running `create()` and charging again.
+   */
+  subscription?: SubscriptionRecord
 }
 
 /** Wraps a generic key-value {@link Store.Store} with subscription-specific accessors. */
@@ -84,6 +91,7 @@ export function fromStore(
     accessKeyPrefix = defaultAccessKeyPrefix,
     activationPrefix = defaultActivationPrefix,
     activationTimeoutMs = defaultActivationTimeoutMs,
+    activationRecoveryTimeoutMs = defaultActivationRecoveryTimeoutMs,
     credentialPrefix = defaultCredentialPrefix,
     keyPrefix = defaultKeyPrefix,
     recordPrefix = defaultRecordPrefix,
@@ -168,6 +176,27 @@ export function fromStore(
         return { status: 'existing', subscription: existing }
       }
 
+      // Resume a commit a crash interrupted: an earlier activation created (and
+      // settled) the subscription and stored it under `committingAt`, but its
+      // terminal record puts did not all land, so the non-expiring
+      // `committingAt` marker would otherwise leave this lookup key stuck in
+      // `inFlight` forever. Once the marker is older than the recovery timeout
+      // (so a live commit cannot still be in progress), re-apply the record
+      // puts idempotently from the stored subscription and finish. `create()`
+      // is never called again, so the period is not charged twice.
+      const pending = (await store.get(activationKey(lookupKey))) as ActivationMarker | null
+      if (
+        pending?.committingAt &&
+        pending.subscription &&
+        isRecoverableCommit(pending, activationRecoveryTimeoutMs)
+      ) {
+        const subscription = pending.subscription
+        await store.put(recordKey(subscription.subscriptionId), subscription)
+        await store.put(lookupRecordKey(subscription.lookupKey), subscription.subscriptionId)
+        await clearActivationState(lookupKey, pending.challengeId ?? challengeId)
+        return { status: 'existing', subscription }
+      }
+
       const started = await store.update(
         activationKey(lookupKey),
         (current): Store.Change<unknown, { status: 'started' } | { status: 'inFlight' }> => {
@@ -207,6 +236,7 @@ export function fromStore(
             ...marker,
             committingAt: timestamp(),
             startedAt: timestamp(),
+            subscription,
           },
           result: true,
         }
@@ -407,6 +437,14 @@ export declare namespace fromStore {
     activationPrefix?: string | undefined
     /** Milliseconds before a stuck activation lock can be replaced. @default `900000` */
     activationTimeoutMs?: number | undefined
+    /**
+     * Milliseconds after which a `committingAt` activation marker whose commit
+     * never completed (e.g. the process crashed mid-commit) is resumed from its
+     * persisted subscription instead of blocking the lookup key forever. The
+     * subscription is not re-created, so no additional charge occurs.
+     * @default `900000`
+     */
+    activationRecoveryTimeoutMs?: number | undefined
     /** Key prefix for single-use activation credential markers. @default `'tempo:subscription:credential:'` */
     credentialPrefix?: string | undefined
     /** Key prefix for subscription records. @default `'tempo:subscription:record:'` */
@@ -428,6 +466,15 @@ function isStaleActivation(marker: { startedAt?: string | undefined }, timeoutMs
 
 function isStaleRenewal(subscription: SubscriptionRecord, timeoutMs: number) {
   return isStaleActivation({ startedAt: subscription.inFlightStartedAt }, timeoutMs)
+}
+
+// A committing marker older than the recovery timeout cannot belong to a live
+// commit, so its persisted subscription is safe to finish idempotently.
+function isRecoverableCommit(marker: { committingAt?: string | undefined }, timeoutMs: number) {
+  if (!Number.isFinite(timeoutMs) || timeoutMs < 0) return false
+  const committingAt = new Date(marker.committingAt ?? '').getTime()
+  if (!Number.isFinite(committingAt)) return false
+  return Date.now() - committingAt >= timeoutMs
 }
 
 function clearRenewal(subscription: SubscriptionRecord): SubscriptionRecord {


### PR DESCRIPTION
Fixes #674.

## The bug

`activate()` writes a `committingAt` marker before its terminal record puts. `isStaleActivation` treats any `committingAt` marker as never stale, so a live commit is never overwritten. That guard is deliberate: it stops a second activation from double charging.

But if the process crashes after `committingAt` and before the record puts finish, the marker stays forever. Every later activation returns `inFlight`, `create()` never runs again, and the lookup key is locked for good. The user has paid but can never reach the subscription.

Confirmed on current main. The added test fails without the fix.

## The fix

Persist the created subscription with the `committingAt` marker. Add a new `activationRecoveryTimeoutMs` option (default 15m). Once a `committingAt` marker is older than that timeout, a live commit cannot still be running, so a later activation finishes the commit from the stored subscription and clears the marker.

Key point: the resume never calls `create()` again, so the period is not charged twice. The fresh-marker concurrency guard is unchanged, which the existing `does not replace an activation marker that is committing` test confirms at `activationTimeoutMs: 0`.

## Scope

The activation flow has two crash windows:

| Window | When | This PR |
|---|---|---|
| After `committingAt`, before the record puts | subscription already persisted in the marker | Fixed here |
| After settlement inside `create()`, before `committingAt` | charge happened, nothing persisted yet except on chain | Not fixed here |

This PR closes the first window only.

## Design question for the second window

The second window is the one #674 raises as a design question, and I did not want to decide it for you.

On a crash there, the only record of the charge is on chain, tagged with the volatile `challengeId`. A retry brings a fresh challenge, so it can charge again.

Your renewal path already solves this shape. `renewalReference(subscriptionId, periodIndex)` builds a stable `renewal:<id>:<period>` reference and persists it before the billing hook, so a crashed renewal reconciles against it. Activation instead uses `auto.challengeId` (volatile) as the `settlementReference`.

So a likely fix is to give activation a stable settlement reference too and reconcile against it before charging. Two things I could not settle without your input:

- Does the on chain attribution let a retry query whether a reference already settled, or does the settlement layer need an explicit idempotency check?
- For a custom `activate` hook, reconciliation is the app's job. The framework can only hand it a stable reference and a hook point. Is that the contract you want?

Happy to send that as a follow-up in whatever shape you prefer.

## Verification

`Store.test.ts` for the subscription store passes 20/20, including the concurrency guard test. `tsgo -b` is clean. I could not run the full suite locally (its global setup needs a Tempo localnet RPC unrelated to this change).