### PR TITLE
fix: support standard x402 client payments

### DIFF
--- a/.changeset/standard-x402-exact-client.md
+++ b/.changeset/standard-x402-exact-client.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added client signing support for standard x402 exact EIP-3009 offers without requiring mppx route-binding extensions.

--- a/src/client/internal/Fetch.test.ts
+++ b/src/client/internal/Fetch.test.ts
@@ -1,8 +1,9 @@
 import { Challenge, Credential, Errors, Mcp, Receipt } from 'mppx'
-import { tempo } from 'mppx/client'
+import { evm, tempo } from 'mppx/client'
 import { Mppx as Mppx_server, tempo as tempo_server } from 'mppx/server'
 import { Header as x402_Header, Types as x402_Types, type PaymentRequired } from 'mppx/x402'
 import { Base64 } from 'ox'
+import type { Account } from 'viem'
 import { createClient, defineChain } from 'viem'
 import { describe, expect, test, vi } from 'vp/test'
 import * as Http from '~test/Http.js'
@@ -369,6 +370,15 @@ const x402PaymentRequired = {
   resource: { url: 'https://example.com/api' },
   x402Version: 2,
 } satisfies PaymentRequired
+
+const x402Eip3009Accept = {
+  ...x402PaymentRequired.accepts[0]!,
+  extra: {
+    assetTransferMethod: 'eip3009',
+    name: 'USDC',
+    version: '2',
+  },
+} satisfies x402_Types.PaymentRequirements
 
 /** Builds a valid 402 response with a WWW-Authenticate header. */
 function make402(overrides?: { expires?: string; id?: string; intent?: string; method?: string }) {
@@ -871,7 +881,11 @@ describe('Fetch.from: 402 retry path', () => {
     expect(retryHeaders.get(x402_Types.paymentSignatureHeader)).toBeNull()
   })
 
-  test('uses x402 when no signable Payment-auth challenge is available', async () => {
+  test('signs a standard x402 EIP-3009 challenge without mppx extensions', async () => {
+    const paymentRequired = {
+      ...x402PaymentRequired,
+      accepts: [x402Eip3009Accept],
+    } satisfies PaymentRequired
     let callCount = 0
     const calls: { init: RequestInit | undefined }[] = []
     const mockFetch: typeof globalThis.fetch = async (_input, init) => {
@@ -881,8 +895,7 @@ describe('Fetch.from: 402 retry path', () => {
         return new Response(null, {
           status: 402,
           headers: {
-            [x402_Types.paymentRequiredHeader]:
-              x402_Header.encodePaymentRequired(x402PaymentRequired),
+            [x402_Types.paymentRequiredHeader]: x402_Header.encodePaymentRequired(paymentRequired),
           },
         })
       return new Response('OK', { status: 200 })
@@ -891,13 +904,13 @@ describe('Fetch.from: 402 retry path', () => {
     const fetch = Fetch.from({
       fetch: mockFetch,
       methods: [
-        {
-          name: 'evm',
-          intent: 'charge',
-          context: undefined,
-          createCredential: async () => 'x402-credential',
-        },
-      ] as const,
+        evm.charge({
+          account: accounts[0],
+          currencies: [evm.assets.baseSepolia.USDC],
+          maxAmount: '0.01',
+          networks: [84532],
+        }),
+      ],
     })
 
     const response = await fetch('https://example.com/api')
@@ -905,7 +918,107 @@ describe('Fetch.from: 402 retry path', () => {
     expect(response.status).toBe(200)
     const retryHeaders = new Headers(calls[1]!.init?.headers)
     expect(retryHeaders.get('Authorization')).toBeNull()
-    expect(retryHeaders.get(x402_Types.paymentSignatureHeader)).toBe('x402-credential')
+    const paymentSignature = retryHeaders.get(x402_Types.paymentSignatureHeader)
+    expect(paymentSignature).toBeTruthy()
+    const payload = x402_Header.decodePaymentSignature(paymentSignature!)
+    expect(payload.accepted).toEqual(x402Eip3009Accept)
+    expect(payload.extensions).toBeUndefined()
+    expect(payload.resource).toEqual(paymentRequired.resource)
+    if (!('authorization' in payload.payload)) throw new Error()
+    expect(payload.payload.authorization.nonce).toMatch(/^0x[0-9a-f]{64}$/)
+  })
+
+  test('skips unsupported and policy-rejected x402 offers before signing a later offer', async () => {
+    const paymentRequired = {
+      ...x402PaymentRequired,
+      accepts: [
+        {
+          ...x402Eip3009Accept,
+          extra: { ...x402Eip3009Accept.extra, assetTransferMethod: 'permit2' },
+        },
+        { ...x402Eip3009Accept, network: 'eip155:8453' },
+        { ...x402Eip3009Accept, amount: '10001' },
+        { ...x402Eip3009Accept, extra: { assetTransferMethod: 'eip3009' } },
+        x402Eip3009Accept,
+      ],
+    } satisfies PaymentRequired
+    let callCount = 0
+    const calls: { init: RequestInit | undefined }[] = []
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      calls.push({ init })
+      callCount++
+      if (callCount === 1)
+        return new Response(null, {
+          status: 402,
+          headers: {
+            [x402_Types.paymentRequiredHeader]: x402_Header.encodePaymentRequired(paymentRequired),
+          },
+        })
+      return new Response('OK', { status: 200 })
+    }
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [
+        evm.charge({
+          account: accounts[0],
+          currencies: [evm.assets.baseSepolia.USDC],
+          maxAmount: '0.01',
+          networks: [84532],
+        }),
+      ],
+    })
+
+    const response = await fetch('https://example.com/api')
+
+    expect(response.status).toBe(200)
+    expect(calls).toHaveLength(2)
+    const paymentSignature = new Headers(calls[1]!.init?.headers).get(
+      x402_Types.paymentSignatureHeader,
+    )
+    expect(paymentSignature).toBeTruthy()
+    expect(x402_Header.decodePaymentSignature(paymentSignature!).accepted).toEqual(
+      x402Eip3009Accept,
+    )
+  })
+
+  test('does not sign or retry when every x402 offer is unsupported or rejected by policy', async () => {
+    const signTypedData = vi.fn(async () => '0x1234' as const)
+    const paymentRequired = {
+      ...x402PaymentRequired,
+      accepts: [
+        {
+          ...x402Eip3009Accept,
+          extra: { ...x402Eip3009Accept.extra, assetTransferMethod: 'permit2' },
+        },
+        { ...x402Eip3009Accept, network: 'eip155:8453' },
+        { ...x402Eip3009Accept, amount: '10001' },
+        { ...x402Eip3009Accept, extra: { assetTransferMethod: 'eip3009' } },
+      ],
+    } satisfies PaymentRequired
+    const mockFetch = vi.fn<typeof globalThis.fetch>(
+      async () =>
+        new Response(null, {
+          status: 402,
+          headers: {
+            [x402_Types.paymentRequiredHeader]: x402_Header.encodePaymentRequired(paymentRequired),
+          },
+        }),
+    )
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [
+        evm.charge({
+          account: { ...accounts[0], signTypedData } as unknown as Account,
+          currencies: [evm.assets.baseSepolia.USDC],
+          maxAmount: '0.01',
+          networks: [84532],
+        }),
+      ],
+    })
+
+    await expect(fetch('https://example.com/api')).rejects.toThrow('No method found for challenges')
+    expect(mockFetch).toHaveBeenCalledOnce()
+    expect(signTypedData).not.toHaveBeenCalled()
   })
 
   test('lets orderChallenges force x402 before native Payment-auth', async () => {

--- a/src/evm/client/Charge.ts
+++ b/src/evm/client/Charge.ts
@@ -18,6 +18,13 @@ import * as Types from '../Types.js'
  */
 export function charge(parameters: charge.Parameters) {
   return Method.toClient(Methods.charge, {
+    canHandleChallenge({ challenge }) {
+      if (!isX402Challenge(challenge)) return true
+      return x402_Exact.canHandleChallenge({
+        challenge: challenge as never,
+        config: parameters as x402_Exact.Config,
+      })
+    },
     context: z.object({
       account: z.optional(z.custom<Account>()),
     }),

--- a/src/x402/client/Exact.test.ts
+++ b/src/x402/client/Exact.test.ts
@@ -8,7 +8,7 @@ import * as Assets from '../Assets.js'
 import * as Header from '../Header.js'
 import * as RouteBinding from '../internal/RouteBinding.js'
 import * as Types from '../Types.js'
-import { createCredential } from './Exact.js'
+import { canHandleChallenge, createCredential } from './Exact.js'
 
 type X402Challenge = Parameters<typeof createCredential>[0]['challenge']
 
@@ -207,7 +207,7 @@ describe('x402 exact credential helper', () => {
     expect(signTypedData).not.toHaveBeenCalled()
   })
 
-  test('signs EIP-3009 exact payment payloads', async () => {
+  test('signs mppx-bound EIP-3009 exact payment payloads', async () => {
     const signTypedData = vi.fn(async () => '0x1234')
     const config = {
       account: {
@@ -271,9 +271,143 @@ describe('x402 exact credential helper', () => {
       throw new Error()
     expect(first.payload.authorization.nonce).not.toBe(second.payload.authorization.nonce)
   })
+
+  test('signs standard EIP-3009 payloads with fresh random nonces', async () => {
+    const signTypedData = vi.fn(async () => '0x1234' as const)
+    const config = {
+      account: {
+        ...account,
+        signTypedData,
+      } as unknown as Account,
+      currencies: [usdc],
+      maxAmount: '0.01',
+      networks: [Chains.baseSepolia],
+    } as const
+
+    const first = Header.decodePaymentSignature(
+      await createCredential({
+        challenge: challenge({ extensions: undefined }),
+        config,
+        context: {},
+      }),
+    )
+    const second = Header.decodePaymentSignature(
+      await createCredential({
+        challenge: challenge({ extensions: undefined }),
+        config,
+        context: {},
+      }),
+    )
+
+    expect(signTypedData).toHaveBeenCalledTimes(2)
+    expect(first.extensions).toBeUndefined()
+    expect(first.resource?.url).toBe('https://example.com/paid')
+    if (!('authorization' in first.payload) || !('authorization' in second.payload))
+      throw new Error()
+    expect(first.payload.authorization.nonce).toMatch(/^0x[0-9a-f]{64}$/)
+    expect(second.payload.authorization.nonce).toMatch(/^0x[0-9a-f]{64}$/)
+    expect(first.payload.authorization.nonce).not.toBe(second.payload.authorization.nonce)
+  })
+
+  test('preserves non-mppx extensions without treating them as route binding', async () => {
+    const extensions = {
+      bazaar: {
+        info: { catalog: 'cdp' },
+        schema: { type: 'object' },
+      },
+    }
+    const credential = await createCredential({
+      challenge: challenge({ extensions }),
+      config: {
+        account,
+        currencies: [usdc],
+        maxAmount: '0.01',
+        networks: [Chains.baseSepolia],
+      },
+      context: {},
+    })
+    const paymentPayload = Header.decodePaymentSignature(credential)
+
+    expect(paymentPayload.extensions).toEqual(extensions)
+    if (!('authorization' in paymentPayload.payload)) throw new Error()
+    expect(paymentPayload.payload.authorization.nonce).toMatch(/^0x[0-9a-f]{64}$/)
+  })
+
+  test('rejects standard challenges without resource information before signing', async () => {
+    const signTypedData = vi.fn(async () => '0x1234' as const)
+
+    await expect(
+      createCredential({
+        challenge: challenge({ extensions: undefined, resource: undefined }),
+        config: {
+          account: { ...account, signTypedData } as unknown as Account,
+          currencies: [usdc],
+          maxAmount: '0.01',
+          networks: [Chains.baseSepolia],
+        },
+        context: {},
+      }),
+    ).rejects.toThrow('x402 exact EIP-3009 requires resource information.')
+    expect(signTypedData).not.toHaveBeenCalled()
+  })
+
+  test('recognizes supported bound and standard challenges', () => {
+    const config = {
+      account,
+      currencies: [usdc],
+      maxAmount: '0.01',
+      networks: [Chains.baseSepolia],
+    } as const
+
+    expect(canHandleChallenge({ challenge: challenge(), config })).toBe(true)
+    expect(canHandleChallenge({ challenge: challenge({ extensions: undefined }), config })).toBe(
+      true,
+    )
+  })
+
+  test.each([
+    {
+      label: 'a missing resource',
+      overrides: { resource: undefined },
+    },
+    {
+      label: 'Permit2',
+      overrides: {
+        extra: { assetTransferMethod: 'permit2', name: 'USDC', version: '2' },
+      },
+    },
+    {
+      label: 'missing token name',
+      overrides: { extra: { assetTransferMethod: 'eip3009', version: '2' } },
+    },
+    {
+      label: 'missing token version',
+      overrides: { extra: { assetTransferMethod: 'eip3009', name: 'USDC' } },
+    },
+    {
+      label: 'a disallowed network',
+      overrides: { network: 'eip155:8453' },
+    },
+    {
+      label: 'an amount over policy',
+      overrides: { amount: '10001' },
+    },
+  ])('does not claim support for $label', ({ overrides }) => {
+    expect(
+      canHandleChallenge({
+        challenge: challenge(overrides as Partial<Types.ExactRequest>),
+        config: {
+          account,
+          currencies: [usdc],
+          maxAmount: '0.01',
+          networks: [Chains.baseSepolia],
+        },
+      }),
+    ).toBe(false)
+  })
 })
 
-function challenge(overrides: Partial<Types.PaymentRequirements> = {}): X402Challenge {
+function challenge(overrides: Partial<Types.ExactRequest> = {}): X402Challenge {
   return Challenge.from({
     id: 'x402-test',
     intent: 'charge',

--- a/src/x402/client/Exact.ts
+++ b/src/x402/client/Exact.ts
@@ -17,9 +17,10 @@ export async function createCredential(parameters: createCredential.Parameters):
   const request = parameters.challenge.request as Types.ExactRequest
   const accepted = Types.toPaymentRequirements(request)
   assertPolicy(parameters.config, accepted)
-  if (!request.resource || !request.extensions?.mppx)
-    throw new Error('x402 exact EIP-3009 requires route binding.')
-  const extensions = withNonceSalt(request.extensions)
+  if (!request.resource) throw new Error('x402 exact EIP-3009 requires resource information.')
+  const extensions = request.extensions?.mppx
+    ? withNonceSalt(request.extensions)
+    : request.extensions
   const transferMethod = accepted.extra?.assetTransferMethod ?? 'eip3009'
   if (transferMethod !== 'eip3009')
     throw new Error(`x402 exact ${String(transferMethod)} signing is not implemented yet.`)
@@ -32,11 +33,13 @@ export async function createCredential(parameters: createCredential.Parameters):
   const now = Math.floor(Date.now() / 1000)
   const authorization: Types.ExactEip3009Payload['authorization'] = {
     from: getAddress(account.address),
-    nonce: RouteBinding.nonce({
-      accepted,
-      extensions,
-      resource: request.resource,
-    }),
+    nonce: extensions?.mppx
+      ? RouteBinding.nonce({
+          accepted,
+          extensions,
+          resource: request.resource,
+        })
+      : randomAuthorizationNonce(),
     to: getAddress(accepted.payTo),
     validAfter: (now - 600).toString(),
     validBefore: (now + accepted.maxTimeoutSeconds).toString(),
@@ -61,7 +64,7 @@ export async function createCredential(parameters: createCredential.Parameters):
 
   return Header.encodePaymentSignature({
     accepted,
-    extensions,
+    ...(extensions ? { extensions } : {}),
     payload: {
       authorization,
       signature,
@@ -71,11 +74,39 @@ export async function createCredential(parameters: createCredential.Parameters):
   })
 }
 
+/** Returns whether this client can sign the given x402 exact challenge. */
+export function canHandleChallenge(parameters: canHandleChallenge.Parameters): boolean {
+  const request = parameters.challenge.request as Types.ExactRequest
+  let accepted: Types.PaymentRequirements
+  try {
+    accepted = Types.toPaymentRequirements(request)
+    assertPolicy(parameters.config, accepted)
+  } catch {
+    return false
+  }
+
+  if (!request.resource) return false
+
+  const transferMethod = accepted.extra?.assetTransferMethod ?? 'eip3009'
+  if (transferMethod !== 'eip3009') return false
+
+  const name = accepted.extra?.name
+  const version = accepted.extra?.version
+  return typeof name === 'string' && typeof version === 'string'
+}
+
 export declare namespace createCredential {
   type Parameters = {
     challenge: Challenge.Challenge<Types.ExactRequest>
     config: Config
     context?: Context | undefined
+  }
+}
+
+export declare namespace canHandleChallenge {
+  type Parameters = {
+    challenge: Challenge.Challenge<Types.ExactRequest>
+    config: Config
   }
 }
 
@@ -179,8 +210,16 @@ function withNonceSalt(extensions: Types.Extensions): Types.Extensions {
 }
 
 function randomNonceSalt(): string {
+  return randomBytes32().slice(2)
+}
+
+function randomAuthorizationNonce(): `0x${string}` {
+  return randomBytes32()
+}
+
+function randomBytes32(): `0x${string}` {
   const crypto = globalThis.crypto
   if (!crypto?.getRandomValues) throw new Error('x402 exact requires crypto randomness.')
   const bytes = crypto.getRandomValues(new Uint8Array(32))
-  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')
+  return `0x${Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')}`
 }


### PR DESCRIPTION
## Motivation

Standard x402 V2 providers do not include the optional mppx route-binding extension. The client rejected those otherwise payable EIP-3009 challenges, including services indexed through the CDP Bazaar.

References [#623](https://github.com/wevm/mppx/pull/623)

## Summary

- Added standard x402 exact EIP-3009 signing with random authorization nonces
- Preserved derived nonces for mppx route-bound challenges
- Filtered unsupported and policy-rejected x402 offers before challenge selection
- Added helper and fetch-path regression coverage for bound, unbound, mixed-offer, and fail-closed cases

## Key design considerations

- Standard x402 fallback still requires resource information and existing network, currency, and amount policies
- Non-mppx extensions are preserved without being treated as route binding
- Permit2 and offers missing EIP-3009 domain metadata remain unsupported and are skipped before signing