### PR TITLE
feat(tempo): support machine-token sessions without refunds

### DIFF
--- a/.changeset/machine-sessions-route.md
+++ b/.changeset/machine-sessions-route.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added opt-in machine-token settlement for Tempo sessions while preserving the merchant's configured payout currency. Machine-token channels can close after the full deposit is spent; partial close remains disabled until the reserve supports returning restricted escrow.

--- a/src/server/Methods.test-d.ts
+++ b/src/server/Methods.test-d.ts
@@ -5,7 +5,9 @@ import type { StripeClient } from '../stripe/internal/types.js'
 
 test('accepts the machine-token option on Tempo charges and the global constructor', () => {
   expectTypeOf(tempo.charge({ machineTokenEnabled: true })).toHaveProperty('verify')
+  expectTypeOf(tempo.session({ machineTokenEnabled: true })).toHaveProperty('verify')
   expectTypeOf(tempo({ machineTokenEnabled: true })[0]).toHaveProperty('verify')
+  expectTypeOf(tempo({ machineTokenEnabled: true })[1]).toHaveProperty('verify')
 })
 
 test('all server method constructors expose typed canOffer hooks', () => {

--- a/src/server/Methods.test.ts
+++ b/src/server/Methods.test.ts
@@ -6,13 +6,13 @@ import { accounts } from '~test/tempo/viem.js'
 const recipient = '0x0000000000000000000000000000000000000001'
 
 describe('Tempo machine token', () => {
-  test('preserves the option on direct and global charge methods', () => {
+  test('preserves the option on charge and session methods', () => {
     const direct = tempo.charge({ machineTokenEnabled: true })
     const [global, session] = tempo({ machineTokenEnabled: true })
 
     expect((direct.defaults as { machineTokenEnabled?: boolean }).machineTokenEnabled).toBe(true)
     expect((global.defaults as { machineTokenEnabled?: boolean }).machineTokenEnabled).toBe(true)
-    expect(session.defaults).not.toHaveProperty('machineTokenEnabled')
+    expect((session.defaults as { machineTokenEnabled?: boolean }).machineTokenEnabled).toBe(true)
   })
 })
 

--- a/src/tempo/Methods.test.ts
+++ b/src/tempo/Methods.test.ts
@@ -263,6 +263,41 @@ describe('session', () => {
     expect(request.methodDetails?.minVoucherDelta).toBe('100000')
   })
 
+  test('schema: binds machine-token capability without changing logical payment fields', () => {
+    const currency = '0x20c0000000000000000000000000000000000001'
+    const recipient = '0x1234567890abcdef1234567890abcdef12345678'
+    const request = Methods.session.schema.request.parse({
+      amount: '1',
+      currency,
+      decimals: 6,
+      machineTokenEnabled: true,
+      recipient,
+      unitType: 'token',
+    })
+
+    expect(request).toMatchObject({
+      currency,
+      methodDetails: { machineTokenEnabled: true },
+      recipient,
+    })
+  })
+
+  test('schema: omits refund-only machine-token credential fields', () => {
+    const authorizationSignature = `0x${'44'.repeat(65)}`
+    const refundSignature = `0x${'22'.repeat(65)}`
+    const credential = Methods.session.schema.credential.payload.parse({
+      action: 'close',
+      authorizationSignature,
+      channelId: `0x${'11'.repeat(32)}`,
+      cumulativeAmount: '100000',
+      refundSignature,
+      signature: `0x${'33'.repeat(65)}`,
+    })
+
+    expect(credential).not.toHaveProperty('authorizationSignature')
+    expect(credential).not.toHaveProperty('refundSignature')
+  })
+
   test('schema: preserves precompile session snapshots in method details', () => {
     const sessionSnapshot = {
       acceptedCumulative: '2',

--- a/src/tempo/Methods.ts
+++ b/src/tempo/Methods.ts
@@ -256,6 +256,7 @@ export const session = Method.from({
               z.transform((v): boolean => (typeof v === 'object' ? true : v)),
             ),
           ),
+          machineTokenEnabled: z.optional(z.boolean()),
           minVoucherDelta: z.optional(z.amount()),
           operator: z.optional(z.address()),
           recipient: z.optional(z.string()),
@@ -280,6 +281,7 @@ export const session = Method.from({
           decimals,
           escrowContract,
           feePayer,
+          machineTokenEnabled,
           minVoucherDelta,
           operator,
           sessionProtocol,
@@ -302,6 +304,7 @@ export const session = Method.from({
             }),
             ...(chainId !== undefined && { chainId }),
             ...(feePayer !== undefined && { feePayer }),
+            ...(machineTokenEnabled !== undefined && { machineTokenEnabled }),
             ...(operator !== undefined && { operator }),
             ...(sessionProtocol !== undefined && {
               [Constants.MethodDetailKeys.sessionProtocol]: sessionProtocol,

--- a/src/tempo/internal/defaults.ts
+++ b/src/tempo/internal/defaults.ts
@@ -29,8 +29,8 @@ export const machineToken = {
   [chainId.testnet]: {
     feeToken: tokens.pathUsd,
     session: true,
-    swap: '0x0EdC4d63Daf0FdeA89C95357eC85D6Fc2eD41cB8',
-    token: '0x20c00000000000000000000004645c8f96629cE6',
+    swap: '0xD2E54024506079A62ceb2b698148D240036662E4',
+    token: '0x20C000000000000000000000785C8D7ebcC0b982',
   },
 } as const satisfies Partial<
   Record<

--- a/src/tempo/internal/defaults.ts
+++ b/src/tempo/internal/defaults.ts
@@ -27,10 +27,17 @@ export const machineToken = {
     token: '0x20C0000000000000000000003793c39601711f19',
   },
   [chainId.testnet]: {
-    swap: '0x07f1FE0467Ae01DE340024aa4b7DD9729b1c169b',
-    token: '0x20c000000000000000000000f85bbCa724044De0',
+    feeToken: tokens.pathUsd,
+    session: true,
+    swap: '0x0EdC4d63Daf0FdeA89C95357eC85D6Fc2eD41cB8',
+    token: '0x20c00000000000000000000004645c8f96629cE6',
   },
-} as const satisfies Partial<Record<ChainId, { swap: `0x${string}`; token: `0x${string}` }>>
+} as const satisfies Partial<
+  Record<
+    ChainId,
+    { feeToken?: `0x${string}`; session?: true; swap: `0x${string}`; token: `0x${string}` }
+  >
+>
 
 /**
  * Default token decimals for TIP-20 stablecoins (e.g. pathUSD, USDC).

--- a/src/tempo/internal/machine-token.test.ts
+++ b/src/tempo/internal/machine-token.test.ts
@@ -10,6 +10,7 @@ const deployment = defaults.machineToken[chainId]
 const targetToken = '0x20c0000000000000000000000000000000000001'
 const recipient = '0x2222222222222222222222222222222222222222'
 const payer = '0x1111111111111111111111111111111111111111'
+const sessionPayee = '0x44d7c1edfdfdfdfdfdfdfdfd0000000000000001'
 const memo = `0x${'ab'.repeat(32)}` as const
 const client = createClient({
   transport: custom({ request: async () => undefined as never }),
@@ -175,5 +176,146 @@ describe('Tempo machine token', () => {
         transfers: [...transfers, transfers[0]!],
       }),
     ).toBeUndefined()
+  })
+
+  test('resolves active session routes without exposing them to merchant configuration', async () => {
+    vi.resetModules()
+    vi.doMock('viem/actions', () => ({
+      call: vi.fn(),
+      readContract: vi.fn(async (_client, parameters: { functionName: string }) => {
+        if (parameters.functionName === 'sessionRouteFor') return sessionPayee
+        if (parameters.functionName === 'sessionRoutes') return [recipient, targetToken]
+        throw new Error(`unexpected function ${parameters.functionName}`)
+      }),
+    }))
+
+    try {
+      const MachineToken = await import('./machine-token.js')
+      await expect(
+        MachineToken.findSessionRoute(client, {
+          chainId,
+          merchant: recipient,
+          targetToken,
+        }),
+      ).resolves.toEqual({
+        merchant: recipient,
+        operator: deployment.swap,
+        payee: sessionPayee,
+        targetToken,
+        token: deployment.token,
+      })
+      await expect(
+        MachineToken.getSessionRoute(client, { chainId, payee: sessionPayee }),
+      ).resolves.toEqual({
+        merchant: recipient,
+        operator: deployment.swap,
+        payee: sessionPayee,
+        targetToken,
+        token: deployment.token,
+      })
+      await expect(
+        MachineToken.findVerifiedSessionRoute(client, {
+          chainId,
+          merchant: recipient,
+          targetToken,
+        }),
+      ).resolves.toEqual(expect.objectContaining({ merchant: recipient, payee: sessionPayee }))
+      await expect(
+        MachineToken.resolveSessionRoute(client, { chainId, payee: sessionPayee }),
+      ).resolves.toEqual({
+        merchant: recipient,
+        operator: deployment.swap,
+        payee: sessionPayee,
+        targetToken,
+        token: deployment.token,
+      })
+      await expect(
+        MachineToken.matchSessionRoute(client, {
+          chainId,
+          descriptor: {
+            operator: deployment.swap,
+            payee: sessionPayee,
+            token: deployment.token,
+          },
+          merchant: recipient,
+          targetToken,
+        }),
+      ).resolves.toEqual(expect.objectContaining({ merchant: recipient, targetToken }))
+      await expect(
+        MachineToken.matchSessionRoute(client, {
+          chainId,
+          descriptor: {
+            operator: deployment.swap,
+            payee: sessionPayee,
+            token: deployment.token,
+          },
+          merchant: payer,
+          targetToken,
+        }),
+      ).resolves.toBeUndefined()
+      expect(MachineToken.isSessionSupported(chainId)).toBe(true)
+      expect(MachineToken.isSessionSupported(defaults.chainId.mainnet)).toBe(false)
+      expect(MachineToken.getSessionFeeToken(chainId)).toBe(defaults.tokens.pathUsd)
+      expect(MachineToken.getSessionFeeToken(defaults.chainId.mainnet)).toBeUndefined()
+    } finally {
+      vi.doUnmock('viem/actions')
+      vi.resetModules()
+    }
+  })
+
+  test('separates the challenge capability flag from the trusted descriptor pair', async () => {
+    const MachineToken = await import('./machine-token.js')
+    expect(
+      MachineToken.isSessionEnabledChallenge({
+        request: { methodDetails: { chainId, machineTokenEnabled: true } },
+      }),
+    ).toBe(true)
+    expect(
+      MachineToken.isSessionEnabledChallenge({
+        request: { methodDetails: { chainId, machineTokenEnabled: false } },
+      }),
+    ).toBe(false)
+    expect(
+      MachineToken.matchSessionDescriptor({
+        chainId,
+        descriptor: { operator: deployment.swap, token: deployment.token },
+      }),
+    ).toEqual(deployment)
+    expect(
+      MachineToken.matchSessionDescriptor({
+        chainId,
+        descriptor: { operator: recipient, token: deployment.token },
+      }),
+    ).toBeUndefined()
+  })
+
+  test('rejects virtual payees that are no longer the active merchant route', async () => {
+    vi.resetModules()
+    vi.doMock('viem/actions', () => ({
+      call: vi.fn(),
+      readContract: vi.fn(async (_client, parameters: { functionName: string }) => {
+        if (parameters.functionName === 'sessionRoutes') return [recipient, targetToken]
+        if (parameters.functionName === 'sessionRouteFor')
+          return '0x0000000000000000000000000000000000000000'
+        throw new Error(`unexpected function ${parameters.functionName}`)
+      }),
+    }))
+
+    try {
+      const MachineToken = await import('./machine-token.js')
+      await expect(
+        MachineToken.resolveSessionRoute(client, { chainId, payee: sessionPayee }),
+      ).resolves.toBeUndefined()
+      await expect(
+        MachineToken.resolveSessionRoute(client, {
+          active: false,
+          chainId,
+          payee: sessionPayee,
+        }),
+      ).resolves.toEqual(expect.objectContaining({ merchant: recipient, targetToken }))
+    } finally {
+      vi.doUnmock('viem/actions')
+      vi.resetModules()
+    }
   })
 })

--- a/src/tempo/internal/machine-token.ts
+++ b/src/tempo/internal/machine-token.ts
@@ -3,6 +3,7 @@ import {
   decodeFunctionData,
   encodeFunctionData,
   isAddressEqual,
+  zeroAddress,
   type Address,
   type Client,
 } from 'viem'
@@ -23,6 +24,29 @@ const swapAbi = [
     name: 'swapTo',
     outputs: [],
     stateMutability: 'nonpayable',
+    type: 'function',
+  },
+] as const
+
+const sessionRouteAbi = [
+  {
+    inputs: [
+      { name: 'merchant', type: 'address' },
+      { name: 'targetToken', type: 'address' },
+    ],
+    name: 'sessionRouteFor',
+    outputs: [{ name: 'routeAddress', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [{ name: 'routeAddress', type: 'address' }],
+    name: 'sessionRoutes',
+    outputs: [
+      { name: 'merchant', type: 'address' },
+      { name: 'targetToken', type: 'address' },
+    ],
+    stateMutability: 'view',
     type: 'function',
   },
 ] as const
@@ -50,6 +74,24 @@ export type Transfer = {
   recipient: Address
 }
 
+export type SessionDescriptor = {
+  authorizedSigner: Address
+  expiringNonceHash: Hex.Hex
+  operator: Address
+  payee: Address
+  payer: Address
+  salt: Hex.Hex
+  token: Address
+}
+
+export type SessionRoute = {
+  merchant: Address
+  operator: Address
+  payee: Address
+  targetToken: Address
+  token: Address
+}
+
 /** Shared first-party machine-token configuration for Tempo methods. */
 export type Options = {
   /** Enables first-party machine-token settlement for supported Tempo methods. */
@@ -61,9 +103,153 @@ function getDeployment(chainId: number | undefined) {
   return defaults.machineToken[chainId as keyof typeof defaults.machineToken]
 }
 
+function getSessionDeployment(chainId: number | undefined) {
+  const deployment = getDeployment(chainId)
+  if (!deployment || !('session' in deployment) || deployment.session !== true) return undefined
+  return deployment
+}
+
 /** Returns whether a first-party machine-token route is deployed on a chain. */
 export function isSupported(chainId: number | undefined): boolean {
   return !!getDeployment(chainId)
+}
+
+/** Returns whether the first-party machine token supports TIP-1034 sessions on a chain. */
+export function isSessionSupported(chainId: number | undefined): boolean {
+  return !!getSessionDeployment(chainId)
+}
+
+/** Returns the liquid fee token used for machine-session management transactions. */
+export function getSessionFeeToken(chainId: number | undefined): Address | undefined {
+  return getSessionDeployment(chainId)?.feeToken
+}
+
+/** Resolves the active virtual payee for a merchant's target-currency session route. */
+export async function findSessionRoute(
+  client: Client,
+  parameters: { chainId: number; merchant: Address; targetToken: Address },
+): Promise<SessionRoute | undefined> {
+  const deployment = getSessionDeployment(parameters.chainId)
+  if (!deployment) return undefined
+  const payee = await readContract(client, {
+    address: deployment.swap,
+    abi: sessionRouteAbi,
+    functionName: 'sessionRouteFor',
+    args: [parameters.merchant, parameters.targetToken],
+  })
+  if (isAddressEqual(payee, zeroAddress)) return undefined
+  return {
+    merchant: parameters.merchant,
+    operator: deployment.swap,
+    payee,
+    targetToken: parameters.targetToken,
+    token: deployment.token,
+  }
+}
+
+/** Resolves the immutable merchant payout bound to a virtual machine-session payee. */
+export async function getSessionRoute(
+  client: Client,
+  parameters: { chainId: number; payee: Address },
+): Promise<SessionRoute | undefined> {
+  const deployment = getSessionDeployment(parameters.chainId)
+  if (!deployment) return undefined
+  const [merchant, targetToken] = await readContract(client, {
+    address: deployment.swap,
+    abi: sessionRouteAbi,
+    functionName: 'sessionRoutes',
+    args: [parameters.payee],
+  })
+  if (isAddressEqual(merchant, zeroAddress) || isAddressEqual(targetToken, zeroAddress))
+    return undefined
+  return {
+    merchant,
+    operator: deployment.swap,
+    payee: parameters.payee,
+    targetToken,
+    token: deployment.token,
+  }
+}
+
+/** Resolves an active route and verifies its immutable reverse merchant binding. */
+export async function findVerifiedSessionRoute(
+  client: Client,
+  parameters: { chainId: number; merchant: Address; targetToken: Address },
+): Promise<SessionRoute | undefined> {
+  const active = await findSessionRoute(client, parameters)
+  if (!active) return undefined
+  const route = await getSessionRoute(client, { chainId: parameters.chainId, payee: active.payee })
+  if (
+    !route ||
+    !isAddressEqual(route.merchant, parameters.merchant) ||
+    !isAddressEqual(route.targetToken, parameters.targetToken)
+  )
+    return undefined
+  return route
+}
+
+/** Resolves a virtual payee and, unless closing, proves its route is still active. */
+export async function resolveSessionRoute(
+  client: Client,
+  parameters: { active?: boolean | undefined; chainId: number; payee: Address },
+): Promise<SessionRoute | undefined> {
+  const route = await getSessionRoute(client, parameters)
+  if (!route || parameters.active === false) return route
+  const active = await findSessionRoute(client, {
+    chainId: parameters.chainId,
+    merchant: route.merchant,
+    targetToken: route.targetToken,
+  })
+  if (!active || !isAddressEqual(active.payee, parameters.payee)) return undefined
+  return route
+}
+
+/** Matches the trusted router and token pair for a machine-token session descriptor. */
+export function matchSessionDescriptor(parameters: {
+  chainId: number | undefined
+  descriptor: Pick<SessionDescriptor, 'operator' | 'token'>
+}) {
+  const deployment = getSessionDeployment(parameters.chainId)
+  if (!deployment) return undefined
+  if (
+    !isAddressEqual(parameters.descriptor.operator, deployment.swap) ||
+    !isAddressEqual(parameters.descriptor.token, deployment.token)
+  )
+    return undefined
+  return deployment
+}
+
+/** Returns whether an authenticated session challenge permits the machine-token rail. */
+export function isSessionEnabledChallenge(challenge: { request: { methodDetails?: unknown } }) {
+  const methodDetails = challenge.request.methodDetails
+  if (!methodDetails || typeof methodDetails !== 'object') return false
+  return (methodDetails as { machineTokenEnabled?: unknown }).machineTokenEnabled === true
+}
+
+/** Verifies that a machine-session descriptor resolves to the challenged merchant payout. */
+export async function matchSessionRoute(
+  client: Client,
+  parameters: {
+    active?: boolean | undefined
+    chainId: number
+    descriptor: Pick<SessionDescriptor, 'operator' | 'payee' | 'token'>
+    merchant: Address
+    targetToken: Address
+  },
+): Promise<SessionRoute | undefined> {
+  if (!matchSessionDescriptor(parameters)) return undefined
+  const route = await resolveSessionRoute(client, {
+    active: parameters.active,
+    chainId: parameters.chainId,
+    payee: parameters.descriptor.payee,
+  })
+  if (
+    !route ||
+    !isAddressEqual(route.merchant, parameters.merchant) ||
+    !isAddressEqual(route.targetToken, parameters.targetToken)
+  )
+    return undefined
+  return route
 }
 
 /** Resolves the canonical first-party settlement route for a compatible charge. */

--- a/src/tempo/server/Methods.ts
+++ b/src/tempo/server/Methods.ts
@@ -36,9 +36,9 @@ function createSessionMethod<const parameters extends tempo.Parameters>(
 /**
  * Creates the common Tempo `charge` and `session` methods from shared parameters.
  *
- * `machineTokenEnabled` and `relay` currently apply only to `charge`. The
- * machine-token option is accepted globally so other Tempo methods can adopt
- * it without another provider-level configuration surface.
+ * `machineTokenEnabled` lets compatible clients fund either method with the
+ * first-party machine token while the merchant continues to request its payout
+ * currency and recipient normally.
  *
  * @example
  * ```ts

--- a/src/tempo/session/client/ChannelOps.test.ts
+++ b/src/tempo/session/client/ChannelOps.test.ts
@@ -1,6 +1,7 @@
 import { Hex } from 'ox'
 import { type Address, createClient, custom, zeroAddress } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
+import { Transaction } from 'viem/tempo'
 import { describe, expect, test } from 'vp/test'
 
 import * as Channel from '../precompile/Channel.js'
@@ -234,5 +235,41 @@ describe('precompile client ChannelOps credential builders', () => {
       }),
     )
     expect(mocks.prepareTransactionRequest.mock.calls[0]?.[1]).not.toHaveProperty('feePayer')
+  })
+
+  test('uses an explicit liquid fee token for machine-token channel management', async () => {
+    mocks.prepareTransactionRequest.mockClear()
+    const feeToken = '0x0000000000000000000000000000000000000004' as Address
+    const transaction = await Transaction.serialize({
+      chainId,
+      calls: [],
+      feeToken,
+      nonce: 0,
+    })
+    mocks.signTransaction.mockResolvedValueOnce(transaction)
+
+    await ChannelOps.createOpenPayload(client, account, {
+      chainId,
+      deposit: 100n,
+      feeToken,
+      initialAmount: 10n,
+      payee: descriptor.payee,
+      token: descriptor.token,
+    })
+    await ChannelOps.createTopUpPayload(
+      client,
+      account,
+      descriptor,
+      10n,
+      chainId,
+      false,
+      tip20ChannelEscrow,
+      [],
+      feeToken,
+    )
+
+    expect(mocks.prepareTransactionRequest.mock.calls).toHaveLength(2)
+    expect(mocks.prepareTransactionRequest.mock.calls[0]?.[1]).toMatchObject({ feeToken })
+    expect(mocks.prepareTransactionRequest.mock.calls[1]?.[1]).toMatchObject({ feeToken })
   })
 })

--- a/src/tempo/session/client/ChannelOps.ts
+++ b/src/tempo/session/client/ChannelOps.ts
@@ -239,6 +239,7 @@ export async function createOpenPayload(
     deposit: bigint
     escrow?: Address | undefined
     feePayer?: boolean | undefined
+    feeToken?: Address | undefined
     initialAmount: bigint
     operator?: Address | undefined
     payee: Address
@@ -263,7 +264,7 @@ export async function createOpenPayload(
     account,
     calls: [...(parameters.prefixCalls ?? []), { to: escrow, data: openData }],
     feePayer: parameters.feePayer,
-    feeToken: parameters.token,
+    feeToken: parameters.feeToken ?? parameters.token,
   })
   const transaction = await signPreparedTempoTransaction(client, prepared)
   const signed = Transaction.deserialize(transaction as Transaction.TransactionSerializedTempo)
@@ -322,6 +323,7 @@ export async function createTopUpPayload(
   feePayer?: boolean | undefined,
   escrow: Address = tip20ChannelEscrow,
   prefixCalls: readonly TempoChannelCall[] = [],
+  feeToken: Address = descriptor.token,
 ): Promise<TopUpCredentialPayload> {
   const channelId = Channel.computeId({
     ...descriptor,
@@ -343,7 +345,7 @@ export async function createTopUpPayload(
       },
     ],
     feePayer,
-    feeToken: descriptor.token,
+    feeToken,
     validAfter: randomValidAfter(),
   })
   const transaction = await signPreparedTempoTransaction(client, prepared)

--- a/src/tempo/session/client/CredentialState.ts
+++ b/src/tempo/session/client/CredentialState.ts
@@ -666,16 +666,17 @@ export async function executeCredentialPlan(
   plan: CredentialPlan,
   sink: ChannelSink,
   autoSwap: AutoSwap.resolve.Resolved | false = false,
+  feeToken?: Address | undefined,
 ): Promise<SessionCredentialPayload> {
   switch (plan.type) {
     case 'open':
-      return open(plan, sink, autoSwap)
+      return open(plan, sink, autoSwap, feeToken)
     case 'recover':
       return recover(plan, sink)
     case 'voucher':
       return voucher(plan, sink)
     case 'manual':
-      return manual(plan, sink, autoSwap)
+      return manual(plan, sink, autoSwap, feeToken)
   }
 }
 
@@ -702,6 +703,7 @@ async function open(
   plan: Extract<CredentialPlan, { type: 'open' }>,
   sink: ChannelSink,
   autoSwap: AutoSwap.resolve.Resolved | false,
+  feeToken?: Address | undefined,
 ): Promise<SessionCredentialPayload> {
   const { account, resolved } = plan
   const deposit = resolveOpeningDeposit({
@@ -715,6 +717,7 @@ async function open(
     deposit,
     escrow: resolved.escrow,
     feePayer: resolved.feePayer,
+    feeToken,
     initialAmount: resolved.amount,
     operator: resolved.operator,
     payee: resolved.payee,
@@ -811,6 +814,7 @@ async function manual(
   plan: Extract<CredentialPlan, { type: 'manual' }>,
   sink: ChannelSink,
   autoSwap: AutoSwap.resolve.Resolved | false,
+  feeToken?: Address | undefined,
 ): Promise<SessionCredentialPayload> {
   const { account, context, decimals, resolved } = plan
   const { descriptor } = context
@@ -839,6 +843,7 @@ async function manual(
       resolved,
     },
     autoSwap,
+    feeToken,
   )
   await applyCumulative(sink, resolved.key, payload)
   return payload
@@ -847,12 +852,13 @@ async function manual(
 async function executeManualCredential(
   parameters: ManualCredentialParameters,
   autoSwap: AutoSwap.resolve.Resolved | false,
+  feeToken?: Address | undefined,
 ): Promise<SessionCredentialPayload> {
   switch (parameters.context.action) {
     case 'open':
       return manualOpen(parameters)
     case 'topUp':
-      return manualTopUp(parameters, autoSwap)
+      return manualTopUp(parameters, autoSwap, feeToken)
     case 'voucher':
       return manualVoucher(parameters)
     case 'close':
@@ -889,6 +895,7 @@ async function manualOpen(
 async function manualTopUp(
   parameters: ManualCredentialParameters,
   autoSwap: AutoSwap.resolve.Resolved | false,
+  feeToken?: Address | undefined,
 ): Promise<SessionCredentialPayload> {
   const { account, channelId, context, decimals, descriptor, resolved } = parameters
   const additionalDeposit = requireContextAmount(context, decimals, 'additionalDeposit', 'topUp')
@@ -916,6 +923,7 @@ async function manualTopUp(
       client: resolved.client,
       tokenOut: resolved.token,
     }),
+    feeToken,
   )
 }
 

--- a/src/tempo/session/client/Session.test.ts
+++ b/src/tempo/session/client/Session.test.ts
@@ -1,4 +1,11 @@
-import { type Address, createClient, custom, decodeFunctionData, encodeFunctionResult } from 'viem'
+import {
+  type Address,
+  createClient,
+  custom,
+  decodeFunctionData,
+  encodeFunctionResult,
+  isAddressEqual,
+} from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { Account as TempoAccount, Secp256k1, Transaction } from 'viem/tempo'
 import { describe, expect, test, vi } from 'vp/test'
@@ -10,6 +17,7 @@ import * as Constants from '../../../Constants.js'
 import * as Credential from '../../../Credential.js'
 import * as z from '../../../zod.js'
 import * as AutoSwap from '../../internal/auto-swap.js'
+import * as defaults from '../../internal/defaults.js'
 import * as Methods from '../../Methods.js'
 import * as Channel from '../precompile/Channel.js'
 import { escrowAbi } from '../precompile/escrow.abi.js'
@@ -39,6 +47,66 @@ const client = createClient({
           functionName: 'getChannelState',
           result: { settled: 0n, deposit: 1_000n, closeRequestedAt: 0 },
         })
+      throw new Error(`unexpected rpc request: ${args.method}`)
+    },
+  }),
+})
+
+const machineSessionPayee = '0x44D7c1EDFdfdfDFdFdFDFDFd0000000000000001' as Address
+const sessionRouteAbi = [
+  {
+    inputs: [
+      { name: 'merchant', type: 'address' },
+      { name: 'targetToken', type: 'address' },
+    ],
+    name: 'sessionRouteFor',
+    outputs: [{ name: 'routeAddress', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [{ name: 'routeAddress', type: 'address' }],
+    name: 'sessionRoutes',
+    outputs: [
+      { name: 'merchant', type: 'address' },
+      { name: 'targetToken', type: 'address' },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+] as const
+const machineClient = createClient({
+  account,
+  chain: { id: chainId } as never,
+  transport: custom({
+    async request(args) {
+      if (args.method === 'eth_chainId') return `0x${chainId.toString(16)}`
+      if (args.method === 'eth_getTransactionCount') return '0x0'
+      if (args.method === 'eth_estimateGas') return '0x5208'
+      if (args.method === 'eth_maxPriorityFeePerGas') return '0x1'
+      if (args.method === 'eth_getBlockByNumber') return { baseFeePerGas: '0x1' }
+      if (args.method === 'eth_call') {
+        const call = (args.params as [{ data?: `0x${string}`; to?: Address }])[0]
+        if (call.data && call.to && isAddressEqual(call.to, defaults.machineToken[chainId].swap)) {
+          const decoded = decodeFunctionData({ abi: sessionRouteAbi, data: call.data })
+          if (decoded.functionName === 'sessionRouteFor')
+            return encodeFunctionResult({
+              abi: sessionRouteAbi,
+              functionName: 'sessionRouteFor',
+              result: machineSessionPayee,
+            })
+          return encodeFunctionResult({
+            abi: sessionRouteAbi,
+            functionName: 'sessionRoutes',
+            result: [descriptor.payee, descriptor.token],
+          })
+        }
+        return encodeFunctionResult({
+          abi: escrowAbi,
+          functionName: 'getChannelState',
+          result: { settled: 0n, deposit: 1_000n, closeRequestedAt: 0 },
+        })
+      }
       throw new Error(`unexpected rpc request: ${args.method}`)
     },
   }),
@@ -220,6 +288,147 @@ describe('precompile client session', () => {
         }),
       }),
     ).toBe(false)
+  })
+
+  test('lets normal clients use an enabled challenge while machine clients require the flag', () => {
+    const normalMethod = session({ account, getClient: () => client })
+    const machineMethod = session({
+      account,
+      getClient: () => client,
+      machineTokenEnabled: true,
+    })
+    const machineEnabledChallenge = makeSessionChallenge({
+      methodDetails: {
+        chainId,
+        escrowContract: tip20ChannelEscrow,
+        machineTokenEnabled: true,
+        sessionProtocol: Constants.SessionProtocols.v2,
+      },
+    })
+    const ordinaryChallenge = makeSessionChallenge()
+
+    expect(normalMethod.canHandleChallenge?.({ challenge: ordinaryChallenge })).toBe(true)
+    expect(normalMethod.canHandleChallenge?.({ challenge: machineEnabledChallenge })).toBe(true)
+    expect(machineMethod.canHandleChallenge?.({ challenge: ordinaryChallenge })).toBe(false)
+    expect(machineMethod.canHandleChallenge?.({ challenge: machineEnabledChallenge })).toBe(true)
+  })
+
+  test('shapes an enabled logical challenge into the canonical machine-token channel', async () => {
+    const deployment = defaults.machineToken[chainId]
+    const challenge = makeSessionChallenge({
+      methodDetails: {
+        chainId,
+        escrowContract: tip20ChannelEscrow,
+        machineTokenEnabled: true,
+        sessionProtocol: Constants.SessionProtocols.v2,
+      },
+    })
+    const credential = await session({
+      account,
+      decimals: 0,
+      getClient: () => machineClient,
+      machineTokenEnabled: true,
+      maxDeposit: '100',
+    }).createCredential({ challenge, context: {} })
+    const payload = deserialize(credential)
+
+    expect(challenge.request).toMatchObject({
+      currency: descriptor.token,
+      recipient: descriptor.payee,
+    })
+    expect(payload).toMatchObject({
+      action: 'open',
+      descriptor: {
+        operator: deployment.swap,
+        payee: machineSessionPayee,
+        token: deployment.token,
+      },
+    })
+    expect(openArgs(payload).slice(0, 4)).toEqual([
+      machineSessionPayee,
+      deployment.swap,
+      deployment.token,
+      100n,
+    ])
+  })
+
+  test('rejects closing a machine-token channel with unused deposit', async () => {
+    const deployment = defaults.machineToken[chainId]
+    const challenge = makeSessionChallenge({
+      methodDetails: {
+        chainId,
+        escrowContract: tip20ChannelEscrow,
+        machineTokenEnabled: true,
+        sessionProtocol: Constants.SessionProtocols.v2,
+      },
+    })
+    const machineDescriptor = {
+      ...descriptor,
+      operator: deployment.swap,
+      payee: machineSessionPayee,
+      token: deployment.token,
+    }
+    const channelId = Channel.computeId({
+      ...machineDescriptor,
+      chainId,
+      escrow: tip20ChannelEscrow,
+    })
+    const channelStore = createChannelStore()
+    await channelStore.set({
+      chainId,
+      channelId,
+      cumulativeAmount: 25n,
+      deposit: 1_000n,
+      descriptor: machineDescriptor,
+      escrow: tip20ChannelEscrow,
+      opened: true,
+    })
+
+    await expect(
+      session({
+        account,
+        channelStore,
+        decimals: 0,
+        getClient: () => machineClient,
+        machineTokenEnabled: true,
+      }).createCredential({
+        challenge,
+        context: {
+          action: 'close',
+          channelId,
+          cumulativeAmountRaw: '25',
+          descriptor: machineDescriptor,
+        },
+      }),
+    ).rejects.toThrow('Machine-token session refunds are not supported')
+
+    const credential = await session({
+      account,
+      channelStore,
+      decimals: 0,
+      getClient: () => machineClient,
+      machineTokenEnabled: true,
+    }).createCredential({
+      challenge,
+      context: {
+        action: 'close',
+        channelId,
+        cumulativeAmountRaw: '1000',
+        descriptor: machineDescriptor,
+      },
+    })
+    const payload = deserialize(credential)
+    if (payload.action !== 'close') throw new Error('expected close credential')
+    expect(payload).not.toHaveProperty('authorizationSignature')
+    expect(payload).not.toHaveProperty('refundSignature')
+    expect(
+      Voucher.verifyVoucher(
+        tip20ChannelEscrow,
+        chainId,
+        { channelId, cumulativeAmount: 1_000n, signature: payload.signature },
+        account.address,
+      ),
+    ).toBe(true)
   })
 
   test('drives paid SSE responses with a supplied credential', async () => {

--- a/src/tempo/session/client/Session.ts
+++ b/src/tempo/session/client/Session.ts
@@ -1,4 +1,4 @@
-import { type Address, parseUnits } from 'viem'
+import { isAddressEqual, type Address, parseUnits } from 'viem'
 import { tempo as tempo_chain } from 'viem/chains'
 
 import * as MethodChallenge from '../../../client/internal/MethodChallenge.js'
@@ -14,7 +14,9 @@ import type {
 } from '../../client/ResolveAccount.js'
 import * as AutoSwap from '../../internal/auto-swap.js'
 import * as defaults from '../../internal/defaults.js'
+import * as MachineToken from '../../internal/machine-token.js'
 import * as Methods from '../../Methods.js'
+import * as Chain from '../precompile/Chain.js'
 import * as Channel from '../precompile/Channel.js'
 import {
   deserializeSessionReceipt,
@@ -23,7 +25,7 @@ import {
   requireSessionCredentialContext,
 } from '../precompile/Protocol.js'
 import { serializeCredential, type ChannelEntry } from './ChannelOps.js'
-import { createChannelStore, type ChannelStore } from './ChannelStore.js'
+import { channelKey, createChannelStore, type ChannelStore } from './ChannelStore.js'
 import {
   canSignDescriptor,
   executeCredentialPlan,
@@ -109,6 +111,65 @@ function acknowledgesOpen(
   )
 }
 
+function applyMachineTokenRoute(
+  resolved: ChallengeContext,
+  route: MachineToken.SessionRoute,
+): ChallengeContext {
+  const snapshotDescriptor = resolved.snapshot?.descriptor
+  const snapshotMatches =
+    snapshotDescriptor &&
+    isAddressEqual(snapshotDescriptor.payee, route.payee) &&
+    isAddressEqual(snapshotDescriptor.operator, route.operator) &&
+    isAddressEqual(snapshotDescriptor.token, route.token)
+  return {
+    ...resolved,
+    key: channelKey({
+      chainId: resolved.chainId,
+      escrow: resolved.escrow,
+      payee: route.payee,
+      token: route.token,
+    }),
+    operator: route.operator,
+    payee: route.payee,
+    snapshot: snapshotMatches ? resolved.snapshot : undefined,
+    token: route.token,
+  }
+}
+
+async function resolveMachineTokenChallengeContext(
+  resolved: ChallengeContext,
+  context: CredentialContext | undefined,
+): Promise<ChallengeContext> {
+  const descriptor = context?.descriptor ?? resolved.snapshot?.descriptor
+  if (
+    descriptor &&
+    MachineToken.matchSessionDescriptor({ chainId: resolved.chainId, descriptor })
+  ) {
+    const route = await MachineToken.matchSessionRoute(resolved.client, {
+      active: context?.action !== 'close',
+      chainId: resolved.chainId,
+      descriptor,
+      merchant: resolved.payee,
+      targetToken: resolved.token,
+    })
+    if (!route)
+      throw new Error('Machine-token channel is not bound to this merchant session challenge.')
+    return applyMachineTokenRoute(resolved, route)
+  }
+
+  // Explicit low-level operations may still manage a normal channel even when
+  // this client generally prefers the machine-token rail.
+  if (hasSessionAction(context)) return resolved
+
+  const route = await MachineToken.findVerifiedSessionRoute(resolved.client, {
+    chainId: resolved.chainId,
+    merchant: resolved.payee,
+    targetToken: resolved.token,
+  })
+  if (!route) throw new Error('No active machine-token route for this merchant session challenge.')
+  return applyMachineTokenRoute(resolved, route)
+}
+
 /**
  * Creates the low-level TIP-1034 session payment method for use with `Mppx.create()`.
  *
@@ -124,7 +185,9 @@ export function session(parameters: session.Parameters = {}) {
     channelStore,
     decimals = defaults.decimals,
     escrow: escrowOverride,
+    feeToken: feeTokenParameter,
     getClient: getClientParameter,
+    machineTokenEnabled = false,
     maxDeposit: maxDepositParameter,
     topUpAmount: topUpAmountParameter,
     onChannelUpdate,
@@ -180,16 +243,21 @@ export function session(parameters: session.Parameters = {}) {
     })
 
   const method = Method.toClient(Methods.session, {
-    canHandleChallenge: ({ challenge }) => isTip1034SessionChallenge(challenge),
+    canHandleChallenge: ({ challenge }) => {
+      if (!isTip1034SessionChallenge(challenge)) return false
+      return !machineTokenEnabled || MachineToken.isSessionEnabledChallenge(challenge)
+    },
     context: sessionContextSchema,
     async createCredential(parameters) {
       const { challenge, context } = parameters
-      const resolved = await resolveChallengeContext({
+      let resolved = await resolveChallengeContext({
         allowCustomEscrow,
         challenge,
         escrowOverride,
         getClient,
       })
+      if (machineTokenEnabled)
+        resolved = await resolveMachineTokenChallengeContext(resolved, context)
       const attempt = MethodResponse.getAttempt(parameters)
       let release = () => {}
       try {
@@ -223,11 +291,33 @@ export function session(parameters: session.Parameters = {}) {
                 notifyUpdate() {},
               }
             : sink
+        const machineSession =
+          plan.resolved.operator &&
+          MachineToken.matchSessionDescriptor({
+            chainId: plan.resolved.chainId,
+            descriptor: {
+              operator: plan.resolved.operator,
+              token: plan.resolved.token,
+            },
+          })
         const payload = await executeCredentialPlan(
           plan,
           credentialSink,
           AutoSwap.resolve(context?.autoSwap ?? autoSwapParameter, AutoSwap.defaultCurrencies),
+          feeTokenParameter ??
+            (machineSession ? MachineToken.getSessionFeeToken(plan.resolved.chainId) : undefined),
         )
+        if (machineSession && payload.action === 'close') {
+          const state = await Chain.getChannelState(
+            plan.resolved.client,
+            payload.channelId,
+            plan.resolved.escrow,
+          )
+          if (BigInt(payload.cumulativeAmount) !== state.deposit)
+            throw new Error(
+              'Machine-token session refunds are not supported; close requires cumulative spend to equal the on-chain deposit.',
+            )
+        }
         const credential = await serializeCredential(
           challenge,
           payload,
@@ -415,8 +505,12 @@ export declare namespace session {
       decimals?: number | undefined
       /** Exact TIP20EscrowChannel address pin. Takes precedence over `allowCustomEscrow`. */
       escrow?: Address | undefined
+      /** Fee token for channel management transactions. Machine-token sessions default to PathUSD. */
+      feeToken?: Address | undefined
       /** Maximum channel deposit in human-readable units. Caps server-suggested opens and automatic top-ups. */
       maxDeposit?: string | undefined
+      /** Uses the first-party machine-token rail when the server's logical session challenge permits it. */
+      machineTokenEnabled?: boolean | undefined
       /**
        * Preferred automatic top-up size in human-readable units. When omitted,
        * a bounded server `suggestedDeposit` is preferred, then the exact shortfall.

--- a/src/tempo/session/client/SessionManager.test.ts
+++ b/src/tempo/session/client/SessionManager.test.ts
@@ -1890,11 +1890,13 @@ describe('Session', () => {
     })
 
     test('surfaces close failure problem details', async () => {
+      const actions: SessionCredentialPayload['action'][] = []
       const mockFetch = vi.fn().mockImplementation((_input, init?: RequestInit) => {
         const authorization = new Headers(init?.headers).get('Authorization')
         const payload = authorization
           ? Credential.deserialize<SessionCredentialPayload>(authorization).payload
           : undefined
+        if (payload) actions.push(payload.action)
 
         if (!payload)
           return Promise.resolve(
@@ -1946,6 +1948,10 @@ describe('Session', () => {
       await expect(s.close()).rejects.toThrow(
         'Close request failed with status 500: close failed [WWW-Authenticate: Payment error="close_failed"]',
       )
+
+      const resumed = await s.fetch('https://api.example.com/resource')
+      expect(resumed.status).toBe(200)
+      expect(actions).toEqual(['open', 'close', 'voucher'])
     })
   })
 })

--- a/src/tempo/session/client/SessionManager.ts
+++ b/src/tempo/session/client/SessionManager.ts
@@ -326,7 +326,9 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
     resolveAccount: parameters.resolveAccount,
     escrow: parameters.escrow,
     decimals: config.decimals,
+    feeToken: parameters.feeToken,
     maxDeposit: parameters.maxDeposit,
+    machineTokenEnabled: parameters.machineTokenEnabled,
     topUpAmount: parameters.topUpAmount,
     channelStore: store,
     onChannelUpdate(entry) {
@@ -903,6 +905,11 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
     },
 
     async close() {
+      const previous = captureRuntimeStateSnapshot({
+        channel: runtime.channel,
+        spent: runtime.spent,
+        state: runtime.state,
+      })
       const currentSocket = runtime.socketSession
       const target = resolveCloseTarget({
         channel: runtime.channel,
@@ -911,24 +918,29 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
       })
       if (!target) return undefined
 
-      const activeSocket = currentSocket?.socket
-      if (currentSocket && activeSocket?.readyState === WebSocketReadyState.OPEN) {
-        const receipt = await closeSocketSession({
-          activeSocket,
-          createSessionCredential,
-          currentSocket,
-          spent: runtime.spent,
-          target,
-          waitForCloseReady: receipts.waitForCloseReady,
-          waitForReceipt: receipts.waitForReceipt,
-        })
-        activateCurrentChannel()
-        dispatch({ type: 'closeStarted' })
-        dispatch({ type: 'closed', receipt })
-        return receipt
-      }
+      try {
+        const activeSocket = currentSocket?.socket
+        if (currentSocket && activeSocket?.readyState === WebSocketReadyState.OPEN) {
+          const receipt = await closeSocketSession({
+            activeSocket,
+            createSessionCredential,
+            currentSocket,
+            spent: runtime.spent,
+            target,
+            waitForCloseReady: receipts.waitForCloseReady,
+            waitForReceipt: receipts.waitForReceipt,
+          })
+          activateCurrentChannel()
+          dispatch({ type: 'closeStarted' })
+          dispatch({ type: 'closed', receipt })
+          return receipt
+        }
 
-      return closeHttpSessionAndApply(target)
+        return await closeHttpSessionAndApply(target)
+      } catch (error) {
+        await restoreRuntime(previous)
+        throw error
+      }
     },
   }
 
@@ -986,10 +998,14 @@ export namespace sessionManager {
       decimals?: number | undefined
       /** Exact TIP20EscrowChannel address pin. Takes precedence over `allowCustomEscrow`. */
       escrow?: Address | undefined
+      /** Fee token for channel management transactions. Machine-token sessions default to PathUSD. */
+      feeToken?: Address | undefined
       /** Fetch implementation used for HTTP probes, management posts, and paid retries. */
       fetch?: typeof globalThis.fetch | undefined
       /** Maximum deposit in human-readable units (e.g. `'10'` for 10 tokens). Converted to raw units via `decimals`. */
       maxDeposit?: string | undefined
+      /** Uses the first-party machine-token rail when the server's logical session challenge permits it. */
+      machineTokenEnabled?: boolean | undefined
       /**
        * Preferred automatic top-up size in human-readable units. When omitted,
        * a bounded server `suggestedDeposit` is preferred, then the exact shortfall.

--- a/src/tempo/session/precompile/Chain.test.ts
+++ b/src/tempo/session/precompile/Chain.test.ts
@@ -12,7 +12,7 @@ import {
   type Hex,
 } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { Abis, Addresses, Transaction } from 'viem/tempo'
+import { Abis, Addresses, Chain as TempoChain, Transaction } from 'viem/tempo'
 import { describe, expect, test } from 'vp/test'
 
 import { VerificationFailedError } from '../../../Errors.js'
@@ -57,7 +57,7 @@ function createMockClient(
 ) {
   return createClient({
     account: feePayer,
-    chain: { id: chainId } as never,
+    chain: TempoChain.testnet,
     transport: custom({
       async request(args) {
         parameters.rpcMethods?.push(args.method)
@@ -168,13 +168,14 @@ async function createSerializedTransaction(parameters: {
     data?: `0x${string}` | undefined
     value?: bigint | undefined
   }[]
+  feeToken?: Address | false | undefined
   gas?: bigint | undefined
   signed?: boolean | undefined
 }) {
   return (await Transaction.serialize({
     chainId,
     calls: parameters.calls,
-    feeToken: descriptor.token,
+    ...(parameters.feeToken === false ? {} : { feeToken: parameters.feeToken ?? descriptor.token }),
     nonce: 0,
     ...(parameters.gas !== undefined ? { gas: parameters.gas } : {}),
     ...(parameters.signed
@@ -222,6 +223,7 @@ function autoSwapCalls(amountOut: bigint = deposit) {
 async function createOpenTransaction(
   parameters: {
     authorizedSigner?: `0x${string}` | undefined
+    feeToken?: Address | false | undefined
     gas?: bigint | undefined
     operator?: `0x${string}` | undefined
     payee?: `0x${string}` | undefined
@@ -251,6 +253,7 @@ async function createOpenTransaction(
   })
   return createSerializedTransaction({
     calls: [...(parameters.prefixCalls ?? []), { to: parameters.to ?? tip20ChannelEscrow, data }],
+    feeToken: parameters.feeToken,
     gas: parameters.gas,
     signed: parameters.signed,
   })
@@ -260,6 +263,7 @@ async function createTopUpTransaction(
   parameters: {
     additionalDeposit?: bigint | undefined
     descriptor_?: Channel.ChannelDescriptor | undefined
+    feeToken?: Address | false | undefined
     gas?: bigint | undefined
     signed?: boolean | undefined
     to?: `0x${string}` | undefined
@@ -282,6 +286,7 @@ async function createTopUpTransaction(
   })
   return createSerializedTransaction({
     calls: [...(parameters.prefixCalls ?? []), { to: parameters.to ?? tip20ChannelEscrow, data }],
+    feeToken: parameters.feeToken,
     gas: parameters.gas,
     signed: parameters.signed,
   })
@@ -827,6 +832,57 @@ describe('precompile broadcastOpenTransaction', () => {
     ).toHaveLength(2)
   })
 
+  test('fee-payer completes open with an explicit allowed fee token', async () => {
+    let broadcast: Hex | undefined
+    const serializedTransaction = await createOpenTransaction({
+      feeToken: false,
+      gas: 100_000n,
+      signed: true,
+    })
+    const transaction = Transaction.deserialize(
+      serializedTransaction as Transaction.TransactionSerializedTempo,
+    )
+    const payer = transaction.from!
+    const expiringNonceHash = Channel.computeExpiringNonceHash(
+      Channel.transactionForExpiringNonceHash({ feePayer, transaction }),
+      { sender: payer },
+    )
+    const expectedDescriptor = { ...descriptor, payer, expiringNonceHash }
+    const channelId = Channel.computeId({
+      ...expectedDescriptor,
+      chainId,
+      escrow: tip20ChannelEscrow,
+    })
+    const state = { settled: 0n, deposit, closeRequestedAt: 0 }
+
+    await Chain.broadcastOpenTransaction({
+      allowedFeeTokens: [sourceToken],
+      chainId,
+      client: createMockClient({
+        channel: { descriptor: expectedDescriptor, state },
+        onRequest(method, params) {
+          if (method === 'eth_sendRawTransactionSync') broadcast = (params as readonly [Hex])[0]
+        },
+        receipt: receipt([openedLog({ channelId, expiringNonceHash })]),
+      }),
+      escrowContract: tip20ChannelEscrow,
+      expectedAuthorizedSigner: descriptor.authorizedSigner,
+      expectedChannelId: channelId,
+      expectedCurrency: descriptor.token,
+      expectedExpiringNonceHash: expiringNonceHash,
+      expectedOperator: descriptor.operator,
+      expectedPayee: descriptor.payee,
+      expectedPayer: payer,
+      feePayer,
+      serializedTransaction,
+    })
+
+    expect(broadcast).toBeDefined()
+    expect(
+      Transaction.deserialize(broadcast as Transaction.TransactionSerializedTempo).feeToken,
+    ).toBe(sourceToken)
+  })
+
   test('hosted fee-payer relays a sender-signed open without local co-signing', async () => {
     const rpcMethods: string[] = []
     const serializedTransaction = await createOpenTransaction({ signed: true })
@@ -1193,6 +1249,41 @@ describe('precompile broadcastTopUpTransaction', () => {
     expect(
       rpcMethods.slice(0, broadcastIndex).filter((method) => method === 'eth_call'),
     ).toHaveLength(2)
+  })
+
+  test('fee-payer completes top-up with an explicit allowed fee token', async () => {
+    let broadcast: Hex | undefined
+    const serializedTransaction = await createTopUpTransaction({
+      feeToken: false,
+      gas: 100_000n,
+      signed: true,
+    })
+    const channelId = Channel.computeId({ ...descriptor, chainId, escrow: tip20ChannelEscrow })
+    const newDeposit = deposit * 2n
+
+    await Chain.broadcastTopUpTransaction({
+      additionalDeposit: deposit,
+      allowedFeeTokens: [sourceToken],
+      chainId,
+      client: createMockClient({
+        channel: { descriptor, state: { settled: 0n, deposit: newDeposit, closeRequestedAt: 0 } },
+        onRequest(method, params) {
+          if (method === 'eth_sendRawTransactionSync') broadcast = (params as readonly [Hex])[0]
+        },
+        receipt: receipt([topUpLog({ channelId, newDeposit })]),
+      }),
+      descriptor,
+      escrowContract: tip20ChannelEscrow,
+      expectedChannelId: channelId,
+      expectedCurrency: descriptor.token,
+      feePayer,
+      serializedTransaction,
+    })
+
+    expect(broadcast).toBeDefined()
+    expect(
+      Transaction.deserialize(broadcast as Transaction.TransactionSerializedTempo).feeToken,
+    ).toBe(sourceToken)
   })
 
   test('rejects top-up calldata amount mismatches before broadcasting', async () => {

--- a/src/tempo/session/precompile/Chain.ts
+++ b/src/tempo/session/precompile/Chain.ts
@@ -18,8 +18,34 @@ import { resolveFeeToken } from '../../internal/fee-token.js'
 import * as ChannelOps from '../server/ChannelOps.js'
 import * as ChannelUtils from './Channel.js'
 import type { ChannelDescriptor } from './Channel.js'
-import { escrowAbi } from './escrow.abi.js'
+import { channelDescriptorInput, escrowAbi } from './escrow.abi.js'
 import { tip20ChannelEscrow } from './Protocol.js'
+
+const machineSessionAbi = [
+  {
+    type: 'function',
+    name: 'settleSession',
+    stateMutability: 'nonpayable',
+    inputs: [
+      channelDescriptorInput,
+      { name: 'cumulativeAmount', type: 'uint96' },
+      { name: 'signature', type: 'bytes' },
+    ],
+    outputs: [],
+  },
+  {
+    type: 'function',
+    name: 'closeSession',
+    stateMutability: 'nonpayable',
+    inputs: [
+      channelDescriptorInput,
+      { name: 'cumulativeAmount', type: 'uint96' },
+      { name: 'captureAmount', type: 'uint96' },
+      { name: 'signature', type: 'bytes' },
+    ],
+    outputs: [],
+  },
+] as const
 
 /** Minimal on-chain state read back after precompile transaction receipts. */
 export type ReceiptValidationChannelState = {
@@ -637,6 +663,26 @@ export async function settleOnChain(
   )
 }
 
+/** Submit a settle transaction through the first-party machine-token session router. */
+export async function settleMachineSessionOnChain(
+  client: Client,
+  descriptor: ChannelDescriptor,
+  cumulativeAmount: bigint,
+  signature: Hex,
+  router: Address,
+  options?: ChannelTransactionOptions,
+): Promise<Hex> {
+  assertUint96(cumulativeAmount)
+  const args = [descriptorTuple(descriptor), cumulativeAmount, signature] as const
+  return sendPrecompileTransaction(
+    client,
+    router,
+    encodeFunctionData({ abi: machineSessionAbi, functionName: 'settleSession', args }),
+    'settle machine-token session',
+    options,
+  )
+}
+
 /**
  * Submit a top-up transaction on-chain.
  */
@@ -716,6 +762,28 @@ export async function closeOnChain(
     escrow,
     encodeFunctionData({ abi: escrowAbi, functionName: 'close', args }),
     'close',
+    options,
+  )
+}
+
+/** Submit a cooperative close through the first-party machine-token session router. */
+export async function closeMachineSessionOnChain(
+  client: Client,
+  descriptor: ChannelDescriptor,
+  cumulativeAmount: bigint,
+  captureAmount: bigint,
+  signature: Hex,
+  router: Address,
+  options?: ChannelTransactionOptions,
+): Promise<Hex> {
+  assertUint96(cumulativeAmount)
+  assertUint96(captureAmount)
+  const args = [descriptorTuple(descriptor), cumulativeAmount, captureAmount, signature] as const
+  return sendPrecompileTransaction(
+    client,
+    router,
+    encodeFunctionData({ abi: machineSessionAbi, functionName: 'closeSession', args }),
+    'close machine-token session',
     options,
   )
 }

--- a/src/tempo/session/precompile/Chain.ts
+++ b/src/tempo/session/precompile/Chain.ts
@@ -957,6 +957,8 @@ export type BroadcastOpenTransactionResult = {
 
 /** Inputs for broadcasting and verifying a client-signed TIP-1034 open transaction. */
 export type BroadcastOpenTransactionParameters = {
+  /** Fee tokens allowed when the server completes a sponsored transaction. Defaults to the channel currency. */
+  allowedFeeTokens?: readonly Address[] | undefined
   /** Hook invoked after calldata validation but before broadcasting. */
   beforeBroadcast?:
     | ((result: Omit<BroadcastOpenTransactionResult, 'txHash' | 'state'>) => Promise<void> | void)
@@ -1042,7 +1044,7 @@ export function validateOpenCredentialTransaction(
   })
   if (parameters.feePayer) assertSenderSigned(transaction)
   validateCredentialSponsorship({
-    allowedFeeTokens: [parameters.expectedCurrency],
+    allowedFeeTokens: parameters.allowedFeeTokens ?? [parameters.expectedCurrency],
     challengeExpires: parameters.challengeExpires,
     chainId: parameters.chainId,
     details: {
@@ -1083,7 +1085,7 @@ export async function broadcastOpenTransaction(
     challengeExpires: parameters.challengeExpires,
     chainId: parameters.chainId,
     client: parameters.client,
-    allowedFeeTokens: [parameters.expectedCurrency],
+    allowedFeeTokens: parameters.allowedFeeTokens ?? [parameters.expectedCurrency],
     details: {
       channelId: parameters.expectedChannelId,
       currency: parameters.expectedCurrency,
@@ -1136,6 +1138,8 @@ export type BroadcastTopUpTransactionResult = {
 export type BroadcastTopUpTransactionParameters = {
   /** Additional deposit amount expected in the top-up calldata. */
   additionalDeposit: bigint
+  /** Fee tokens allowed when the server completes a sponsored transaction. Defaults to the channel currency. */
+  allowedFeeTokens?: readonly Address[] | undefined
   /** Challenge expiration propagated into fee-payer policy checks. */
   challengeExpires?: string | undefined
   /** Chain ID used for fee-payer transaction signing. */
@@ -1195,7 +1199,7 @@ export function validateTopUpCredentialTransaction(
   })
   if (parameters.feePayer) assertSenderSigned(transaction)
   validateCredentialSponsorship({
-    allowedFeeTokens: [parameters.expectedCurrency],
+    allowedFeeTokens: parameters.allowedFeeTokens ?? [parameters.expectedCurrency],
     challengeExpires: parameters.challengeExpires,
     chainId: parameters.chainId,
     details: {
@@ -1219,7 +1223,7 @@ export async function broadcastTopUpTransaction(
     challengeExpires: parameters.challengeExpires,
     chainId: parameters.chainId,
     client: parameters.client,
-    allowedFeeTokens: [parameters.expectedCurrency],
+    allowedFeeTokens: parameters.allowedFeeTokens ?? [parameters.expectedCurrency],
     details: {
       additionalDeposit: parameters.additionalDeposit.toString(),
       channelId: parameters.expectedChannelId,

--- a/src/tempo/session/precompile/escrow.abi.ts
+++ b/src/tempo/session/precompile/escrow.abi.ts
@@ -14,7 +14,7 @@ const channelStateComponents = [
   { name: 'closeRequestedAt', type: 'uint32' },
 ] as const
 
-const channelDescriptorInput = {
+export const channelDescriptorInput = {
   name: 'descriptor',
   type: 'tuple',
   components: channelDescriptorComponents,

--- a/src/tempo/session/server/ChannelStore.ts
+++ b/src/tempo/session/server/ChannelStore.ts
@@ -356,7 +356,11 @@ export function resolveHighestVoucher(parameters: HighestVoucherParameters): Hig
 
   return {
     highestVoucherAmount: cumulativeAmount,
-    highestVoucher: { channelId, cumulativeAmount, signature },
+    highestVoucher: {
+      channelId,
+      cumulativeAmount,
+      signature,
+    },
   }
 }
 

--- a/src/tempo/session/server/CredentialVerification.test.ts
+++ b/src/tempo/session/server/CredentialVerification.test.ts
@@ -88,6 +88,28 @@ describe('SessionCredentialGuards', () => {
       })
     })
 
+    test('drops refund-only machine-token fields from close credentials', () => {
+      const authorizationSignature = `0x${'ab'.repeat(65)}` as Hex
+      const refundSignature = `0x${'cd'.repeat(65)}` as Hex
+      expect(
+        requireSessionCredentialPayload({
+          action: 'close',
+          authorizationSignature,
+          channelId,
+          cumulativeAmount: '1',
+          descriptor,
+          refundSignature,
+          signature,
+        }),
+      ).toEqual({
+        action: 'close',
+        channelId,
+        cumulativeAmount: '1',
+        descriptor,
+        signature,
+      })
+    })
+
     test('validates transaction payload fields by action', () => {
       expect(
         requireSessionCredentialPayload({

--- a/src/tempo/session/server/CredentialVerification.ts
+++ b/src/tempo/session/server/CredentialVerification.ts
@@ -17,6 +17,7 @@ import {
   VerificationFailedError,
 } from '../../../Errors.js'
 import type * as FeePayer from '../../internal/fee-payer.js'
+import * as MachineToken from '../../internal/machine-token.js'
 import * as Chain from '../precompile/Chain.js'
 import { readChannelClosedReceiptFields } from '../precompile/Chain.js'
 import * as Channel from '../precompile/Channel.js'
@@ -30,7 +31,11 @@ import {
 import * as Voucher from '../precompile/Voucher.js'
 import * as ChannelStore from './ChannelStore.js'
 import { getChallengePaymentFields } from './RequestState.js'
-import { assertSettlementSender, getClientAccount, type OnSessionSettlement } from './Settlement.js'
+import {
+  assertChannelSettlementSender,
+  getClientAccount,
+  type OnSessionSettlement,
+} from './Settlement.js'
 
 /** Returns the effective voucher signer for a TIP-1034 descriptor. */
 export function authorizedSigner(descriptor: Channel.ChannelDescriptor): Address {
@@ -95,6 +100,87 @@ export function validateChannelDescriptor(
     throw new VerificationFailedError({
       reason: 'channel descriptor operator does not match server operator',
     })
+  }
+}
+
+/** Resolves a trusted machine-token descriptor into the ordinary session verification shape. */
+export async function resolveCredentialChallenge(parameters: {
+  challenge: Challenge.Challenge
+  chainId: number
+  client: Chain.TransactionClient
+  escrow: Address
+  expectedOperator?: Address | undefined
+  payload: SessionCredentialPayload
+}): Promise<{ challenge: Challenge.Challenge; expectedOperator?: Address | undefined }> {
+  const { challenge, chainId, client, escrow, payload } = parameters
+  const { descriptor } = payload
+  const channelId = ChannelStore.normalizeChannelId(payload.channelId)
+  const request = getChallengePaymentFields(challenge)
+  const expectedOperator = parameters.expectedOperator ?? zeroAddress
+  const direct =
+    isAddressEqual(descriptor.payee, request.recipient) &&
+    isAddressEqual(descriptor.token, request.currency) &&
+    isAddressEqual(descriptor.operator, expectedOperator)
+
+  if (direct) {
+    validateChannelDescriptor(
+      descriptor,
+      channelId,
+      chainId,
+      escrow,
+      request.recipient,
+      request.currency,
+      expectedOperator,
+    )
+    return { challenge, expectedOperator: parameters.expectedOperator }
+  }
+
+  const computed = Channel.computeId({ ...descriptor, chainId, escrow })
+  if (computed.toLowerCase() !== channelId.toLowerCase())
+    throw new VerificationFailedError({ reason: 'channel descriptor does not match channelId' })
+
+  if (!MachineToken.isSessionEnabledChallenge(challenge)) {
+    // Preserve the existing field-specific rejection for ordinary sessions.
+    validateChannelDescriptor(
+      descriptor,
+      channelId,
+      chainId,
+      escrow,
+      request.recipient,
+      request.currency,
+      expectedOperator,
+    )
+  }
+
+  const route = await MachineToken.matchSessionRoute(client, {
+    active: payload.action !== 'close',
+    chainId,
+    descriptor,
+    merchant: request.recipient,
+    targetToken: request.currency,
+  })
+  if (!route)
+    throw new VerificationFailedError({
+      reason: 'machine-token channel is not bound to the challenged merchant and currency',
+    })
+
+  const methodDetails =
+    challenge.request.methodDetails && typeof challenge.request.methodDetails === 'object'
+      ? challenge.request.methodDetails
+      : {}
+  // The outer Mppx layer already authenticated the original challenge. This derived
+  // request is used only by the existing descriptor and transaction validators.
+  return {
+    challenge: {
+      ...challenge,
+      request: {
+        ...challenge.request,
+        currency: route.token,
+        methodDetails: { ...methodDetails, operator: route.operator },
+        recipient: route.payee,
+      },
+    },
+    expectedOperator: route.operator,
   }
 }
 
@@ -417,18 +503,20 @@ export async function validateCredentialPayload(
   parameters: ValidateCredentialPayloadParameters,
 ): Promise<CredentialPayloadValidation> {
   const { payload } = parameters
+  const resolved = await resolveCredentialChallenge(parameters)
+  const context = { ...parameters, ...resolved }
   switch (payload.action) {
     case 'open':
-      await validateOpenCredential(parameters, payload)
+      await validateOpenCredential(context, payload)
       break
     case 'topUp':
-      await validateTopUpCredential(parameters, payload)
+      await validateTopUpCredential(context, payload)
       break
     case 'voucher':
-      await validateVoucherCredential(parameters, payload)
+      await validateVoucherCredential(context, payload)
       break
     case 'close':
-      await validateCloseCredential(parameters, payload)
+      await validateCloseCredential(context, payload)
       break
   }
   return { action: payload.action, channelId: ChannelStore.normalizeChannelId(payload.channelId) }
@@ -623,6 +711,20 @@ async function resolveVoucherChannelState(parameters: {
   }
 }
 
+function assertMachineSessionCanClose(parameters: {
+  chainId: number
+  captureAmount: bigint
+  deposit: bigint
+  descriptor: ChannelDescriptor
+}): void {
+  if (!MachineToken.matchSessionDescriptor(parameters)) return
+  if (parameters.captureAmount !== parameters.deposit)
+    throw new VerificationFailedError({
+      reason:
+        'machine-token session refunds are not supported; close requires the full deposit to be spent',
+    })
+}
+
 async function validateCloseCredential(
   parameters: ValidateCredentialPayloadParameters,
   payload: Extract<SessionCredentialPayload, { action: 'close' }>,
@@ -673,13 +775,21 @@ async function validateCloseCredential(
   const captureAmount = uint96(channel.spent > state.settled ? channel.spent : state.settled)
   if (captureAmount > state.deposit)
     throw new AmountExceedsDepositError({ reason: 'close capture amount exceeds on-chain deposit' })
+  assertMachineSessionCanClose({
+    chainId,
+    captureAmount,
+    deposit: state.deposit,
+    descriptor: payload.descriptor,
+  })
   const account = parameters.account ?? getClientAccount(client)
-  assertSettlementSender({
+  assertChannelSettlementSender({
     operation: 'close',
     channelId,
+    chainId,
     operator: channel.operator,
     payee: channel.payee,
     sender: account?.address,
+    token: channel.token,
   })
 }
 
@@ -687,7 +797,8 @@ async function validateCloseCredential(
 export async function broadcastCredentialPayload(
   context: BroadcastCredentialPayloadParameters,
 ): Promise<SessionReceipt> {
-  const receipt = await broadcastCredentialAction(context)
+  const resolved = await resolveCredentialChallenge(context)
+  const receipt = await broadcastCredentialAction({ ...context, ...resolved })
   if (refreshOnChainVerificationCache[context.payload.action])
     context.lastOnChainVerified.set(receipt.channelId, Date.now())
   return receipt
@@ -987,9 +1098,19 @@ async function handleCloseCredential(
     channel.authorizedSigner,
   )
   if (!valid) throw new InvalidSignatureError({ reason: 'invalid voucher signature' })
+  const machineDeployment = MachineToken.matchSessionDescriptor({
+    chainId,
+    descriptor: channel.descriptor,
+  })
   let captureAmount = uint96(channel.spent > state.settled ? channel.spent : state.settled)
   if (captureAmount > state.deposit)
     throw new AmountExceedsDepositError({ reason: 'close capture amount exceeds on-chain deposit' })
+  assertMachineSessionCanClose({
+    chainId,
+    captureAmount,
+    deposit: state.deposit,
+    descriptor: channel.descriptor,
+  })
   const pendingCloseStartedAt = BigInt(Math.floor(Date.now() / 1000) || 1)
   const previousCloseRequestedAt = channel.closeRequestedAt
   let pendingCloseMarked = false
@@ -1011,30 +1132,46 @@ async function handleCloseCredential(
   let txHash: Hex | undefined
   let receipt: Awaited<ReturnType<typeof Chain.waitForSuccessfulReceipt>>
   try {
-    assertSettlementSender({
+    assertChannelSettlementSender({
       operation: 'close',
       channelId,
+      chainId,
       operator: channel.operator,
       payee: channel.payee,
       sender: account?.address,
+      token: channel.token,
     })
-    txHash = await Chain.closeOnChain(
-      client,
-      channel.descriptor,
-      cumulativeAmount,
-      captureAmount,
-      payload.signature,
-      escrow,
-      account
-        ? {
-            account,
-            ...(typeof parameters.feePayer === 'object' ? { feePayer: parameters.feePayer } : {}),
-            ...(parameters.feePayerPolicy ? { feePayerPolicy: parameters.feePayerPolicy } : {}),
-            ...(parameters.feeToken ? { feeToken: parameters.feeToken } : {}),
-            candidateFeeTokens: [channel.token],
-          }
-        : undefined,
-    )
+    const feeToken =
+      parameters.feeToken ??
+      (machineDeployment ? MachineToken.getSessionFeeToken(chainId) : undefined)
+    const transactionOptions = account
+      ? {
+          account,
+          ...(typeof parameters.feePayer === 'object' ? { feePayer: parameters.feePayer } : {}),
+          ...(parameters.feePayerPolicy ? { feePayerPolicy: parameters.feePayerPolicy } : {}),
+          ...(feeToken ? { feeToken } : {}),
+          candidateFeeTokens: [feeToken ?? channel.token],
+        }
+      : undefined
+    txHash = machineDeployment
+      ? await Chain.closeMachineSessionOnChain(
+          client,
+          channel.descriptor,
+          cumulativeAmount,
+          captureAmount,
+          payload.signature,
+          machineDeployment.swap,
+          transactionOptions,
+        )
+      : await Chain.closeOnChain(
+          client,
+          channel.descriptor,
+          cumulativeAmount,
+          captureAmount,
+          payload.signature,
+          escrow,
+          transactionOptions,
+        )
     receipt = await Chain.waitForSuccessfulReceipt(client, txHash)
   } catch (error) {
     if (pendingCloseMarked) {
@@ -1050,8 +1187,15 @@ async function handleCloseCredential(
     Chain.getChannelEvent(receipt, 'ChannelClosed', channelId),
   )
   const { refundedToPayer, settledToPayee } = closed
-  if (settledToPayee > captureAmount || settledToPayee + refundedToPayer > state.deposit)
+  if (machineDeployment) {
+    if (settledToPayee !== state.deposit || refundedToPayer !== 0n)
+      throw new VerificationFailedError({
+        reason: 'machine-token ChannelClosed amounts are invalid',
+      })
+  } else if (settledToPayee > captureAmount || settledToPayee + refundedToPayer > state.deposit) {
     throw new VerificationFailedError({ reason: 'ChannelClosed amounts do not match state' })
+  }
+  const logicalSettled = machineDeployment ? captureAmount : settledToPayee
   const updated = await store.updateChannel(channelId, (current) =>
     ChannelStore.finalizeClosedChannelState({
       captureAmount,
@@ -1068,8 +1212,8 @@ async function handleCloseCredential(
           txHash,
           channelId,
           trigger: 'close' as const,
-          amount: settledToPayee,
-          delta: settledToPayee - state.settled,
+          amount: logicalSettled,
+          delta: logicalSettled - state.settled,
         }),
       )
     } catch {

--- a/src/tempo/session/server/CredentialVerification.ts
+++ b/src/tempo/session/server/CredentialVerification.ts
@@ -424,7 +424,7 @@ export type BroadcastCredentialPayloadParameters = {
   feePayer?: viem_Account | true | undefined
   /** Optional policy for fee-sponsored close/open/top-up transactions. */
   feePayerPolicy?: Partial<FeePayer.Policy> | undefined
-  /** Optional fee token override for close transactions. */
+  /** Optional fee token override for sponsored management and settlement transactions. */
   feeToken?: Address | undefined
   /** Last successful on-chain refresh timestamp per channel ID. */
   lastOnChainVerified: Map<Hex, number>
@@ -483,6 +483,7 @@ export type ValidateCredentialPayloadParameters = Pick<
   | 'expectedOperator'
   | 'feePayer'
   | 'feePayerPolicy'
+  | 'feeToken'
   | 'lastOnChainVerified'
   | 'minVoucherDelta'
   | 'payload'
@@ -549,6 +550,7 @@ async function validateOpenCredential(
     expectedOperator,
   )
   const transaction = Chain.validateOpenCredentialTransaction({
+    ...(parameters.feeToken ? { allowedFeeTokens: [parameters.feeToken] } : {}),
     challengeExpires: challenge.expires,
     chainId,
     escrowContract: escrow,
@@ -614,6 +616,7 @@ async function validateTopUpCredential(
   })
   const transaction = Chain.validateTopUpCredentialTransaction({
     additionalDeposit,
+    ...(parameters.feeToken ? { allowedFeeTokens: [parameters.feeToken] } : {}),
     challengeExpires: challenge.expires,
     chainId,
     descriptor: channel.descriptor,
@@ -861,6 +864,7 @@ async function handleOpenCredential(
   )
 
   const result = await Chain.broadcastOpenTransaction({
+    ...(parameters.feeToken ? { allowedFeeTokens: [parameters.feeToken] } : {}),
     challengeExpires: challenge.expires,
     chainId,
     client,
@@ -950,6 +954,7 @@ async function handleTopUpCredential(
   })
   const result = await Chain.broadcastTopUpTransaction({
     additionalDeposit,
+    ...(parameters.feeToken ? { allowedFeeTokens: [parameters.feeToken] } : {}),
     challengeExpires: challenge.expires,
     chainId,
     client,

--- a/src/tempo/session/server/MachineTokenNegotiation.test.ts
+++ b/src/tempo/session/server/MachineTokenNegotiation.test.ts
@@ -1,0 +1,237 @@
+import {
+  type Address,
+  createClient,
+  custom,
+  encodeAbiParameters,
+  encodeFunctionData,
+  zeroAddress,
+} from 'viem'
+import { describe, expect, test } from 'vp/test'
+
+import * as Constants from '../../../Constants.js'
+import * as defaults from '../../internal/defaults.js'
+import * as Methods from '../../Methods.js'
+import * as Channel from '../precompile/Channel.js'
+import { tip20ChannelEscrow } from '../precompile/Protocol.js'
+import { resolveCredentialChallenge } from './CredentialVerification.js'
+import { session } from './Session.js'
+
+const chainId = defaults.chainId.testnet
+const deployment = defaults.machineToken[chainId]
+const merchant = '0x2222222222222222222222222222222222222222' as Address
+const otherMerchant = '0x3333333333333333333333333333333333333333' as Address
+const payer = '0x1111111111111111111111111111111111111111' as Address
+const targetToken = '0x20C0000000000000000000000000000000000001' as Address
+const routeAddress = '0x44D7c1EDFdfdfDFdFdFDFDFd0000000000000001' as Address
+
+const routeAbi = [
+  {
+    inputs: [
+      { name: 'merchant', type: 'address' },
+      { name: 'targetToken', type: 'address' },
+    ],
+    name: 'sessionRouteFor',
+    outputs: [{ name: 'routeAddress', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [{ name: 'routeAddress', type: 'address' }],
+    name: 'sessionRoutes',
+    outputs: [
+      { name: 'merchant', type: 'address' },
+      { name: 'targetToken', type: 'address' },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+] as const
+
+function routeClient(active = true) {
+  const sessionRouteForSelector = encodeFunctionData({
+    abi: routeAbi,
+    functionName: 'sessionRouteFor',
+    args: [merchant, targetToken],
+  }).slice(0, 10)
+  const sessionRoutesSelector = encodeFunctionData({
+    abi: routeAbi,
+    functionName: 'sessionRoutes',
+    args: [routeAddress],
+  }).slice(0, 10)
+
+  return createClient({
+    chain: { id: chainId } as never,
+    transport: custom({
+      async request(args) {
+        if (args.method === 'eth_chainId') return `0x${chainId.toString(16)}`
+        if (args.method === 'eth_call') {
+          const data = (args.params as [{ data?: `0x${string}` }])[0].data
+          if (data?.slice(0, 10) === sessionRouteForSelector)
+            return encodeAbiParameters([{ type: 'address' }], [active ? routeAddress : zeroAddress])
+          if (data?.slice(0, 10) === sessionRoutesSelector)
+            return encodeAbiParameters(
+              [{ type: 'address' }, { type: 'address' }],
+              [merchant, targetToken],
+            )
+        }
+        throw new Error(`unexpected RPC request: ${args.method}`)
+      },
+    }),
+  })
+}
+
+function logicalRequest() {
+  return {
+    amount: '1',
+    chainId,
+    currency: targetToken,
+    decimals: 6,
+    machineTokenEnabled: true,
+    recipient: merchant,
+    unitType: 'request' as const,
+  }
+}
+
+function challenge(recipient: Address = merchant, machineTokenEnabled = true) {
+  return {
+    id: 'machine-session-challenge',
+    intent: 'session',
+    method: 'tempo',
+    realm: 'merchant.example',
+    request: {
+      amount: '1000000',
+      currency: targetToken,
+      methodDetails: {
+        chainId,
+        escrowContract: tip20ChannelEscrow,
+        machineTokenEnabled,
+        sessionProtocol: Constants.SessionProtocols.v2,
+      },
+      recipient,
+      unitType: 'request',
+    },
+  } as const
+}
+
+const descriptor = {
+  authorizedSigner: payer,
+  expiringNonceHash: `0x${'22'.repeat(32)}` as const,
+  operator: deployment.swap,
+  payee: routeAddress,
+  payer,
+  salt: `0x${'11'.repeat(32)}` as const,
+  token: deployment.token,
+}
+const channelId = Channel.computeId({
+  ...descriptor,
+  chainId,
+  escrow: tip20ChannelEscrow,
+})
+
+describe('machine-token session negotiation', () => {
+  test('keeps the server request logical and binds the capability into method details', async () => {
+    const method = session({
+      amount: '1',
+      chainId,
+      currency: targetToken,
+      getClient: () => routeClient(),
+      machineTokenEnabled: true,
+      recipient: merchant,
+      unitType: 'request',
+    })
+
+    const request = await method.request!({ credential: null, request: logicalRequest() } as never)
+    expect(request).toMatchObject({
+      currency: targetToken,
+      machineTokenEnabled: true,
+      recipient: merchant,
+    })
+    expect(Methods.session.schema.request.parse(request)).toMatchObject({
+      currency: targetToken,
+      methodDetails: { chainId, machineTokenEnabled: true },
+      recipient: merchant,
+    })
+  })
+
+  test('accepts only the canonical route for the challenged merchant and currency', async () => {
+    await expect(
+      resolveCredentialChallenge({
+        challenge: challenge(),
+        chainId,
+        client: routeClient(),
+        escrow: tip20ChannelEscrow,
+        payload: {
+          action: 'voucher',
+          channelId,
+          cumulativeAmount: '1',
+          descriptor,
+          signature: '0x',
+        },
+      }),
+    ).resolves.toMatchObject({
+      challenge: { request: { currency: deployment.token, recipient: routeAddress } },
+      expectedOperator: deployment.swap,
+    })
+
+    await expect(
+      resolveCredentialChallenge({
+        challenge: challenge(otherMerchant),
+        chainId,
+        client: routeClient(),
+        escrow: tip20ChannelEscrow,
+        payload: {
+          action: 'voucher',
+          channelId,
+          cumulativeAmount: '1',
+          descriptor,
+          signature: '0x',
+        },
+      }),
+    ).rejects.toThrow('not bound to the challenged merchant and currency')
+    await expect(
+      resolveCredentialChallenge({
+        challenge: challenge(merchant, false),
+        chainId,
+        client: routeClient(),
+        escrow: tip20ChannelEscrow,
+        payload: {
+          action: 'voucher',
+          channelId,
+          cumulativeAmount: '1',
+          descriptor,
+          signature: '0x',
+        },
+      }),
+    ).rejects.toThrow('payee does not match server destination')
+  })
+
+  test('requires an active route for payments but permits an immutable route during close', async () => {
+    await expect(
+      resolveCredentialChallenge({
+        challenge: challenge(),
+        chainId,
+        client: routeClient(false),
+        escrow: tip20ChannelEscrow,
+        payload: {
+          action: 'voucher',
+          channelId,
+          cumulativeAmount: '1',
+          descriptor,
+          signature: '0x',
+        },
+      }),
+    ).rejects.toThrow('not bound to the challenged merchant and currency')
+    await expect(
+      resolveCredentialChallenge({
+        challenge: challenge(),
+        chainId,
+        client: routeClient(false),
+        escrow: tip20ChannelEscrow,
+        payload: { action: 'close', channelId, cumulativeAmount: '1', descriptor, signature: '0x' },
+      }),
+    ).resolves.toMatchObject({
+      challenge: { request: { recipient: routeAddress } },
+      expectedOperator: deployment.swap,
+    })
+  })
+})

--- a/src/tempo/session/server/RequestState.test.ts
+++ b/src/tempo/session/server/RequestState.test.ts
@@ -1,6 +1,6 @@
 import type { Address, Hex } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { describe, expect, test } from 'vp/test'
+import { describe, expect, test, vi } from 'vp/test'
 
 import type * as Credential from '../../../Credential.js'
 import type { SessionCredentialPayload } from '../precompile/Protocol.js'
@@ -542,6 +542,31 @@ describe('SessionSnapshotHints', () => {
           item.name,
         ).resolves.toBeUndefined()
       }
+    })
+
+    test('permits an independently verified alternate descriptor in reusable hints', async () => {
+      const logicalRecipient = '0x0000000000000000000000000000000000000005' as Address
+      const logicalCurrency = '0x0000000000000000000000000000000000000006' as Address
+      const matchPaymentFields = vi.fn(() => true)
+
+      await expect(
+        resolveSessionSnapshot({
+          amount: 50n,
+          channelId,
+          expected: {
+            chainId: 4217,
+            currency: logicalCurrency,
+            escrowContract,
+            recipient: logicalRecipient,
+          },
+          matchPaymentFields,
+          store: store(channel()),
+        }),
+      ).resolves.toEqual(expect.objectContaining({ descriptor }))
+      expect(matchPaymentFields).toHaveBeenCalledWith(
+        expect.objectContaining({ descriptor }),
+        expect.objectContaining({ currency: logicalCurrency, recipient: logicalRecipient }),
+      )
     })
 
     test('omits hints for missing, non-precompile, closing, or finalized channels', async () => {

--- a/src/tempo/session/server/RequestState.ts
+++ b/src/tempo/session/server/RequestState.ts
@@ -11,6 +11,7 @@ import * as Constants from '../../../Constants.js'
 import type * as Credential from '../../../Credential.js'
 import { VerificationFailedError } from '../../../Errors.js'
 import type { Challenge } from '../../../index.js'
+import type { MaybePromise } from '../../../internal/types.js'
 import type * as z from '../../../zod.js'
 import * as Methods from '../../Methods.js'
 import {
@@ -38,6 +39,8 @@ export type ResolveSessionSnapshotParameters = {
   channelId: Hex | undefined
   /** Payment fields the reusable channel must match before it is advertised. */
   expected?: SessionSnapshotPaymentFields | undefined
+  /** Optional alternate-rail matcher when the stored descriptor differs from logical payment fields. */
+  matchPaymentFields?: MatchSessionSnapshotPaymentFields | undefined
   /** Server channel store. */
   store: ChannelStore.ChannelStore
 }
@@ -53,6 +56,12 @@ export type SessionSnapshotPaymentFields = {
   /** Payee address expected by the challenge. */
   recipient: Address
 }
+
+/** Validates an alternate channel descriptor against the logical session payment fields. */
+export type MatchSessionSnapshotPaymentFields = (
+  channel: ChannelStore.StoredPrecompileChannel,
+  expected: SessionSnapshotPaymentFields,
+) => MaybePromise<boolean>
 
 /** Request metadata available to `resolveChannelId` without exposing a mutable `Request`. */
 export type SessionChannelIdRequest = {
@@ -138,7 +147,7 @@ export async function resolveSessionChannelId(parameters: {
 export async function resolveSessionSnapshot(
   parameters: ResolveSessionSnapshotParameters,
 ): Promise<SessionSnapshot | undefined> {
-  const { amount, channelId, expected, store } = parameters
+  const { amount, channelId, expected, matchPaymentFields, store } = parameters
   if (!channelId) return undefined
   const channel = await store.getChannel(ChannelStore.normalizeChannelId(channelId))
   if (!channel || !ChannelStore.isPrecompileState(channel)) return undefined
@@ -146,7 +155,12 @@ export async function resolveSessionSnapshot(
   if (channel.closeRequestedAt !== 0n) return undefined
   if (!channel.highestVoucher) return undefined
   if (channel.highestVoucher.cumulativeAmount !== channel.highestVoucherAmount) return undefined
-  if (expected && !matchesSnapshotPaymentFields(channel, expected)) return undefined
+  if (
+    expected &&
+    !matchesSnapshotPaymentFields(channel, expected) &&
+    !(await matchPaymentFields?.(channel, expected))
+  )
+    return undefined
   const requiredCumulative = channel.spent + amount
   return {
     acceptedCumulative: channel.highestVoucherAmount.toString(),
@@ -242,6 +256,8 @@ export type SessionMethodDetails = {
   escrowContract: Address
   /** Whether this challenge allows fee-sponsored management transactions. */
   feePayer?: boolean | undefined
+  /** Whether clients may fund this logical session through the first-party machine-token rail. */
+  machineTokenEnabled?: boolean | undefined
   /** Minimum raw-unit increase required for voucher credentials. */
   minVoucherDelta?: string | undefined
   /** Channel operator address the client should encode in new open transactions. */
@@ -264,6 +280,7 @@ export type ResolveSessionPaymentRequestParameters = {
   decimals: number
   defaultFeePayer?: viem_Account | undefined
   getClient: ResolveRequestChainIdParameters['getClient']
+  matchSnapshotPaymentFields?: MatchSessionSnapshotPaymentFields | undefined
   parameterChainId?: number | undefined
   parameterEscrowContract?: Address | undefined
   parameterFeePayer?: ParameterFeePayer
@@ -328,6 +345,7 @@ function isCanonicalSessionMethodDetails(value: unknown): value is SessionMethod
     typeof value.escrowContract === 'string' &&
     isAddress(value.escrowContract, { strict: false }) &&
     (value.feePayer === undefined || typeof value.feePayer === 'boolean') &&
+    (value.machineTokenEnabled === undefined || typeof value.machineTokenEnabled === 'boolean') &&
     (value.minVoucherDelta === undefined || typeof value.minVoucherDelta === 'string') &&
     (value.operator === undefined ||
       (typeof value.operator === 'string' && isAddress(value.operator, { strict: false }))) &&
@@ -384,6 +402,7 @@ export async function resolveSessionPaymentRequest(
     decimals,
     defaultFeePayer,
     getClient,
+    matchSnapshotPaymentFields,
     parameterChainId,
     parameterEscrowContract,
     parameterFeePayer,
@@ -427,6 +446,7 @@ export async function resolveSessionPaymentRequest(
       escrowContract,
       recipient: readChallengeAddress(request.recipient, 'recipient'),
     },
+    matchPaymentFields: matchSnapshotPaymentFields,
     store,
   })
   const { operator: _operator, ...requestWithoutOperator } = request

--- a/src/tempo/session/server/Session.ts
+++ b/src/tempo/session/server/Session.ts
@@ -5,7 +5,7 @@
  * and one-shot settlement. Each incoming request carries a session credential
  * with a cumulative voucher that the server validates and records.
  */
-import { isAddress, type Address, type Hex } from 'viem'
+import { isAddress, isAddressEqual, type Address, type Hex } from 'viem'
 import { tempo as tempo_chain } from 'viem/chains'
 
 import * as Challenge from '../../../Challenge.js'
@@ -21,6 +21,7 @@ import * as Client from '../../../viem/Client.js'
 import * as Account from '../../internal/account.js'
 import * as defaults from '../../internal/defaults.js'
 import * as FeePayer from '../../internal/fee-payer.js'
+import * as MachineToken from '../../internal/machine-token.js'
 import type * as types from '../../internal/types.js'
 import * as Methods from '../../Methods.js'
 import * as ChargeServer from '../../server/Charge.js'
@@ -36,6 +37,7 @@ import { requireSessionCredentialPayload } from './CredentialVerification.js'
 import {
   type ResolveSessionChannelId,
   resolveCredentialVerificationContext,
+  type MatchSessionSnapshotPaymentFields,
   resolveSessionChannelId,
   resolveSessionSnapshot,
   resolveSessionPaymentRequest,
@@ -71,6 +73,7 @@ type SessionDefaultValues = {
   amount: session.Parameters['amount']
   currency: session.Parameters['currency']
   decimals: number
+  machineTokenEnabled: boolean | undefined
   operator: session.Parameters['operator']
   recipient: Address | undefined
   suggestedDeposit: session.Parameters['suggestedDeposit']
@@ -105,6 +108,7 @@ type BootstrapPreflightParameters = {
     chainId?: number | undefined
   }): MaybePromise<{ chain?: { id?: number | undefined } | undefined }>
   input: Request
+  matchSnapshotPaymentFields?: MatchSessionSnapshotPaymentFields | undefined
   parameterChainId?: number | undefined
   parameterEscrowContract?: Address | undefined
   paymentRequest: SessionPaymentRequestInput
@@ -297,6 +301,7 @@ async function handleBootstrapPreflight(
       ),
       recipient: readBootstrapAddress(request.recipient, 'recipient'),
     },
+    matchPaymentFields: parameters.matchSnapshotPaymentFields,
     store: parameters.store,
   })
   const headers = new Headers({ 'Cache-Control': 'no-store' })
@@ -317,6 +322,7 @@ export function session<const parameters extends session.Parameters>(
     channelStateTtl = 5_000,
     currency = defaults.resolveCurrency(parameters),
     decimals = defaults.decimals,
+    machineTokenEnabled,
     operator,
     store: rawStore = Store.memory(),
     suggestedDeposit,
@@ -335,6 +341,26 @@ export function session<const parameters extends session.Parameters>(
     getClient: parameters.getClient,
     rpcUrl: defaults.rpcUrl,
   })
+  const matchSnapshotPaymentFields: MatchSessionSnapshotPaymentFields | undefined =
+    machineTokenEnabled
+      ? async (channel, expected) => {
+          if (
+            channel.chainId !== expected.chainId ||
+            !isAddressEqual(channel.escrowContract, expected.escrowContract)
+          )
+            return false
+          return !!(await MachineToken.matchSessionRoute(
+            await getClient({ chainId: expected.chainId }),
+            {
+              active: true,
+              chainId: expected.chainId,
+              descriptor: channel.descriptor,
+              merchant: expected.recipient,
+              targetToken: expected.currency,
+            },
+          ))
+        }
+      : undefined
   const settleScheduled: SettleChargedSessionChannel = async (channel) => {
     if (!isSettlementDue(channel, settlementSchedule)) return undefined
     return maybeSettleScheduled({
@@ -487,6 +513,7 @@ export function session<const parameters extends session.Parameters>(
       amount,
       currency,
       decimals,
+      machineTokenEnabled,
       operator,
       recipient,
       suggestedDeposit,
@@ -509,6 +536,7 @@ export function session<const parameters extends session.Parameters>(
             defaultRecipient: recipient,
             expires,
             getClient,
+            matchSnapshotPaymentFields,
             parameterChainId: parameters.chainId,
             parameterEscrowContract: parameters.escrowContract,
             paymentRequest: options,
@@ -527,6 +555,7 @@ export function session<const parameters extends session.Parameters>(
         decimals,
         defaultFeePayer: feePayer,
         getClient,
+        matchSnapshotPaymentFields,
         parameterChainId: parameters.chainId,
         parameterEscrowContract: parameters.escrowContract,
         parameterFeePayer: parameters.feePayer,
@@ -534,6 +563,13 @@ export function session<const parameters extends session.Parameters>(
         resolveChannelId: parameters.resolveChannelId,
         store,
       })
+      if (
+        resolvedRequest.machineTokenEnabled &&
+        !MachineToken.isSessionSupported(resolvedRequest.chainId)
+      )
+        throw new Error(
+          `Machine-token sessions are not supported on chainId ${resolvedRequest.chainId}.`,
+        )
       return {
         ...resolvedRequest,
         sessionProtocol: Constants.SessionProtocols.v2,
@@ -635,7 +671,8 @@ export namespace session {
 
     /** Optional fee token used for server-driven close transactions. */
     feeToken?: Address | undefined
-  } & Account.resolve.Parameters &
+  } & MachineToken.Options &
+    Account.resolve.Parameters &
     Client.getResolver.Parameters &
     Defaults &
     Method.ComposableHooks<typeof Methods.session>

--- a/src/tempo/session/server/Session.ts
+++ b/src/tempo/session/server/Session.ts
@@ -425,6 +425,7 @@ export function session<const parameters extends session.Parameters>(
       expectedOperator: context.methodDetails.operator,
       feePayer: context.feePayer,
       feePayerPolicy: parameters.feePayerPolicy,
+      feeToken: parameters.feeToken,
       lastOnChainVerified,
       minVoucherDelta: context.minVoucherDelta,
       payload,

--- a/src/tempo/session/server/Settlement.ts
+++ b/src/tempo/session/server/Settlement.ts
@@ -20,6 +20,7 @@ import type { MaybePromise } from '../../../internal/types.js'
 import type * as Method from '../../../Method.js'
 import * as Store from '../../../Store.js'
 import type * as FeePayer from '../../internal/fee-payer.js'
+import * as MachineToken from '../../internal/machine-token.js'
 import { isSessionContentRequest } from '../../server/internal/request-body.js'
 import * as Chain from '../precompile/Chain.js'
 import { readSettledReceiptFields } from '../precompile/Chain.js'
@@ -344,6 +345,12 @@ export type SettlementSenderParameters = {
   sender: Address | undefined
 }
 
+/** Inputs used to select direct reserve settlement or the machine-token router. */
+export type ChannelSettlementSenderParameters = SettlementSenderParameters & {
+  chainId: number
+  token: Address
+}
+
 /** Options for server-driven precompile settlement transactions. */
 export type SettlementTransactionOptions = {
   /** Account used to send the settlement transaction. Defaults to the viem client account. */
@@ -411,6 +418,19 @@ export function assertSettlementSender(parameters: SettlementSenderParameters) {
   })
 }
 
+/** Validates a direct payee/operator sender, or any funded caller for a trusted router channel. */
+export function assertChannelSettlementSender(parameters: ChannelSettlementSenderParameters) {
+  const deployment = MachineToken.matchSessionDescriptor({
+    chainId: parameters.chainId,
+    descriptor: { operator: parameters.operator, token: parameters.token },
+  })
+  if (!deployment) return assertSettlementSender(parameters)
+  if (parameters.sender) return
+  throw new Error(
+    `Cannot ${parameters.operation} machine-token channel ${parameters.channelId}: no account available. Pass an account override, or provide a getClient() that returns an account-bearing client.`,
+  )
+}
+
 /** Applies automatic settlement when the server-owned schedule is due. */
 export async function maybeSettleScheduled(
   parameters: MaybeSettleScheduledParameters,
@@ -446,30 +466,49 @@ export async function settle(
   if (!channel.highestVoucher) throw new VerificationFailedError({ reason: 'no voucher to settle' })
   const escrow = options?.escrowContract ?? channel.escrowContract
   const account = options?.account ?? getClientAccount(client)
-  assertSettlementSender({
+  assertChannelSettlementSender({
     operation: 'settle',
     channelId,
+    chainId: channel.chainId,
     operator: channel.operator,
     payee: channel.payee,
     sender: account?.address,
+    token: channel.token,
   })
   const amount = uint96(channel.highestVoucher.cumulativeAmount)
-  const txHash = await Chain.settleOnChain(
-    client,
-    channel.descriptor,
-    amount,
-    channel.highestVoucher.signature,
-    escrow,
-    account
-      ? {
-          account,
-          ...(options?.feePayer ? { feePayer: options.feePayer } : {}),
-          ...(options?.feePayerPolicy ? { feePayerPolicy: options.feePayerPolicy } : {}),
-          ...(options?.feeToken ? { feeToken: options.feeToken } : {}),
-          candidateFeeTokens: options?.candidateFeeTokens ?? [channel.token],
-        }
-      : undefined,
-  )
+  const machineDeployment = MachineToken.matchSessionDescriptor({
+    chainId: channel.chainId,
+    descriptor: channel.descriptor,
+  })
+  const feeToken =
+    options?.feeToken ??
+    (machineDeployment ? MachineToken.getSessionFeeToken(channel.chainId) : undefined)
+  const transactionOptions = account
+    ? {
+        account,
+        ...(options?.feePayer ? { feePayer: options.feePayer } : {}),
+        ...(options?.feePayerPolicy ? { feePayerPolicy: options.feePayerPolicy } : {}),
+        ...(feeToken ? { feeToken } : {}),
+        candidateFeeTokens: options?.candidateFeeTokens ?? [feeToken ?? channel.token],
+      }
+    : undefined
+  const txHash = machineDeployment
+    ? await Chain.settleMachineSessionOnChain(
+        client,
+        channel.descriptor,
+        amount,
+        channel.highestVoucher.signature,
+        machineDeployment.swap,
+        transactionOptions,
+      )
+    : await Chain.settleOnChain(
+        client,
+        channel.descriptor,
+        amount,
+        channel.highestVoucher.signature,
+        escrow,
+        transactionOptions,
+      )
   const receipt = await Chain.waitForSuccessfulReceipt(client, txHash)
   const settled = readSettledReceiptFields(Chain.getChannelEvent(receipt, 'Settled', channelId))
   const { newSettled } = settled


### PR DESCRIPTION
## Why

Merchants should enable machine-token-funded sessions with one flag, and deferring partial refunds removes the extra router and refund signatures from session credentials.

## What

- Keep server challenges in the merchant normal currency and recipient, with only `machineTokenEnabled: true` added.
- Reshape opted-in client channels to verified machineUSD virtual routes and settle them through the combined router with ordinary reserve vouchers.
- Complete fee-sponsored open and top-up transactions with the server configured liquid fee token, including pathUSD-sponsored machineUSD channels.
- Allow full-spend close and reject partial close before broadcast until the reserve supports restricted-token refunds.
- Preserve ordinary session and charge behavior and configure the verified no-refund Moderato deployment.
