### PR TITLE
feat(tempo): support unified machine-token payments

### DIFF
--- a/.changeset/machine-sessions-route.md
+++ b/.changeset/machine-sessions-route.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added implicit machine-token funding to Tempo sessions and moved Tempo charges and sessions to the unified machineUSD deployment. Clients use machineUSD when a verified route and sufficient balance are available and otherwise pay the challenged token. Configured fee-token overrides were bound into session challenges, and concurrent session requests rechecked top-up requirements after serialized opens.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ const mppx = Mppx.create({
   methods: [
     tempo({
       currency: '0x20c0000000000000000000000000000000000000',
+      machineTokenEnabled: true,
       recipient: '0x742d35Cc6634c0532925a3b844bC9e7595F8fE00',
     }),
   ],
@@ -82,6 +83,11 @@ Mppx.create({
 // Global fetch now handles 402 automatically
 const res = await fetch('https://mpp.dev/api/ping/paid')
 ```
+
+The client API is the same for PathUSD, USDC.e, and machineUSD. A server advertises
+`machineTokenEnabled`; the client uses machineUSD when a verified route and sufficient balance
+are available, and otherwise pays the token requested by the challenge. Sessions keep the selected
+rail until the channel closes.
 
 ## Examples
 

--- a/src/cli/sessions/Manager.ts
+++ b/src/cli/sessions/Manager.ts
@@ -44,18 +44,20 @@ function assertCloseChallengeScope(challenge: TempoSessionChallenge, channel: Ch
   const chainId = (challenge.request.methodDetails as { chainId?: unknown } | undefined)?.chainId
   if (chainId !== undefined && chainId !== channel.chainId)
     throw new Error('Close challenge changed the session chain.')
+  if (resolveEscrow(challenge, channel.escrow).toLowerCase() !== channel.escrow.toLowerCase())
+    throw new Error('Close challenge changed the session escrow.')
+  const payee = channel.paymentScope?.payee ?? channel.descriptor.payee
+  const token = channel.paymentScope?.token ?? channel.descriptor.token
   if (
     typeof challenge.request.recipient !== 'string' ||
-    challenge.request.recipient.toLowerCase() !== channel.descriptor.payee.toLowerCase()
+    challenge.request.recipient.toLowerCase() !== payee.toLowerCase()
   )
     throw new Error('Close challenge changed the session payee.')
   if (
     typeof challenge.request.currency !== 'string' ||
-    challenge.request.currency.toLowerCase() !== channel.descriptor.token.toLowerCase()
+    challenge.request.currency.toLowerCase() !== token.toLowerCase()
   )
     throw new Error('Close challenge changed the session token.')
-  if (resolveEscrow(challenge, channel.escrow).toLowerCase() !== channel.escrow.toLowerCase())
-    throw new Error('Close challenge changed the session escrow.')
   const snapshot = getSessionSnapshot(challenge)
   if (snapshot && snapshot.channelId.toLowerCase() !== channel.channelId.toLowerCase())
     throw new Error('Close challenge changed the session channel.')

--- a/src/cli/sessions/store.test.ts
+++ b/src/cli/sessions/store.test.ts
@@ -9,9 +9,11 @@ vi.mock('node:fs/promises', async (importOriginal) => ({
 }))
 
 import type * as Challenge from '../../Challenge.js'
+import * as defaults from '../../tempo/internal/defaults.js'
 import type { ChannelEntry } from '../../tempo/session/client/ChannelOps.js'
 import { entryKey } from '../../tempo/session/client/ChannelStore.js'
-import type { SessionReceipt } from '../../tempo/session/precompile/Protocol.js'
+import * as Channel from '../../tempo/session/precompile/Channel.js'
+import { tip20ChannelEscrow, type SessionReceipt } from '../../tempo/session/precompile/Protocol.js'
 import sessions from './commands.js'
 import {
   createSessionRegistry,
@@ -29,8 +31,24 @@ const payee = '0x2222222222222222222222222222222222222222' as Address
 const token = '0x3333333333333333333333333333333333333333' as Address
 const escrow = '0x4444444444444444444444444444444444444444' as Address
 const operator = '0x0000000000000000000000000000000000000000' as Address
-const channelId = `0x${'aa'.repeat(32)}` as Hex
-const mainnetChannelId = `0x${'bb'.repeat(32)}` as Hex
+const machinePayee = '0x7777777777777777777777777777777777777777' as Address
+const descriptor = {
+  payer,
+  payee,
+  operator,
+  token,
+  salt: `0x${'55'.repeat(32)}` as Hex,
+  authorizedSigner: payer,
+  expiringNonceHash: `0x${'66'.repeat(32)}` as Hex,
+}
+const channelId = Channel.computeId({ ...descriptor, escrow, chainId: 42431 })
+const mainnetChannelId = Channel.computeId({ ...descriptor, escrow, chainId: 4217 })
+const machineDescriptor = {
+  ...descriptor,
+  operator: defaults.machineToken[42431].swap,
+  payee: machinePayee,
+  token: defaults.machineToken[42431].token,
+}
 
 let temporaryDirectory: string
 let stateRoot: string
@@ -47,21 +65,18 @@ afterEach(async () => {
 })
 
 function channel(overrides: Partial<ChannelEntry> = {}): ChannelEntry {
+  const nextDescriptor = overrides.descriptor ?? descriptor
+  const nextEscrow = overrides.escrow ?? escrow
+  const nextChainId = overrides.chainId ?? 42431
   return {
-    channelId,
+    channelId:
+      overrides.channelId ??
+      Channel.computeId({ ...nextDescriptor, escrow: nextEscrow, chainId: nextChainId }),
     cumulativeAmount: 10n,
     deposit: 100n,
-    descriptor: {
-      payer,
-      payee,
-      operator,
-      token,
-      salt: `0x${'55'.repeat(32)}`,
-      authorizedSigner: payer,
-      expiringNonceHash: `0x${'66'.repeat(32)}`,
-    },
-    escrow,
-    chainId: 42431,
+    descriptor: nextDescriptor,
+    escrow: nextEscrow,
+    chainId: nextChainId,
     opened: true,
     ...overrides,
   }
@@ -80,6 +95,28 @@ function challenge(id = 'challenge-1', chainId = 42431): Challenge.Challenge {
       methodDetails: { chainId, escrowContract: escrow },
     },
   }
+}
+
+function machineChallenge(): Challenge.Challenge {
+  return {
+    ...challenge('machine-challenge'),
+    request: {
+      ...challenge('machine-challenge').request,
+      methodDetails: {
+        chainId: 42431,
+        escrowContract: tip20ChannelEscrow,
+        machineTokenEnabled: true,
+      },
+    },
+  }
+}
+
+function machineChannel(): ChannelEntry {
+  return channel({
+    descriptor: machineDescriptor,
+    escrow: tip20ChannelEscrow,
+    paymentScope: { payee, token },
+  })
 }
 
 function receipt(overrides: Partial<SessionReceipt> = {}): SessionReceipt {
@@ -387,6 +424,35 @@ describe('createSessionRegistry', () => {
 })
 
 describe('toChannelStore', () => {
+  test('persists and reuses a machine channel under its logical challenge scope', async () => {
+    const registry = createSessionRegistry(registryOptions())
+    const logicalScope = scope({ escrow: tip20ChannelEscrow })
+    const machine = machineChannel()
+    const context = (): SessionPersistenceContext => ({
+      status: 'open',
+      account: { address: payer },
+      endpoint: 'https://api.example.test/query',
+      challenge: machineChallenge(),
+    })
+    const opened = toChannelStore(registry, {
+      scope: logicalScope,
+      selection: 'new',
+      context,
+    })
+    await opened.set(machine)
+
+    expect(await registry.getPreferred(logicalScope)).toBe(machine.channelId)
+    const automatic = toChannelStore(registry, {
+      scope: logicalScope,
+      selection: 'auto',
+      context,
+    })
+    expect(await automatic.get(entryKey(machine))).toEqual(machine)
+
+    await registry.remove(machine.channelId)
+    expect(await registry.getPreferred(logicalScope)).toBeUndefined()
+  })
+
   test('uses preferred open sessions and never reuses opening sessions', async () => {
     const registry = createSessionRegistry(registryOptions())
     let status: SessionPersistenceContext['status'] = 'opening'
@@ -481,8 +547,16 @@ describe('toChannelStore', () => {
     expect(await store.get(entryKey(channel()))).toEqual(channel())
     await store.delete(entryKey(channel()))
 
-    const replacementId = `0x${'bb'.repeat(32)}` as Hex
-    await store.set(channel({ channelId: replacementId }))
+    const replacementDescriptor = {
+      ...descriptor,
+      salt: `0x${'77'.repeat(32)}` as Hex,
+    }
+    const replacementId = Channel.computeId({
+      ...replacementDescriptor,
+      escrow,
+      chainId: 42431,
+    })
+    await store.set(channel({ channelId: replacementId, descriptor: replacementDescriptor }))
 
     expect(await registry.get(channelId)).toMatchObject({ status: 'stale', spent: 2n, units: 3 })
     expect(await registry.get(replacementId)).toMatchObject({

--- a/src/cli/sessions/store.ts
+++ b/src/cli/sessions/store.ts
@@ -18,6 +18,7 @@ import {
   isTempoSessionChallenge,
   type TempoSessionChallenge,
 } from '../../tempo/session/client/Transports.js'
+import * as Channel from '../../tempo/session/precompile/Channel.js'
 import type { SessionReceipt } from '../../tempo/session/precompile/Protocol.js'
 import * as z from '../../zod.js'
 
@@ -161,6 +162,12 @@ const storedChannelSchema = z.object({
   escrow: z.address(),
   chainId: z.number(),
   opened: z.boolean(),
+  paymentScope: z.optional(
+    z.object({
+      payee: z.address(),
+      token: z.address(),
+    }),
+  ),
 })
 const accountSchema = z.object({
   name: z.optional(z.string()),
@@ -253,8 +260,8 @@ export function sessionScopeKey(scope: SessionScope): string {
 export function sessionScope(channel: ChannelEntry): SessionScope {
   return {
     payer: channel.descriptor.payer,
-    payee: channel.descriptor.payee,
-    token: channel.descriptor.token,
+    payee: channel.paymentScope?.payee ?? channel.descriptor.payee,
+    token: channel.paymentScope?.token ?? channel.descriptor.token,
     escrow: channel.escrow,
     chainId: channel.chainId,
   }
@@ -321,9 +328,8 @@ export function createSessionRegistry(options: CreateSessionRegistryOptions = {}
     const previousValue = await readJson(file)
     const previous =
       previousValue === undefined ? undefined : parseStoredSession(previousValue, file)
-    if (previous) assertSameSession(previous, input, file)
-
     const challenge = parseSessionChallenge(input.challenge, file)
+    if (previous) assertSameSession(previous, input, file)
     assertChallengeMatchesChannel(challenge, channel, file)
     const receipt = input.receipt
       ? sanitizeReceipt(input.receipt, channel.channelId, file)
@@ -743,6 +749,12 @@ function channelIdentity(channel: ChannelEntry): object {
     ),
     escrow: channel.escrow.toLowerCase(),
     chainId: channel.chainId,
+    paymentScope: channel.paymentScope
+      ? {
+          payee: channel.paymentScope.payee.toLowerCase(),
+          token: channel.paymentScope.token.toLowerCase(),
+        }
+      : undefined,
   }
 }
 
@@ -751,12 +763,16 @@ function assertChallengeMatchesChannel(
   channel: ChannelEntry,
   file?: string | undefined,
 ): void {
+  const expectedChannelId = Channel.computeId({
+    ...channel.descriptor,
+    chainId: channel.chainId,
+    escrow: channel.escrow,
+  })
+  if (expectedChannelId.toLowerCase() !== channel.channelId.toLowerCase())
+    throw stateError(file, 'Session channel ID does not match its descriptor.')
   const payee = normalizeAddress(challenge.request.recipient, 'challenge recipient', file)
   const token = normalizeAddress(challenge.request.currency, 'challenge currency', file)
-  if (payee !== channel.descriptor.payee.toLowerCase())
-    throw stateError(file, 'Session challenge payee does not match the channel.')
-  if (token !== channel.descriptor.token.toLowerCase())
-    throw stateError(file, 'Session challenge token does not match the channel.')
+  const scope = normalizeScope(sessionScope(channel))
   if (resolveEscrow(challenge, channel.escrow).toLowerCase() !== channel.escrow.toLowerCase())
     throw stateError(file, 'Session challenge escrow does not match the channel.')
   if (isObject(challenge.request.methodDetails)) {
@@ -764,6 +780,10 @@ function assertChallengeMatchesChannel(
     if (methodDetails.chainId !== undefined && methodDetails.chainId !== channel.chainId)
       throw stateError(file, 'Session challenge chain does not match the channel.')
   }
+  if (payee !== scope.payee)
+    throw stateError(file, 'Session challenge payee does not match the channel.')
+  if (token !== scope.token)
+    throw stateError(file, 'Session challenge token does not match the channel.')
 }
 
 function assertChannelScope(
@@ -771,14 +791,7 @@ function assertChannelScope(
   scope: SessionScope,
   file?: string | undefined,
 ): void {
-  const normalized = normalizeScope(scope)
-  if (
-    channel.descriptor.payer.toLowerCase() !== normalized.payer ||
-    channel.descriptor.payee.toLowerCase() !== normalized.payee ||
-    channel.descriptor.token.toLowerCase() !== normalized.token ||
-    channel.escrow.toLowerCase() !== normalized.escrow ||
-    channel.chainId !== normalized.chainId
-  )
+  if (sessionScopeKey(sessionScope(channel)) !== sessionScopeKey(scope))
     throw stateError(file, 'Session channel does not match the selected payment scope.')
 }
 

--- a/src/server/Methods.test-d.ts
+++ b/src/server/Methods.test-d.ts
@@ -3,9 +3,11 @@ import { expectTypeOf, test } from 'vp/test'
 
 import type { StripeClient } from '../stripe/internal/types.js'
 
-test('accepts the machine-token option on Tempo charges and the global constructor', () => {
+test('accepts the server-only machine-token option on Tempo constructors', () => {
   expectTypeOf(tempo.charge({ machineTokenEnabled: true })).toHaveProperty('verify')
+  expectTypeOf(tempo.session({ machineTokenEnabled: true })).toHaveProperty('verify')
   expectTypeOf(tempo({ machineTokenEnabled: true })[0]).toHaveProperty('verify')
+  expectTypeOf(tempo({ machineTokenEnabled: true })[1]).toHaveProperty('verify')
 })
 
 test('all server method constructors expose typed canOffer hooks', () => {

--- a/src/server/Methods.test.ts
+++ b/src/server/Methods.test.ts
@@ -6,13 +6,13 @@ import { accounts } from '~test/tempo/viem.js'
 const recipient = '0x0000000000000000000000000000000000000001'
 
 describe('Tempo machine token', () => {
-  test('preserves the option on direct and global charge methods', () => {
+  test('preserves the option on charge and session methods', () => {
     const direct = tempo.charge({ machineTokenEnabled: true })
     const [global, session] = tempo({ machineTokenEnabled: true })
 
     expect((direct.defaults as { machineTokenEnabled?: boolean }).machineTokenEnabled).toBe(true)
     expect((global.defaults as { machineTokenEnabled?: boolean }).machineTokenEnabled).toBe(true)
-    expect(session.defaults).not.toHaveProperty('machineTokenEnabled')
+    expect((session.defaults as { machineTokenEnabled?: boolean }).machineTokenEnabled).toBe(true)
   })
 })
 

--- a/src/tempo/Methods.test.ts
+++ b/src/tempo/Methods.test.ts
@@ -263,6 +263,42 @@ describe('session', () => {
     expect(request.methodDetails?.minVoucherDelta).toBe('100000')
   })
 
+  test('schema: binds machine-token capability without changing logical payment fields', () => {
+    const currency = '0x20c0000000000000000000000000000000000001'
+    const feeToken = '0x20c0000000000000000000000000000000000002'
+    const recipient = '0x1234567890abcdef1234567890abcdef12345678'
+    const request = Methods.session.schema.request.parse({
+      amount: '1',
+      currency,
+      decimals: 6,
+      feeToken,
+      machineTokenEnabled: true,
+      recipient,
+      unitType: 'token',
+    })
+
+    expect(request).toMatchObject({
+      currency,
+      methodDetails: { feeToken, machineTokenEnabled: true },
+      recipient,
+    })
+  })
+
+  test('schema: preserves machine-token close refund authorization', () => {
+    const authorizationSignature = `0x${'44'.repeat(65)}`
+    const refundSignature = `0x${'22'.repeat(65)}`
+    const credential = Methods.session.schema.credential.payload.parse({
+      action: 'close',
+      authorizationSignature,
+      channelId: `0x${'11'.repeat(32)}`,
+      cumulativeAmount: '100000',
+      refundSignature,
+      signature: `0x${'33'.repeat(65)}`,
+    })
+
+    expect(credential).toMatchObject({ authorizationSignature, refundSignature })
+  })
+
   test('schema: preserves precompile session snapshots in method details', () => {
     const sessionSnapshot = {
       acceptedCumulative: '2',

--- a/src/tempo/Methods.ts
+++ b/src/tempo/Methods.ts
@@ -209,6 +209,7 @@ export const session = Method.from({
       payload: z.discriminatedUnion('action', [
         z.object({
           action: z.literal('open'),
+          authorizationSignature: z.optional(z.signature()),
           authorizedSigner: z.optional(z.string()),
           channelId: z.hash(),
           cumulativeAmount: z.amount(),
@@ -227,6 +228,7 @@ export const session = Method.from({
         }),
         z.object({
           action: z.literal('voucher'),
+          authorizationSignature: z.optional(z.signature()),
           channelId: z.hash(),
           cumulativeAmount: z.amount(),
           descriptor: z.optional(z.custom<PrecompileChannel.ChannelDescriptor>()),
@@ -234,9 +236,11 @@ export const session = Method.from({
         }),
         z.object({
           action: z.literal('close'),
+          authorizationSignature: z.optional(z.signature()),
           channelId: z.hash(),
           cumulativeAmount: z.amount(),
           descriptor: z.optional(z.custom<PrecompileChannel.ChannelDescriptor>()),
+          refundSignature: z.optional(z.signature()),
           signature: z.signature(),
         }),
       ]),
@@ -256,6 +260,8 @@ export const session = Method.from({
               z.transform((v): boolean => (typeof v === 'object' ? true : v)),
             ),
           ),
+          feeToken: z.optional(z.address()),
+          machineTokenEnabled: z.optional(z.boolean()),
           minVoucherDelta: z.optional(z.amount()),
           operator: z.optional(z.address()),
           recipient: z.optional(z.string()),
@@ -280,6 +286,8 @@ export const session = Method.from({
           decimals,
           escrowContract,
           feePayer,
+          feeToken,
+          machineTokenEnabled,
           minVoucherDelta,
           operator,
           sessionProtocol,
@@ -302,6 +310,8 @@ export const session = Method.from({
             }),
             ...(chainId !== undefined && { chainId }),
             ...(feePayer !== undefined && { feePayer }),
+            ...(feeToken !== undefined && { feeToken }),
+            ...(machineTokenEnabled !== undefined && { machineTokenEnabled }),
             ...(operator !== undefined && { operator }),
             ...(sessionProtocol !== undefined && {
               [Constants.MethodDetailKeys.sessionProtocol]: sessionProtocol,

--- a/src/tempo/client/Charge.test.ts
+++ b/src/tempo/client/Charge.test.ts
@@ -276,7 +276,7 @@ describe('tempo.charge client', () => {
       signTransaction,
       signTypedData: vi.fn(),
     }))
-    vi.doMock('../internal/machine-token.js', () => ({
+    vi.doMock('../internal/machine-token-charge.js', () => ({
       findRoute: findMachineTokenRoute,
     }))
     vi.doMock('../internal/auto-swap.js', () => ({
@@ -345,7 +345,7 @@ describe('tempo.charge client', () => {
       ])
     } finally {
       vi.doUnmock('viem/actions')
-      vi.doUnmock('../internal/machine-token.js')
+      vi.doUnmock('../internal/machine-token-charge.js')
       vi.doUnmock('../internal/auto-swap.js')
       vi.resetModules()
     }
@@ -368,7 +368,7 @@ describe('tempo.charge client', () => {
       signTransaction: vi.fn(),
       signTypedData: vi.fn(),
     }))
-    vi.doMock('../internal/machine-token.js', () => ({
+    vi.doMock('../internal/machine-token-charge.js', () => ({
       findRoute: vi.fn(async () => ({ calls: machineTokenCalls })),
     }))
 
@@ -411,7 +411,7 @@ describe('tempo.charge client', () => {
       expect(credential.payload).toEqual({ hash, type: 'hash' })
     } finally {
       vi.doUnmock('viem/actions')
-      vi.doUnmock('../internal/machine-token.js')
+      vi.doUnmock('../internal/machine-token-charge.js')
       vi.resetModules()
     }
   })

--- a/src/tempo/client/Charge.ts
+++ b/src/tempo/client/Charge.ts
@@ -19,7 +19,7 @@ import * as Attribution from '../Attribution.js'
 import * as AutoSwap from '../internal/auto-swap.js'
 import * as Charge_internal from '../internal/charge.js'
 import * as defaults from '../internal/defaults.js'
-import * as MachineToken from '../internal/machine-token.js'
+import * as MachineTokenCharge from '../internal/machine-token-charge.js'
 import * as Proof from '../internal/proof.js'
 import * as Methods from '../Methods.js'
 import type * as AccountResolution from './ResolveAccount.js'
@@ -169,7 +169,7 @@ export function charge(parameters: charge.Parameters = {}) {
       })()
 
       const machineTokenRoute = machineTokenEnabled
-        ? await MachineToken.findRoute(client, {
+        ? await MachineTokenCharge.findRoute(client, {
             account: account.address,
             chainId,
             currency,

--- a/src/tempo/internal/defaults.test.ts
+++ b/src/tempo/internal/defaults.test.ts
@@ -5,6 +5,7 @@ import {
   currency,
   decimals,
   escrowContract,
+  machineToken,
   resolveCurrency,
   rpcUrl,
   tokens,
@@ -56,6 +57,18 @@ describe('escrowContract', () => {
   test('testnet escrow contract', () => {
     expect(escrowContract[chainId.testnet]).toBe('0xe1c4d3dce17bc111181ddf716f75bae49e61a336')
   })
+})
+
+describe('machineToken', () => {
+  test.each([chainId.mainnet, chainId.testnet])(
+    'chain %i uses the unified machine-token deployment',
+    (id) => {
+      expect(machineToken[id]).toEqual({
+        swap: '0xd588ED9Ae08643A450157Adaf61c3C0C1BBd0dbb',
+        token: '0x20c0000000000000000000006637932dE5413804',
+      })
+    },
+  )
 })
 
 describe('currency', () => {

--- a/src/tempo/internal/defaults.ts
+++ b/src/tempo/internal/defaults.ts
@@ -20,15 +20,15 @@ export const currency = {
   [chainId.testnet]: tokens.pathUsd,
 } as const satisfies Record<ChainId, string>
 
-/** First-party machine-token swap deployments. */
+/** Unified first-party machine-token deployments used by charges and sessions. */
 export const machineToken = {
   [chainId.mainnet]: {
-    swap: '0xC6D32f013E0fA3e83B63Dc680E99826761595732',
-    token: '0x20C0000000000000000000003793c39601711f19',
+    swap: '0xd588ED9Ae08643A450157Adaf61c3C0C1BBd0dbb',
+    token: '0x20c0000000000000000000006637932dE5413804',
   },
   [chainId.testnet]: {
-    swap: '0x07f1FE0467Ae01DE340024aa4b7DD9729b1c169b',
-    token: '0x20c000000000000000000000f85bbCa724044De0',
+    swap: '0xd588ED9Ae08643A450157Adaf61c3C0C1BBd0dbb',
+    token: '0x20c0000000000000000000006637932dE5413804',
   },
 } as const satisfies Partial<Record<ChainId, { swap: `0x${string}`; token: `0x${string}` }>>
 

--- a/src/tempo/internal/machine-token-charge.test.ts
+++ b/src/tempo/internal/machine-token-charge.test.ts
@@ -3,9 +3,8 @@ import { Abis } from 'viem/tempo'
 import { describe, expect, test, vi } from 'vp/test'
 
 import * as defaults from './defaults.js'
-import type { Transfer } from './machine-token.js'
 
-const chainId = defaults.chainId.testnet
+const chainId = defaults.chainId.mainnet
 const deployment = defaults.machineToken[chainId]
 const targetToken = '0x20c0000000000000000000000000000000000001'
 const recipient = '0x2222222222222222222222222222222222222222'
@@ -14,9 +13,9 @@ const memo = `0x${'ab'.repeat(32)}` as const
 const client = createClient({
   transport: custom({ request: async () => undefined as never }),
 })
-const transfers = [{ amount: 1_000_000n, memo, recipient }] satisfies readonly Transfer[]
+const transfers = [{ amount: 1_000_000n, memo, recipient }] as const
 
-describe('Tempo machine token', () => {
+describe('Tempo machine-token charges', () => {
   test('builds and validates the exact first-party approve + swapTo calls', async () => {
     vi.resetModules()
     vi.doMock('viem/actions', () => ({
@@ -25,8 +24,8 @@ describe('Tempo machine token', () => {
     }))
 
     try {
-      const MachineToken = await import('./machine-token.js')
-      const route = await MachineToken.findRoute(client, {
+      const MachineTokenCharge = await import('./machine-token-charge.js')
+      const route = await MachineTokenCharge.findRoute(client, {
         account: payer,
         chainId,
         currency: targetToken,
@@ -35,7 +34,7 @@ describe('Tempo machine token', () => {
 
       expect(route?.calls).toHaveLength(2)
       expect(
-        MachineToken.matchRoute({
+        MachineTokenCharge.matchRoute({
           calls: route!.calls,
           chainId,
           currency: targetToken,
@@ -43,7 +42,7 @@ describe('Tempo machine token', () => {
         })?.transfers,
       ).toEqual(transfers)
       expect(
-        MachineToken.matchRoute({
+        MachineTokenCharge.matchRoute({
           calls: route!.calls,
           chainId,
           currency: targetToken,
@@ -65,9 +64,9 @@ describe('Tempo machine token', () => {
     }))
 
     try {
-      const MachineToken = await import('./machine-token.js')
+      const MachineTokenCharge = await import('./machine-token-charge.js')
       await expect(
-        MachineToken.findRoute(client, {
+        MachineTokenCharge.findRoute(client, {
           account: payer,
           chainId,
           currency: targetToken,
@@ -90,9 +89,9 @@ describe('Tempo machine token', () => {
     }))
 
     try {
-      const MachineToken = await import('./machine-token.js')
+      const MachineTokenCharge = await import('./machine-token-charge.js')
       await expect(
-        MachineToken.findRoute(client, {
+        MachineTokenCharge.findRoute(client, {
           account: payer,
           chainId,
           currency: targetToken,
@@ -113,8 +112,8 @@ describe('Tempo machine token', () => {
     }))
 
     try {
-      const MachineToken = await import('./machine-token.js')
-      const route = await MachineToken.findRoute(client, {
+      const MachineTokenCharge = await import('./machine-token-charge.js')
+      const route = await MachineTokenCharge.findRoute(client, {
         account: payer,
         chainId,
         currency: targetToken,
@@ -122,7 +121,7 @@ describe('Tempo machine token', () => {
       })
 
       expect(
-        MachineToken.matchRoute({
+        MachineTokenCharge.matchRoute({
           calls: [...route!.calls, route!.calls[0]!],
           chainId,
           currency: targetToken,
@@ -130,7 +129,7 @@ describe('Tempo machine token', () => {
         }),
       ).toBeUndefined()
       expect(
-        MachineToken.matchRoute({
+        MachineTokenCharge.matchRoute({
           calls: [
             route!.calls[0]!,
             {
@@ -154,26 +153,27 @@ describe('Tempo machine token', () => {
   })
 
   test('does not use unconfigured chains', async () => {
-    const MachineToken = await import('./machine-token.js')
+    const MachineTokenCharge = await import('./machine-token-charge.js')
     await expect(
-      MachineToken.findRoute(client, {
+      MachineTokenCharge.findRoute(client, {
         account: payer,
         chainId: 69420,
         currency: targetToken,
         transfers,
       }),
     ).resolves.toBeUndefined()
-    expect(MachineToken.getSettlementSender(69420)).toBeUndefined()
+    expect(MachineTokenCharge.getSettlementSender(69420)).toBeUndefined()
   })
 
   test('falls back for split charges', async () => {
-    const MachineToken = await import('./machine-token.js')
-    expect(
-      MachineToken.getRoute({
+    const MachineTokenCharge = await import('./machine-token-charge.js')
+    await expect(
+      MachineTokenCharge.findRoute(client, {
+        account: payer,
         chainId,
         currency: targetToken,
         transfers: [...transfers, transfers[0]!],
       }),
-    ).toBeUndefined()
+    ).resolves.toBeUndefined()
   })
 })

--- a/src/tempo/internal/machine-token-charge.ts
+++ b/src/tempo/internal/machine-token-charge.ts
@@ -27,7 +27,7 @@ const swapAbi = [
   },
 ] as const
 
-export type Call = {
+type Call = {
   data?: Hex.Hex | undefined
   to?: Address | undefined
   value?: bigint | undefined
@@ -44,16 +44,10 @@ type Route = {
   transfers: readonly [{ amount: bigint; memo: Hex.Hex; recipient: Address }]
 }
 
-export type Transfer = {
+type Transfer = {
   amount: bigint | string
   memo?: string | undefined
   recipient: Address
-}
-
-/** Shared first-party machine-token configuration for Tempo methods. */
-export type Options = {
-  /** Enables first-party machine-token settlement for supported Tempo methods. */
-  machineTokenEnabled?: boolean | undefined
 }
 
 function getDeployment(chainId: number | undefined) {
@@ -61,7 +55,7 @@ function getDeployment(chainId: number | undefined) {
   return defaults.machineToken[chainId as keyof typeof defaults.machineToken]
 }
 
-/** Returns whether a first-party machine-token route is deployed on a chain. */
+/** Returns whether a first-party machine-token charge route is deployed on a chain. */
 export function isSupported(chainId: number | undefined): boolean {
   return !!getDeployment(chainId)
 }
@@ -171,7 +165,7 @@ export function matchRoute(parameters: {
   }
 }
 
-/** Returns the trusted sender that settles the configured route on a chain. */
+/** Returns the trusted sender that settles the configured charge route on a chain. */
 export function getSettlementSender(chainId: number | undefined): Address | undefined {
   return getDeployment(chainId)?.swap
 }

--- a/src/tempo/internal/machine-token-session.test.ts
+++ b/src/tempo/internal/machine-token-session.test.ts
@@ -1,0 +1,117 @@
+import { createClient, custom, zeroAddress, type Address } from 'viem'
+import { Account as TempoAccount, Secp256k1 } from 'viem/tempo'
+import { describe, expect, test } from 'vp/test'
+
+import * as defaults from './defaults.js'
+import * as MachineTokenSession from './machine-token-session.js'
+
+const mocks = vi.hoisted(() => ({ readContract: vi.fn() }))
+
+vi.mock('viem/actions', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('viem/actions')>()),
+  readContract: mocks.readContract,
+}))
+
+const chainId = defaults.chainId.mainnet
+const deployment = defaults.machineToken[chainId]
+const merchant = '0x2222222222222222222222222222222222222222' as Address
+const otherMerchant = '0x3333333333333333333333333333333333333333' as Address
+const payer = '0x1111111111111111111111111111111111111111' as Address
+const sessionPayee = '0x44d7c1edfdfdfdfdfdfdfdfd0000000000000001' as Address
+const targetToken = '0x20c0000000000000000000000000000000000001' as Address
+const overrideToken = '0x5555555555555555555555555555555555555555' as Address
+const descriptor = {
+  operator: deployment.swap,
+  payee: sessionPayee,
+  token: deployment.token,
+} as const
+const client = createClient({ transport: custom({ request: async () => undefined as never }) })
+const route = { chainId, merchant, targetToken }
+const matchedRoute = { ...route, descriptor }
+
+function mockRoute(
+  activePayee: Address = sessionPayee,
+  binding: readonly [Address, Address] = [merchant, targetToken],
+) {
+  mocks.readContract.mockImplementation(
+    (_client: unknown, { functionName }: { functionName: string }) =>
+      functionName === 'sessionRouteFor' ? activePayee : binding,
+  )
+}
+
+describe('Tempo machine-token sessions', () => {
+  test('binds the configured route in both directions', async () => {
+    mockRoute()
+    await expect(
+      Promise.all([
+        MachineTokenSession.resolveRoute(client, route),
+        MachineTokenSession.matchRoute(client, matchedRoute),
+        MachineTokenSession.matchRoute(client, {
+          ...matchedRoute,
+          descriptor: { ...descriptor, operator: otherMerchant },
+        }),
+      ]),
+    ).resolves.toEqual([descriptor, descriptor, undefined])
+
+    mockRoute(sessionPayee, [otherMerchant, targetToken])
+    await expect(MachineTokenSession.matchRoute(client, matchedRoute)).resolves.toBeUndefined()
+  })
+
+  test('requires the active route except for a historical close', async () => {
+    mockRoute(zeroAddress)
+    await expect(
+      Promise.all([
+        MachineTokenSession.matchRoute(client, matchedRoute),
+        MachineTokenSession.matchRoute(client, { ...matchedRoute, active: false }),
+      ]),
+    ).resolves.toEqual([undefined, descriptor])
+  })
+
+  test('derives the management fee token from the payment rail', async () => {
+    expect([
+      MachineTokenSession.resolveFeeToken({ chainId, paymentToken: deployment.token }),
+      MachineTokenSession.resolveFeeToken({ chainId, paymentToken: targetToken }),
+      MachineTokenSession.resolveFeeToken({
+        chainId,
+        override: overrideToken,
+        paymentToken: deployment.token,
+      }),
+    ]).toEqual([defaults.tokens.pathUsd, targetToken, overrideToken])
+  })
+
+  test('checks balance and signs router authorizations with an access key', async () => {
+    mocks.readContract.mockResolvedValue(42n)
+    const hasBalance = (amount: bigint) =>
+      MachineTokenSession.hasSufficientBalance(client, {
+        account: payer,
+        amount,
+        token: deployment.token,
+      })
+    await expect(Promise.all([42n, 43n].map(hasBalance))).resolves.toEqual([true, false])
+
+    const root = TempoAccount.fromSecp256k1(Secp256k1.randomPrivateKey())
+    const accessKey = TempoAccount.fromSecp256k1(Secp256k1.randomPrivateKey(), { access: root })
+    const authorization = {
+      channelId: `0x${'12'.repeat(32)}` as const,
+      cumulativeAmount: 42n,
+    }
+    const authorizationContext = {
+      authorization,
+      chainId,
+      router: deployment.swap,
+    }
+    const signature = await MachineTokenSession.signAuthorization(
+      client,
+      accessKey,
+      authorizationContext,
+    )
+    const verify = (expectedSigner: Address) =>
+      MachineTokenSession.verifyAuthorization({
+        ...authorizationContext,
+        expectedSigner,
+        signature,
+      })
+
+    expect([verify(accessKey.accessKeyAddress), verify(root.address)]).toEqual([true, false])
+  })
+})

--- a/src/tempo/internal/machine-token-session.ts
+++ b/src/tempo/internal/machine-token-session.ts
@@ -1,0 +1,244 @@
+import type * as Hex from 'ox/Hex'
+import { SignatureEnvelope } from 'ox/tempo'
+import {
+  hashTypedData,
+  isAddressEqual,
+  parseAbi,
+  zeroAddress,
+  type Account,
+  type Address,
+  type Client,
+} from 'viem'
+import { readContract, signTypedData } from 'viem/actions'
+import { Actions } from 'viem/tempo'
+
+import { isAccessKeyAccount } from './account.js'
+import * as defaults from './defaults.js'
+import { parseCanonicalEnvelope, serializeCanonicalEnvelope } from './signature-envelope.js'
+
+const sessionRouteAbi = parseAbi([
+  'function sessionRouteFor(address merchant,address targetToken) view returns (address routeAddress)',
+  'function sessionRoutes(address routeAddress) view returns (address merchant,address targetToken)',
+])
+
+const authorizationTypes = {
+  SessionAuthorization: [
+    { name: 'channelId', type: 'bytes32' },
+    { name: 'cumulativeAmount', type: 'uint96' },
+  ],
+} as const
+
+type Deployment = (typeof defaults.machineToken)[keyof typeof defaults.machineToken]
+
+/** Verified machine-token session route. */
+export type Route = {
+  operator: Address
+  payee: Address
+  token: Address
+}
+
+type Authorization = {
+  channelId: Hex.Hex
+  cumulativeAmount: bigint
+}
+
+function getDeployment(chainId: number | undefined): Deployment | undefined {
+  if (chainId === undefined) return undefined
+  return defaults.machineToken[chainId as keyof typeof defaults.machineToken]
+}
+
+/** Returns whether a unified machine-token router is configured on a chain. */
+export function isSupported(chainId: number | undefined): boolean {
+  return !!getDeployment(chainId)
+}
+
+/** Matches a session descriptor to the configured router and machine token. */
+export function matchDeployment(parameters: {
+  chainId: number | undefined
+  descriptor: { operator: Address; token: Address }
+}): Deployment | undefined {
+  const deployment = getDeployment(parameters.chainId)
+  return deployment &&
+    isAddressEqual(parameters.descriptor.operator, deployment.swap) &&
+    isAddressEqual(parameters.descriptor.token, deployment.token)
+    ? deployment
+    : undefined
+}
+
+/** Returns whether an authenticated session challenge permits the machine-token rail. */
+export function isEnabledChallenge(challenge: { request: { methodDetails?: unknown } }): boolean {
+  return (
+    (challenge.request.methodDetails as { machineTokenEnabled?: unknown } | null | undefined)
+      ?.machineTokenEnabled === true
+  )
+}
+
+/** Resolves the fee token from the payment token and an optional explicit override. */
+export function resolveFeeToken(parameters: {
+  chainId: number | undefined
+  override?: Address | undefined
+  paymentToken: Address
+}): Address {
+  if (parameters.override) return parameters.override
+  const deployment = getDeployment(parameters.chainId)
+  if (deployment && isAddressEqual(parameters.paymentToken, deployment.token))
+    return defaults.tokens.pathUsd
+  return parameters.paymentToken
+}
+
+/** Returns whether an account has enough of a TIP-20 token for an operation. */
+export async function hasSufficientBalance(
+  client: Client,
+  parameters: { account: Address; amount: bigint; token: Address },
+): Promise<boolean> {
+  try {
+    const balance = await readContract(
+      client,
+      Actions.token.getBalance.call(client, {
+        account: parameters.account,
+        token: parameters.token,
+      }) as never,
+    )
+    return (balance as bigint) >= parameters.amount
+  } catch {
+    return false
+  }
+}
+
+function authorizationDomain(router: Address, chainId: number) {
+  return {
+    name: 'MachineUSD Session Router',
+    version: '1',
+    chainId,
+    verifyingContract: router,
+  } as const
+}
+
+function hashAuthorization(parameters: {
+  authorization: Authorization
+  chainId: number
+  router: Address
+}): Hex.Hex {
+  return hashTypedData({
+    domain: authorizationDomain(parameters.router, parameters.chainId),
+    types: authorizationTypes,
+    primaryType: 'SessionAuthorization',
+    message: parameters.authorization,
+  })
+}
+
+/** Signs a cumulative amount in the router-specific authorization domain. */
+export async function signAuthorization(
+  client: Client,
+  account: Account,
+  parameters: { authorization: Authorization; chainId: number; router: Address },
+): Promise<Hex.Hex> {
+  const signature = isAccessKeyAccount(account)
+    ? await account.sign({
+        hash: hashAuthorization(parameters),
+        raw: true,
+      })
+    : await signTypedData(client, {
+        account,
+        domain: authorizationDomain(parameters.router, parameters.chainId),
+        types: authorizationTypes,
+        primaryType: 'SessionAuthorization',
+        message: parameters.authorization,
+      })
+  return serializeCanonicalEnvelope(signature, 'Machine-token session authorizations')
+}
+
+/** Verifies a cumulative authorization in the router-specific domain. */
+export function verifyAuthorization(parameters: {
+  authorization: Authorization
+  chainId: number
+  expectedSigner: Address
+  router: Address
+  signature: Hex.Hex
+}): boolean {
+  try {
+    const envelope = parseCanonicalEnvelope(parameters.signature)
+    if (!envelope) return false
+    const payload = hashAuthorization(parameters)
+    return SignatureEnvelope.verify(envelope, { address: parameters.expectedSigner, payload })
+  } catch {
+    return false
+  }
+}
+
+async function readRoute(
+  client: Client,
+  deployment: Deployment,
+  parameters: {
+    active: boolean
+    merchant: Address
+    payee?: Address | undefined
+    targetToken: Address
+  },
+): Promise<Route | undefined> {
+  const payee =
+    parameters.payee ??
+    (await readContract(client, {
+      address: deployment.swap,
+      abi: sessionRouteAbi,
+      functionName: 'sessionRouteFor',
+      args: [parameters.merchant, parameters.targetToken],
+    }))
+  if (isAddressEqual(payee, zeroAddress)) return undefined
+
+  const [binding, activePayee] = await Promise.all([
+    readContract(client, {
+      address: deployment.swap,
+      abi: sessionRouteAbi,
+      functionName: 'sessionRoutes',
+      args: [payee],
+    }),
+    parameters.active && parameters.payee
+      ? readContract(client, {
+          address: deployment.swap,
+          abi: sessionRouteAbi,
+          functionName: 'sessionRouteFor',
+          args: [parameters.merchant, parameters.targetToken],
+        })
+      : payee,
+  ])
+  if (
+    isAddressEqual(binding[0], zeroAddress) ||
+    isAddressEqual(binding[1], zeroAddress) ||
+    !isAddressEqual(binding[0], parameters.merchant) ||
+    !isAddressEqual(binding[1], parameters.targetToken) ||
+    !isAddressEqual(activePayee, payee)
+  )
+    return undefined
+  return { operator: deployment.swap, payee, token: deployment.token }
+}
+
+/** Resolves the active virtual payee and verifies its immutable reverse binding. */
+export async function resolveRoute(
+  client: Client,
+  parameters: { chainId: number; merchant: Address; targetToken: Address },
+): Promise<Route | undefined> {
+  const deployment = getDeployment(parameters.chainId)
+  if (!deployment) return undefined
+  return readRoute(client, deployment, { ...parameters, active: true })
+}
+
+/** Verifies a descriptor against the trusted router and merchant payout binding. */
+export async function matchRoute(
+  client: Client,
+  parameters: {
+    active?: boolean | undefined
+    chainId: number
+    descriptor: { operator: Address; payee: Address; token: Address }
+    merchant: Address
+    targetToken: Address
+  },
+): Promise<Route | undefined> {
+  const deployment = matchDeployment(parameters)
+  if (!deployment) return undefined
+  return readRoute(client, deployment, {
+    ...parameters,
+    active: parameters.active !== false,
+    payee: parameters.descriptor.payee,
+  })
+}

--- a/src/tempo/internal/signature-envelope.ts
+++ b/src/tempo/internal/signature-envelope.ts
@@ -1,0 +1,34 @@
+import { SignatureEnvelope } from 'ox/tempo'
+import type { Hex } from 'viem'
+
+function isPrimitiveEnvelope(type: string): boolean {
+  return type === 'secp256k1' || type === 'p256' || type === 'webAuthn'
+}
+
+/**
+ * Canonicalizes a fresh TIP-1020 primitive signature for transport. Keychain
+ * wrappers, multisig signatures, and magic-suffixed encodings are rejected.
+ */
+export function serializeCanonicalEnvelope(signature: Hex, subject: string): Hex {
+  const envelope = SignatureEnvelope.from(signature as SignatureEnvelope.Serialized)
+  if (!isPrimitiveEnvelope(envelope.type))
+    throw new Error(
+      `${subject} require a TIP-1020 primitive signature; received "${envelope.type}".`,
+    )
+  return SignatureEnvelope.serialize(envelope)
+}
+
+/**
+ * Parses an incoming signature into a canonical TIP-1020 primitive envelope.
+ * Returns `undefined` for wrapper envelopes and aliased (non-canonical)
+ * encodings, so verified signatures can be replayed on-chain byte-for-byte.
+ */
+export function parseCanonicalEnvelope(
+  signature: Hex,
+): SignatureEnvelope.SignatureEnvelope | undefined {
+  const envelope = SignatureEnvelope.from(signature as SignatureEnvelope.Serialized)
+  if (!isPrimitiveEnvelope(envelope.type)) return undefined
+  if (SignatureEnvelope.serialize(envelope).toLowerCase() !== signature.toLowerCase())
+    return undefined
+  return envelope
+}

--- a/src/tempo/server/Charge.test.ts
+++ b/src/tempo/server/Charge.test.ts
@@ -31,7 +31,7 @@ import { accounts, asset, chain, client, fundAccount, http } from '~test/tempo/v
 import * as Store from '../../Store.js'
 import * as Attribution from '../Attribution.js'
 import * as defaults from '../internal/defaults.js'
-import * as MachineToken from '../internal/machine-token.js'
+import * as MachineTokenCharge from '../internal/machine-token-charge.js'
 import * as Proof from '../internal/proof.js'
 
 const realm = 'api.example.com'
@@ -1230,7 +1230,7 @@ describe('tempo', () => {
         machineTokenEnabled: true,
         supportedModes: ['pull'],
       })
-      const calls = MachineToken.getRoute({
+      const calls = MachineTokenCharge.getRoute({
         chainId: defaults.chainId.testnet,
         currency: asset,
         transfers: [

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -34,7 +34,7 @@ import * as Charge_internal from '../internal/charge.js'
 import * as defaults from '../internal/defaults.js'
 import * as FeePayer from '../internal/fee-payer.js'
 import { resolveFeeToken } from '../internal/fee-token.js'
-import * as MachineToken from '../internal/machine-token.js'
+import * as MachineTokenCharge from '../internal/machine-token-charge.js'
 import * as Proof from '../internal/proof.js'
 import * as Selectors from '../internal/selectors.js'
 import type * as types from '../internal/types.js'
@@ -149,7 +149,7 @@ export function charge<const parameters extends charge.Parameters>(
     const memo = methodDetails?.memo as `0x${string}` | undefined
     const machineTokenEnabled = methodDetails?.machineTokenEnabled === true
     const settlementSender = machineTokenEnabled
-      ? MachineToken.getSettlementSender(chainId)
+      ? MachineTokenCharge.getSettlementSender(chainId)
       : undefined
     const isZeroAmount = BigInt(amount) === 0n
 
@@ -310,8 +310,8 @@ export function charge<const parameters extends charge.Parameters>(
       !!(typeof request.feePayer === 'object' ? request.feePayer : feePayer || feePayerUrl)
     const transfers = getExpectedTransfers({ amount, memo, methodDetails, recipient })
     const machineTokenRoute = machineTokenEnabled
-      ? MachineToken.matchRoute({
-          calls: (transaction.calls ?? []) as readonly MachineToken.Call[],
+      ? MachineTokenCharge.matchRoute({
+          calls: transaction.calls ?? [],
           chainId: chainId ?? client.chain?.id,
           currency,
           transfers,
@@ -466,7 +466,7 @@ export function charge<const parameters extends charge.Parameters>(
       })()
       if (client.chain?.id !== chainId)
         throw new Error(`Client not configured with chainId ${chainId}.`)
-      if (request.machineTokenEnabled && !MachineToken.isSupported(chainId))
+      if (request.machineTokenEnabled && !MachineTokenCharge.isSupported(chainId))
         throw new Error(`Machine tokens are not supported on chainId ${chainId}.`)
 
       const resolvedFeePayer = (() => {
@@ -790,7 +790,9 @@ export declare namespace charge {
     source?: { address: `0x${string}`; chainId: number } | undefined
   }
 
-  type Parameters = MachineToken.Options & {
+  type Parameters = {
+    /** Enables first-party machine-token settlement for supported Tempo charges. */
+    machineTokenEnabled?: boolean | undefined
     /** Render payment page when Accept header is text/html (e.g. in browsers) */
     html?: boolean | Html.Config | undefined
     /**

--- a/src/tempo/server/Methods.ts
+++ b/src/tempo/server/Methods.ts
@@ -36,9 +36,9 @@ function createSessionMethod<const parameters extends tempo.Parameters>(
 /**
  * Creates the common Tempo `charge` and `session` methods from shared parameters.
  *
- * `machineTokenEnabled` and `relay` currently apply only to `charge`. The
- * machine-token option is accepted globally so other Tempo methods can adopt
- * it without another provider-level configuration surface.
+ * `machineTokenEnabled` lets compatible clients fund either method with the
+ * first-party machine token while the merchant continues to request its payout
+ * currency and recipient normally.
  *
  * @example
  * ```ts

--- a/src/tempo/session/client/ChannelOps.test.ts
+++ b/src/tempo/session/client/ChannelOps.test.ts
@@ -1,6 +1,7 @@
 import { Hex } from 'ox'
 import { type Address, createClient, custom, zeroAddress } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
+import { Transaction } from 'viem/tempo'
 import { describe, expect, test } from 'vp/test'
 
 import * as Channel from '../precompile/Channel.js'
@@ -234,5 +235,41 @@ describe('precompile client ChannelOps credential builders', () => {
       }),
     )
     expect(mocks.prepareTransactionRequest.mock.calls[0]?.[1]).not.toHaveProperty('feePayer')
+  })
+
+  test('uses an explicit liquid fee token for machine-token channel management', async () => {
+    mocks.prepareTransactionRequest.mockClear()
+    const feeToken = '0x0000000000000000000000000000000000000004' as Address
+    const transaction = await Transaction.serialize({
+      chainId,
+      calls: [],
+      feeToken,
+      nonce: 0,
+    })
+    mocks.signTransaction.mockResolvedValueOnce(transaction)
+
+    await ChannelOps.createOpenPayload(client, account, {
+      chainId,
+      deposit: 100n,
+      feeToken,
+      initialAmount: 10n,
+      payee: descriptor.payee,
+      token: descriptor.token,
+    })
+    await ChannelOps.createTopUpPayload(
+      client,
+      account,
+      descriptor,
+      10n,
+      chainId,
+      false,
+      tip20ChannelEscrow,
+      [],
+      feeToken,
+    )
+
+    expect(mocks.prepareTransactionRequest.mock.calls).toHaveLength(2)
+    expect(mocks.prepareTransactionRequest.mock.calls[0]?.[1]).toMatchObject({ feeToken })
+    expect(mocks.prepareTransactionRequest.mock.calls[1]?.[1]).toMatchObject({ feeToken })
   })
 })

--- a/src/tempo/session/client/ChannelOps.ts
+++ b/src/tempo/session/client/ChannelOps.ts
@@ -53,6 +53,8 @@ export type ChannelEntry = {
   chainId: number
   /** Whether the client considers the channel reusable for new vouchers. */
   opened: boolean
+  /** Logical merchant payment scope when it differs from the on-chain descriptor. */
+  paymentScope?: { payee: Address; token: Address } | undefined
 }
 
 function isObject(value: unknown): value is Record<string, unknown> {
@@ -239,6 +241,7 @@ export async function createOpenPayload(
     deposit: bigint
     escrow?: Address | undefined
     feePayer?: boolean | undefined
+    feeToken?: Address | undefined
     initialAmount: bigint
     operator?: Address | undefined
     payee: Address
@@ -263,7 +266,7 @@ export async function createOpenPayload(
     account,
     calls: [...(parameters.prefixCalls ?? []), { to: escrow, data: openData }],
     feePayer: parameters.feePayer,
-    feeToken: parameters.token,
+    feeToken: parameters.feeToken ?? parameters.token,
   })
   const transaction = await signPreparedTempoTransaction(client, prepared)
   const signed = Transaction.deserialize(transaction as Transaction.TransactionSerializedTempo)
@@ -322,6 +325,7 @@ export async function createTopUpPayload(
   feePayer?: boolean | undefined,
   escrow: Address = tip20ChannelEscrow,
   prefixCalls: readonly TempoChannelCall[] = [],
+  feeToken: Address = descriptor.token,
 ): Promise<TopUpCredentialPayload> {
   const channelId = Channel.computeId({
     ...descriptor,
@@ -343,7 +347,7 @@ export async function createTopUpPayload(
       },
     ],
     feePayer,
-    feeToken: descriptor.token,
+    feeToken,
     validAfter: randomValidAfter(),
   })
   const transaction = await signPreparedTempoTransaction(client, prepared)

--- a/src/tempo/session/client/ChannelStore.ts
+++ b/src/tempo/session/client/ChannelStore.ts
@@ -13,12 +13,6 @@ export type ChannelStore = {
   delete(key: string): MaybePromise<void>
 }
 
-/** Channel persistence and update notification for credential results. */
-export type ChannelSink = {
-  store: ChannelStore
-  notifyUpdate: (entry: ChannelEntry) => void
-}
-
 /** Returns the scope key for a reusable payer session channel. */
 export function channelKey(scope: {
   payee: Address
@@ -33,8 +27,8 @@ export function channelKey(scope: {
 /** Returns the scope key for a stored channel entry. */
 export function entryKey(entry: ChannelEntry): string {
   return channelKey({
-    payee: entry.descriptor.payee,
-    token: entry.descriptor.token,
+    payee: entry.paymentScope?.payee ?? entry.descriptor.payee,
+    token: entry.paymentScope?.token ?? entry.descriptor.token,
     escrow: entry.escrow,
     chainId: entry.chainId,
   })

--- a/src/tempo/session/client/CredentialState.test.ts
+++ b/src/tempo/session/client/CredentialState.test.ts
@@ -16,7 +16,6 @@ import {
   deserializeEntry,
   entryKey,
   serializeEntry,
-  type ChannelSink,
 } from './ChannelStore.js'
 import {
   canSignDescriptor,
@@ -37,11 +36,6 @@ import {
   type ChallengeContext,
   type SessionContext,
 } from './CredentialState.js'
-
-/** Builds a credential sink backed by a fresh in-memory store. */
-function sink(): ChannelSink {
-  return { store: createChannelStore(), notifyUpdate: () => {} }
-}
 
 describe('ChannelCache', () => {
   const channelId = `0x${'11'.repeat(32)}` as Hex
@@ -262,6 +256,7 @@ describe('CredentialPlan', () => {
   const channelId = `0x${'11'.repeat(32)}` as Hex
   const snapshotChannelId = `0x${'12'.repeat(32)}` as Hex
   const escrow = '0x4D50500000000000000000000000000000000000' as Address
+  const feeToken = '0x20c0000000000000000000000000000000000004' as Address
   const payee = '0x0000000000000000000000000000000000000002' as Address
   const token = '0x20c0000000000000000000000000000000000001' as Address
 
@@ -351,6 +346,7 @@ describe('CredentialPlan', () => {
           chainId: 42431,
           escrowContract: escrow,
           feePayer: true,
+          feeToken,
           [Constants.MethodDetailKeys.sessionSnapshot]: snapshot(),
         },
         recipient: payee,
@@ -375,6 +371,7 @@ describe('CredentialPlan', () => {
         client,
         escrow: escrow.toLowerCase(),
         feePayer: true,
+        feeToken,
         payee,
         snapshot: snapshot(),
         suggestedDepositRaw: '100',
@@ -501,20 +498,16 @@ describe('CredentialPlan', () => {
         resolved: challengeContext(),
       })
 
-      await expect(executeCredentialPlan(plan, sink())).rejects.toThrow(
+      await expect(executeCredentialPlan(plan)).rejects.toThrow(
         'context descriptor payee does not match challenge',
       )
     })
 
     test('leaves stored scope entry unchanged when a manual credential targets another channel', async () => {
       const entry = channel()
-      const originalCumulative = entry.cumulativeAmount
-      const notifications: ChannelEntry[] = []
-      const store = createChannelStore()
       const manualDescriptor = { ...descriptor, salt: `0x${'55'.repeat(32)}` as Hex }
-      await store.set(entry)
 
-      await executeCredentialPlan(
+      const result = await executeCredentialPlan(
         planCredential({
           account,
           entry,
@@ -526,13 +519,10 @@ describe('CredentialPlan', () => {
           decimals: 6,
           resolved: challengeContext(),
         }),
-        { store, notifyUpdate: (updated) => notifications.push(updated) },
       )
 
-      const stored = await store.get(entryKey(entry))
-      expect(stored?.channelId).toBe(entry.channelId)
-      expect(stored?.cumulativeAmount).toBe(originalCumulative)
-      expect(notifications).toEqual([])
+      expect(result.entry).toBeUndefined()
+      expect(entry.cumulativeAmount).toBe(10n)
     })
 
     test('plans recovery from server snapshot when no reusable cache entry exists', () => {
@@ -547,6 +537,25 @@ describe('CredentialPlan', () => {
       if (plan.type !== 'recover') throw new Error('expected recover plan')
       expect(plan.context.channelId).toBe(snapshotChannelId)
       expect(plan.context.descriptor).toBe(snapshotDescriptor)
+    })
+
+    test('plans a fresh open when the snapshot descriptor targets another rail', () => {
+      const machineSnapshot = {
+        ...snapshot(),
+        descriptor: {
+          ...snapshotDescriptor,
+          payee: '0x0000000000000000000000000000000000000009' as Address,
+          token: '0x20c0000000000000000000000000000000000002' as Address,
+        },
+      }
+      const plan = planCredential({
+        account,
+        entry: undefined,
+        decimals: 6,
+        resolved: challengeContext({ snapshot: machineSnapshot }),
+      })
+
+      expect(plan.type).toBe('open')
     })
 
     test('plans voucher reuse before snapshot recovery when cache entry is open', () => {

--- a/src/tempo/session/client/CredentialState.ts
+++ b/src/tempo/session/client/CredentialState.ts
@@ -28,7 +28,7 @@ import {
   type ChannelEntry,
   type TempoChannelCall,
 } from './ChannelOps.js'
-import { channelKey, entryKey, type ChannelSink } from './ChannelStore.js'
+import { channelKey } from './ChannelStore.js'
 import { assertWithinMaxDeposit, resolveOpeningDeposit } from './Runtime.js'
 
 /** Credential payload variants that carry cumulative voucher authorization. */
@@ -52,32 +52,24 @@ export function readCredentialCumulativeAmount(
   return BigInt(payload.cumulativeAmount)
 }
 
-/**
- * Persists a channel entry through the sink and notifies observers. Closed
- * channels are removed from the store but still reported to observers so callers
- * can react to the close.
- */
-async function storeChannelEntry(sink: ChannelSink, entry: ChannelEntry): Promise<void> {
-  if (entry.opened) await sink.store.set(entry)
-  else await sink.store.delete(entryKey(entry))
-  sink.notifyUpdate(entry)
-}
-
-/** Applies a credential payload's cumulative amount to the stored channel at `key`. */
-async function applyCumulative(
-  sink: ChannelSink,
-  key: string,
+/** Applies a credential payload to a matching cached channel without persisting it. */
+function applyCredential(
+  entry: ChannelEntry | undefined,
   payload: SessionCredentialPayload,
-): Promise<void> {
+): ChannelEntry | undefined {
   const cumulativeAmount = readCredentialCumulativeAmount(payload)
-  if (cumulativeAmount === undefined) return
-  const entry = await sink.store.get(key)
-  if (!entry) return
-  if (entry.channelId.toLowerCase() !== payload.channelId.toLowerCase()) return
-  entry.cumulativeAmount =
-    entry.cumulativeAmount > cumulativeAmount ? entry.cumulativeAmount : cumulativeAmount
-  if (payload.action === 'close') entry.opened = false
-  await storeChannelEntry(sink, entry)
+  if (
+    cumulativeAmount === undefined ||
+    !entry ||
+    entry.channelId.toLowerCase() !== payload.channelId.toLowerCase()
+  )
+    return undefined
+  return {
+    ...entry,
+    cumulativeAmount:
+      entry.cumulativeAmount > cumulativeAmount ? entry.cumulativeAmount : cumulativeAmount,
+    opened: payload.action === 'close' ? false : entry.opened,
+  }
 }
 
 const hexSchema = z.custom<Hex>(
@@ -204,6 +196,8 @@ export type ClientSessionMethodDetails = {
   escrow?: Address | undefined
   /** Whether the challenge allows fee-sponsored open/top-up transactions. */
   feePayer?: boolean | undefined
+  /** Fee token selected by the server for open/top-up transactions. */
+  feeToken?: Address | undefined
   /** Channel operator address advertised by the server. */
   operator?: Address | undefined
   /** Server bootstrap snapshot for a reusable session channel. */
@@ -275,9 +269,12 @@ export type ChallengeContext = {
   client: Client
   escrow: Address
   feePayer?: boolean | undefined
+  feeToken?: Address | undefined
   key: string
   operator?: Address | undefined
   payee: Address
+  /** Logical merchant scope when the channel uses an indirect payment route. */
+  paymentScope?: { payee: Address; token: Address } | undefined
   snapshot?: SessionSnapshot | undefined
   /** Server-provided raw deposit hint for opening a channel, before local maxDeposit capping. */
   suggestedDepositRaw?: string | undefined
@@ -370,8 +367,15 @@ export type CredentialPlan =
       account: ViemAccount
       context: ManualSessionDescriptorContext
       decimals: number
+      entry?: ChannelEntry | undefined
       resolved: ChallengeContext
     }
+
+/** Signed credential plus the channel state to commit after all signing succeeds. */
+export type CredentialResult = {
+  payload: SessionCredentialPayload
+  entry?: ChannelEntry | undefined
+}
 
 type ManualCredentialParameters = Pick<
   Extract<CredentialPlan, { type: 'manual' }>,
@@ -397,6 +401,7 @@ function readMethodDetails(challenge: Challenge.Challenge): ClientSessionMethodD
     escrowContract: readOptionalAddress(methodDetails.escrowContract),
     escrow: readOptionalAddress(methodDetails.escrow),
     feePayer: typeof methodDetails.feePayer === 'boolean' ? methodDetails.feePayer : undefined,
+    feeToken: readOptionalAddress(methodDetails.feeToken),
     operator: readOptionalAddress(methodDetails.operator),
     sessionSnapshot: Constants.getMethodDetail<SessionSnapshot>(
       methodDetails,
@@ -440,6 +445,7 @@ export async function resolveChallengeContext(
     client,
     escrow,
     feePayer: methodDetails.feePayer,
+    feeToken: methodDetails.feeToken,
     key: channelKey({ payee, token, escrow, chainId }),
     operator: methodDetails.operator,
     payee,
@@ -639,6 +645,7 @@ export function planCredential(parameters: PlanCredentialParameters): Credential
       account,
       context,
       decimals,
+      entry,
       resolved,
     }
   }
@@ -647,14 +654,24 @@ export function planCredential(parameters: PlanCredentialParameters): Credential
     throw new Error('descriptor required to reuse TIP-1034 channel')
   const recoverContext = resolveRecoverContext({ context, snapshot: resolved.snapshot })
   if (!entry && recoverContext && canSignDescriptor(account, recoverContext.descriptor)) {
-    return {
-      type: 'recover',
-      account,
-      context: recoverContext,
-      decimals,
-      maxDeposit,
-      resolved,
-    }
+    // A server snapshot may describe another rail's channel (e.g. a
+    // machine-token descriptor advertised to a direct-rail client); ignore
+    // hints that do not match this challenge instead of failing recovery on
+    // every attempt. Explicit caller descriptors keep failing loudly in
+    // recovery validation.
+    const recoverable =
+      context?.descriptor !== undefined ||
+      (isSameAddress(recoverContext.descriptor.payee, resolved.payee) &&
+        isSameAddress(recoverContext.descriptor.token, resolved.token))
+    if (recoverable)
+      return {
+        type: 'recover',
+        account,
+        context: recoverContext,
+        decimals,
+        maxDeposit,
+        resolved,
+      }
   }
   if (entry?.opened && canSignDescriptor(account, entry.descriptor))
     return { type: 'voucher', account, entry, maxDeposit, resolved }
@@ -664,18 +681,18 @@ export function planCredential(parameters: PlanCredentialParameters): Credential
 /** Executes a credential plan and returns the concrete session credential payload. */
 export async function executeCredentialPlan(
   plan: CredentialPlan,
-  sink: ChannelSink,
   autoSwap: AutoSwap.resolve.Resolved | false = false,
-): Promise<SessionCredentialPayload> {
+  feeToken?: Address | undefined,
+): Promise<CredentialResult> {
   switch (plan.type) {
     case 'open':
-      return open(plan, sink, autoSwap)
+      return open(plan, autoSwap, feeToken)
     case 'recover':
-      return recover(plan, sink)
+      return recover(plan)
     case 'voucher':
-      return voucher(plan, sink)
+      return voucher(plan)
     case 'manual':
-      return manual(plan, sink, autoSwap)
+      return manual(plan, autoSwap, feeToken)
   }
 }
 
@@ -700,9 +717,9 @@ async function resolveAutoSwapCalls(
 
 async function open(
   plan: Extract<CredentialPlan, { type: 'open' }>,
-  sink: ChannelSink,
   autoSwap: AutoSwap.resolve.Resolved | false,
-): Promise<SessionCredentialPayload> {
+  feeToken?: Address | undefined,
+): Promise<CredentialResult> {
   const { account, resolved } = plan
   const deposit = resolveOpeningDeposit({
     contextDepositRaw: plan.context?.depositRaw,
@@ -715,6 +732,7 @@ async function open(
     deposit,
     escrow: resolved.escrow,
     feePayer: resolved.feePayer,
+    feeToken,
     initialAmount: resolved.amount,
     operator: resolved.operator,
     payee: resolved.payee,
@@ -726,22 +744,24 @@ async function open(
     }),
     token: resolved.token,
   })
-  await storeChannelEntry(sink, {
-    channelId: payload.channelId,
-    cumulativeAmount: resolved.amount,
-    deposit,
-    descriptor: payload.descriptor,
-    escrow: resolved.escrow,
-    chainId: resolved.chainId,
-    opened: true,
-  })
-  return payload
+  return {
+    payload,
+    entry: {
+      channelId: payload.channelId,
+      cumulativeAmount: resolved.amount,
+      deposit,
+      descriptor: payload.descriptor,
+      escrow: resolved.escrow,
+      chainId: resolved.chainId,
+      opened: true,
+      ...(resolved.paymentScope && { paymentScope: resolved.paymentScope }),
+    },
+  }
 }
 
 async function recover(
   plan: Extract<CredentialPlan, { type: 'recover' }>,
-  sink: ChannelSink,
-): Promise<SessionCredentialPayload> {
+): Promise<CredentialResult> {
   const { account, context, decimals, maxDeposit, resolved } = plan
   const { descriptor } = context
   const reusable = await resolveReusableChannel({
@@ -775,22 +795,24 @@ async function recover(
     resolved.chainId,
     resolved.escrow,
   )
-  await storeChannelEntry(sink, {
-    channelId: reusable.channelId,
-    cumulativeAmount,
-    deposit: reusable.state.deposit,
-    descriptor,
-    escrow: resolved.escrow,
-    chainId: resolved.chainId,
-    opened: true,
-  })
-  return payload
+  return {
+    payload,
+    entry: {
+      channelId: reusable.channelId,
+      cumulativeAmount,
+      deposit: reusable.state.deposit,
+      descriptor,
+      escrow: resolved.escrow,
+      chainId: resolved.chainId,
+      opened: true,
+      ...(resolved.paymentScope && { paymentScope: resolved.paymentScope }),
+    },
+  }
 }
 
 async function voucher(
   plan: Extract<CredentialPlan, { type: 'voucher' }>,
-  sink: ChannelSink,
-): Promise<SessionCredentialPayload> {
+): Promise<CredentialResult> {
   const { account, entry, resolved } = plan
   const cumulativeAmount = entry.cumulativeAmount + resolved.amount
   assertWithinMaxDeposit(cumulativeAmount, plan.maxDeposit)
@@ -802,16 +824,14 @@ async function voucher(
     resolved.chainId,
     resolved.escrow,
   )
-  entry.cumulativeAmount = cumulativeAmount
-  await storeChannelEntry(sink, entry)
-  return payload
+  return { payload, entry: { ...entry, cumulativeAmount } }
 }
 
 async function manual(
   plan: Extract<CredentialPlan, { type: 'manual' }>,
-  sink: ChannelSink,
   autoSwap: AutoSwap.resolve.Resolved | false,
-): Promise<SessionCredentialPayload> {
+  feeToken?: Address | undefined,
+): Promise<CredentialResult> {
   const { account, context, decimals, resolved } = plan
   const { descriptor } = context
   const channelId = Channel.computeId({
@@ -839,20 +859,21 @@ async function manual(
       resolved,
     },
     autoSwap,
+    feeToken,
   )
-  await applyCumulative(sink, resolved.key, payload)
-  return payload
+  return { payload, entry: applyCredential(plan.entry, payload) }
 }
 
 async function executeManualCredential(
   parameters: ManualCredentialParameters,
   autoSwap: AutoSwap.resolve.Resolved | false,
+  feeToken?: Address | undefined,
 ): Promise<SessionCredentialPayload> {
   switch (parameters.context.action) {
     case 'open':
       return manualOpen(parameters)
     case 'topUp':
-      return manualTopUp(parameters, autoSwap)
+      return manualTopUp(parameters, autoSwap, feeToken)
     case 'voucher':
       return manualVoucher(parameters)
     case 'close':
@@ -889,6 +910,7 @@ async function manualOpen(
 async function manualTopUp(
   parameters: ManualCredentialParameters,
   autoSwap: AutoSwap.resolve.Resolved | false,
+  feeToken?: Address | undefined,
 ): Promise<SessionCredentialPayload> {
   const { account, channelId, context, decimals, descriptor, resolved } = parameters
   const additionalDeposit = requireContextAmount(context, decimals, 'additionalDeposit', 'topUp')
@@ -916,6 +938,7 @@ async function manualTopUp(
       client: resolved.client,
       tokenOut: resolved.token,
     }),
+    feeToken,
   )
 }
 

--- a/src/tempo/session/client/Session.test.ts
+++ b/src/tempo/session/client/Session.test.ts
@@ -1,28 +1,32 @@
 import { type Address, createClient, custom, decodeFunctionData, encodeFunctionResult } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { Account as TempoAccount, Secp256k1, Transaction } from 'viem/tempo'
-import { describe, expect, test, vi } from 'vp/test'
+import { afterEach, describe, expect, test, vi } from 'vp/test'
 
 import { serialize as serializeChallenge, type Challenge } from '../../../Challenge.js'
 import * as Fetch from '../../../client/internal/Fetch.js'
 import * as MethodChallenge from '../../../client/internal/MethodChallenge.js'
+import * as MethodResponse from '../../../client/internal/MethodResponse.js'
 import * as Constants from '../../../Constants.js'
 import * as Credential from '../../../Credential.js'
 import * as z from '../../../zod.js'
 import * as AutoSwap from '../../internal/auto-swap.js'
+import * as defaults from '../../internal/defaults.js'
+import * as MachineTokenSession from '../../internal/machine-token-session.js'
 import * as Methods from '../../Methods.js'
 import * as Channel from '../precompile/Channel.js'
 import { escrowAbi } from '../precompile/escrow.abi.js'
 import { tip20ChannelEscrow } from '../precompile/Protocol.js'
 import * as Types from '../precompile/Protocol.js'
 import * as Voucher from '../precompile/Voucher.js'
+import type { ChannelEntry } from './ChannelOps.js'
 import { channelKey, createChannelStore } from './ChannelStore.js'
 import { session } from './Session.js'
 
 const account = privateKeyToAccount(
   '0xac0974bec39a17e36ba6a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
 )
-const chainId = 42431
+const chainId = defaults.chainId.mainnet
 const client = createClient({
   account,
   chain: { id: chainId } as never,
@@ -53,6 +57,47 @@ const descriptor = {
   authorizedSigner: account.address,
   expiringNonceHash: `0x${'22'.repeat(32)}` as `0x${string}`,
 } satisfies Channel.ChannelDescriptor
+
+const deployment = defaults.machineToken[chainId]
+const machineDescriptor: Channel.ChannelDescriptor = {
+  ...descriptor,
+  operator: deployment.swap,
+  payee: '0x44D7c1EDFdfdfDFdFdFDFDFd0000000000000001',
+  token: deployment.token,
+}
+const machineRoute = {
+  operator: machineDescriptor.operator,
+  payee: machineDescriptor.payee,
+  token: machineDescriptor.token,
+}
+const machineChannelId = Channel.computeId({
+  ...machineDescriptor,
+  chainId,
+  escrow: tip20ChannelEscrow,
+})
+
+function mockMachineRoute({ funded = true, route = true } = {}) {
+  const resolved = route ? machineRoute : undefined
+  vi.spyOn(MachineTokenSession, 'resolveRoute').mockResolvedValue(resolved)
+  vi.spyOn(MachineTokenSession, 'matchRoute').mockResolvedValue(resolved)
+  vi.spyOn(MachineTokenSession, 'hasSufficientBalance').mockResolvedValue(funded)
+}
+
+afterEach(() => vi.restoreAllMocks())
+
+function getMachineEntry(overrides: Partial<ChannelEntry> = {}): ChannelEntry {
+  return {
+    chainId,
+    channelId: machineChannelId,
+    cumulativeAmount: 100n,
+    deposit: 1_000n,
+    descriptor: machineDescriptor,
+    escrow: tip20ChannelEscrow,
+    opened: true,
+    paymentScope: { payee: descriptor.payee, token: descriptor.token },
+    ...overrides,
+  }
+}
 
 type SessionChallenge = Challenge<
   z.output<typeof Methods.session.schema.request>,
@@ -98,6 +143,13 @@ function makeSessionChallenge(
     },
   })
 }
+
+const machineChallenge = makeSessionChallenge({
+  methodDetails: {
+    escrowContract: tip20ChannelEscrow,
+    machineTokenEnabled: true,
+  },
+})
 
 function paymentRequired(challenge: SessionChallenge, headers?: HeadersInit): Response {
   const responseHeaders = new Headers(headers)
@@ -150,6 +202,17 @@ function makeSessionMethod(
   })
 }
 
+async function makeStoredMachineMethod(entryOverrides: Partial<ChannelEntry> = {}) {
+  const entry = getMachineEntry(entryOverrides)
+  const channelStore = createChannelStore()
+  await channelStore.set(entry)
+  return {
+    entry,
+    channelStore,
+    method: makeSessionMethod(channelStore),
+  }
+}
+
 function makeSessionFetch(
   fetch: typeof globalThis.fetch,
   channelStore = createChannelStore(),
@@ -193,6 +256,14 @@ function transactionCalls(payload: Types.SessionCredentialPayload) {
   return transaction.calls as readonly { to?: Address; data?: `0x${string}` }[]
 }
 
+function transactionFeeToken(transaction: `0x${string}`) {
+  return (
+    Transaction.deserialize(
+      transaction as Transaction.TransactionSerializedTempo,
+    ) as Transaction.TransactionSerializableTempo
+  ).feeToken
+}
+
 describe('precompile client session', () => {
   test('handles only TIP-1034 session challenges', () => {
     const method = session({ account, getClient: () => client })
@@ -220,6 +291,175 @@ describe('precompile client session', () => {
         }),
       }),
     ).toBe(false)
+  })
+
+  test.each([
+    ['funded balance', true, true, 'machine'],
+    ['insufficient balance', true, false, 'direct'],
+    ['no route', false, true, 'direct'],
+  ] as const)('selects the %s rail implicitly', async (_name, route, funded, rail) => {
+    mockMachineRoute({ funded, route })
+    const expected = rail === 'machine' ? machineDescriptor : descriptor
+    const payload = deserialize(
+      await session({
+        account,
+        decimals: 0,
+        getClient: () => client,
+      }).createCredential({ challenge: machineChallenge, context: {} }),
+    )
+
+    expect(payload).toMatchObject({
+      action: 'open',
+      descriptor: { operator: expected.operator, payee: expected.payee, token: expected.token },
+    })
+  })
+
+  test.each([
+    ['direct', false],
+    ['machine', true],
+  ] as const)('uses an advertised fee-token override for %s opens', async (_rail, machine) => {
+    if (machine) mockMachineRoute()
+    const feeToken = defaults.tokens.usdc
+    const payload = deserialize(
+      await session({ account, decimals: 0, getClient: () => client }).createCredential({
+        challenge: makeSessionChallenge({
+          methodDetails: {
+            escrowContract: tip20ChannelEscrow,
+            feeToken,
+            ...(machine ? { machineTokenEnabled: true } : {}),
+          },
+        }),
+        context: {},
+      }),
+    )
+    if (payload.action !== 'open') throw new Error('expected open payload')
+
+    expect(transactionFeeToken(payload.transaction)).toBe(feeToken.toLowerCase())
+  })
+
+  test('uses an advertised fee-token override for top-ups', async () => {
+    const feeToken = defaults.tokens.usdc
+    const payload = deserialize(
+      await session({ account, decimals: 0, getClient: () => client }).createCredential({
+        challenge: makeSessionChallenge({
+          methodDetails: { escrowContract: tip20ChannelEscrow, feeToken },
+        }),
+        context: { action: 'topUp', additionalDepositRaw: '100', descriptor },
+      }),
+    )
+    if (payload.action !== 'topUp') throw new Error('expected top-up payload')
+
+    expect(transactionFeeToken(payload.transaction)).toBe(feeToken.toLowerCase())
+  })
+
+  test('reuses a funded machine channel and does not switch rails later', async () => {
+    mockMachineRoute()
+    const { entry, method } = await makeStoredMachineMethod()
+
+    const payload = deserialize(
+      await method.createCredential({ challenge: machineChallenge, context: {} }),
+    )
+    expect(payload).toMatchObject({
+      action: 'voucher',
+      authorizationSignature: expect.any(String),
+      channelId: entry.channelId,
+      cumulativeAmount: '200',
+    })
+
+    vi.mocked(MachineTokenSession.matchRoute).mockResolvedValue(undefined)
+    await expect(
+      method.createCredential({ challenge: machineChallenge, context: {} }),
+    ).rejects.toThrow('Machine-token channel is not bound to this merchant session challenge.')
+  })
+
+  test('keeps a direct fallback when the machine route recovers', async () => {
+    mockMachineRoute({ route: false })
+    const channelStore = createChannelStore()
+    const method = makeSessionMethod(channelStore)
+    const opened = deserialize(
+      await method.createCredential({ challenge: machineChallenge, context: {} }),
+    )
+    expect(opened).toMatchObject({
+      action: 'open',
+      descriptor: { payee: descriptor.payee, token: descriptor.token },
+    })
+
+    vi.mocked(MachineTokenSession.resolveRoute).mockResolvedValue(machineRoute)
+    expect(
+      deserialize(await method.createCredential({ challenge: machineChallenge, context: {} })),
+    ).toMatchObject({ action: 'voucher', channelId: opened.channelId, cumulativeAmount: '200' })
+  })
+
+  test('rejects an underfunded machine top-up without changing the channel', async () => {
+    mockMachineRoute({ funded: false })
+    const { channelStore, entry, method } = await makeStoredMachineMethod()
+
+    await expect(
+      method.createCredential({
+        challenge: machineChallenge,
+        context: {
+          action: 'topUp',
+          additionalDepositRaw: '50',
+          channelId: entry.channelId,
+          descriptor: entry.descriptor,
+        },
+      }),
+    ).rejects.toThrow('Insufficient machine-token balance for session top-up.')
+    expect(await channelStore.get(defaultChannelKey)).toEqual(entry)
+  })
+
+  test('persists only after supplemental machine authorization is signed', async () => {
+    mockMachineRoute()
+    vi.spyOn(MachineTokenSession, 'signAuthorization').mockRejectedValue(
+      new Error('supplemental signing failed'),
+    )
+    const { channelStore, entry, method } = await makeStoredMachineMethod()
+
+    await expect(
+      method.createCredential({ challenge: machineChallenge, context: {} }),
+    ).rejects.toThrow('supplemental signing failed')
+    expect(await channelStore.get(defaultChannelKey)).toEqual(entry)
+  })
+
+  test('closes a machine channel after the server stops advertising new machine sessions', async () => {
+    mockMachineRoute()
+    const { entry, method } = await makeStoredMachineMethod({ cumulativeAmount: 25n })
+    const payload = deserialize(
+      await method.createCredential({
+        challenge: makeSessionChallenge(),
+        context: {
+          action: 'close',
+          channelId: entry.channelId,
+          cumulativeAmountRaw: '25',
+          descriptor: entry.descriptor,
+        },
+      }),
+    )
+    if (payload.action !== 'close' || !payload.authorizationSignature || !payload.refundSignature)
+      throw new Error('expected machine-token close authorizations')
+
+    expect(vi.mocked(MachineTokenSession.matchRoute).mock.calls[0]?.[1].active).toBe(false)
+    expect(
+      MachineTokenSession.verifyAuthorization({
+        authorization: { channelId: entry.channelId, cumulativeAmount: 25n },
+        chainId,
+        expectedSigner: account.address,
+        router: deployment.swap,
+        signature: payload.authorizationSignature,
+      }),
+    ).toBe(true)
+    expect(
+      Voucher.verifyVoucher(
+        tip20ChannelEscrow,
+        chainId,
+        {
+          channelId: entry.channelId,
+          cumulativeAmount: 1_000n,
+          signature: payload.refundSignature,
+        },
+        account.address,
+      ),
+    ).toBe(true)
   })
 
   test('drives paid SSE responses with a supplied credential', async () => {
@@ -502,53 +742,47 @@ describe('precompile client session', () => {
     expect(await channelStore.get(defaultChannelKey)).toMatchObject({ opened: true })
   })
 
-  test('serializes concurrent opens against the committed channel', async () => {
+  test('re-prepares after a concurrent open commits', async () => {
     const challenge = makeSessionChallenge()
     const channelStore = createChannelStore()
-    const actions: Types.SessionCredentialPayload['action'][] = []
-    const vouchers: bigint[] = []
-    const firstGate = Promise.withResolvers<void>()
-    const firstRequest = Promise.withResolvers<void>()
-    const waitersReady = Promise.withResolvers<void>()
-    let credentialPlans = 0
-    const fetch = Fetch.from({
-      fetch: async (input, init) => {
+    const method = makeSessionMethod(channelStore)
+    const input = 'https://example.com/resource'
+    const topUps: Types.SessionCredentialPayload[] = []
+    const prepareParameters = {
+      challenge,
+      context: {},
+      fetch: async (_input: RequestInfo | URL, init?: RequestInit) => {
         const authorization = new Headers(init?.headers).get(Constants.Headers.authorization)
-        if (!authorization) return paymentRequired(challenge)
-        const payload = deserialize(authorization)
-        actions.push(payload.action)
-        if (payload.action === 'topUp') return new Response(null, { status: 204 })
-        if (payload.action === 'voucher') vouchers.push(BigInt(payload.cumulativeAmount))
-        if (input.toString().endsWith('/first')) {
-          firstRequest.resolve()
-          await firstGate.promise
-          return new Response('paid')
-        }
-        return new Response('rejected', { status: 500 })
+        if (!authorization) throw new Error('expected top-up credential')
+        topUps.push(deserialize(authorization))
+        return new Response(null, { status: 204 })
       },
-      methods: [
-        makeSessionMethod(channelStore, {
-          resolveAccount() {
-            if (++credentialPlans === 3) waitersReady.resolve()
-            return account
-          },
-        }),
-      ],
+      input,
+    }
+    await MethodChallenge.handle(method, prepareParameters)
+    await channelStore.set({
+      chainId,
+      channelId: Channel.computeId({ ...descriptor, chainId, escrow: tip20ChannelEscrow }),
+      cumulativeAmount: 100n,
+      deposit: 100n,
+      descriptor,
+      escrow: tip20ChannelEscrow,
+      opened: true,
     })
+    const parameters = { challenge, context: {} }
+    const prepare = vi.fn(() => MethodChallenge.handle(method, prepareParameters))
+    MethodResponse.attachAttempt(method, parameters, { prepare })
 
-    const first = fetch('https://example.com/first')
-    await firstRequest.promise
-    const second = fetch('https://example.com/second')
-    const third = fetch('https://example.com/third')
-    await waitersReady.promise
-    firstGate.resolve()
+    const payload = deserialize(await method.createCredential(parameters))
 
-    expect((await first).status).toBe(200)
-    expect((await second).status).toBe(500)
-    expect((await third).status).toBe(500)
-    expect(actions).toEqual(['open', 'topUp', 'voucher', 'topUp', 'voucher'])
-    expect(vouchers).toEqual([200n, 300n])
-    expect(await channelStore.get(defaultChannelKey)).toMatchObject({ opened: true })
+    expect(prepare).toHaveBeenCalledOnce()
+    expect(topUps).toMatchObject([{ action: 'topUp', additionalDeposit: '100' }])
+    expect(payload).toMatchObject({ action: 'voucher', cumulativeAmount: '200' })
+    expect(await channelStore.get(defaultChannelKey)).toMatchObject({
+      cumulativeAmount: 200n,
+      deposit: 200n,
+      opened: true,
+    })
   })
 
   test('replaces a stored channel owned by another account', async () => {

--- a/src/tempo/session/client/Session.ts
+++ b/src/tempo/session/client/Session.ts
@@ -1,6 +1,7 @@
-import { type Address, parseUnits } from 'viem'
+import { isAddressEqual, type Account as ViemAccount, type Address, parseUnits } from 'viem'
 import { tempo as tempo_chain } from 'viem/chains'
 
+import type * as Challenge from '../../../Challenge.js'
 import * as MethodChallenge from '../../../client/internal/MethodChallenge.js'
 import * as MethodResponse from '../../../client/internal/MethodResponse.js'
 import * as Constants from '../../../Constants.js'
@@ -14,28 +15,32 @@ import type {
 } from '../../client/ResolveAccount.js'
 import * as AutoSwap from '../../internal/auto-swap.js'
 import * as defaults from '../../internal/defaults.js'
+import * as MachineTokenSession from '../../internal/machine-token-session.js'
 import * as Methods from '../../Methods.js'
+import * as Chain from '../precompile/Chain.js'
 import * as Channel from '../precompile/Channel.js'
 import {
   deserializeSessionReceipt,
   isEventStream,
   readSessionChallengeAmount,
   requireSessionCredentialContext,
+  tip20ChannelEscrow,
 } from '../precompile/Protocol.js'
-import { serializeCredential, type ChannelEntry } from './ChannelOps.js'
-import { createChannelStore, type ChannelStore } from './ChannelStore.js'
+import { createVoucherPayload, serializeCredential, type ChannelEntry } from './ChannelOps.js'
+import { createChannelStore, entryKey, type ChannelStore } from './ChannelStore.js'
 import {
   canSignDescriptor,
   executeCredentialPlan,
   hasSessionAction,
   planCredential,
+  requireContextAmount,
   resolveChallengeContext,
   resolveRecoverContext,
   sessionContextSchema,
   type ChallengeContext,
   type SessionContext as CredentialContext,
 } from './CredentialState.js'
-import { assertWithinMaxDeposit, resolveAutomaticTopUp } from './Runtime.js'
+import { assertWithinMaxDeposit, resolveAutomaticTopUp, resolveOpeningDeposit } from './Runtime.js'
 import {
   getSessionSnapshot,
   handleSseNeedVoucher,
@@ -109,6 +114,53 @@ function acknowledgesOpen(
   )
 }
 
+function applyMachineTokenRoute(
+  resolved: ChallengeContext,
+  route: MachineTokenSession.Route,
+): ChallengeContext {
+  const snapshotDescriptor = resolved.snapshot?.descriptor
+  const snapshotMatches =
+    snapshotDescriptor &&
+    isAddressEqual(snapshotDescriptor.payee, route.payee) &&
+    isAddressEqual(snapshotDescriptor.operator, route.operator) &&
+    isAddressEqual(snapshotDescriptor.token, route.token)
+  return {
+    ...resolved,
+    operator: route.operator,
+    payee: route.payee,
+    paymentScope: { payee: resolved.payee, token: resolved.token },
+    snapshot: snapshotMatches ? resolved.snapshot : undefined,
+    token: route.token,
+  }
+}
+
+async function resolveMachineContext(
+  resolved: ChallengeContext,
+  context: CredentialContext | undefined,
+): Promise<ChallengeContext | undefined> {
+  const descriptor = context?.descriptor ?? resolved.snapshot?.descriptor
+  if (!descriptor) return undefined
+  if (!MachineTokenSession.matchDeployment({ chainId: resolved.chainId, descriptor }))
+    return undefined
+  const closing = context?.action === 'close'
+  if (
+    (!closing && !MachineTokenSession.isEnabledChallenge(resolved.challenge)) ||
+    !isAddressEqual(resolved.escrow, tip20ChannelEscrow)
+  )
+    return undefined
+
+  const route = await MachineTokenSession.matchRoute(resolved.client, {
+    active: !closing,
+    chainId: resolved.chainId,
+    descriptor,
+    merchant: resolved.payee,
+    targetToken: resolved.token,
+  })
+  if (!route)
+    throw new Error('Machine-token channel is not bound to this merchant session challenge.')
+  return applyMachineTokenRoute(resolved, route)
+}
+
 /**
  * Creates the low-level TIP-1034 session payment method for use with `Mppx.create()`.
  *
@@ -141,7 +193,13 @@ export function session(parameters: session.Parameters = {}) {
   const topUpAmount =
     topUpAmountParameter !== undefined ? parseUnits(topUpAmountParameter, decimals) : undefined
   const store = channelStore ?? createChannelStore()
-  const sink = { store, notifyUpdate: (entry: ChannelEntry) => onChannelUpdate?.(entry) }
+
+  const commitEntry = async (entry: ChannelEntry | undefined) => {
+    if (!entry) return
+    if (entry.opened) await store.set(entry)
+    else await store.delete(entryKey(entry))
+    onChannelUpdate?.(entry)
+  }
 
   const resolveCredentialAccount = async (
     resolved: ChallengeContext,
@@ -165,77 +223,174 @@ export function session(parameters: session.Parameters = {}) {
     )
   }
 
-  const resolveCredentialPlan = async (
-    resolved: ChallengeContext,
-    context: CredentialContext | undefined,
-    entry: ChannelEntry | undefined,
-  ) =>
-    planCredential({
-      account: await resolveCredentialAccount(resolved, context, entry),
-      entry,
-      context,
-      decimals,
-      maxDeposit,
-      resolved,
+  const resolveContext = (challenge: Challenge.Challenge) =>
+    resolveChallengeContext({
+      allowCustomEscrow,
+      challenge,
+      escrowOverride,
+      getClient,
     })
+
+  /** Selects one rail for this channel lifecycle before any credential is signed. */
+  const resolveRail = async (direct: ChallengeContext, context: CredentialContext | undefined) => {
+    let account: ViemAccount | undefined
+    const descriptor = context?.descriptor ?? direct.snapshot?.descriptor
+    if (descriptor || hasSessionAction(context)) {
+      const machine = descriptor ? await resolveMachineContext(direct, context) : undefined
+      const resolved = machine ?? direct
+      return {
+        account,
+        entry: await store.get(resolved.key),
+        machine: machine !== undefined,
+        resolved,
+      }
+    }
+
+    const directEntry = await store.get(direct.key)
+    if (directEntry?.opened) {
+      if (
+        !MachineTokenSession.matchDeployment({
+          chainId: direct.chainId,
+          descriptor: directEntry.descriptor,
+        })
+      )
+        return { account, entry: directEntry, machine: false, resolved: direct }
+      const machine = await resolveMachineContext(direct, { descriptor: directEntry.descriptor })
+      if (!machine)
+        throw new Error('Machine-token channel is not bound to this merchant session challenge.')
+      return { account, entry: directEntry, machine: true, resolved: machine }
+    }
+    if (
+      !MachineTokenSession.isEnabledChallenge(direct.challenge) ||
+      !isAddressEqual(direct.escrow, tip20ChannelEscrow)
+    )
+      return { account, entry: undefined, machine: false, resolved: direct }
+
+    const route = await MachineTokenSession.resolveRoute(direct.client, {
+      chainId: direct.chainId,
+      merchant: direct.payee,
+      targetToken: direct.token,
+    }).catch(() => undefined)
+    if (!route) return { account, entry: undefined, machine: false, resolved: direct }
+
+    const machine = applyMachineTokenRoute(direct, route)
+    account = await resolveCredentialAccount(machine, context, undefined)
+    const openingDeposit = resolveOpeningDeposit({
+      contextDepositRaw: context?.depositRaw,
+      maxDeposit,
+      requestAmount: direct.amount,
+      suggestedDepositRaw: direct.suggestedDepositRaw,
+    })
+    const funded = await MachineTokenSession.hasSufficientBalance(machine.client, {
+      account: account.address,
+      amount: openingDeposit,
+      token: machine.token,
+    })
+    return funded
+      ? { account, entry: undefined, machine: true, resolved: machine }
+      : { account, entry: undefined, machine: false, resolved: direct }
+  }
 
   const method = Method.toClient(Methods.session, {
     canHandleChallenge: ({ challenge }) => isTip1034SessionChallenge(challenge),
     context: sessionContextSchema,
     async createCredential(parameters) {
       const { challenge, context } = parameters
-      const resolved = await resolveChallengeContext({
-        allowCustomEscrow,
-        challenge,
-        escrowOverride,
-        getClient,
-      })
       const attempt = MethodResponse.getAttempt(parameters)
       let release = () => {}
       try {
-        let entry = await store.get(resolved.key)
-        let plan = await resolveCredentialPlan(resolved, context, entry)
-        if (attempt && plan.type === 'open') {
-          release = await lockChannel(store, resolved.key)
-          const nextEntry = await store.get(resolved.key)
-          if (nextEntry?.channelId !== entry?.channelId) {
-            entry = nextEntry
-            if (entry?.opened) {
-              await attempt.prepare()
-              entry = await store.get(resolved.key)
-            }
-            plan = await resolveCredentialPlan(resolved, context, entry)
-          }
+        const direct = await resolveContext(challenge)
+        if (!hasSessionAction(context) && context?.descriptor === undefined) {
+          release = await lockChannel(store, direct.key)
+          if (attempt && (await store.get(direct.key))?.opened) await attempt.prepare()
         }
-        let pendingOpen: ChannelEntry | undefined
-        // Defer opens only when low-level Fetch owns the response lifecycle.
-        // SessionManager unregisters this hook and keeps its existing transaction boundary.
-        const credentialSink =
-          attempt && plan.type === 'open'
-            ? {
-                store: {
-                  get: (key: string) => store.get(key),
-                  async set(next: ChannelEntry) {
-                    pendingOpen = next
-                  },
-                  delete: (key: string) => store.delete(key),
-                },
-                notifyUpdate() {},
-              }
-            : sink
-        const payload = await executeCredentialPlan(
+        const { account, entry, machine, resolved } = await resolveRail(direct, context)
+        const credentialAccount =
+          account ?? (await resolveCredentialAccount(resolved, context, entry))
+        const plan = planCredential({
+          account: credentialAccount,
+          entry,
+          context,
+          decimals,
+          maxDeposit,
+          resolved,
+        })
+        if (machine && plan.type === 'manual' && plan.context.action === 'topUp') {
+          const additionalDeposit = requireContextAmount(
+            plan.context,
+            plan.decimals,
+            'additionalDeposit',
+            'topUp',
+          )
+          if (
+            !(await MachineTokenSession.hasSufficientBalance(plan.resolved.client, {
+              account: plan.account.address,
+              amount: additionalDeposit,
+              token: plan.resolved.token,
+            }))
+          )
+            throw new Error('Insufficient machine-token balance for session top-up.')
+        }
+        const feeToken = MachineTokenSession.resolveFeeToken({
+          chainId: resolved.chainId,
+          override: resolved.feeToken,
+          paymentToken: resolved.token,
+        })
+        const result = await executeCredentialPlan(
           plan,
-          credentialSink,
           AutoSwap.resolve(context?.autoSwap ?? autoSwapParameter, AutoSwap.defaultCurrencies),
+          feeToken,
         )
+        let { payload } = result
+        if (machine && payload.action !== 'topUp') {
+          if (payload.action === 'close') {
+            const state = await Chain.getChannelState(
+              plan.resolved.client,
+              payload.channelId,
+              plan.resolved.escrow,
+            )
+            if (state.deposit === 0n)
+              throw new Error('Cannot authorize a machine-token refund for an empty channel.')
+            // The refund authorization covers the full on-chain deposit, while
+            // the close voucher remains the exact amount the merchant captures.
+            const depositSignature =
+              BigInt(payload.cumulativeAmount) === state.deposit
+                ? payload.signature
+                : (
+                    await createVoucherPayload(
+                      plan.resolved.client,
+                      plan.account,
+                      payload.descriptor,
+                      state.deposit,
+                      plan.resolved.chainId,
+                      plan.resolved.escrow,
+                    )
+                  ).signature
+            payload = { ...payload, refundSignature: depositSignature }
+          }
+          const authorizationSignature = await MachineTokenSession.signAuthorization(
+            plan.resolved.client,
+            plan.account,
+            {
+              authorization: {
+                channelId: payload.channelId,
+                cumulativeAmount: BigInt(payload.cumulativeAmount),
+              },
+              chainId: plan.resolved.chainId,
+              router: plan.resolved.operator!,
+            },
+          )
+          payload = { ...payload, authorizationSignature }
+        }
+        if (!(attempt && plan.type === 'open')) await commitEntry(result.entry)
         const credential = await serializeCredential(
           challenge,
           payload,
           resolved.chainId,
           plan.account,
         )
-        if (attempt && pendingOpen) {
-          const opened = pendingOpen
+        if (attempt && plan.type === 'open' && result.entry) {
+          const opened = result.entry
           attempt.settle = async (outcome) => {
             const accepted =
               outcome.status === 'accepted' || acknowledgesOpen(outcome, challenge, opened)
@@ -247,8 +402,7 @@ export function session(parameters: session.Parameters = {}) {
                   !current?.opened ||
                   current.channelId.toLowerCase() !== opened.channelId.toLowerCase()
                 ) {
-                  await store.set(opened)
-                  sink.notifyUpdate(opened)
+                  await commitEntry(opened)
                 }
               }
               return true
@@ -304,22 +458,26 @@ export function session(parameters: session.Parameters = {}) {
       })
     const nextDeposit = knownDeposit + additionalDeposit
     if (nextDeposit === channel.deposit) return
-    const updated = { ...channel, deposit: nextDeposit }
+    const current = await store.get(entryKey(channel))
+    const latest =
+      current?.channelId.toLowerCase() === channel.channelId.toLowerCase() ? current : channel
+    const updated = {
+      ...latest,
+      deposit: latest.deposit > nextDeposit ? latest.deposit : nextDeposit,
+    }
     await store.set(updated)
-    sink.notifyUpdate(updated)
+    onChannelUpdate?.(updated)
   }
 
   MethodChallenge.register(method, async ({ challenge, context, fetch, input }) => {
     if (!isTip1034SessionChallenge(challenge)) return
     const sessionContext = context === undefined ? undefined : sessionContextSchema.parse(context)
     if (hasSessionAction(sessionContext)) return
-    const resolved = await resolveChallengeContext({
-      allowCustomEscrow,
-      challenge,
-      escrowOverride,
-      getClient,
-    })
-    const channel = await store.get(resolved.key)
+    const direct = await resolveContext(challenge)
+    const { entry: channel, resolved } = await resolveRail(direct, sessionContext).catch(() => ({
+      entry: undefined,
+      resolved: direct,
+    }))
     if (!channel?.opened) return
     const snapshot =
       resolved.snapshot?.channelId.toLowerCase() === channel.channelId.toLowerCase()
@@ -347,10 +505,10 @@ export function session(parameters: session.Parameters = {}) {
     method,
     async ({ challenge, credential, fetch, headers, input, refetch, response, signal }) => {
       if (!isTip1034SessionChallenge(challenge)) return response
+      const credentialContext = requireSessionCredentialContext(
+        Credential.deserialize(credential).payload,
+      )
       if (!isEventStream(response)) {
-        const credentialContext = requireSessionCredentialContext(
-          Credential.deserialize(credential).payload,
-        )
         if (
           credentialContext.action === 'open' &&
           headers.get('accept')?.toLowerCase().includes('text/event-stream')
@@ -359,15 +517,10 @@ export function session(parameters: session.Parameters = {}) {
         return response
       }
 
-      const channelKey = (
-        await resolveChallengeContext({
-          allowCustomEscrow,
-          challenge,
-          escrowOverride,
-          getClient,
-        })
-      ).key
-      let channel = await store.get(channelKey)
+      const resolvedContext = await resolveContext(challenge)
+        .then(async (direct) => (await resolveMachineContext(direct, credentialContext)) ?? direct)
+        .catch(() => undefined)
+      const channel = resolvedContext ? await store.get(resolvedContext.key) : undefined
       const driver = {
         assertVoucherWithinLocalLimit: (cumulativeAmount) =>
           assertWithinMaxDeposit(cumulativeAmount, maxDeposit),

--- a/src/tempo/session/client/SessionManager.test.ts
+++ b/src/tempo/session/client/SessionManager.test.ts
@@ -1,10 +1,12 @@
 import { createClient, custom, encodeFunctionResult, type Address, type Hex } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { describe, expect, test, vi } from 'vp/test'
+import { afterEach, describe, expect, test, vi } from 'vp/test'
 
 import * as Challenge from '../../../Challenge.js'
 import * as Constants from '../../../Constants.js'
 import * as Credential from '../../../Credential.js'
+import * as defaults from '../../internal/defaults.js'
+import * as MachineTokenSession from '../../internal/machine-token-session.js'
 import type { ChannelEntry } from '../client/ChannelOps.js'
 import { createJsonChannelStore, entryKey, type ChannelStore } from '../client/ChannelStore.js'
 import * as Channel from '../precompile/Channel.js'
@@ -15,7 +17,9 @@ import type { NeedVoucherEvent, SessionReceipt } from '../precompile/Protocol.js
 import { formatNeedVoucherEvent, parseEvent } from '../precompile/Protocol.js'
 import type { SessionCredentialPayload } from '../precompile/Protocol.js'
 import * as Voucher from '../precompile/Voucher.js'
+import { getSessionManagerInternals } from './internal/SessionManager.js'
 import { computeFallbackCloseAmount, sessionManager } from './SessionManager.js'
+import type { TempoSessionChallenge } from './Transports.js'
 
 const channelId = '0x0000000000000000000000000000000000000000000000000000000000000001' as Hex
 const challengeId = 'test-challenge-1'
@@ -23,6 +27,8 @@ const realm = 'test.example.com'
 const account = privateKeyToAccount(
   '0xac0974bec39a17e36ba6a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
 )
+
+afterEach(() => vi.restoreAllMocks())
 
 const client = createClient({
   account,
@@ -75,6 +81,18 @@ const storedDescriptor = {
 
 const storedChannelId = Channel.computeId({
   ...storedDescriptor,
+  chainId: 4217,
+  escrow: tip20ChannelEscrow,
+})
+const machineDeployment = defaults.machineToken[4217]
+const machineDescriptor = {
+  ...storedDescriptor,
+  operator: machineDeployment.swap,
+  payee: '0x44D7c1EDFdfdfDFdFdFDFDFd0000000000000001' as Address,
+  token: machineDeployment.token,
+}
+const machineChannelId = Channel.computeId({
+  ...machineDescriptor,
   chainId: 4217,
   escrow: tip20ChannelEscrow,
 })
@@ -414,16 +432,21 @@ describe('Session', () => {
       expect(posted[0]).toMatchObject({ action: 'voucher', channelId: storedChannelId })
     })
 
-    test('seeds a same-route HEAD snapshot and resolves the account when resuming it', async () => {
+    test('seeds a machine HEAD snapshot under its logical scope', async () => {
       const { store, set } = makeChannelStore()
       const posted: SessionCredentialPayload[] = []
+      vi.spyOn(MachineTokenSession, 'matchRoute').mockResolvedValue({
+        operator: machineDescriptor.operator,
+        payee: machineDescriptor.payee,
+        token: machineDescriptor.token,
+      })
       const highestVoucher = {
-        channelId: storedChannelId,
+        channelId: machineChannelId,
         cumulativeAmount: '1000000',
         signature: await Voucher.signVoucher(
           client,
           account,
-          { channelId: storedChannelId, cumulativeAmount: 1_000_000n },
+          { channelId: machineChannelId, cumulativeAmount: 1_000_000n },
           tip20ChannelEscrow,
           4217,
         ),
@@ -448,9 +471,9 @@ describe('Session', () => {
                 [Constants.Headers.paymentSessionSnapshot]: sessionManager.serializeSnapshot({
                   acceptedCumulative: '1000000',
                   chainId: 4217,
-                  channelId: storedChannelId,
+                  channelId: machineChannelId,
                   deposit: '10000000',
-                  descriptor: storedDescriptor,
+                  descriptor: machineDescriptor,
                   escrow: tip20ChannelEscrow,
                   highestVoucher,
                   requiredCumulative: '1000000',
@@ -462,17 +485,39 @@ describe('Session', () => {
             }),
           )
         }
-        // The seeded snapshot is not sent as a first-request hint; the content
-        // request gets a 402 and resumes from the entry index with a voucher.
+        // The seeded snapshot is sent as the first-request hint and remains
+        // available through the local entry index when the server retries.
         const authorization = headers.get(Constants.Headers.authorization)
         const payload = authorization
           ? Credential.deserialize<SessionCredentialPayload>(authorization).payload
           : undefined
         if (payload) posted.push(payload)
         if (!payload) {
-          expect(s.channelId).toBe(storedChannelId)
+          expect(s.channelId).toBe(machineChannelId)
           expect(s.cumulative).toBe(1_000_000n)
-          return Promise.resolve(make402Response())
+          return Promise.resolve(
+            make402Response(
+              makeChallenge({
+                methodDetails: {
+                  chainId: 4217,
+                  escrowContract: tip20ChannelEscrow,
+                  machineTokenEnabled: true,
+                  sessionProtocol: Constants.SessionProtocols.v2,
+                  sessionSnapshot: {
+                    acceptedCumulative: '1000000',
+                    chainId: 4217,
+                    channelId: machineChannelId,
+                    deposit: '10000000',
+                    descriptor: machineDescriptor,
+                    escrow: tip20ChannelEscrow,
+                    requiredCumulative: '1000000',
+                    settled: '0',
+                    spent: '0',
+                  },
+                },
+              }),
+            ),
+          )
         }
         return Promise.resolve(makeOkResponse())
       })
@@ -488,8 +533,13 @@ describe('Session', () => {
       const response = await s.fetch('https://api.example.com/data')
 
       expect(response.status).toBe(200)
-      expect(set).toHaveBeenCalledWith(expect.objectContaining({ channelId: storedChannelId }))
-      expect(posted[0]).toMatchObject({ action: 'voucher', channelId: storedChannelId })
+      expect(set).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channelId: machineChannelId,
+          paymentScope: { payee: storedDescriptor.payee, token: storedDescriptor.token },
+        }),
+      )
+      expect(posted[0]).toMatchObject({ action: 'voucher', channelId: machineChannelId })
       expect(resolveAccount).toHaveBeenCalledTimes(2)
       expect(resolveAccount).toHaveBeenNthCalledWith(1, {
         account,
@@ -497,7 +547,7 @@ describe('Session', () => {
         operation: { authority: account.address, kind: 'authorizePaymentChannel' },
       })
       const contentCall = mockFetch.mock.calls.find((call) => call[1]?.method !== 'HEAD')
-      expect(new Headers(contentCall?.[1]?.headers).get('Payment-Session')).toBeNull()
+      expect(new Headers(contentCall?.[1]?.headers).get('Payment-Session')).toBe(machineChannelId)
     })
 
     test('does not cache a server snapshot for a channel that is closed on-chain', async () => {
@@ -1766,6 +1816,58 @@ describe('Session', () => {
 
       await s.close()
       expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    test('classifies a snapshot-hydrated machine channel without paymentScope', async () => {
+      vi.spyOn(MachineTokenSession, 'matchRoute').mockResolvedValue({
+        operator: machineDescriptor.operator,
+        payee: machineDescriptor.payee,
+        token: machineDescriptor.token,
+      })
+      const challenge = makeChallenge({
+        amount: '100',
+        methodDetails: {
+          chainId: 4217,
+          escrowContract: tip20ChannelEscrow,
+          sessionProtocol: Constants.SessionProtocols.v2,
+          sessionSnapshot: {
+            acceptedCumulative: '900',
+            chainId: 4217,
+            channelId: machineChannelId,
+            deposit: '1000',
+            descriptor: machineDescriptor,
+            escrow: tip20ChannelEscrow,
+            requiredCumulative: '900',
+            settled: '600',
+            spent: '400',
+          },
+        },
+      }) as TempoSessionChallenge
+      let closePayload: Extract<SessionCredentialPayload, { action: 'close' }> | undefined
+      const fetch = vi.fn(async (_input, init?: RequestInit) => {
+        const authorization = new Headers(init?.headers).get(Constants.Headers.authorization)
+        if (!authorization) throw new Error('expected close credential')
+        const payload = Credential.deserialize<SessionCredentialPayload>(authorization).payload
+        if (payload.action !== 'close') throw new Error(`unexpected ${payload.action} credential`)
+        closePayload = payload
+        return new Response(null, { status: 200 })
+      })
+      const manager = sessionManager({ account, client, fetch })
+      getSessionManagerInternals(manager).rehydrate({
+        channel: channelEntry({
+          channelId: machineChannelId,
+          cumulativeAmount: 900n,
+          deposit: 1_000n,
+          descriptor: machineDescriptor,
+        }),
+        challenge,
+        input: 'https://api.example.com/resource',
+        spent: 400n,
+      })
+
+      await manager.close()
+
+      expect(closePayload?.cumulativeAmount).toBe('600')
     })
 
     test('tracks spent from HTTP error receipts and closes at that amount', async () => {

--- a/src/tempo/session/client/SessionManager.ts
+++ b/src/tempo/session/client/SessionManager.ts
@@ -11,12 +11,14 @@ import * as Account from '../../../viem/Account.js'
 import * as Client from '../../../viem/Client.js'
 import { charge as chargePlugin } from '../../client/Charge.js'
 import * as defaults from '../../internal/defaults.js'
+import * as MachineTokenSession from '../../internal/machine-token-session.js'
 import type { ChannelEntry } from '../client/ChannelOps.js'
 import { createChannelStore, entryKey, type ChannelStore } from '../client/ChannelStore.js'
 import { hydrateSessionSnapshot, type SessionContext } from '../client/CredentialState.js'
 import { session as sessionPlugin } from '../client/Session.js'
 import * as Channel from '../precompile/Channel.js'
 import { deserializeSessionReceipt } from '../precompile/Protocol.js'
+import { tip20ChannelEscrow } from '../precompile/Protocol.js'
 import type { SessionReceipt } from '../precompile/Protocol.js'
 import {
   deserializeSnapshot as deserializeSessionSnapshot,
@@ -405,7 +407,10 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
   }
 
   /** Persists a server snapshot into the channel store and returns the entry. */
-  async function storeSnapshotHeader(response: Response): Promise<ChannelEntry | undefined> {
+  async function storeSnapshotHeader(
+    response: Response,
+    paymentScope?: { payee: Address; token: Address } | undefined,
+  ): Promise<ChannelEntry | undefined> {
     const header = response.headers.get(Constants.Headers.paymentSessionSnapshot)
     if (!header) return undefined
     const snapshot = deserializeSessionSnapshot(header)
@@ -420,11 +425,17 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
           kind: 'authorizePaymentChannel',
         },
       })) ?? defaultAccount
-    const { entry, spent } = await hydrateSessionSnapshot({ account, client, snapshot })
+    const hydrated = await hydrateSessionSnapshot({ account, client, snapshot })
+    const entry =
+      paymentScope &&
+      (paymentScope.payee.toLowerCase() !== hydrated.entry.descriptor.payee.toLowerCase() ||
+        paymentScope.token.toLowerCase() !== hydrated.entry.descriptor.token.toLowerCase())
+        ? { ...hydrated.entry, paymentScope }
+        : hydrated.entry
     assertVoucherWithinLocalLimit(entry.cumulativeAmount)
     await Promise.resolve(store.set(entry)).catch(() => undefined)
     runtime.channel = entry
-    runtime.spent = spent
+    runtime.spent = hydrated.spent
     return entry
   }
 
@@ -465,7 +476,11 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
           [Constants.Headers.authorization]: credential,
         },
       })
-      if (response.ok) return await storeSnapshotHeader(response)
+      if (response.ok)
+        return await storeSnapshotHeader(response, {
+          payee: challenge.request.recipient as Address,
+          token: challenge.request.currency as Address,
+        })
       return undefined
     } catch {
       return undefined
@@ -511,8 +526,9 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
     }
 
     const acceptedCumulative = BigInt(snapshot.acceptedCumulative)
+    const settled = BigInt(snapshot.settled)
     const snapshotSpent = BigInt(snapshot.spent)
-    if (acceptedCumulative < 0n || snapshotSpent < 0n) {
+    if (acceptedCumulative < 0n || settled < 0n || snapshotSpent < 0n) {
       throw new Error('close snapshot amounts must not be negative')
     }
     if (snapshotSpent > acceptedCumulative) {
@@ -521,7 +537,7 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
     if (acceptedCumulative > channel.cumulativeAmount) {
       throw new Error('close snapshot accepted cumulative exceeds local voucher state')
     }
-    return { acceptedCumulative, spent: snapshotSpent }
+    return { acceptedCumulative, settled, spent: snapshotSpent }
   }
 
   function applyCloseSnapshot(target: CloseTarget, challenge: TempoSessionChallenge) {
@@ -544,8 +560,19 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
     const snapshot = applySnapshot
       ? applyCloseSnapshot(target, challenge)
       : validateCloseSnapshot(target.channel, challenge)
-    const closeAmount =
-      snapshot?.acceptedCumulative ?? getFallbackCloseAmount(challenge, target.channelId)
+    const machineSession =
+      target.channel.escrow.toLowerCase() === tip20ChannelEscrow.toLowerCase() &&
+      MachineTokenSession.matchDeployment({
+        chainId: target.channel.chainId,
+        descriptor: target.channel.descriptor,
+      }) !== undefined
+    const closeAmount = snapshot
+      ? machineSession
+        ? snapshot.spent > snapshot.settled
+          ? snapshot.spent
+          : snapshot.settled
+        : snapshot.acceptedCumulative
+      : getFallbackCloseAmount(challenge, target.channelId)
     if (closeAmount > target.channel.cumulativeAmount) {
       throw new Error('fallback close amount exceeds local voucher state')
     }
@@ -690,13 +717,11 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
     }
     channelUse = use
 
-    // Cold starts resume from `channelStore` after the 402 reveals the scope.
-    const liveHint = runtime.channel?.opened ? runtime.channel.channelId : undefined
-
     try {
       await bootstrapSession(input, init)
       use.trackCreates = true
 
+      const liveHint = runtime.channel?.opened ? runtime.channel.channelId : undefined
       let effectiveInit = requestInitWithSessionHint(input, init, liveHint)
       // Stored channels may be stale, so retry once after evicting the resumed entry.
       let canRetryResumed = !previous.channel?.opened

--- a/src/tempo/session/precompile/Chain.test.ts
+++ b/src/tempo/session/precompile/Chain.test.ts
@@ -12,7 +12,7 @@ import {
   type Hex,
 } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { Abis, Addresses, Transaction } from 'viem/tempo'
+import { Abis, Addresses, Chain as TempoChain, Transaction } from 'viem/tempo'
 import { describe, expect, test } from 'vp/test'
 
 import { VerificationFailedError } from '../../../Errors.js'
@@ -57,7 +57,7 @@ function createMockClient(
 ) {
   return createClient({
     account: feePayer,
-    chain: { id: chainId } as never,
+    chain: TempoChain.testnet,
     transport: custom({
       async request(args) {
         parameters.rpcMethods?.push(args.method)
@@ -168,13 +168,14 @@ async function createSerializedTransaction(parameters: {
     data?: `0x${string}` | undefined
     value?: bigint | undefined
   }[]
+  feeToken?: Address | false | undefined
   gas?: bigint | undefined
   signed?: boolean | undefined
 }) {
   return (await Transaction.serialize({
     chainId,
     calls: parameters.calls,
-    feeToken: descriptor.token,
+    ...(parameters.feeToken === false ? {} : { feeToken: parameters.feeToken ?? descriptor.token }),
     nonce: 0,
     ...(parameters.gas !== undefined ? { gas: parameters.gas } : {}),
     ...(parameters.signed
@@ -222,6 +223,7 @@ function autoSwapCalls(amountOut: bigint = deposit) {
 async function createOpenTransaction(
   parameters: {
     authorizedSigner?: `0x${string}` | undefined
+    feeToken?: Address | false | undefined
     gas?: bigint | undefined
     operator?: `0x${string}` | undefined
     payee?: `0x${string}` | undefined
@@ -251,6 +253,7 @@ async function createOpenTransaction(
   })
   return createSerializedTransaction({
     calls: [...(parameters.prefixCalls ?? []), { to: parameters.to ?? tip20ChannelEscrow, data }],
+    feeToken: parameters.feeToken,
     gas: parameters.gas,
     signed: parameters.signed,
   })
@@ -333,7 +336,7 @@ describe('precompile receipt wait', () => {
 })
 
 describe('precompile server transactions', () => {
-  test('marks server-driven close and settle transactions for hosted fee-payer sponsorship', async () => {
+  test('marks server transactions for hosted sponsorship and preserves the machine close ABI', async () => {
     const rpcMethods: string[] = []
     const preparedRequests: Record<string, unknown>[] = []
     const signedRequests: Record<string, unknown>[] = []
@@ -368,12 +371,23 @@ describe('precompile server transactions', () => {
       account: sender,
       feePayer: true,
     })
+    await Chain.closeMachineSessionOnChain(
+      client,
+      descriptor,
+      1n,
+      `0x${'11'.repeat(65)}`,
+      `0x${'22'.repeat(65)}`,
+      `0x${'33'.repeat(65)}`,
+      '0x7777777777777777777777777777777777777777',
+      { account: sender, feePayer: true },
+    )
 
-    expect(preparedRequests.map(({ feePayer }) => feePayer)).toEqual([true, true])
-    expect(signedRequests.map(({ feePayer }) => feePayer)).toEqual([true, true])
-    expect(rpcMethods.filter((method) => method === 'eth_sendRawTransaction')).toHaveLength(2)
+    expect(preparedRequests.map(({ feePayer }) => feePayer)).toEqual([true, true, true])
+    expect(signedRequests.map(({ feePayer }) => feePayer)).toEqual([true, true, true])
+    expect(rpcMethods.filter((method) => method === 'eth_sendRawTransaction')).toHaveLength(3)
     expect(rpcMethods).not.toContain('eth_sendTransaction')
     expect(rpcMethods).not.toContain('eth_call')
+    expect((preparedRequests[2]!.data as Hex).slice(0, 10)).toBe('0x6563b635')
   })
 
   test('does not add a fee-payer signature when the sender and fee payer are the same account', async () => {
@@ -824,7 +838,12 @@ describe('precompile broadcastOpenTransaction', () => {
 
   test('fee-payer simulates open before raw broadcast', async () => {
     const rpcMethods: string[] = []
-    const serializedTransaction = await createOpenTransaction({ gas: 100_000n, signed: true })
+    let broadcast: Hex | undefined
+    const serializedTransaction = await createOpenTransaction({
+      feeToken: false,
+      gas: 100_000n,
+      signed: true,
+    })
     const transaction = Transaction.deserialize(
       serializedTransaction as Transaction.TransactionSerializedTempo,
     )
@@ -842,9 +861,13 @@ describe('precompile broadcastOpenTransaction', () => {
     const state = { settled: 0n, deposit, closeRequestedAt: 0 }
 
     await Chain.broadcastOpenTransaction({
+      allowedFeeTokens: [sourceToken],
       chainId,
       client: createMockClient({
         channel: { descriptor: expectedDescriptor, state },
+        onRequest(method, params) {
+          if (method === 'eth_sendRawTransactionSync') broadcast = (params as readonly [Hex])[0]
+        },
         receipt: receipt([openedLog({ channelId, expiringNonceHash })]),
         rpcMethods,
       }),
@@ -856,7 +879,7 @@ describe('precompile broadcastOpenTransaction', () => {
       expectedOperator: descriptor.operator,
       expectedPayee: descriptor.payee,
       expectedPayer: payer,
-      feePayer: mockFeePayer,
+      feePayer,
       serializedTransaction,
     })
 
@@ -868,6 +891,9 @@ describe('precompile broadcastOpenTransaction', () => {
     expect(
       rpcMethods.slice(0, broadcastIndex).filter((method) => method === 'eth_call'),
     ).toHaveLength(2)
+    expect(
+      Transaction.deserialize(broadcast as Transaction.TransactionSerializedTempo).feeToken,
+    ).toBe(sourceToken)
   })
 
   test('hosted fee-payer relays a sender-signed open without local co-signing', async () => {

--- a/src/tempo/session/precompile/Chain.ts
+++ b/src/tempo/session/precompile/Chain.ts
@@ -1,5 +1,11 @@
 import type { Account, Address, Client, Hex } from 'viem'
-import { decodeFunctionData, encodeFunctionData, isAddressEqual, parseEventLogs } from 'viem'
+import {
+  decodeFunctionData,
+  encodeFunctionData,
+  isAddressEqual,
+  parseAbi,
+  parseEventLogs,
+} from 'viem'
 import {
   call,
   prepareTransactionRequest,
@@ -20,6 +26,11 @@ import * as ChannelUtils from './Channel.js'
 import type { ChannelDescriptor } from './Channel.js'
 import { escrowAbi } from './escrow.abi.js'
 import { tip20ChannelEscrow } from './Protocol.js'
+
+const machineSessionAbi = parseAbi([
+  'function settleSession((address payer,address payee,address operator,address token,bytes32 salt,address authorizedSigner,bytes32 expiringNonceHash) descriptor,uint96 cumulativeAmount,bytes signature,bytes authorizationSignature)',
+  'function closeSession((address payer,address payee,address operator,address token,bytes32 salt,address authorizedSigner,bytes32 expiringNonceHash) descriptor,uint96 cumulativeAmount,bytes signature,bytes authorizationSignature,bytes refundSignature)',
+])
 
 /** Minimal on-chain state read back after precompile transaction receipts. */
 export type ReceiptValidationChannelState = {
@@ -639,6 +650,48 @@ export async function settleOnChain(
   )
 }
 
+function encodeMachineSessionCall(
+  descriptor: ChannelDescriptor,
+  cumulativeAmount: bigint,
+  signature: Hex,
+  authorizationSignature: Hex,
+  refundSignature?: Hex | undefined,
+): Hex {
+  assertUint96(cumulativeAmount)
+  const args = [
+    descriptorTuple(descriptor),
+    cumulativeAmount,
+    signature,
+    authorizationSignature,
+  ] as const
+  return refundSignature === undefined
+    ? encodeFunctionData({ abi: machineSessionAbi, functionName: 'settleSession', args })
+    : encodeFunctionData({
+        abi: machineSessionAbi,
+        functionName: 'closeSession',
+        args: [...args, refundSignature],
+      })
+}
+
+/** Submit a settle transaction through the first-party machine-token session router. */
+export async function settleMachineSessionOnChain(
+  client: Client,
+  descriptor: ChannelDescriptor,
+  cumulativeAmount: bigint,
+  signature: Hex,
+  authorizationSignature: Hex,
+  router: Address,
+  options?: ChannelTransactionOptions,
+): Promise<Hex> {
+  return sendPrecompileTransaction(
+    client,
+    router,
+    encodeMachineSessionCall(descriptor, cumulativeAmount, signature, authorizationSignature),
+    'settle machine-token session',
+    options,
+  )
+}
+
 /**
  * Submit a top-up transaction on-chain.
  */
@@ -718,6 +771,32 @@ export async function closeOnChain(
     escrow,
     encodeFunctionData({ abi: escrowAbi, functionName: 'close', args }),
     'close',
+    options,
+  )
+}
+
+/** Submit a cooperative close through the first-party machine-token session router. */
+export async function closeMachineSessionOnChain(
+  client: Client,
+  descriptor: ChannelDescriptor,
+  cumulativeAmount: bigint,
+  signature: Hex,
+  authorizationSignature: Hex,
+  refundSignature: Hex,
+  router: Address,
+  options?: ChannelTransactionOptions,
+): Promise<Hex> {
+  return sendPrecompileTransaction(
+    client,
+    router,
+    encodeMachineSessionCall(
+      descriptor,
+      cumulativeAmount,
+      signature,
+      authorizationSignature,
+      refundSignature,
+    ),
+    'close machine-token session',
     options,
   )
 }
@@ -891,6 +970,8 @@ export type BroadcastOpenTransactionResult = {
 
 /** Inputs for broadcasting and verifying a client-signed TIP-1034 open transaction. */
 export type BroadcastOpenTransactionParameters = {
+  /** Fee tokens allowed when the server completes a sponsored transaction. Defaults to the channel currency. */
+  allowedFeeTokens?: readonly Address[] | undefined
   /** Hook invoked after calldata validation but before broadcasting. */
   beforeBroadcast?:
     | ((result: Omit<BroadcastOpenTransactionResult, 'txHash' | 'state'>) => Promise<void> | void)
@@ -976,7 +1057,7 @@ export function validateOpenCredentialTransaction(
   })
   if (parameters.feePayer) assertSenderSigned(transaction)
   validateCredentialSponsorship({
-    allowedFeeTokens: [parameters.expectedCurrency],
+    allowedFeeTokens: parameters.allowedFeeTokens ?? [parameters.expectedCurrency],
     challengeExpires: parameters.challengeExpires,
     chainId: parameters.chainId,
     details: {
@@ -1017,7 +1098,7 @@ export async function broadcastOpenTransaction(
     challengeExpires: parameters.challengeExpires,
     chainId: parameters.chainId,
     client: parameters.client,
-    allowedFeeTokens: [parameters.expectedCurrency],
+    allowedFeeTokens: parameters.allowedFeeTokens ?? [parameters.expectedCurrency],
     details: {
       channelId: parameters.expectedChannelId,
       currency: parameters.expectedCurrency,
@@ -1070,6 +1151,8 @@ export type BroadcastTopUpTransactionResult = {
 export type BroadcastTopUpTransactionParameters = {
   /** Additional deposit amount expected in the top-up calldata. */
   additionalDeposit: bigint
+  /** Fee tokens allowed when the server completes a sponsored transaction. Defaults to the channel currency. */
+  allowedFeeTokens?: readonly Address[] | undefined
   /** Challenge expiration propagated into fee-payer policy checks. */
   challengeExpires?: string | undefined
   /** Chain ID used for fee-payer transaction signing. */
@@ -1129,7 +1212,7 @@ export function validateTopUpCredentialTransaction(
   })
   if (parameters.feePayer) assertSenderSigned(transaction)
   validateCredentialSponsorship({
-    allowedFeeTokens: [parameters.expectedCurrency],
+    allowedFeeTokens: parameters.allowedFeeTokens ?? [parameters.expectedCurrency],
     challengeExpires: parameters.challengeExpires,
     chainId: parameters.chainId,
     details: {
@@ -1153,7 +1236,7 @@ export async function broadcastTopUpTransaction(
     challengeExpires: parameters.challengeExpires,
     chainId: parameters.chainId,
     client: parameters.client,
-    allowedFeeTokens: [parameters.expectedCurrency],
+    allowedFeeTokens: parameters.allowedFeeTokens ?? [parameters.expectedCurrency],
     details: {
       additionalDeposit: parameters.additionalDeposit.toString(),
       channelId: parameters.expectedChannelId,

--- a/src/tempo/session/precompile/Protocol.ts
+++ b/src/tempo/session/precompile/Protocol.ts
@@ -81,6 +81,8 @@ export type OpenCredentialPayload = {
   transaction: Hex
   /** Voucher signature for `cumulativeAmount`. */
   signature: Hex
+  /** Machine-token-only router-domain guard for `cumulativeAmount`. */
+  authorizationSignature?: Hex | undefined
   /** Descriptor needed to recover and verify the channel. */
   descriptor: ChannelDescriptor
   /** Initial cumulative spend authorized by the opening voucher, as raw units. */
@@ -118,6 +120,8 @@ export type VoucherCredentialPayload = {
   cumulativeAmount: RawAmountString
   /** Voucher signature for `cumulativeAmount`. */
   signature: Hex
+  /** Machine-token-only router-domain guard for `cumulativeAmount`. */
+  authorizationSignature?: Hex | undefined
 }
 
 /**
@@ -133,6 +137,13 @@ export type CloseCredentialPayload = {
   cumulativeAmount: RawAmountString
   /** Voucher signature for `cumulativeAmount`. */
   signature: Hex
+  /** Machine-token-only router-domain guard for `cumulativeAmount`. */
+  authorizationSignature?: Hex | undefined
+  /**
+   * Machine-token-only signature for the full on-chain deposit. It lets the trusted router
+   * return policy-restricted principal without increasing the merchant's authorized capture.
+   */
+  refundSignature?: Hex | undefined
 }
 
 /**
@@ -164,6 +175,8 @@ export interface SessionVoucher {
  */
 export interface SessionSignedVoucher extends SessionVoucher {
   signature: Hex
+  /** Router-domain guard retained for scheduled machine-token settlement. */
+  authorizationSignature?: Hex | undefined
 }
 
 /**

--- a/src/tempo/session/precompile/Voucher.ts
+++ b/src/tempo/session/precompile/Voucher.ts
@@ -5,6 +5,10 @@ import { signTypedData } from 'viem/actions'
 import { Account as TempoAccount } from 'viem/tempo'
 
 import * as TempoAddress from '../../internal/address.js'
+import {
+  parseCanonicalEnvelope,
+  serializeCanonicalEnvelope,
+} from '../../internal/signature-envelope.js'
 import type { Voucher, SignedVoucher } from './Protocol.js'
 import { uint96 } from './Protocol.js'
 
@@ -58,10 +62,6 @@ function getVoucherPayload(verifyingContract: Address, chainId: number, voucher:
   })
 }
 
-function isPrimitiveEnvelope(type: string): boolean {
-  return type === 'secp256k1' || type === 'p256' || type === 'webAuthn'
-}
-
 function signCanonicalTempoVoucher(
   account: Account,
   parameters: {
@@ -109,13 +109,7 @@ export async function signVoucher(
     })
   })()
 
-  const envelope = SignatureEnvelope.from(signature as SignatureEnvelope.Serialized)
-  if (!isPrimitiveEnvelope(envelope.type))
-    throw new Error(
-      `TIP-1034 vouchers require a TIP-1020 primitive signature; received "${envelope.type}".`,
-    )
-
-  return SignatureEnvelope.serialize(envelope)
+  return serializeCanonicalEnvelope(signature, 'TIP-1034 vouchers')
 }
 
 /**
@@ -131,11 +125,8 @@ export function verifyVoucher(
   expectedSigner: Address,
 ): boolean {
   try {
-    const envelope = SignatureEnvelope.from(voucher.signature as SignatureEnvelope.Serialized)
-
-    if (!isPrimitiveEnvelope(envelope.type)) return false
-    if (SignatureEnvelope.serialize(envelope).toLowerCase() !== voucher.signature.toLowerCase())
-      return false
+    const envelope = parseCanonicalEnvelope(voucher.signature)
+    if (!envelope) return false
 
     const payload = getVoucherPayload(escrowContract, chainId, voucher)
     const signer = SignatureEnvelope.extractAddress({ payload, signature: envelope })
@@ -153,10 +144,12 @@ export function parseVoucherFromPayload(
   channelId: Hex,
   cumulativeAmount: string,
   signature: Hex,
-): SignedVoucher {
+  authorizationSignature?: Hex | undefined,
+): SignedVoucher & { authorizationSignature?: Hex | undefined } {
   return {
     channelId,
     cumulativeAmount: uint96(BigInt(cumulativeAmount)),
     signature,
+    ...(authorizationSignature ? { authorizationSignature } : {}),
   }
 }

--- a/src/tempo/session/server/ChannelStore.test.ts
+++ b/src/tempo/session/server/ChannelStore.test.ts
@@ -414,7 +414,9 @@ describe('ChannelStore state updates', () => {
   })
 
   test('finalizeClosedChannelState closes channel and records newer close voucher', () => {
+    const authorizationSignature = `0x${'aa'.repeat(65)}` as Hex
     const next = ChannelStore.finalizeClosedChannelState({
+      authorizationSignature,
       captureAmount: 60n,
       channelId: stateUpdateChannelId,
       cumulativeAmount: 70n,
@@ -429,7 +431,10 @@ describe('ChannelStore state updates', () => {
       settledOnChain: 60n,
       highestVoucherAmount: 70n,
     })
-    expect(next?.highestVoucher).toEqual(stateUpdateVoucher(70n))
+    expect(next?.highestVoucher).toEqual({
+      ...stateUpdateVoucher(70n),
+      authorizationSignature,
+    })
   })
 })
 

--- a/src/tempo/session/server/ChannelStore.ts
+++ b/src/tempo/session/server/ChannelStore.ts
@@ -73,6 +73,8 @@ export type HighestVoucherParameters = {
   cumulativeAmount: bigint
   /** Candidate voucher signature. */
   signature: Hex
+  /** Optional router-domain authorization retained for machine-token settlement. */
+  authorizationSignature?: Hex | undefined
 }
 
 /** Highest accepted voucher amount plus signed voucher payload. */
@@ -115,6 +117,8 @@ export type OpenChannelStateParameters = {
   cumulativeAmount: bigint
   /** Voucher signature for `cumulativeAmount`. */
   signature: Hex
+  /** Optional router-domain authorization for the initial machine-token voucher. */
+  authorizationSignature?: Hex | undefined
   /** Latest on-chain channel state read after open. */
   state: Chain.ChannelState
 }
@@ -161,6 +165,8 @@ export type PendingCloseUpdate = {
 
 /** Inputs for finalizing local state after a successful close transaction. */
 export type FinalizeClosedChannelParameters = {
+  /** Router authorization paired with the close voucher on machine channels. */
+  authorizationSignature?: Hex | undefined
   /** Amount captured to payee during close. */
   captureAmount: bigint
   /** Normalized channel ID. */
@@ -346,7 +352,7 @@ export function mergeActiveOnChainState(
 
 /** Keeps the existing higher voucher, otherwise stores the supplied candidate voucher. */
 export function resolveHighestVoucher(parameters: HighestVoucherParameters): HighestVoucher {
-  const { channelId, current, cumulativeAmount, signature } = parameters
+  const { authorizationSignature, channelId, current, cumulativeAmount, signature } = parameters
   if (current?.highestVoucherAmount && current.highestVoucherAmount > cumulativeAmount) {
     return {
       highestVoucherAmount: current.highestVoucherAmount,
@@ -356,7 +362,12 @@ export function resolveHighestVoucher(parameters: HighestVoucherParameters): Hig
 
   return {
     highestVoucherAmount: cumulativeAmount,
-    highestVoucher: { channelId, cumulativeAmount, signature },
+    highestVoucher: {
+      channelId,
+      cumulativeAmount,
+      signature,
+      ...(authorizationSignature ? { authorizationSignature } : {}),
+    },
   }
 }
 
@@ -386,8 +397,9 @@ export function openChannelState(parameters: OpenChannelStateParameters): State 
   const { authorizedSigner, chainId, channelId, current, descriptor, escrow, expiringNonceHash } =
     parameters
   const { state } = parameters
-  const { cumulativeAmount, signature } = parameters
+  const { authorizationSignature, cumulativeAmount, signature } = parameters
   const highestVoucher = resolveHighestVoucher({
+    authorizationSignature,
     channelId,
     current,
     cumulativeAmount,
@@ -498,9 +510,11 @@ export function markPendingClose(parameters: MarkPendingCloseParameters): Pendin
 export function finalizeClosedChannelState(
   parameters: FinalizeClosedChannelParameters,
 ): State | null {
-  const { captureAmount, channelId, cumulativeAmount, current, signature } = parameters
+  const { authorizationSignature, captureAmount, channelId, cumulativeAmount, current, signature } =
+    parameters
   if (!current) return current
   const highestVoucher = resolveHighestVoucher({
+    authorizationSignature,
     channelId,
     current,
     cumulativeAmount,

--- a/src/tempo/session/server/CredentialVerification.test.ts
+++ b/src/tempo/session/server/CredentialVerification.test.ts
@@ -1,9 +1,10 @@
-import type { Address, Hex } from 'viem'
+import { zeroAddress, type Address, type Hex } from 'viem'
 import { afterEach, describe, expect, test, vi } from 'vp/test'
 
 import * as Challenge from '../../../Challenge.js'
 import * as Store from '../../../Store.js'
-import { chainId as chainIds } from '../../internal/defaults.js'
+import * as defaults from '../../internal/defaults.js'
+import * as MachineTokenSession from '../../internal/machine-token-session.js'
 import * as Channel from '../precompile/Channel.js'
 import * as Voucher from '../precompile/Voucher.js'
 import * as ChannelStore from './ChannelStore.js'
@@ -13,7 +14,9 @@ import {
   requireSessionCredentialAction,
   requireSessionCredentialPayload,
   requireSessionCredentialPayloadHeader,
+  type ValidateCredentialPayloadParameters,
   validateChannelDescriptor,
+  validateCredentialPayload,
 } from './CredentialVerification.js'
 
 describe('SessionCredentialGuards', () => {
@@ -84,6 +87,30 @@ describe('SessionCredentialGuards', () => {
         channelId,
         cumulativeAmount: '1',
         descriptor,
+        signature,
+      })
+    })
+
+    test('preserves the optional machine-token refund authorization on close', () => {
+      const authorizationSignature = `0x${'ab'.repeat(65)}` as Hex
+      const refundSignature = `0x${'cd'.repeat(65)}` as Hex
+      expect(
+        requireSessionCredentialPayload({
+          action: 'close',
+          authorizationSignature,
+          channelId,
+          cumulativeAmount: '1',
+          descriptor,
+          refundSignature,
+          signature,
+        }),
+      ).toEqual({
+        action: 'close',
+        authorizationSignature,
+        channelId,
+        cumulativeAmount: '1',
+        descriptor,
+        refundSignature,
         signature,
       })
     })
@@ -192,7 +219,7 @@ describe('SessionCredentialGuards', () => {
 
   describe('broadcastCredentialPayload', () => {
     const escrow = '0x4D50500000000000000000000000000000000000' as Address
-    const testChainId = chainIds.testnet
+    const testChainId = defaults.chainId.testnet
     const computedChannelId = Channel.computeId({ ...descriptor, chainId: testChainId, escrow })
     const challenge = Challenge.from({
       id: 'credential-source-test',
@@ -236,6 +263,94 @@ describe('SessionCredentialGuards', () => {
         units: 0,
       }))
     }
+
+    test('binds machine descriptors to a configured route and explicit signer', async () => {
+      const deployment = defaults.machineToken[testChainId]
+      const merchant = '0x0000000000000000000000000000000000000005' as Address
+      const routePayee = '0x0000000000000000000000000000000000000006' as Address
+      const machineDescriptor = {
+        ...descriptor,
+        operator: deployment.swap,
+        payee: routePayee,
+        token: deployment.token,
+      }
+      const machineChallenge = Challenge.from({
+        ...challenge,
+        request: {
+          ...challenge.request,
+          currency: defaults.tokens.usdc,
+          recipient: merchant,
+          methodDetails: {
+            chainId: testChainId,
+            escrowContract: escrow,
+            machineTokenEnabled: true,
+          },
+        },
+      })
+      vi.spyOn(MachineTokenSession, 'matchRoute').mockImplementation(
+        async (_client, { descriptor: candidate }) =>
+          candidate.payee === routePayee
+            ? { operator: deployment.swap, payee: routePayee, token: deployment.token }
+            : undefined,
+      )
+      const parameters = (
+        candidate: Channel.ChannelDescriptor,
+      ): ValidateCredentialPayloadParameters => ({
+        challenge: machineChallenge,
+        channelStateTtl: 5_000,
+        chainId: testChainId,
+        client: {} as never,
+        escrow,
+        lastOnChainVerified: new Map(),
+        minVoucherDelta: 0n,
+        payload: {
+          action: 'voucher',
+          channelId: Channel.computeId({ ...candidate, chainId: testChainId, escrow }),
+          cumulativeAmount: '1',
+          descriptor: candidate,
+          signature,
+        },
+        store: channelStore(),
+      })
+
+      await expect(validateCredentialPayload(parameters(machineDescriptor))).rejects.toThrow(
+        'requires a router authorization',
+      )
+      await expect(broadcastCredentialPayload(parameters(machineDescriptor))).rejects.toThrow(
+        'requires a router authorization',
+      )
+      await expect(
+        validateCredentialPayload(parameters({ ...machineDescriptor, payee: descriptor.payee })),
+      ).rejects.toThrow('not bound to the challenged merchant and currency')
+      await expect(
+        validateCredentialPayload(
+          parameters({ ...machineDescriptor, authorizedSigner: zeroAddress }),
+        ),
+      ).rejects.toThrow('explicit authorizedSigner')
+
+      vi.spyOn(MachineTokenSession, 'verifyAuthorization').mockReturnValue(true)
+      const close = {
+        ...parameters(machineDescriptor),
+        challenge: Challenge.from({
+          ...machineChallenge,
+          request: {
+            ...machineChallenge.request,
+            methodDetails: { chainId: testChainId, escrowContract: escrow },
+          },
+        }),
+        payload: {
+          action: 'close' as const,
+          authorizationSignature: signature,
+          channelId: Channel.computeId({ ...machineDescriptor, chainId: testChainId, escrow }),
+          cumulativeAmount: '1',
+          descriptor: machineDescriptor,
+          refundSignature: signature,
+          signature,
+        },
+      }
+      await expect(validateCredentialPayload(close)).rejects.toThrow('channel not found')
+      await expect(broadcastCredentialPayload(close)).rejects.toThrow('channel not found')
+    })
 
     test.each([
       { label: 'payer', sourceAddress: descriptor.payer },

--- a/src/tempo/session/server/CredentialVerification.ts
+++ b/src/tempo/session/server/CredentialVerification.ts
@@ -17,6 +17,7 @@ import {
   VerificationFailedError,
 } from '../../../Errors.js'
 import type * as FeePayer from '../../internal/fee-payer.js'
+import * as MachineTokenSession from '../../internal/machine-token-session.js'
 import * as Chain from '../precompile/Chain.js'
 import { readChannelClosedReceiptFields } from '../precompile/Chain.js'
 import * as Channel from '../precompile/Channel.js'
@@ -29,24 +30,19 @@ import {
 } from '../precompile/Protocol.js'
 import * as Voucher from '../precompile/Voucher.js'
 import * as ChannelStore from './ChannelStore.js'
-import { getChallengePaymentFields } from './RequestState.js'
-import { assertSettlementSender, getClientAccount, type OnSessionSettlement } from './Settlement.js'
+import { getChallengePaymentFields, type ChallengePaymentFields } from './RequestState.js'
+import {
+  assertSettlementSender,
+  getClientAccount,
+  resolveChannelTransactionOptions,
+  type OnSessionSettlement,
+} from './Settlement.js'
 
 /** Returns the effective voucher signer for a TIP-1034 descriptor. */
 export function authorizedSigner(descriptor: Channel.ChannelDescriptor): Address {
   return isAddressEqual(descriptor.authorizedSigner, zeroAddress)
     ? descriptor.payer
     : descriptor.authorizedSigner
-}
-
-/** Asserts that a credential payload includes a TIP-1034 descriptor. */
-export function assertDescriptor(payload: {
-  descriptor?: Channel.ChannelDescriptor | undefined
-}): asserts payload is { descriptor: Channel.ChannelDescriptor } {
-  if (!payload.descriptor)
-    throw new VerificationFailedError({
-      reason: 'descriptor required for TIP-1034 session action',
-    })
 }
 
 /** Asserts that two TIP-1034 descriptors identify the same channel. */
@@ -95,6 +91,72 @@ export function validateChannelDescriptor(
     throw new VerificationFailedError({
       reason: 'channel descriptor operator does not match server operator',
     })
+  }
+}
+
+type ResolvedCredentialRoute = {
+  allowedFeeTokens: readonly [Address]
+  expectedOperator: Address
+  machineRouter?: Address | undefined
+  payment: ChallengePaymentFields
+}
+
+async function resolveCredentialRoute(parameters: {
+  challenge: Challenge.Challenge
+  chainId: number
+  client: Chain.TransactionClient
+  escrow: Address
+  expectedOperator?: Address | undefined
+  feeToken?: Address | undefined
+  payload: SessionCredentialPayload
+}): Promise<ResolvedCredentialRoute> {
+  const { challenge, chainId, client, escrow, payload } = parameters
+  const { descriptor } = payload
+  const channelId = ChannelStore.normalizeChannelId(payload.channelId)
+  if (
+    Channel.computeId({ ...descriptor, chainId, escrow }).toLowerCase() !== channelId.toLowerCase()
+  )
+    throw new VerificationFailedError({ reason: 'channel descriptor does not match channelId' })
+  const request = getChallengePaymentFields(challenge)
+  const expectedOperator = parameters.expectedOperator ?? zeroAddress
+  const direct =
+    isAddressEqual(descriptor.payee, request.recipient) &&
+    isAddressEqual(descriptor.token, request.currency) &&
+    isAddressEqual(descriptor.operator, expectedOperator)
+
+  const allowedFeeTokens = (paymentToken: Address): readonly [Address] => [
+    MachineTokenSession.resolveFeeToken({
+      chainId,
+      override: parameters.feeToken,
+      paymentToken,
+    }),
+  ]
+  if (direct)
+    return {
+      allowedFeeTokens: allowedFeeTokens(request.currency),
+      expectedOperator,
+      payment: request,
+    }
+  if (payload.action !== 'close' && !MachineTokenSession.isEnabledChallenge(challenge))
+    throw new VerificationFailedError({ reason: 'credential descriptor does not match challenge' })
+
+  const route = await MachineTokenSession.matchRoute(client, {
+    active: payload.action !== 'close',
+    chainId,
+    descriptor,
+    merchant: request.recipient,
+    targetToken: request.currency,
+  })
+  if (!route)
+    throw new VerificationFailedError({
+      reason: 'machine-token channel is not bound to the challenged merchant and currency',
+    })
+
+  return {
+    allowedFeeTokens: allowedFeeTokens(route.token),
+    expectedOperator: route.operator,
+    machineRouter: route.operator,
+    payment: { ...request, currency: route.token, recipient: route.payee },
   }
 }
 
@@ -204,6 +266,10 @@ function readHex(value: unknown, field: string): Hex {
   throw new VerificationFailedError({ reason: `invalid session credential ${field}` })
 }
 
+function readOptionalHex(value: unknown, field: string): Hex | undefined {
+  return value === undefined ? undefined : readHex(value, field)
+}
+
 function readRawAmount(value: unknown, field: string): string {
   if (typeof value === 'string' && /^[0-9]+$/.test(value)) return value
   throw new VerificationFailedError({ reason: `invalid session credential ${field}` })
@@ -275,6 +341,10 @@ export function requireSessionCredentialPayload(payload: unknown): SessionCreden
         channelId: header.channelId,
         transaction: readHex(candidate.transaction, 'transaction'),
         signature: readHex(candidate.signature, 'signature'),
+        authorizationSignature: readOptionalHex(
+          candidate.authorizationSignature,
+          'authorizationSignature',
+        ),
         descriptor: readDescriptor(candidate.descriptor),
         cumulativeAmount: readRawAmount(candidate.cumulativeAmount, 'cumulativeAmount'),
         ...(candidate.authorizedSigner === undefined
@@ -299,6 +369,10 @@ export function requireSessionCredentialPayload(payload: unknown): SessionCreden
         descriptor: readDescriptor(candidate.descriptor),
         cumulativeAmount: readRawAmount(candidate.cumulativeAmount, 'cumulativeAmount'),
         signature: readHex(candidate.signature, 'signature'),
+        authorizationSignature: readOptionalHex(
+          candidate.authorizationSignature,
+          'authorizationSignature',
+        ),
       }
     case 'close':
       return {
@@ -307,6 +381,11 @@ export function requireSessionCredentialPayload(payload: unknown): SessionCreden
         descriptor: readDescriptor(candidate.descriptor),
         cumulativeAmount: readRawAmount(candidate.cumulativeAmount, 'cumulativeAmount'),
         signature: readHex(candidate.signature, 'signature'),
+        authorizationSignature: readOptionalHex(
+          candidate.authorizationSignature,
+          'authorizationSignature',
+        ),
+        refundSignature: readOptionalHex(candidate.refundSignature, 'refundSignature'),
       }
   }
 }
@@ -338,7 +417,7 @@ export type BroadcastCredentialPayloadParameters = {
   feePayer?: viem_Account | true | undefined
   /** Optional policy for fee-sponsored close/open/top-up transactions. */
   feePayerPolicy?: Partial<FeePayer.Policy> | undefined
-  /** Optional fee token override for close transactions. */
+  /** Optional fee token override for sponsored management and settlement transactions. */
   feeToken?: Address | undefined
   /** Last successful on-chain refresh timestamp per channel ID. */
   lastOnChainVerified: Map<Hex, number>
@@ -357,10 +436,11 @@ export type VerifyCredentialPayloadParameters = BroadcastCredentialPayloadParame
 
 /** Narrows shared credential broadcast inputs to one payload action. */
 export type BroadcastCredentialActionParameters<action extends SessionCredentialPayload['action']> =
-  Omit<BroadcastCredentialPayloadParameters, 'payload'> & {
-    /** Credential payload for the selected action. */
-    payload: Extract<SessionCredentialPayload, { action: action }>
-  }
+  Omit<BroadcastCredentialPayloadParameters, 'payload'> &
+    ResolvedCredentialRoute & {
+      /** Credential payload for the selected action. */
+      payload: Extract<SessionCredentialPayload, { action: action }>
+    }
 
 /** @deprecated Use {@link BroadcastCredentialActionParameters}. */
 export type VerifyCredentialActionParameters<action extends SessionCredentialPayload['action']> =
@@ -397,6 +477,7 @@ export type ValidateCredentialPayloadParameters = Pick<
   | 'expectedOperator'
   | 'feePayer'
   | 'feePayerPolicy'
+  | 'feeToken'
   | 'lastOnChainVerified'
   | 'minVoucherDelta'
   | 'payload'
@@ -417,32 +498,30 @@ export async function validateCredentialPayload(
   parameters: ValidateCredentialPayloadParameters,
 ): Promise<CredentialPayloadValidation> {
   const { payload } = parameters
+  const context = await resolveCredentialContext(parameters)
   switch (payload.action) {
     case 'open':
-      await validateOpenCredential(parameters, payload)
+      await validateOpenCredential(context, payload)
       break
     case 'topUp':
-      await validateTopUpCredential(parameters, payload)
+      await validateTopUpCredential(context, payload)
       break
     case 'voucher':
-      await validateVoucherCredential(parameters, payload)
+      await validateVoucherCredential(context, payload)
       break
     case 'close':
-      await validateCloseCredential(parameters, payload)
+      await validateCloseCredential(context, payload)
       break
   }
   return { action: payload.action, channelId: ChannelStore.normalizeChannelId(payload.channelId) }
 }
 
 async function validateOpenCredential(
-  parameters: ValidateCredentialPayloadParameters,
+  parameters: ValidateCredentialPayloadParameters & ResolvedCredentialRoute,
   payload: Extract<SessionCredentialPayload, { action: 'open' }>,
 ) {
-  const { challenge, chainId, client, escrow } = parameters
-  const request = getChallengePaymentFields(challenge)
-  const expectedOperator = parameters.expectedOperator ?? zeroAddress
+  const { challenge, chainId, client, escrow, expectedOperator, payment: request } = parameters
   const cumulativeAmount = uint96(BigInt(payload.cumulativeAmount))
-  assertDescriptor(payload)
   if (
     payload.authorizedSigner !== undefined &&
     !isAddressEqual(payload.authorizedSigner, payload.descriptor.authorizedSigner)
@@ -461,6 +540,7 @@ async function validateOpenCredential(
     expectedOperator,
   )
   const transaction = Chain.validateOpenCredentialTransaction({
+    allowedFeeTokens: parameters.allowedFeeTokens,
     challengeExpires: challenge.expires,
     chainId,
     escrowContract: escrow,
@@ -498,14 +578,19 @@ async function validateOpenCredential(
 }
 
 async function validateTopUpCredential(
-  parameters: ValidateCredentialPayloadParameters,
+  parameters: ValidateCredentialPayloadParameters & ResolvedCredentialRoute,
   payload: Extract<SessionCredentialPayload, { action: 'topUp' }>,
 ) {
-  const { challenge, chainId, client, escrow, store } = parameters
-  const request = getChallengePaymentFields(challenge)
-  const expectedOperator = parameters.expectedOperator ?? zeroAddress
+  const {
+    challenge,
+    chainId,
+    client,
+    escrow,
+    expectedOperator,
+    payment: request,
+    store,
+  } = parameters
   const additionalDeposit = uint96(BigInt(payload.additionalDeposit))
-  assertDescriptor(payload)
   const channelId = ChannelStore.normalizeChannelId(payload.channelId)
   validateChannelDescriptor(
     payload.descriptor,
@@ -526,6 +611,7 @@ async function validateTopUpCredential(
   })
   const transaction = Chain.validateTopUpCredentialTransaction({
     additionalDeposit,
+    allowedFeeTokens: parameters.allowedFeeTokens,
     challengeExpires: challenge.expires,
     chainId,
     descriptor: channel.descriptor,
@@ -545,11 +631,10 @@ async function validateTopUpCredential(
 }
 
 async function validateVoucherCredential(
-  parameters: ValidateCredentialPayloadParameters,
+  parameters: ValidateCredentialPayloadParameters & ResolvedCredentialRoute,
   payload: Extract<SessionCredentialPayload, { action: 'voucher' }>,
 ) {
   const {
-    challenge,
     chainId,
     client,
     credentialSource,
@@ -558,16 +643,16 @@ async function validateVoucherCredential(
     store,
     channelStateTtl,
     lastOnChainVerified,
+    payment: request,
   } = parameters
-  const request = getChallengePaymentFields(challenge)
-  const expectedOperator = parameters.expectedOperator ?? zeroAddress
+  const { expectedOperator } = parameters
   const channelId = ChannelStore.normalizeChannelId(payload.channelId)
   const voucher = Voucher.parseVoucherFromPayload(
     channelId,
     payload.cumulativeAmount,
     payload.signature,
+    payload.authorizationSignature,
   )
-  assertDescriptor(payload)
   validateChannelDescriptor(
     payload.descriptor,
     channelId,
@@ -623,23 +708,87 @@ async function resolveVoucherChannelState(parameters: {
   }
 }
 
-async function validateCloseCredential(
-  parameters: ValidateCredentialPayloadParameters,
+function verifyMachineSessionAuthorization(parameters: {
+  chainId: number
+  payload: SessionCredentialPayload
+  router: Address | undefined
+}): void {
+  const { chainId, payload, router } = parameters
+  if (payload.action === 'topUp') return undefined
+  if (!router) return undefined
+  // The escrow resolves a zero authorizedSigner to the payer, but the router
+  // domain is bound to an explicit signer; reject the delegation up front
+  // instead of failing signature verification against the zero address.
+  if (isAddressEqual(payload.descriptor.authorizedSigner, zeroAddress))
+    throw new VerificationFailedError({
+      reason: 'machine-token sessions require an explicit authorizedSigner',
+    })
+  if (!payload.authorizationSignature)
+    throw new VerificationFailedError({
+      reason: 'machine-token voucher requires a router authorization',
+    })
+  const valid = MachineTokenSession.verifyAuthorization({
+    authorization: {
+      channelId: ChannelStore.normalizeChannelId(payload.channelId),
+      cumulativeAmount: uint96(BigInt(payload.cumulativeAmount)),
+    },
+    chainId,
+    expectedSigner: payload.descriptor.authorizedSigner,
+    router,
+    signature: payload.authorizationSignature,
+  })
+  if (!valid)
+    throw new InvalidSignatureError({ reason: 'invalid machine-token router authorization' })
+}
+
+async function resolveCredentialContext<
+  const parameters extends
+    | BroadcastCredentialPayloadParameters
+    | ValidateCredentialPayloadParameters,
+>(parameters: parameters): Promise<parameters & ResolvedCredentialRoute> {
+  const route = await resolveCredentialRoute(parameters)
+  verifyMachineSessionAuthorization({
+    chainId: parameters.chainId,
+    payload: parameters.payload,
+    router: route.machineRouter,
+  })
+  return { ...parameters, ...route }
+}
+
+function assertMachineCloseAmount(
+  machineRouter: Address | undefined,
+  cumulativeAmount: bigint,
+  captureAmount: bigint,
+) {
+  if (machineRouter && cumulativeAmount !== captureAmount)
+    throw new VerificationFailedError({
+      reason: `machine-token close voucher amount must equal ${captureAmount} (capture amount)`,
+    })
+}
+
+async function inspectCloseCredential(
+  parameters: ValidateCredentialPayloadParameters & ResolvedCredentialRoute,
   payload: Extract<SessionCredentialPayload, { action: 'close' }>,
 ) {
-  const { challenge, chainId, client, escrow, store } = parameters
-  const request = getChallengePaymentFields(challenge)
-  const expectedOperator = parameters.expectedOperator ?? zeroAddress
+  const {
+    account: accountOverride,
+    chainId,
+    client,
+    escrow,
+    expectedOperator,
+    machineRouter,
+    payment,
+    store,
+  } = parameters
   const cumulativeAmount = uint96(BigInt(payload.cumulativeAmount))
   const channelId = ChannelStore.normalizeChannelId(payload.channelId)
-  assertDescriptor(payload)
   validateChannelDescriptor(
     payload.descriptor,
     channelId,
     chainId,
     escrow,
-    request.recipient,
-    request.currency,
+    payment.recipient,
+    payment.currency,
     expectedOperator,
   )
   const channel = await ChannelStore.loadPrecompileChannel({
@@ -663,31 +812,70 @@ async function validateCloseCredential(
     throw new VerificationFailedError({
       reason: `close voucher amount must be >= ${state.settled} (on-chain settled)`,
     })
-  const valid = await Voucher.verifyVoucher(
-    escrow,
-    chainId,
-    { channelId, cumulativeAmount, signature: payload.signature },
-    channel.authorizedSigner,
+  if (
+    !(await Voucher.verifyVoucher(
+      escrow,
+      chainId,
+      { channelId, cumulativeAmount, signature: payload.signature },
+      channel.authorizedSigner,
+    ))
   )
-  if (!valid) throw new InvalidSignatureError({ reason: 'invalid voucher signature' })
+    throw new InvalidSignatureError({ reason: 'invalid voucher signature' })
+
+  const refundSignature = machineRouter ? payload.refundSignature : undefined
+  if (machineRouter) {
+    if (!refundSignature)
+      throw new VerificationFailedError({
+        reason: 'machine-token close requires a refund authorization',
+      })
+    if (
+      !(await Voucher.verifyVoucher(
+        escrow,
+        chainId,
+        { channelId, cumulativeAmount: uint96(state.deposit), signature: refundSignature },
+        payload.descriptor.authorizedSigner,
+      ))
+    )
+      throw new InvalidSignatureError({ reason: 'invalid machine-token refund authorization' })
+  }
+
   const captureAmount = uint96(channel.spent > state.settled ? channel.spent : state.settled)
   if (captureAmount > state.deposit)
     throw new AmountExceedsDepositError({ reason: 'close capture amount exceeds on-chain deposit' })
-  const account = parameters.account ?? getClientAccount(client)
-  assertSettlementSender({
-    operation: 'close',
+  assertMachineCloseAmount(machineRouter, cumulativeAmount, captureAmount)
+  const account = accountOverride ?? getClientAccount(client)
+  if (!machineRouter || !account)
+    assertSettlementSender({
+      operation: 'close',
+      channelId,
+      operator: channel.operator,
+      payee: channel.payee,
+      sender: account?.address,
+    })
+  return {
+    account,
+    authorizationSignature: machineRouter ? payload.authorizationSignature : undefined,
+    captureAmount,
+    channel,
     channelId,
-    operator: channel.operator,
-    payee: channel.payee,
-    sender: account?.address,
-  })
+    cumulativeAmount,
+    refundSignature,
+    state,
+  }
+}
+
+async function validateCloseCredential(
+  parameters: ValidateCredentialPayloadParameters & ResolvedCredentialRoute,
+  payload: Extract<SessionCredentialPayload, { action: 'close' }>,
+) {
+  await inspectCloseCredential(parameters, payload)
 }
 
 /** Broadcasts a validated session credential payload and applies its state transition. */
 export async function broadcastCredentialPayload(
   context: BroadcastCredentialPayloadParameters,
 ): Promise<SessionReceipt> {
-  const receipt = await broadcastCredentialAction(context)
+  const receipt = await broadcastCredentialAction(await resolveCredentialContext(context))
   if (refreshOnChainVerificationCache[context.payload.action])
     context.lastOnChainVerified.set(receipt.channelId, Date.now())
   return receipt
@@ -701,7 +889,7 @@ export async function verifyCredentialPayload(
 }
 
 function broadcastCredentialAction(
-  context: BroadcastCredentialPayloadParameters,
+  context: BroadcastCredentialPayloadParameters & ResolvedCredentialRoute,
 ): Promise<SessionReceipt> {
   const { payload } = context
   switch (payload.action) {
@@ -717,7 +905,7 @@ function broadcastCredentialAction(
 }
 
 function actionContext<action extends SessionCredentialPayload['action']>(
-  context: BroadcastCredentialPayloadParameters,
+  context: BroadcastCredentialPayloadParameters & ResolvedCredentialRoute,
   payload: Extract<SessionCredentialPayload, { action: action }>,
 ): BroadcastCredentialActionParameters<action> {
   return { ...context, payload }
@@ -726,11 +914,17 @@ function actionContext<action extends SessionCredentialPayload['action']>(
 async function handleOpenCredential(
   parameters: OpenCredentialActionParameters,
 ): Promise<SessionReceipt> {
-  const { store, client, challenge, payload, chainId, escrow } = parameters
-  const request = getChallengePaymentFields(challenge)
-  const expectedOperator = parameters.expectedOperator ?? zeroAddress
+  const {
+    store,
+    client,
+    challenge,
+    payload,
+    chainId,
+    escrow,
+    expectedOperator,
+    payment: request,
+  } = parameters
   const cumulativeAmount = uint96(BigInt(payload.cumulativeAmount))
-  assertDescriptor(payload)
   if (
     payload.authorizedSigner !== undefined &&
     !isAddressEqual(payload.authorizedSigner, payload.descriptor.authorizedSigner)
@@ -750,6 +944,7 @@ async function handleOpenCredential(
   )
 
   const result = await Chain.broadcastOpenTransaction({
+    allowedFeeTokens: parameters.allowedFeeTokens,
     challengeExpires: challenge.expires,
     chainId,
     client,
@@ -797,6 +992,7 @@ async function handleOpenCredential(
       expiringNonceHash: result.expiringNonceHash,
       cumulativeAmount,
       signature: payload.signature,
+      authorizationSignature: payload.authorizationSignature,
       state,
     }),
   )
@@ -814,11 +1010,17 @@ async function handleOpenCredential(
 async function handleTopUpCredential(
   parameters: TopUpCredentialActionParameters,
 ): Promise<SessionReceipt> {
-  const { store, client, challenge, payload, chainId, escrow } = parameters
-  const request = getChallengePaymentFields(challenge)
-  const expectedOperator = parameters.expectedOperator ?? zeroAddress
+  const {
+    store,
+    client,
+    challenge,
+    payload,
+    chainId,
+    escrow,
+    expectedOperator,
+    payment: request,
+  } = parameters
   const additionalDeposit = uint96(BigInt(payload.additionalDeposit))
-  assertDescriptor(payload)
   const channelId = ChannelStore.normalizeChannelId(payload.channelId)
   validateChannelDescriptor(
     payload.descriptor,
@@ -839,6 +1041,7 @@ async function handleTopUpCredential(
   })
   const result = await Chain.broadcastTopUpTransaction({
     additionalDeposit,
+    allowedFeeTokens: parameters.allowedFeeTokens,
     challengeExpires: challenge.expires,
     chainId,
     client,
@@ -880,16 +1083,16 @@ async function handleVoucherCredential(
     minVoucherDelta,
     channelStateTtl,
     lastOnChainVerified,
+    payment: request,
   } = parameters
-  const request = getChallengePaymentFields(challenge)
-  const expectedOperator = parameters.expectedOperator ?? zeroAddress
+  const { expectedOperator } = parameters
   const channelId = ChannelStore.normalizeChannelId(payload.channelId)
   const voucher = Voucher.parseVoucherFromPayload(
     channelId,
     payload.cumulativeAmount,
     payload.signature,
+    payload.authorizationSignature,
   )
-  assertDescriptor(payload)
   validateChannelDescriptor(
     payload.descriptor,
     channelId,
@@ -944,52 +1147,18 @@ async function handleVoucherCredential(
 async function handleCloseCredential(
   parameters: CloseCredentialActionParameters,
 ): Promise<SessionReceipt> {
-  const { store, client, challenge, payload, chainId, escrow } = parameters
-  const request = getChallengePaymentFields(challenge)
-  const expectedOperator = parameters.expectedOperator ?? zeroAddress
-  const cumulativeAmount = uint96(BigInt(payload.cumulativeAmount))
-  const channelId = ChannelStore.normalizeChannelId(payload.channelId)
-  assertDescriptor(payload)
-  validateChannelDescriptor(
-    payload.descriptor,
+  const { store, client, challenge, payload, escrow, machineRouter } = parameters
+  const inspected = await inspectCloseCredential(parameters, payload)
+  const {
+    account,
+    authorizationSignature,
+    channel,
     channelId,
-    chainId,
-    escrow,
-    request.recipient,
-    request.currency,
-    expectedOperator,
-  )
-  const channel = await ChannelStore.loadPrecompileChannel({
-    descriptor: payload.descriptor,
-    channelId,
-    chainId,
-    escrow,
-    store,
-  })
-  if (channel.finalized) throw new ChannelClosedError({ reason: 'channel is already finalized' })
-  const state = await Chain.getChannelState(client, channelId, escrow)
-  if (state.closeRequestedAt !== 0)
-    throw new ChannelClosedError({ reason: 'channel has a pending close request' })
-  if (state.deposit === 0n && (cumulativeAmount !== 0n || channel.spent !== 0n))
-    throw new ChannelClosedError({ reason: 'channel deposit is zero (settled)' })
-  if (cumulativeAmount < channel.spent)
-    throw new VerificationFailedError({
-      reason: `close voucher amount must be >= ${channel.spent} (spent)`,
-    })
-  if (cumulativeAmount < state.settled)
-    throw new VerificationFailedError({
-      reason: `close voucher amount must be >= ${state.settled} (on-chain settled)`,
-    })
-  const valid = await Voucher.verifyVoucher(
-    escrow,
-    chainId,
-    { channelId, cumulativeAmount: cumulativeAmount, signature: payload.signature },
-    channel.authorizedSigner,
-  )
-  if (!valid) throw new InvalidSignatureError({ reason: 'invalid voucher signature' })
-  let captureAmount = uint96(channel.spent > state.settled ? channel.spent : state.settled)
-  if (captureAmount > state.deposit)
-    throw new AmountExceedsDepositError({ reason: 'close capture amount exceeds on-chain deposit' })
+    cumulativeAmount,
+    refundSignature,
+    state,
+  } = inspected
+  let { captureAmount } = inspected
   const pendingCloseStartedAt = BigInt(Math.floor(Date.now() / 1000) || 1)
   const previousCloseRequestedAt = channel.closeRequestedAt
   let pendingCloseMarked = false
@@ -1002,39 +1171,42 @@ async function handleCloseCredential(
       onChainSettled: state.settled,
     })
     if (next.state) {
+      assertMachineCloseAmount(machineRouter, cumulativeAmount, next.captureAmount)
       captureAmount = next.captureAmount
       pendingCloseMarked = true
     }
     return next.state
   })
-  const account = parameters.account ?? getClientAccount(client)
   let txHash: Hex | undefined
   let receipt: Awaited<ReturnType<typeof Chain.waitForSuccessfulReceipt>>
   try {
-    assertSettlementSender({
-      operation: 'close',
-      channelId,
-      operator: channel.operator,
-      payee: channel.payee,
-      sender: account?.address,
-    })
-    txHash = await Chain.closeOnChain(
-      client,
-      channel.descriptor,
-      cumulativeAmount,
-      captureAmount,
-      payload.signature,
-      escrow,
-      account
-        ? {
-            account,
-            ...(parameters.feePayer ? { feePayer: parameters.feePayer } : {}),
-            ...(parameters.feePayerPolicy ? { feePayerPolicy: parameters.feePayerPolicy } : {}),
-            ...(parameters.feeToken ? { feeToken: parameters.feeToken } : {}),
-            candidateFeeTokens: [channel.token],
-          }
-        : undefined,
-    )
+    const transactionOptions = resolveChannelTransactionOptions(channel, parameters, account)
+    if (machineRouter) {
+      if (!authorizationSignature || !refundSignature)
+        throw new VerificationFailedError({
+          reason: 'machine-token close requires router and refund authorizations',
+        })
+      txHash = await Chain.closeMachineSessionOnChain(
+        client,
+        channel.descriptor,
+        cumulativeAmount,
+        payload.signature,
+        authorizationSignature,
+        refundSignature,
+        machineRouter,
+        transactionOptions,
+      )
+    } else {
+      txHash = await Chain.closeOnChain(
+        client,
+        channel.descriptor,
+        cumulativeAmount,
+        captureAmount,
+        payload.signature,
+        escrow,
+        transactionOptions,
+      )
+    }
     receipt = await Chain.waitForSuccessfulReceipt(client, txHash)
   } catch (error) {
     if (pendingCloseMarked) {
@@ -1050,10 +1222,18 @@ async function handleCloseCredential(
     Chain.getChannelEvent(receipt, 'ChannelClosed', channelId),
   )
   const { refundedToPayer, settledToPayee } = closed
-  if (settledToPayee > captureAmount || settledToPayee + refundedToPayer > state.deposit)
+  if (machineRouter) {
+    if (settledToPayee !== state.deposit || refundedToPayer !== 0n)
+      throw new VerificationFailedError({
+        reason: 'machine-token ChannelClosed amounts are invalid',
+      })
+  } else if (settledToPayee > captureAmount || settledToPayee + refundedToPayer > state.deposit) {
     throw new VerificationFailedError({ reason: 'ChannelClosed amounts do not match state' })
+  }
+  const logicalSettled = machineRouter ? captureAmount : settledToPayee
   const updated = await store.updateChannel(channelId, (current) =>
     ChannelStore.finalizeClosedChannelState({
+      authorizationSignature,
       captureAmount,
       channelId,
       cumulativeAmount,
@@ -1068,8 +1248,8 @@ async function handleCloseCredential(
           txHash,
           channelId,
           trigger: 'close' as const,
-          amount: settledToPayee,
-          delta: settledToPayee - state.settled,
+          amount: logicalSettled,
+          delta: logicalSettled - state.settled,
         }),
       )
     } catch {

--- a/src/tempo/session/server/RequestState.test.ts
+++ b/src/tempo/session/server/RequestState.test.ts
@@ -1,6 +1,6 @@
 import type { Address, Hex } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { describe, expect, test } from 'vp/test'
+import { describe, expect, test, vi } from 'vp/test'
 
 import type * as Credential from '../../../Credential.js'
 import type { SessionCredentialPayload } from '../precompile/Protocol.js'
@@ -542,6 +542,40 @@ describe('SessionSnapshotHints', () => {
           item.name,
         ).resolves.toBeUndefined()
       }
+    })
+
+    test('uses alternate descriptor matchers only as optional reuse hints', async () => {
+      const logicalRecipient = '0x0000000000000000000000000000000000000005' as Address
+      const logicalCurrency = '0x0000000000000000000000000000000000000006' as Address
+      const matchPaymentFields = vi.fn(() => true)
+      const parameters = {
+        amount: 50n,
+        channelId,
+        expected: {
+          chainId: 4217,
+          currency: logicalCurrency,
+          escrowContract,
+          recipient: logicalRecipient,
+        },
+        store: store(channel()),
+      }
+
+      await expect(resolveSessionSnapshot({ ...parameters, matchPaymentFields })).resolves.toEqual(
+        expect.objectContaining({ descriptor }),
+      )
+      expect(matchPaymentFields).toHaveBeenCalledWith(
+        expect.objectContaining({ descriptor }),
+        expect.objectContaining({ currency: logicalCurrency, recipient: logicalRecipient }),
+      )
+
+      await expect(
+        resolveSessionSnapshot({
+          ...parameters,
+          matchPaymentFields: async () => {
+            throw new Error('rpc unavailable')
+          },
+        }),
+      ).resolves.toBeUndefined()
     })
 
     test('omits hints for missing, non-precompile, closing, or finalized channels', async () => {

--- a/src/tempo/session/server/RequestState.ts
+++ b/src/tempo/session/server/RequestState.ts
@@ -11,6 +11,7 @@ import * as Constants from '../../../Constants.js'
 import type * as Credential from '../../../Credential.js'
 import { VerificationFailedError } from '../../../Errors.js'
 import type { Challenge } from '../../../index.js'
+import type { MaybePromise } from '../../../internal/types.js'
 import type * as z from '../../../zod.js'
 import * as Methods from '../../Methods.js'
 import {
@@ -38,6 +39,8 @@ export type ResolveSessionSnapshotParameters = {
   channelId: Hex | undefined
   /** Payment fields the reusable channel must match before it is advertised. */
   expected?: SessionSnapshotPaymentFields | undefined
+  /** Optional alternate-rail matcher when the stored descriptor differs from logical payment fields. */
+  matchPaymentFields?: MatchSessionSnapshotPaymentFields | undefined
   /** Server channel store. */
   store: ChannelStore.ChannelStore
 }
@@ -53,6 +56,12 @@ export type SessionSnapshotPaymentFields = {
   /** Payee address expected by the challenge. */
   recipient: Address
 }
+
+/** Validates an alternate channel descriptor against the logical session payment fields. */
+export type MatchSessionSnapshotPaymentFields = (
+  channel: ChannelStore.StoredPrecompileChannel,
+  expected: SessionSnapshotPaymentFields,
+) => MaybePromise<boolean>
 
 /** Request metadata available to `resolveChannelId` without exposing a mutable `Request`. */
 export type SessionChannelIdRequest = {
@@ -138,7 +147,7 @@ export async function resolveSessionChannelId(parameters: {
 export async function resolveSessionSnapshot(
   parameters: ResolveSessionSnapshotParameters,
 ): Promise<SessionSnapshot | undefined> {
-  const { amount, channelId, expected, store } = parameters
+  const { amount, channelId, expected, matchPaymentFields, store } = parameters
   if (!channelId) return undefined
   const channel = await store.getChannel(ChannelStore.normalizeChannelId(channelId))
   if (!channel || !ChannelStore.isPrecompileState(channel)) return undefined
@@ -146,7 +155,16 @@ export async function resolveSessionSnapshot(
   if (channel.closeRequestedAt !== 0n) return undefined
   if (!channel.highestVoucher) return undefined
   if (channel.highestVoucher.cumulativeAmount !== channel.highestVoucherAmount) return undefined
-  if (expected && !matchesSnapshotPaymentFields(channel, expected)) return undefined
+  if (expected && !matchesSnapshotPaymentFields(channel, expected)) {
+    // The snapshot is an optional reuse hint: a failing matcher (for example a
+    // transient RPC error during the route check) must omit the hint rather
+    // than fail challenge issuance or bootstrap preflight.
+    let matched = false
+    try {
+      matched = (await matchPaymentFields?.(channel, expected)) ?? false
+    } catch {}
+    if (!matched) return undefined
+  }
   const requiredCumulative = channel.spent + amount
   return {
     acceptedCumulative: channel.highestVoucherAmount.toString(),
@@ -242,6 +260,10 @@ export type SessionMethodDetails = {
   escrowContract: Address
   /** Whether this challenge allows fee-sponsored management transactions. */
   feePayer?: boolean | undefined
+  /** Fee token clients must use for open/top-up transactions. */
+  feeToken?: Address | undefined
+  /** Whether clients may fund this logical session through the first-party machine-token rail. */
+  machineTokenEnabled?: boolean | undefined
   /** Minimum raw-unit increase required for voucher credentials. */
   minVoucherDelta?: string | undefined
   /** Channel operator address the client should encode in new open transactions. */
@@ -264,6 +286,7 @@ export type ResolveSessionPaymentRequestParameters = {
   decimals: number
   defaultFeePayer?: viem_Account | undefined
   getClient: ResolveRequestChainIdParameters['getClient']
+  matchSnapshotPaymentFields?: MatchSessionSnapshotPaymentFields | undefined
   parameterChainId?: number | undefined
   parameterEscrowContract?: Address | undefined
   parameterFeePayer?: ParameterFeePayer
@@ -328,6 +351,9 @@ function isCanonicalSessionMethodDetails(value: unknown): value is SessionMethod
     typeof value.escrowContract === 'string' &&
     isAddress(value.escrowContract, { strict: false }) &&
     (value.feePayer === undefined || typeof value.feePayer === 'boolean') &&
+    (value.feeToken === undefined ||
+      (typeof value.feeToken === 'string' && isAddress(value.feeToken, { strict: false }))) &&
+    (value.machineTokenEnabled === undefined || typeof value.machineTokenEnabled === 'boolean') &&
     (value.minVoucherDelta === undefined || typeof value.minVoucherDelta === 'string') &&
     (value.operator === undefined ||
       (typeof value.operator === 'string' && isAddress(value.operator, { strict: false }))) &&
@@ -384,6 +410,7 @@ export async function resolveSessionPaymentRequest(
     decimals,
     defaultFeePayer,
     getClient,
+    matchSnapshotPaymentFields,
     parameterChainId,
     parameterEscrowContract,
     parameterFeePayer,
@@ -427,6 +454,7 @@ export async function resolveSessionPaymentRequest(
       escrowContract,
       recipient: readChallengeAddress(request.recipient, 'recipient'),
     },
+    matchPaymentFields: request.machineTokenEnabled ? matchSnapshotPaymentFields : undefined,
     store,
   })
   const { operator: _operator, ...requestWithoutOperator } = request

--- a/src/tempo/session/server/Session.test.ts
+++ b/src/tempo/session/server/Session.test.ts
@@ -28,6 +28,8 @@ import * as Http from '~test/Http.js'
 import * as NodeRequest from '../../../server/Request.js'
 import * as Store from '../../../Store.js'
 import { charge as clientCharge } from '../../client/Charge.js'
+import * as defaults from '../../internal/defaults.js'
+import * as MachineTokenSession from '../../internal/machine-token-session.js'
 import * as Methods from '../../Methods.js'
 import * as ClientOps from '../client/ChannelOps.js'
 import { sessionManager as precompileSessionManager } from '../client/SessionManager.js'
@@ -280,6 +282,9 @@ async function createOpenPayload(
     account?: typeof payer | undefined
     operator?: Address | undefined
     authorizedSigner?: Address | undefined
+    feeToken?: Address | undefined
+    payee?: Address | undefined
+    token?: Address | undefined
   } = {},
 ): Promise<Extract<SessionCredentialPayload, { action: 'open' }>> {
   const account = parameters.account ?? payer
@@ -289,16 +294,18 @@ async function createOpenPayload(
   const salt = `0x${(++saltCounter).toString(16).padStart(64, '0')}` as Hex
   const operator = parameters.operator ?? zeroAddress
   const authorizedSigner = parameters.authorizedSigner ?? account.address
+  const channelPayee = parameters.payee ?? payee
+  const channelToken = parameters.token ?? token
   const data = encodeFunctionData({
     abi: escrowAbi,
     functionName: 'open',
-    args: [payee, operator, token, deposit, salt, authorizedSigner],
+    args: [channelPayee, operator, channelToken, deposit, salt, authorizedSigner],
   })
   const signingClient = createSigningClient(account)
   const transaction = (await Transaction.serialize({
     chainId,
     calls: [{ to: escrow, data }],
-    feeToken: token,
+    feeToken: parameters.feeToken ?? channelToken,
     nonce: 0,
   })) as Hex
   const expiringNonceHash = Channel.computeExpiringNonceHash(
@@ -309,9 +316,9 @@ async function createOpenPayload(
   )
   const descriptor = {
     payer: account.address,
-    payee,
+    payee: channelPayee,
     operator,
-    token,
+    token: channelToken,
     salt,
     authorizedSigner,
     expiringNonceHash,
@@ -360,10 +367,10 @@ function sponsorTransaction(
   }) as Hex
 }
 
-async function createSponsoredOpenPayload(): Promise<
-  Extract<SessionCredentialPayload, { action: 'open' }>
-> {
-  const payload = await createOpenPayload()
+async function createSponsoredOpenPayload(
+  feeToken?: Address | undefined,
+): Promise<Extract<SessionCredentialPayload, { action: 'open' }>> {
+  const payload = await createOpenPayload({ feeToken })
   const transaction = sponsorTransaction(payload.transaction)
   const signed = Transaction.deserialize(transaction as Transaction.TransactionSerializedTempo)
   const expiringNonceHash = Channel.computeExpiringNonceHash(
@@ -520,8 +527,8 @@ async function persistPrecompileChannel(
     escrowContract: tip20ChannelEscrow,
     closeRequestedAt: 0n,
     payer: payload.descriptor.payer,
-    payee,
-    token,
+    payee: payload.descriptor.payee,
+    token: payload.descriptor.token,
     authorizedSigner: payload.descriptor.authorizedSigner,
     deposit: 1_000n,
     settledOnChain: 0n,
@@ -560,6 +567,38 @@ describe('precompile server session unit guardrails', () => {
 
     expect(challengeRequest.sessionProtocol).toBe(Constants.SessionProtocols.v2)
   })
+
+  test.each([
+    { chainId, escrowContract: tip20ChannelEscrow, enabled: true },
+    { chainId: 69_420, escrowContract: tip20ChannelEscrow, enabled: false },
+    {
+      chainId,
+      escrowContract: '0x9999999999999999999999999999999999999999' as Address,
+      enabled: false,
+    },
+  ])(
+    'advertises machine-token sessions only for configured canonical deployments',
+    async ({ chainId: requestChainId, escrowContract, enabled }) => {
+      const { method } = createServer({
+        chainId: requestChainId,
+        escrowContract: escrowContract as Address,
+        getClient: () => ({ chain: { id: requestChainId } }) as never,
+        machineTokenEnabled: true,
+      })
+      const resolved = await method.request!({
+        credential: null,
+        request: {
+          amount: '1',
+          currency: token,
+          decimals: 0,
+          machineTokenEnabled: true,
+          recipient: payee,
+          unitType: 'request',
+        },
+      } as never)
+      expect(resolved.machineTokenEnabled).toBe(enabled ? true : undefined)
+    },
+  )
 
   test('request normalizes fee-payer to boolean for challenge issuance and account for verification', async () => {
     const { method } = createServer({ feePayer: wrongPayer })
@@ -676,6 +715,45 @@ describe('precompile server session unit guardrails', () => {
       units: 2,
     })
   })
+
+  test.each([
+    { configured: false, requested: true, reused: true },
+    { configured: true, requested: false, reused: false },
+  ])(
+    'machine snapshot reuse follows the resolved request capability',
+    async ({ configured, requested, reused }) => {
+      const deployment = defaults.machineToken[chainId]
+      const routePayee = '0x0000000000000000000000000000000000000006' as Address
+      const openPayload = await createOpenPayload({
+        operator: deployment.swap,
+        payee: routePayee,
+        token: deployment.token,
+      })
+      const { method, store } = createServer({ machineTokenEnabled: configured })
+      await persistPrecompileChannel(store, openPayload)
+      vi.spyOn(MachineTokenSession, 'matchRoute').mockResolvedValue({
+        operator: deployment.swap,
+        payee: routePayee,
+        token: deployment.token,
+      })
+
+      const request = await method.request!({
+        credential: null,
+        request: {
+          amount: '1',
+          channelId: openPayload.channelId,
+          currency: token,
+          decimals: 0,
+          machineTokenEnabled: requested,
+          recipient: payee,
+          unitType: 'request',
+        },
+      } as never)
+
+      expect(request.sessionSnapshot?.channelId).toBe(reused ? openPayload.channelId : undefined)
+      expect(request.machineTokenEnabled).toBe(requested ? true : undefined)
+    },
+  )
 
   test('request can resolve a server session snapshot from request identity', async () => {
     const openPayload = await createOpenPayload({ initialAmount: 100n })
@@ -910,6 +988,35 @@ describe('precompile server session unit guardrails', () => {
       deposit: 1_000n,
       highestVoucherAmount: 100n,
     })
+  })
+
+  test('advertises and accepts a configured fee token for sponsored credentials', async () => {
+    const feeToken = defaults.tokens.pathUsd
+    const { method, rpcCalls } = createServer({ feePayer: payer, feeToken })
+    const payload = await createSponsoredOpenPayload(feeToken)
+    const request = Methods.session.schema.request.parse(
+      await method.request!({
+        credential: null,
+        request: {
+          amount: '100',
+          currency: token,
+          decimals: 0,
+          recipient: payee,
+          unitType: 'request',
+        },
+      } as never),
+    )
+
+    await method.validate!({
+      credential: {
+        challenge: { ...makeChallenge(payload.channelId), request },
+        payload,
+      },
+      request: request as unknown as VerifyRequest,
+    })
+
+    expect(request.methodDetails.feeToken).toBe(feeToken)
+    expect(rpcCalls).toEqual([])
   })
 
   test('rejects sponsored credentials that exceed the fee-payer policy during validation', async () => {

--- a/src/tempo/session/server/Session.ts
+++ b/src/tempo/session/server/Session.ts
@@ -5,7 +5,7 @@
  * and one-shot settlement. Each incoming request carries a session credential
  * with a cumulative voucher that the server validates and records.
  */
-import { isAddress, type Address, type Hex } from 'viem'
+import { isAddress, isAddressEqual, type Address, type Hex } from 'viem'
 import { tempo as tempo_chain } from 'viem/chains'
 
 import * as Challenge from '../../../Challenge.js'
@@ -21,6 +21,7 @@ import * as Client from '../../../viem/Client.js'
 import * as Account from '../../internal/account.js'
 import * as defaults from '../../internal/defaults.js'
 import * as FeePayer from '../../internal/fee-payer.js'
+import * as MachineTokenSession from '../../internal/machine-token-session.js'
 import type * as types from '../../internal/types.js'
 import * as Methods from '../../Methods.js'
 import * as ChargeServer from '../../server/Charge.js'
@@ -36,6 +37,7 @@ import { requireSessionCredentialPayload } from './CredentialVerification.js'
 import {
   type ResolveSessionChannelId,
   resolveCredentialVerificationContext,
+  type MatchSessionSnapshotPaymentFields,
   resolveSessionChannelId,
   resolveSessionSnapshot,
   resolveSessionPaymentRequest,
@@ -71,6 +73,7 @@ type SessionDefaultValues = {
   amount: session.Parameters['amount']
   currency: session.Parameters['currency']
   decimals: number
+  machineTokenEnabled: boolean | undefined
   operator: session.Parameters['operator']
   recipient: Address | undefined
   suggestedDeposit: session.Parameters['suggestedDeposit']
@@ -105,6 +108,7 @@ type BootstrapPreflightParameters = {
     chainId?: number | undefined
   }): MaybePromise<{ chain?: { id?: number | undefined } | undefined }>
   input: Request
+  matchSnapshotPaymentFields?: MatchSessionSnapshotPaymentFields | undefined
   parameterChainId?: number | undefined
   parameterEscrowContract?: Address | undefined
   paymentRequest: SessionPaymentRequestInput
@@ -297,6 +301,9 @@ async function handleBootstrapPreflight(
       ),
       recipient: readBootstrapAddress(request.recipient, 'recipient'),
     },
+    matchPaymentFields: parameters.paymentRequest.machineTokenEnabled
+      ? parameters.matchSnapshotPaymentFields
+      : undefined,
     store: parameters.store,
   })
   const headers = new Headers({ 'Cache-Control': 'no-store' })
@@ -317,6 +324,7 @@ export function session<const parameters extends session.Parameters>(
     channelStateTtl = 5_000,
     currency = defaults.resolveCurrency(parameters),
     decimals = defaults.decimals,
+    machineTokenEnabled,
     operator,
     store: rawStore = Store.memory(),
     suggestedDeposit,
@@ -336,6 +344,24 @@ export function session<const parameters extends session.Parameters>(
     getClient: parameters.getClient,
     rpcUrl: defaults.rpcUrl,
   })
+  const matchSnapshotPaymentFields: MatchSessionSnapshotPaymentFields = async (
+    channel,
+    expected,
+  ) => {
+    if (
+      channel.chainId !== expected.chainId ||
+      !isAddressEqual(channel.escrowContract, expected.escrowContract) ||
+      !isAddressEqual(expected.escrowContract, tip20ChannelEscrow)
+    )
+      return false
+    return !!(await MachineTokenSession.matchRoute(await getClient({ chainId: expected.chainId }), {
+      active: true,
+      chainId: expected.chainId,
+      descriptor: channel.descriptor,
+      merchant: expected.recipient,
+      targetToken: expected.currency,
+    }))
+  }
   const settleScheduled: SettleChargedSessionChannel = async (channel) => {
     if (!isSettlementDue(channel, settlementSchedule)) return undefined
     return maybeSettleScheduled({
@@ -400,6 +426,7 @@ export function session<const parameters extends session.Parameters>(
       expectedOperator: context.methodDetails.operator,
       feePayer: context.feePayer,
       feePayerPolicy: parameters.feePayerPolicy,
+      feeToken: context.methodDetails.feeToken,
       lastOnChainVerified,
       minVoucherDelta: context.minVoucherDelta,
       payload,
@@ -443,7 +470,7 @@ export function session<const parameters extends session.Parameters>(
       expectedOperator: context.methodDetails.operator,
       feePayer: context.feePayer,
       feePayerPolicy: parameters.feePayerPolicy,
-      feeToken: parameters.feeToken,
+      feeToken: context.methodDetails.feeToken,
       lastOnChainVerified,
       minVoucherDelta: context.minVoucherDelta,
       onSessionSettlement,
@@ -488,6 +515,7 @@ export function session<const parameters extends session.Parameters>(
       amount,
       currency,
       decimals,
+      machineTokenEnabled,
       operator,
       recipient,
       suggestedDeposit,
@@ -510,6 +538,7 @@ export function session<const parameters extends session.Parameters>(
             defaultRecipient: recipient,
             expires,
             getClient,
+            matchSnapshotPaymentFields,
             parameterChainId: parameters.chainId,
             parameterEscrowContract: parameters.escrowContract,
             paymentRequest: options,
@@ -528,6 +557,7 @@ export function session<const parameters extends session.Parameters>(
         decimals,
         defaultFeePayer: feePayer,
         getClient,
+        matchSnapshotPaymentFields,
         parameterChainId: parameters.chainId,
         parameterEscrowContract: parameters.escrowContract,
         parameterFeePayer: parameters.feePayer,
@@ -535,8 +565,19 @@ export function session<const parameters extends session.Parameters>(
         resolveChannelId: parameters.resolveChannelId,
         store,
       })
+      // Only advertise the capability when this logical session can use a
+      // configured unified router on the canonical escrow.
+      const { machineTokenEnabled: requestedMachineTokenEnabled, ...requestWithoutMachineToken } =
+        resolvedRequest
+      const machineSessionSupported =
+        MachineTokenSession.isSupported(resolvedRequest.chainId) &&
+        isAddressEqual(resolvedRequest.escrowContract, tip20ChannelEscrow)
       return {
-        ...resolvedRequest,
+        ...requestWithoutMachineToken,
+        feeToken: parameters.feeToken,
+        ...(requestedMachineTokenEnabled && machineSessionSupported
+          ? { machineTokenEnabled: true }
+          : {}),
         sessionProtocol: Constants.SessionProtocols.v2,
       }
     },
@@ -634,8 +675,10 @@ export namespace session {
     /** Server-owned automatic settlement cadence. Clients do not receive or control this schedule. */
     settlementSchedule?: SettlementSchedule | undefined
 
-    /** Optional fee token used for server-driven close transactions. */
+    /** Optional fee token for management and server-driven settle/close transactions. */
     feeToken?: Address | undefined
+    /** Enables first-party machine-token funding when the configured deployment is available. */
+    machineTokenEnabled?: boolean | undefined
   } & Account.resolve.Parameters &
     Client.getResolver.Parameters &
     Defaults &

--- a/src/tempo/session/server/Settlement.test.ts
+++ b/src/tempo/session/server/Settlement.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test, vi } from 'vp/test'
 import * as Challenge from '../../../Challenge.js'
 import type * as Credential from '../../../Credential.js'
 import type * as Method from '../../../Method.js'
+import * as defaults from '../../internal/defaults.js'
 import { createSessionReceipt } from '../precompile/Protocol.js'
 import type * as ChannelStore from './ChannelStore.js'
 import {
@@ -12,6 +13,7 @@ import {
   isSettlementDue,
   readRequestFeePayer,
   resolveCredentialFeePayer,
+  resolveChannelTransactionOptions,
   resolveRequestFeePayer,
   resolveSettlementProgress,
 } from './Settlement.js'
@@ -170,6 +172,37 @@ describe('FeePayerResolution', () => {
           request: { feePayer: {} },
         }),
       ).toBe(defaultFeePayer)
+    })
+
+    test('derives settlement fee tokens from the channel token', () => {
+      const chainId = defaults.chainId.mainnet
+      expect(
+        resolveChannelTransactionOptions(
+          {
+            chainId,
+            token: defaults.machineToken[chainId].token,
+          },
+          undefined,
+          defaultFeePayer,
+        ),
+      ).toMatchObject({
+        candidateFeeTokens: [defaults.tokens.pathUsd],
+        feeToken: defaults.tokens.pathUsd,
+      })
+      expect(
+        resolveChannelTransactionOptions(
+          {
+            chainId,
+            token: defaults.tokens.usdc,
+          },
+          { feePayer: true },
+          defaultFeePayer,
+        ),
+      ).toMatchObject({
+        candidateFeeTokens: [defaults.tokens.usdc],
+        feePayer: true,
+        feeToken: defaults.tokens.usdc,
+      })
     })
   })
 })

--- a/src/tempo/session/server/Settlement.ts
+++ b/src/tempo/session/server/Settlement.ts
@@ -20,6 +20,7 @@ import type { MaybePromise } from '../../../internal/types.js'
 import type * as Method from '../../../Method.js'
 import * as Store from '../../../Store.js'
 import type * as FeePayer from '../../internal/fee-payer.js'
+import * as MachineTokenSession from '../../internal/machine-token-session.js'
 import { isSessionContentRequest } from '../../server/internal/request-body.js'
 import * as Chain from '../precompile/Chain.js'
 import { readSettledReceiptFields } from '../precompile/Chain.js'
@@ -406,6 +407,30 @@ export function assertSettlementSender(parameters: SettlementSenderParameters) {
   })
 }
 
+/**
+ * Assembles transaction options for settle/close transactions. Direct
+ * channels pay fees in their payment token; machine channels use PathUSD.
+ */
+export function resolveChannelTransactionOptions(
+  channel: Pick<ChannelStore.StoredPrecompileChannel, 'chainId' | 'token'>,
+  options: SettlementTransactionOptions | undefined,
+  account: viem_Account | undefined,
+): Chain.ChannelTransactionOptions | undefined {
+  if (!account) return undefined
+  const feeToken = MachineTokenSession.resolveFeeToken({
+    chainId: channel.chainId,
+    override: options?.feeToken,
+    paymentToken: channel.token,
+  })
+  return {
+    account,
+    ...(options?.feePayer ? { feePayer: options.feePayer } : {}),
+    ...(options?.feePayerPolicy ? { feePayerPolicy: options.feePayerPolicy } : {}),
+    feeToken,
+    candidateFeeTokens: options?.candidateFeeTokens ?? [feeToken],
+  }
+}
+
 /** Applies automatic settlement when the server-owned schedule is due. */
 export async function maybeSettleScheduled(
   parameters: MaybeSettleScheduledParameters,
@@ -441,30 +466,46 @@ export async function settle(
   if (!channel.highestVoucher) throw new VerificationFailedError({ reason: 'no voucher to settle' })
   const escrow = options?.escrowContract ?? channel.escrowContract
   const account = options?.account ?? getClientAccount(client)
-  assertSettlementSender({
-    operation: 'settle',
-    channelId,
-    operator: channel.operator,
-    payee: channel.payee,
-    sender: account?.address,
-  })
+  const machineRouter = MachineTokenSession.matchDeployment({
+    chainId: channel.chainId,
+    descriptor: channel.descriptor,
+  })?.swap
+  if (!machineRouter || !account)
+    assertSettlementSender({
+      operation: 'settle',
+      channelId,
+      operator: channel.operator,
+      payee: channel.payee,
+      sender: account?.address,
+    })
   const amount = uint96(channel.highestVoucher.cumulativeAmount)
-  const txHash = await Chain.settleOnChain(
-    client,
-    channel.descriptor,
-    amount,
-    channel.highestVoucher.signature,
-    escrow,
-    account
-      ? {
-          account,
-          ...(options?.feePayer ? { feePayer: options.feePayer } : {}),
-          ...(options?.feePayerPolicy ? { feePayerPolicy: options.feePayerPolicy } : {}),
-          ...(options?.feeToken ? { feeToken: options.feeToken } : {}),
-          candidateFeeTokens: options?.candidateFeeTokens ?? [channel.token],
-        }
-      : undefined,
-  )
+  const transactionOptions = resolveChannelTransactionOptions(channel, options, account)
+  let txHash: Hex
+  if (machineRouter) {
+    const authorizationSignature = channel.highestVoucher.authorizationSignature
+    if (!authorizationSignature)
+      throw new VerificationFailedError({
+        reason: 'machine-token voucher is missing its router authorization',
+      })
+    txHash = await Chain.settleMachineSessionOnChain(
+      client,
+      channel.descriptor,
+      amount,
+      channel.highestVoucher.signature,
+      authorizationSignature,
+      machineRouter,
+      transactionOptions,
+    )
+  } else {
+    txHash = await Chain.settleOnChain(
+      client,
+      channel.descriptor,
+      amount,
+      channel.highestVoucher.signature,
+      escrow,
+      transactionOptions,
+    )
+  }
   const receipt = await Chain.waitForSuccessfulReceipt(client, txHash)
   const settled = readSettledReceiptFields(Chain.getChannelEvent(receipt, 'Settled', channelId))
   const { newSettled } = settled


### PR DESCRIPTION
## Why

Merchants should be able to accept machineUSD for Tempo charges and sessions without changing the token or recipient they advertise. Clients should use machineUSD when the merchant permits it and the payer can use it, then fall back to the advertised token. Each configured chain should use one unified machine-token deployment while existing direct Mercator sessions remain unchanged.

## What

- Add implicit machineUSD selection with direct-token fallback.
- Configure Tempo charges and sessions with the same unified `{ swap, token }` deployment on mainnet and Moderato, while keeping their protocol adapters separate.
- Keep the selected session rail sticky, validate router authorization, use PathUSD for machine-session fees, and preserve correct close and refund behavior.
