### PR TITLE
examples: add Peer Cash merchant cash-out flow

### DIFF
--- a/examples/peer-cash/README.md
+++ b/examples/peer-cash/README.md
@@ -1,0 +1,58 @@
+# MPP revenue to Peer Cash
+
+A merchant server that accepts Base USDC over MPP, counts successful settlements, and prepares
+an unsigned Peer Cash plan once confirmed revenue reaches a threshold.
+
+The public MPP route and the cash-out planner are separate listeners. The planner binds to
+`127.0.0.1` and never accepts private keys, signs, or broadcasts. The merchant wallet that receives
+the MPP revenue keeps custody and decides whether to submit the returned transactions.
+
+## Setup
+
+```bash
+npx gitpick wevm/mppx/examples/peer-cash
+pnpm i
+
+export MPPX_RECIPIENT=0xMerchantWallet
+export X402_FACILITATOR_URL=https://your-facilitator.example
+export MPP_SECRET_KEY=replace-with-at-least-32-random-characters
+export PEER_CASH_PLATFORM=revolut
+export PEER_CASH_CURRENCY=USD
+export PEER_CASH_PAYEE=your-handle
+export PEER_CASH_THRESHOLD_USDC=10
+
+pnpm dev
+```
+
+Use a facilitator that supports Base mainnet USDC. The recipient must be the merchant-controlled
+Base wallet that will sign any Peer Cash transactions.
+
+## Payment and cash-out flow
+
+Pay the MPP resource with an EVM-capable client:
+
+```bash
+MPPX_PRIVATE_KEY=0x... pnpm mppx http://localhost:5173/api/report
+```
+
+Inspect confirmed, unreserved revenue on the local admin listener:
+
+```bash
+curl http://127.0.0.1:5174/status
+```
+
+After the threshold is reached, prepare a cash-out for all available revenue:
+
+```bash
+curl -X POST http://127.0.0.1:5174/cashout \
+  -H 'content-type: application/json' \
+  -d '{}'
+```
+
+Pass `{"amountUsdc":"5.25"}` to prepare a smaller amount. The response contains unsigned
+transactions and same-index step descriptions. Review them, then sign and submit them with the
+recipient wallet.
+
+The example deduplicates successful MPP receipts and reserves planned amounts in memory so a
+second request cannot prepare the same revenue again. A production service must persist settlement,
+reservation, transaction, and deposit state before exposing an equivalent operator endpoint.

--- a/examples/peer-cash/package.json
+++ b/examples/peer-cash/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "peer-cash",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "check:types": "tsgo -p tsconfig.json",
+    "dev": "tsx src/server.ts",
+    "test": "node --import tsx --test src/*.test.ts"
+  },
+  "dependencies": {
+    "@types/node": "25.6.0",
+    "@typescript/native-preview": "7.0.0-dev.20260707.2",
+    "@zkp2p/cash": "0.4.9",
+    "hono": "4.12.34",
+    "mppx": "latest",
+    "tsx": "4.23.1",
+    "typescript": "catalog:"
+  }
+}

--- a/examples/peer-cash/src/app.test.ts
+++ b/examples/peer-cash/src/app.test.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { usdc } from '@zkp2p/cash'
+
+import { createApp } from './app.js'
+
+test('prepares one unsigned plan from confirmed MPP revenue', async () => {
+  const amounts: bigint[] = []
+  const { adminApp, revenue } = createApp({
+    cash: {
+      async prepare(input) {
+        amounts.push(input.amount)
+        return {
+          accessPolicyRequired: false,
+          register: { hashedOnchainIds: [] },
+          steps: [],
+          txs: [],
+        }
+      },
+    },
+    cashout: { currency: 'USD', payee: 'merchant', platform: 'revolut' },
+    facilitator: 'https://facilitator.example',
+    recipient: '0x0000000000000000000000000000000000000001',
+    secretKey: 'test-secret-key-test-secret-key-32',
+  })
+  revenue.record('0xsettlement', usdc('10'))
+
+  const response = await adminApp.request('http://localhost/cashout', {
+    body: JSON.stringify({}),
+    headers: { 'content-type': 'application/json' },
+    method: 'POST',
+  })
+
+  assert.equal(response.status, 200)
+  assert.deepEqual(amounts, [usdc('10')])
+  assert.equal((await response.json()).revenue.availableUsdc, '0')
+
+  const duplicate = await adminApp.request('http://localhost/cashout', {
+    body: JSON.stringify({}),
+    headers: { 'content-type': 'application/json' },
+    method: 'POST',
+  })
+  assert.equal(duplicate.status, 409)
+})
+
+test('releases revenue when a payout needs an unsupported follow-up', async () => {
+  const { adminApp, revenue } = createApp({
+    cash: {
+      async prepare() {
+        return {
+          accessPolicyRequired: true,
+          register: { hashedOnchainIds: [] },
+          steps: [],
+          txs: [],
+        }
+      },
+    },
+    cashout: { currency: 'USD', payee: 'merchant', platform: 'venmo' },
+    facilitator: 'https://facilitator.example',
+    recipient: '0x0000000000000000000000000000000000000001',
+    secretKey: 'test-secret-key-test-secret-key-32',
+  })
+  revenue.record('0xsettlement', usdc('10'))
+
+  const response = await adminApp.request('http://localhost/cashout', {
+    body: JSON.stringify({}),
+    headers: { 'content-type': 'application/json' },
+    method: 'POST',
+  })
+
+  assert.equal(response.status, 400)
+  assert.equal(revenue.snapshot().available, usdc('10'))
+})

--- a/examples/peer-cash/src/app.ts
+++ b/examples/peer-cash/src/app.ts
@@ -1,0 +1,157 @@
+import { createCashClient, formatUsdc, isCashError, prepareResultToJson, usdc } from '@zkp2p/cash'
+import type { CashClient, CurrencyType } from '@zkp2p/cash'
+import { Hono } from 'hono'
+import { Mppx, evm } from 'mppx/server'
+import type { Facilitator } from 'mppx/x402'
+
+import { RevenueTracker } from './revenue.js'
+
+export type AppOptions = {
+  cash?: Pick<CashClient, 'prepare'> | undefined
+  cashout: {
+    currency: CurrencyType
+    payee: string
+    platform: string
+    thresholdUsdc?: string | undefined
+  }
+  facilitator: string | Facilitator
+  recipient: `0x${string}`
+  secretKey: string
+}
+
+/** Creates an MPP merchant API and a localhost-only Peer Cash planner. */
+export function createApp(options: AppOptions) {
+  const cash = options.cash ?? createCashClient({ environment: 'production' })
+  const revenue = new RevenueTracker(usdc(options.cashout.thresholdUsdc ?? '10'))
+
+  const payments = Mppx.create({
+    methods: [
+      evm.charge({
+        currency: evm.assets.base.USDC,
+        onPaymentSuccess: ({ receipt, request }) => {
+          const recorded = revenue.record(receipt.reference, BigInt(request.amount))
+          if (recorded) {
+            console.log(
+              `MPP payment settled: ${formatUsdc(BigInt(request.amount))} USDC (${receipt.reference})`,
+            )
+          }
+        },
+        recipient: options.recipient,
+        x402: { facilitator: options.facilitator },
+      }),
+    ],
+    secretKey: options.secretKey,
+  })
+
+  const publicApp = new Hono()
+  publicApp.get('/api/health', (c) => c.json({ status: 'ok' }))
+  publicApp.get('/api/report', async (c) => {
+    const result = await payments.evm.charge({
+      amount: '0.01',
+      description: 'Merchant report',
+    })(c.req.raw)
+    if (result.status === 402) return result.challenge
+    return result.withReceipt(c.json({ report: 'paid MPP resource' }))
+  })
+
+  const adminApp = new Hono()
+  adminApp.get('/status', (c) => c.json(formatSnapshot(revenue)))
+  adminApp.post('/cashout', async (c) => {
+    let amount = 0n
+    let reserved = false
+    try {
+      const body = await readCashoutBody(c.req.raw)
+      const snapshot = revenue.snapshot()
+      if (!snapshot.ready) {
+        return c.json(
+          {
+            error: 'confirmed MPP settlements have not reached the cash-out threshold',
+            ...formatSnapshot(revenue),
+          },
+          409,
+        )
+      }
+
+      amount = body.amountUsdc === undefined ? snapshot.available : usdc(body.amountUsdc)
+      if (amount <= 0n) return c.json({ error: 'cash-out amount must be positive' }, 400)
+      if (amount > snapshot.available) {
+        return c.json(
+          {
+            error: 'cash-out amount exceeds confirmed, unreserved MPP settlements',
+            ...formatSnapshot(revenue),
+          },
+          409,
+        )
+      }
+      revenue.reserve(amount)
+      reserved = true
+
+      const prepared = await cash.prepare({
+        amount,
+        receive: {
+          currency: options.cashout.currency,
+          payee: options.cashout.payee,
+          platform: options.cashout.platform,
+        },
+      })
+
+      if (prepared.accessPolicyRequired) {
+        revenue.release(amount)
+        reserved = false
+        return c.json(
+          {
+            error:
+              'this minimal planner does not automate the post-deposit access-policy transaction required by this payout platform',
+            remediation:
+              'use an unrestricted platform or extend the host to finalize the confirmed deposit and call prepareAccessPolicy',
+          },
+          400,
+        )
+      }
+
+      return c.json({
+        amountUsdc: formatUsdc(amount),
+        note: 'Unsigned only. Persist settlement, reservation, and confirmed cash-out state in production.',
+        prepared: prepareResultToJson(prepared),
+        revenue: formatSnapshot(revenue),
+      })
+    } catch (error) {
+      if (reserved) revenue.release(amount)
+      if (isCashError(error)) return c.json({ error: error.toJSON() }, 400)
+      if (error instanceof CashoutRequestError) return c.json({ error: error.message }, 400)
+      console.error('Unable to prepare Peer cash-out', error)
+      return c.json({ error: 'Unable to prepare Peer cash-out' }, 500)
+    }
+  })
+
+  return { adminApp, publicApp, revenue }
+}
+
+function formatSnapshot(revenue: RevenueTracker) {
+  const snapshot = revenue.snapshot()
+  return {
+    availableUsdc: formatUsdc(snapshot.available),
+    ready: snapshot.ready,
+    reservedUsdc: formatUsdc(snapshot.reserved),
+    settledUsdc: formatUsdc(snapshot.settled),
+    thresholdUsdc: formatUsdc(snapshot.threshold),
+  }
+}
+
+async function readCashoutBody(request: Request): Promise<{ amountUsdc?: string | undefined }> {
+  let body: { amountUsdc?: unknown }
+  try {
+    body = (await request.json()) as { amountUsdc?: unknown }
+  } catch {
+    throw new CashoutRequestError('Request body must be JSON.')
+  }
+  if (body.amountUsdc === undefined) return {}
+  if (typeof body.amountUsdc !== 'string' || !/^\d+(\.\d{1,6})?$/.test(body.amountUsdc)) {
+    throw new CashoutRequestError(
+      'amountUsdc must be a positive decimal string with at most six decimals.',
+    )
+  }
+  return { amountUsdc: body.amountUsdc }
+}
+
+class CashoutRequestError extends Error {}

--- a/examples/peer-cash/src/revenue.test.ts
+++ b/examples/peer-cash/src/revenue.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { RevenueTracker } from './revenue.js'
+
+test('deduplicates settlement references', () => {
+  const revenue = new RevenueTracker(10_000_000n)
+
+  assert.equal(revenue.record('0xabc', 6_000_000n), true)
+  assert.equal(revenue.record('0xabc', 6_000_000n), false)
+  assert.deepEqual(revenue.snapshot(), {
+    available: 6_000_000n,
+    ready: false,
+    reserved: 0n,
+    settled: 6_000_000n,
+    threshold: 10_000_000n,
+  })
+})
+
+test('reserves only confirmed, unreserved revenue', () => {
+  const revenue = new RevenueTracker(5_000_000n)
+  revenue.record('0xabc', 7_000_000n)
+  revenue.reserve(5_000_000n)
+
+  assert.equal(revenue.snapshot().available, 2_000_000n)
+  assert.throws(() => revenue.reserve(3_000_000n), /exceeds unreserved settlements/)
+
+  revenue.release(5_000_000n)
+  assert.equal(revenue.snapshot().available, 7_000_000n)
+})

--- a/examples/peer-cash/src/revenue.ts
+++ b/examples/peer-cash/src/revenue.ts
@@ -1,0 +1,59 @@
+export type RevenueSnapshot = {
+  available: bigint
+  ready: boolean
+  reserved: bigint
+  settled: bigint
+  threshold: bigint
+}
+
+/** Tracks confirmed merchant revenue without counting a settlement twice. */
+export class RevenueTracker {
+  readonly #references = new Set<string>()
+  readonly #threshold: bigint
+  #reserved = 0n
+  #settled = 0n
+
+  constructor(threshold: bigint) {
+    if (threshold <= 0n) throw new Error('Revenue threshold must be positive.')
+    this.#threshold = threshold
+  }
+
+  /** Records a successful settlement once, keyed by its receipt reference. */
+  record(reference: string, amount: bigint): boolean {
+    if (!reference) throw new Error('Settlement reference is required.')
+    if (amount <= 0n) throw new Error('Settlement amount must be positive.')
+    if (this.#references.has(reference)) return false
+    this.#references.add(reference)
+    this.#settled += amount
+    return true
+  }
+
+  /** Reserves confirmed revenue before an asynchronous cash-out plan is prepared. */
+  reserve(amount: bigint): void {
+    if (amount <= 0n) throw new Error('Cash-out amount must be positive.')
+    if (amount > this.available) throw new Error('Cash-out exceeds unreserved settlements.')
+    this.#reserved += amount
+  }
+
+  /** Releases a reservation when preparing its cash-out plan fails. */
+  release(amount: bigint): void {
+    if (amount <= 0n || amount > this.#reserved) throw new Error('Invalid reservation release.')
+    this.#reserved -= amount
+  }
+
+  /** Returns confirmed revenue that is not already assigned to a cash-out plan. */
+  get available(): bigint {
+    return this.#settled - this.#reserved
+  }
+
+  /** Returns the current in-memory accounting state. */
+  snapshot(): RevenueSnapshot {
+    return {
+      available: this.available,
+      ready: this.available >= this.#threshold,
+      reserved: this.#reserved,
+      settled: this.#settled,
+      threshold: this.#threshold,
+    }
+  }
+}

--- a/examples/peer-cash/src/server.ts
+++ b/examples/peer-cash/src/server.ts
@@ -1,0 +1,50 @@
+import { createServer } from 'node:http'
+
+import type { CurrencyType } from '@zkp2p/cash'
+import { NodeListener, Request as ServerRequest } from 'mppx/server'
+
+import { createApp } from './app.js'
+
+const recipient = process.env.MPPX_RECIPIENT as `0x${string}` | undefined
+const facilitator = process.env.X402_FACILITATOR_URL
+const secretKey = process.env.MPP_SECRET_KEY
+const platform = process.env.PEER_CASH_PLATFORM
+const currency = process.env.PEER_CASH_CURRENCY
+const payee = process.env.PEER_CASH_PAYEE
+
+if (!recipient || !facilitator || !secretKey || !platform || !currency || !payee) {
+  throw new Error(
+    'MPPX_RECIPIENT, X402_FACILITATOR_URL, MPP_SECRET_KEY, PEER_CASH_PLATFORM, PEER_CASH_CURRENCY, and PEER_CASH_PAYEE are required.',
+  )
+}
+
+const { adminApp, publicApp } = createApp({
+  cashout: {
+    currency: currency as CurrencyType,
+    payee,
+    platform,
+    thresholdUsdc: process.env.PEER_CASH_THRESHOLD_USDC,
+  },
+  facilitator,
+  recipient,
+  secretKey,
+})
+
+serve(publicApp.fetch, Number(process.env.PORT ?? 5173), '0.0.0.0')
+serve(adminApp.fetch, Number(process.env.ADMIN_PORT ?? 5174), '127.0.0.1')
+
+console.log(`MPP merchant API: http://localhost:${process.env.PORT ?? 5173}/api/report`)
+console.log(`Peer Cash planner: http://127.0.0.1:${process.env.ADMIN_PORT ?? 5174}/cashout`)
+
+function serve(
+  fetch: (request: Request) => Response | Promise<Response>,
+  port: number,
+  hostname: string,
+) {
+  const server = createServer(async (req, res) => {
+    const request = ServerRequest.fromNodeListener(req, res)
+    const response = await fetch(request)
+    return NodeListener.sendResponse(res, response)
+  })
+  server.listen(port, hostname)
+}

--- a/examples/peer-cash/tsconfig.json
+++ b/examples/peer-cash/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "lib": ["ESNext", "DOM"],
+    "noEmit": true,
+    "types": ["node"],
+    "paths": {
+      "mppx": ["../../src/index.ts"],
+      "mppx/*": ["../../src/*/index.ts"]
+    }
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,7 @@ overrides:
   '@hono/node-server@<2.0.10': 2.0.10
   undici@>=7.0.0 <7.28.0: 7.28.0
   undici@>=8.0.0 <8.9.0: 8.9.0
+  undici-types@6.19.8: 6.19.2
   socket.io-parser@>=4.0.0 <4.2.7: 4.2.7
   yaml@<2.8.3: '>=2.8.3'
   brace-expansion@>=5.0.0 <5.0.9: 5.0.9
@@ -261,6 +262,30 @@ importers:
       vite:
         specifier: ^8.2.0
         version: 8.2.0(@types/node@25.6.0)(esbuild@0.28.1)(tsx@4.23.11)(yaml@2.9.0)
+
+  examples/peer-cash:
+    dependencies:
+      '@types/node':
+        specifier: 25.6.0
+        version: 25.6.0
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260707.2
+        version: 7.0.0-dev.20260707.2
+      '@zkp2p/cash':
+        specifier: 0.4.9
+        version: 0.4.9(bufferutil@4.1.0)(react@19.2.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(viem@2.55.10(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))
+      hono:
+        specifier: 4.12.34
+        version: 4.12.34
+      mppx:
+        specifier: workspace:*
+        version: link:../..
+      tsx:
+        specifier: 4.23.1
+        version: 4.23.1
+      typescript:
+        specifier: ~7.0.2
+        version: 7.0.2
 
   examples/session/multi-fetch:
     dependencies:
@@ -931,6 +956,9 @@ packages:
     resolution: {integrity: sha512-Clu/xdfgVTf9o7ngLOURaxePwR0j8sjclKEtVij10/jGulwFsPWCvvRgG/XjUVf8Nei+jLG6uwyXzUTGY1DQrw==}
     engines: {node: '>= 20.19.0'}
 
+  '@noble/curves@1.2.0':
+    resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
+
   '@noble/curves@1.4.2':
     resolution: {integrity: sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==}
 
@@ -941,6 +969,10 @@ packages:
   '@noble/curves@1.9.7':
     resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.3.2':
+    resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
+    engines: {node: '>= 16'}
 
   '@noble/hashes@1.4.0':
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
@@ -1512,6 +1544,43 @@ packages:
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
     deprecated: 'Switch to "qr" (new package name) for security updates: npm install qr'
 
+  '@peculiar/asn1-cms@2.8.0':
+    resolution: {integrity: sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==}
+
+  '@peculiar/asn1-csr@2.8.0':
+    resolution: {integrity: sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg==}
+
+  '@peculiar/asn1-ecc@2.8.0':
+    resolution: {integrity: sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==}
+
+  '@peculiar/asn1-pfx@2.8.0':
+    resolution: {integrity: sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg==}
+
+  '@peculiar/asn1-pkcs8@2.8.0':
+    resolution: {integrity: sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA==}
+
+  '@peculiar/asn1-pkcs9@2.8.0':
+    resolution: {integrity: sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ==}
+
+  '@peculiar/asn1-rsa@2.8.0':
+    resolution: {integrity: sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==}
+
+  '@peculiar/asn1-schema@2.8.0':
+    resolution: {integrity: sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==}
+
+  '@peculiar/asn1-x509-attr@2.8.0':
+    resolution: {integrity: sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==}
+
+  '@peculiar/asn1-x509@2.8.0':
+    resolution: {integrity: sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==}
+
+  '@peculiar/utils@2.0.3':
+    resolution: {integrity: sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==}
+
+  '@peculiar/x509@1.14.3':
+    resolution: {integrity: sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==}
+    engines: {node: '>=20.0.0'}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -1550,6 +1619,11 @@ packages:
 
   '@protobufjs/utf8@1.1.2':
     resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
+
+  '@relayprotocol/relay-sdk@7.0.1':
+    resolution: {integrity: sha512-GgoUTeSk3hzTcSivSIEfkUwWLqw+4/wjJD8HA9OM+b4LlK8N8FPkSvqrSHrW6gj5OY/EhcspqXVAnScuCU8AjA==}
+    peerDependencies:
+      viem: 2.55.10
 
   '@remix-run/fetch-router@0.17.0':
     resolution: {integrity: sha512-3FeJGrTqrKKCvZdQWijbCXTEHKcdttkLFbI2ogfpZ+iDYSNZ9036wgDXuuoZqg6d+D0E8Unhk5ZwrLKDCd/hOw==}
@@ -1763,6 +1837,9 @@ packages:
 
   '@types/node@18.19.130':
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
+
+  '@types/node@22.7.5':
+    resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
 
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
@@ -2180,6 +2257,40 @@ packages:
       typescript:
         optional: true
 
+  '@zkp2p/cash@0.4.9':
+    resolution: {integrity: sha512-8lAPVO3fEGPGM2hRszv9wV/IC6XuxOknjJy/ReY+GJdLDbckurjg+Zh5Uu5YDRXs7uf1oqh11uKdHFTNMWLpKQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      react: '>=18'
+      viem: 2.55.10
+    peerDependenciesMeta:
+      react:
+        optional: true
+
+  '@zkp2p/contracts-v2@0.4.0':
+    resolution: {integrity: sha512-wE4IfjRSUVfOiAULoh6eVUj5vExSlcMY6+VsRLOhGq+1q06uy/aS2lMYjzqoDAXibMpYPTVhsuy1MEB2jKGKqw==}
+    peerDependencies:
+      ethers: ^5.0.0 || ^6.0.0
+
+  '@zkp2p/indexer-schema@0.20.0':
+    resolution: {integrity: sha512-EQsmFfp61hI0zzILYoh8aPzf+CGeduoiAQQ+FD27oIQBj5piKFqNQCfzhI14A7lBWtS69gXqjPuJJTo/BOaO3w==}
+    engines: {node: '>=16'}
+
+  '@zkp2p/sdk@0.12.0':
+    resolution: {integrity: sha512-7boAYdUV+R3G+1hFOp7lQLxX9NUDVXtfW3RsgBt4ijhg3BqO9RBgpMfeWfqoE7kRUVDo/xNZL39bhBbXK6NmIA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      react: '>=16.8.0'
+      viem: 2.55.10
+    peerDependenciesMeta:
+      react:
+        optional: true
+
+  '@zkp2p/zkp2p-attestation@2.0.0':
+    resolution: {integrity: sha512-m+HWDYTEW109xSqh0NWJFoWR0ZIoxJqQRguQltfr6RSkALBJFWv5WWDQrcPN0TiqTN2KdLI7BYQTDluZfjq2MA==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   abitype@1.2.3:
     resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
     peerDependencies:
@@ -2255,6 +2366,13 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  aes-js@4.0.0-beta.5:
+    resolution: {integrity: sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==}
+
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
@@ -2307,6 +2425,10 @@ packages:
   asn1@0.2.6:
     resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
 
+  asn1js@3.0.10:
+    resolution: {integrity: sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==}
+    engines: {node: '>=12.0.0'}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -2320,9 +2442,15 @@ packages:
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  axios@1.19.0:
+    resolution: {integrity: sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==}
 
   b4a@1.8.1:
     resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
@@ -2489,6 +2617,10 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   compress-commons@6.0.2:
     resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
     engines: {node: '>= 14'}
@@ -2575,6 +2707,10 @@ packages:
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -2678,6 +2814,10 @@ packages:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
 
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
@@ -2751,6 +2891,10 @@ packages:
 
   ethereum-cryptography@2.2.1:
     resolution: {integrity: sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==}
+
+  ethers@6.17.0:
+    resolution: {integrity: sha512-BpyrpIPJ3ydEVow8zGaz1DuPS7YU8DcWxuBnY9a0UA/lvAPwrMr+EPXsfrul628SRaekPNeIM4UFh/91GWZang==}
+    engines: {node: '>=14.0.0'}
 
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
@@ -2914,6 +3058,10 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
+    engines: {node: '>= 6'}
+
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -3022,6 +3170,10 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
   hono@4.12.34:
     resolution: {integrity: sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==}
     engines: {node: '>=16.9.0'}
@@ -3033,6 +3185,10 @@ packages:
   http-proxy@1.18.1:
     resolution: {integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==}
     engines: {node: '>=8.0.0'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   human-id@4.2.0:
     resolution: {integrity: sha512-K3GbkIWqyvvlpfhBPlbEvD97TtqBpAYA4kt+cn2lD2x2HuohzZCibcA2nOlnJT6exqvJLggoB5nv2dNf192nEA==}
@@ -3327,8 +3483,16 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
   mime-types@3.0.2:
@@ -3671,6 +3835,10 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
@@ -3680,6 +3848,13 @@ packages:
 
   pure-rand@8.4.2:
     resolution: {integrity: sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==}
+
+  pvtsutils@1.3.6:
+    resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
+
+  pvutils@1.2.0:
+    resolution: {integrity: sha512-BbubeCEyTuQjVMakvJQ/Sxbc93F2pwmbsxONT/ZRrwU7Ua38d8unYTwXpTVLAKJ4BDuH9IGztCjQcd/N/39Dvg==}
+    engines: {node: '>=16.0.0'}
 
   qs@6.15.2:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
@@ -3726,6 +3901,9 @@ packages:
   readdir-glob@3.0.0:
     resolution: {integrity: sha512-AhNB2KgKeVJr16nK9LLZbJNWnYoT23ZrumNKFDebHBdkC8KHSqWo871JAUhoWC/RtjEVdqNMFpM6qrwRbaUqpw==}
     engines: {node: '>=18'}
+
+  reflect-metadata@0.2.2:
+    resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -4012,6 +4190,12 @@ packages:
       typescript:
         optional: true
 
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+
+  tslib@2.7.0:
+    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -4024,6 +4208,10 @@ packages:
     resolution: {integrity: sha512-Ry2oTEUnhBdeEdWIztY8kf3/nBGnPnjMLVGL0YfdRXMORuPER5NlKmayqxtxRxwB1xBN+RivRaJfe7PM1rtiyw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  tsyringe@4.10.0:
+    resolution: {integrity: sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==}
+    engines: {node: '>= 6.0.0'}
 
   tweetnacl@0.14.5:
     resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
@@ -4051,6 +4239,9 @@ packages:
 
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+  undici-types@6.19.2:
+    resolution: {integrity: sha512-jvI+p8VJnrOIQ8AU4PyB1ytW68EyrLnI2xvCO3e5umm3nmhNjpugMD1wo+X994PyvUT9dWS/k3vO1wwRIh730Q==}
 
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
@@ -4900,6 +5091,10 @@ snapshots:
 
   '@noble/ciphers@2.3.0': {}
 
+  '@noble/curves@1.2.0':
+    dependencies:
+      '@noble/hashes': 1.3.2
+
   '@noble/curves@1.4.2':
     dependencies:
       '@noble/hashes': 1.4.0
@@ -4911,6 +5106,8 @@ snapshots:
   '@noble/curves@1.9.7':
     dependencies:
       '@noble/hashes': 1.8.0
+
+  '@noble/hashes@1.3.2': {}
 
   '@noble/hashes@1.4.0': {}
 
@@ -5240,6 +5437,100 @@ snapshots:
 
   '@paulmillr/qr@0.2.1': {}
 
+  '@peculiar/asn1-cms@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      '@peculiar/asn1-x509-attr': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-csr@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-ecc@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pfx@2.8.0':
+    dependencies:
+      '@peculiar/asn1-cms': 2.8.0
+      '@peculiar/asn1-pkcs8': 2.8.0
+      '@peculiar/asn1-rsa': 2.8.0
+      '@peculiar/asn1-schema': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pkcs8@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pkcs9@2.8.0':
+    dependencies:
+      '@peculiar/asn1-cms': 2.8.0
+      '@peculiar/asn1-pfx': 2.8.0
+      '@peculiar/asn1-pkcs8': 2.8.0
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      '@peculiar/asn1-x509-attr': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-rsa@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-schema@2.8.0':
+    dependencies:
+      '@peculiar/utils': 2.0.3
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-x509-attr@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-x509@2.8.0':
+    dependencies:
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/utils': 2.0.3
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/utils@2.0.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@peculiar/x509@1.14.3':
+    dependencies:
+      '@peculiar/asn1-cms': 2.8.0
+      '@peculiar/asn1-csr': 2.8.0
+      '@peculiar/asn1-ecc': 2.8.0
+      '@peculiar/asn1-pkcs9': 2.8.0
+      '@peculiar/asn1-rsa': 2.8.0
+      '@peculiar/asn1-schema': 2.8.0
+      '@peculiar/asn1-x509': 2.8.0
+      pvtsutils: 1.3.6
+      reflect-metadata: 0.2.2
+      tslib: 2.8.1
+      tsyringe: 4.10.0
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -5268,6 +5559,14 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.2': {}
+
+  '@relayprotocol/relay-sdk@7.0.1(viem@2.55.10(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))':
+    dependencies:
+      axios: 1.19.0
+      viem: 2.55.10(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   '@remix-run/fetch-router@0.17.0':
     dependencies:
@@ -5441,6 +5740,10 @@ snapshots:
   '@types/node@18.19.130':
     dependencies:
       undici-types: 5.26.5
+
+  '@types/node@22.7.5':
+    dependencies:
+      undici-types: 6.19.2
 
   '@types/node@25.6.0':
     dependencies:
@@ -5690,6 +5993,55 @@ snapshots:
       - react
       - use-sync-external-store
 
+  '@zkp2p/cash@0.4.9(bufferutil@4.1.0)(react@19.2.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(viem@2.55.10(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))':
+    dependencies:
+      '@relayprotocol/relay-sdk': 7.0.1(viem@2.55.10(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))
+      '@zkp2p/sdk': 0.12.0(bufferutil@4.1.0)(react@19.2.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(viem@2.55.10(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))(zod@4.4.3)
+      viem: 2.55.10(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)
+      zod: 4.4.3
+    optionalDependencies:
+      react: 19.2.8
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - typescript
+      - utf-8-validate
+
+  '@zkp2p/contracts-v2@0.4.0(ethers@6.17.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(typescript@7.0.2)(zod@4.4.3)':
+    dependencies:
+      abitype: 1.3.0(typescript@7.0.2)(zod@4.4.3)
+      ethers: 6.17.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - typescript
+      - zod
+
+  '@zkp2p/indexer-schema@0.20.0': {}
+
+  '@zkp2p/sdk@0.12.0(bufferutil@4.1.0)(react@19.2.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(viem@2.55.10(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))(zod@4.4.3)':
+    dependencies:
+      '@zkp2p/contracts-v2': 0.4.0(ethers@6.17.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(typescript@7.0.2)(zod@4.4.3)
+      '@zkp2p/indexer-schema': 0.20.0
+      '@zkp2p/zkp2p-attestation': 2.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ethers: 6.17.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ox: 0.14.33(typescript@7.0.2)(zod@4.4.3)
+      viem: 2.55.10(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)
+    optionalDependencies:
+      react: 19.2.8
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - zod
+
+  '@zkp2p/zkp2p-attestation@2.0.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@peculiar/x509': 1.14.3
+      ethers: 6.17.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   abitype@1.2.3(typescript@7.0.2)(zod@4.4.3):
     optionalDependencies:
       typescript: 7.0.2
@@ -5738,6 +6090,14 @@ snapshots:
       acorn: 8.18.0
 
   acorn@8.18.0: {}
+
+  aes-js@4.0.0-beta.5: {}
+
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
@@ -5801,6 +6161,12 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  asn1js@3.0.10:
+    dependencies:
+      pvtsutils: 1.3.6
+      pvutils: 1.2.0
+      tslib: 2.8.1
+
   assertion-error@2.0.1: {}
 
   ast-metadata-inferer@0.8.1:
@@ -5811,9 +6177,21 @@ snapshots:
 
   async@3.2.6: {}
 
+  asynckit@0.4.0: {}
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  axios@1.19.0:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   b4a@1.8.1: {}
 
@@ -5983,6 +6361,10 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   compress-commons@6.0.2:
     dependencies:
       crc-32: 1.2.2
@@ -6056,6 +6438,8 @@ snapshots:
       es-define-property: 1.0.1
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
 
@@ -6162,6 +6546,13 @@ snapshots:
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.3
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -6285,6 +6676,19 @@ snapshots:
       '@noble/hashes': 1.4.0
       '@scure/bip32': 1.4.0
       '@scure/bip39': 1.3.0
+
+  ethers@6.17.0(bufferutil@4.1.0)(utf-8-validate@5.0.10):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.2
+      '@types/node': 22.7.5
+      aes-js: 4.0.0-beta.5
+      tslib: 2.7.0
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   event-target-shim@5.0.1: {}
 
@@ -6481,6 +6885,14 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  form-data@4.0.6:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
+
   forwarded@0.2.0: {}
 
   fresh@2.0.0: {}
@@ -6591,6 +7003,10 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
   hono@4.12.34: {}
 
   http-errors@2.0.1:
@@ -6608,6 +7024,13 @@ snapshots:
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   human-id@4.2.0: {}
 
@@ -6846,7 +7269,13 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
+  mime-db@1.52.0: {}
+
   mime-db@1.54.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   mime-types@3.0.2:
     dependencies:
@@ -7190,6 +7619,8 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
+  proxy-from-env@2.1.0: {}
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
@@ -7198,6 +7629,12 @@ snapshots:
   punycode@2.3.1: {}
 
   pure-rand@8.4.2: {}
+
+  pvtsutils@1.3.6:
+    dependencies:
+      tslib: 2.8.1
+
+  pvutils@1.2.0: {}
 
   qs@6.15.2:
     dependencies:
@@ -7255,6 +7692,8 @@ snapshots:
   readdir-glob@3.0.0:
     dependencies:
       minimatch: 10.2.5
+
+  reflect-metadata@0.2.2: {}
 
   require-directory@2.1.1: {}
 
@@ -7629,6 +8068,10 @@ snapshots:
     optionalDependencies:
       typescript: 7.0.2
 
+  tslib@1.14.1: {}
+
+  tslib@2.7.0: {}
+
   tslib@2.8.1: {}
 
   tsx@4.23.1:
@@ -7642,6 +8085,10 @@ snapshots:
       esbuild: 0.28.1
     optionalDependencies:
       fsevents: 2.3.3
+
+  tsyringe@4.10.0:
+    dependencies:
+      tslib: 1.14.1
 
   tweetnacl@0.14.5: {}
 
@@ -7687,6 +8134,8 @@ snapshots:
   uint8array-extras@1.5.0: {}
 
   undici-types@5.26.5: {}
+
+  undici-types@6.19.2: {}
 
   undici-types@7.19.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -42,6 +42,7 @@ overrides:
   '@hono/node-server@<2.0.10': '2.0.10'
   undici@>=7.0.0 <7.28.0: '7.28.0'
   undici@>=8.0.0 <8.9.0: '8.9.0'
+  undici-types@6.19.8: '6.19.2'
   socket.io-parser@>=4.0.0 <4.2.7: '4.2.7'
   yaml@<2.8.3: '>=2.8.3'
   brace-expansion@>=5.0.0 <5.0.9: '5.0.9'
@@ -70,6 +71,7 @@ allowBuilds:
   utf-8-validate: true
 
 minimumReleaseAgeExclude:
+  - '@zkp2p/cash@0.4.9'
   - esbuild@0.28.1
   - body-parser@2.3.0
   - brace-expansion@5.0.9


### PR DESCRIPTION
## Summary

- add a Base mainnet MPP merchant example that prepares Peer Cash plans from confirmed USDC revenue
- count each successful payment receipt once and reserve planned amounts before asynchronous preparation
- keep the operator endpoint on a separate localhost listener and return unsigned transactions only
- pin the `undici-types` transitive dependency to a provenance-attested compatible release so the workspace trust policy remains effective

## Why

MPP handles the incoming machine payment. Peer Cash handles a separate merchant operation after settlement: moving Base USDC from the merchant-controlled recipient wallet into a fiat cash-out order. The example keeps those boundaries explicit and does not treat Peer Cash as a payer-side payment method.

## Safety boundaries

- the public server receives payments into `MPPX_RECIPIENT`
- only successful EVM settlement hooks increase tracked revenue
- receipt references are deduplicated
- the cash-out planner binds to `127.0.0.1`
- the planner never accepts private keys, signs, or broadcasts
- payout methods that need a post-deposit access-policy transaction fail closed in this minimal example
- the README calls out the in-memory accounting boundary and the state that a production host must persist

## Validation

- 4 focused accounting and planner tests
- cold server smoke: health and admin status return 200; the paid route returns an MPP + x402-compatible Base USDC 402 challenge
- `pnpm --filter peer-cash check:types`
- `pnpm check:types`
- `pnpm check:types:html`
- `pnpm check:types:examples`
- `pnpm check:ci`
- `pnpm audit --ignore-registry-errors` (no known vulnerabilities)
- `pnpm install --frozen-lockfile`

No changeset: this adds an example without changing the published `mppx` package.
