### PR TITLE
perf: bundle CLI runtime

### DIFF
--- a/.changeset/bundled-cli-runtime.md
+++ b/.changeset/bundled-cli-runtime.md
@@ -1,5 +1,0 @@
----
-'mppx': patch
----
-
-Bundled the CLI runtime so installing `mppx` no longer installed the `incur` dependency tree.

--- a/.changeset/bundled-cli-runtime.md
+++ b/.changeset/bundled-cli-runtime.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Bundled the CLI runtime so installing `mppx` no longer installed the `incur` dependency tree.

--- a/.changeset/dist-only-package.md
+++ b/.changeset/dist-only-package.md
@@ -1,0 +1,5 @@
+---
+'mppx': minor
+---
+
+Bundled the CLI runtime and removed source files, source maps, and source export conditions from the published package.

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Check types
         run: pnpm dev && pnpm exec tsx scripts/build:html.ts && pnpm check:types && pnpm check:types:html && pnpm check:types:examples
 
+      - name: Check package contents and size
+        run: pnpm check:package
+
   test:
     name: Test Runtime
     if: always()

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "scripts": {
-    "build": "pnpm build:html && zile && node scripts/set-workspace-bin.js",
+    "build": "pnpm build:html && zile && pnpm build:cli && node scripts/set-workspace-bin.js",
+    "build:cli": "node --import tsx scripts/build:cli.ts",
     "build:html": "node --import tsx scripts/build:html.ts",
-    "changeset:publish:main": "zile publish:prepare && changeset publish --no-git-tag --tag main && zile publish:post",
-    "changeset:publish": "zile publish:prepare && changeset publish && zile publish:post",
+    "changeset:publish:main": "zile publish:prepare && node --import tsx scripts/build:cli.ts && node --import tsx scripts/prepare:publish.ts && changeset publish --no-git-tag --tag main && zile publish:post",
+    "changeset:publish": "zile publish:prepare && node --import tsx scripts/build:cli.ts && node --import tsx scripts/prepare:publish.ts && changeset publish && zile publish:post",
     "changeset:version": "changeset version && vp fmt .",
     "check": "vp lint --fix && vp fmt --write .",
     "check:ci": "vp lint && vp fmt --check .",
@@ -49,6 +50,7 @@
     "file-type": "catalog:",
     "frog": "^1.0.15",
     "hono": "4.12.32",
+    "incur": "^0.4.26",
     "isows": "^1.0.7",
     "playwright": "^1.62.1",
     "pkg-pr-new": "0.0.88",
@@ -261,7 +263,6 @@
   "dependencies": {
     "@stripe/stripe-js": "9.12.1",
     "eventsource-parser": "3.1.0",
-    "incur": "^0.4.26",
     "ox": "catalog:",
     "structured-headers": "2.0.3",
     "zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "changeset:version": "changeset version && vp fmt .",
     "check": "vp lint --fix && vp fmt --write .",
     "check:ci": "vp lint && vp fmt --check .",
+    "check:package": "node --import tsx scripts/check:package.ts",
     "check:types": "pnpm build:html && tsgo -b",
     "check:types:html": "tsgo -p src/tempo/server/internal/html/tsconfig.json && tsgo -p src/stripe/server/internal/html/tsconfig.json",
     "check:types:examples": "pnpm -r --filter './examples/**' run check:types",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,9 +58,6 @@ importers:
       eventsource-parser:
         specifier: 3.1.0
         version: 3.1.0
-      incur:
-        specifier: ^0.4.26
-        version: 0.4.26
       ox:
         specifier: 0.14.33
         version: 0.14.33(typescript@7.0.2)(zod@4.4.3)
@@ -128,6 +125,9 @@ importers:
       hono:
         specifier: 4.12.34
         version: 4.12.34
+      incur:
+        specifier: ^0.4.26
+        version: 0.4.26
       isows:
         specifier: ^1.0.7
         version: 1.0.7(ws@8.21.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))

--- a/scripts/build:cli.ts
+++ b/scripts/build:cli.ts
@@ -1,0 +1,132 @@
+import fs from 'node:fs'
+import { builtinModules } from 'node:module'
+import path from 'node:path'
+
+import { build } from 'rolldown'
+
+const root = path.resolve(import.meta.dirname, '..')
+const packageJson = JSON.parse(fs.readFileSync(path.resolve(root, 'package.json'), 'utf8'))
+const externalPackages = [
+  '@stripe/stripe-js',
+  'eventsource-parser',
+  'ox',
+  'structured-headers',
+  'viem',
+  'zod',
+]
+const builtins = new Set([...builtinModules, ...builtinModules.map((name) => `node:${name}`)])
+const bundledModuleIds = new Set<string>()
+
+function external(id: string) {
+  if (builtins.has(id)) return true
+  return externalPackages.some((name) => id === name || id.startsWith(`${name}/`))
+}
+
+async function bundle(input: string, file: string) {
+  const result = await build({
+    input: path.resolve(root, input),
+    external,
+    plugins: [
+      {
+        name: 'bundle-incur-stdio',
+        transform(code, id) {
+          if (!id.includes('/incur/') || !id.endsWith('/Mcp.js')) return
+          return code.replace(
+            /importModule\((['"])@modelcontextprotocol\/server\/stdio\1\)/g,
+            "import('@modelcontextprotocol/server')",
+          )
+        },
+      },
+    ],
+    transform: {
+      define: {
+        __MPPX_CLI_VERSION__: JSON.stringify(packageJson.version),
+      },
+    },
+    output: {
+      codeSplitting: false,
+      comments: { legal: true },
+      file: path.resolve(root, file),
+      format: 'esm',
+      minify: true,
+      sourcemap: false,
+    },
+  })
+
+  for (const output of result.output)
+    if (output.type === 'chunk')
+      for (const moduleId of output.moduleIds) bundledModuleIds.add(moduleId)
+
+  fs.rmSync(path.resolve(root, `${file}.map`), { force: true })
+  const code = fs.readFileSync(path.resolve(root, file), 'utf8')
+  if (/from\s*['"]incur['"]|import\(['"]incur['"]\)/.test(code))
+    throw new Error(`${file} still contains an incur import`)
+}
+
+/** Resolve the owning package directory for a bundled node_modules file. */
+function packageDirectory(moduleId: string) {
+  const marker = `${path.sep}node_modules${path.sep}`
+  const markerIndex = moduleId.lastIndexOf(marker)
+  if (markerIndex === -1) return
+
+  const packagePath = moduleId.slice(markerIndex + marker.length).split(path.sep)
+  const segmentCount = packagePath[0]?.startsWith('@') ? 2 : 1
+  return path.join(
+    moduleId.slice(0, markerIndex + marker.length),
+    ...packagePath.slice(0, segmentCount),
+  )
+}
+
+/** Write licenses for packages whose code was included in the CLI bundles. */
+function writeThirdPartyLicenses() {
+  const packageDirectories = new Set(
+    [...bundledModuleIds].map(packageDirectory).filter((value) => value !== undefined),
+  )
+  const notices = [...packageDirectories]
+    .map((directory) => {
+      const manifest = JSON.parse(
+        fs.readFileSync(path.join(directory, 'package.json'), 'utf8'),
+      ) as {
+        license?: string
+        name: string
+        version: string
+      }
+      const licenseFiles = fs
+        .readdirSync(directory)
+        .filter((file) => /^(copying|licen[cs]e|notice)(\..*)?$/i.test(file))
+        .sort()
+
+      return {
+        heading: `${manifest.name}@${manifest.version} (${manifest.license ?? 'license unspecified'})`,
+        licenses: licenseFiles.map((file) => ({
+          file,
+          text: fs.readFileSync(path.join(directory, file), 'utf8').trim(),
+        })),
+      }
+    })
+    .sort((a, b) => a.heading.localeCompare(b.heading))
+
+  const content = notices
+    .map(({ heading, licenses }) => {
+      const sections = licenses.map(
+        ({ file, text }) => `${file}\n${'-'.repeat(file.length)}\n${text}`,
+      )
+      return [`# ${heading}`, ...sections].join('\n\n')
+    })
+    .join('\n\n---\n\n')
+
+  fs.writeFileSync(path.resolve(root, 'dist/cli/THIRD-PARTY-LICENSES.txt'), `${content}\n`)
+}
+
+await bundle('src/cli/cli.ts', 'dist/cli/cli.js')
+await bundle('src/cli/plugins/index.ts', 'dist/cli/plugins/index.js')
+writeThirdPartyLicenses()
+
+const binFile = path.resolve(root, 'dist/bin.js')
+fs.writeFileSync(
+  binFile,
+  "#!/usr/bin/env node\nimport cli from './cli/cli.js'\n\nawait cli.serve()\n",
+)
+fs.chmodSync(binFile, 0o755)
+
+console.log('bundled dist/bin.js and dist/cli/plugins/index.js')

--- a/scripts/check:package.ts
+++ b/scripts/check:package.ts
@@ -1,0 +1,120 @@
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+const root = path.resolve(import.meta.dirname, '..')
+const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'mppx-package-'))
+const limits = {
+  fileCount: 460,
+  packedBytes: 1_200_000,
+  unpackedBytes: 4_750_000,
+}
+
+/** Run a package validation command and fail with its exit status. */
+function run(command: string, args: string[], capture = false) {
+  const result = spawnSync(command, args, {
+    cwd: root,
+    encoding: 'utf8',
+    stdio: capture ? ['ignore', 'pipe', 'inherit'] : 'inherit',
+  })
+  if (result.error) throw result.error
+  if (result.status !== 0) throw new Error(`${command} exited with status ${result.status}`)
+  return result.stdout
+}
+
+/** Collect relative file targets from a package manifest field. */
+function packageTargets(value: unknown): string[] {
+  if (typeof value === 'string') return value.startsWith('./') ? [value.slice(2)] : []
+  if (!value || typeof value !== 'object') return []
+  return Object.values(value).flatMap(packageTargets)
+}
+
+try {
+  run(process.execPath, ['--import', 'tsx', 'scripts/build:html.ts'])
+  run('pnpm', ['exec', 'zile', 'publish:prepare'])
+  run(process.execPath, ['--import', 'tsx', 'scripts/build:cli.ts'])
+  run(process.execPath, ['--import', 'tsx', 'scripts/prepare:publish.ts'])
+
+  const pack = JSON.parse(
+    run('pnpm', ['pack', '--pack-destination', temporaryDirectory, '--json'], true),
+  ) as {
+    filename: string
+    files: { path: string }[]
+  }
+  const paths = pack.files.map((file) => file.path)
+  const allowedRootFiles = new Set(['CHANGELOG.md', 'LICENSE', 'README.md', 'package.json'])
+  const unexpected = paths.filter(
+    (file) => !file.startsWith('dist/') && !allowedRootFiles.has(file),
+  )
+  if (unexpected.length > 0)
+    throw new Error(
+      `Unexpected package files:\n${unexpected.map((file) => `- ${file}`).join('\n')}`,
+    )
+
+  const forbidden = paths.filter(
+    (file) =>
+      file.startsWith('src/') ||
+      file.includes('/node_modules/') ||
+      /(?:^|\/)node_modules\//.test(file) ||
+      /\.map$/.test(file) ||
+      /(?:^|\/)__tests__(?:\/|$)/.test(file) ||
+      /\.(?:test|spec)\.[cm]?[jt]sx?$/.test(file),
+  )
+  if (forbidden.length > 0)
+    throw new Error(`Forbidden package files:\n${forbidden.map((file) => `- ${file}`).join('\n')}`)
+
+  const extractDirectory = path.join(temporaryDirectory, 'extract')
+  fs.mkdirSync(extractDirectory)
+  run('tar', ['-xzf', pack.filename, '-C', extractDirectory])
+  const manifest = JSON.parse(
+    fs.readFileSync(path.join(extractDirectory, 'package/package.json'), 'utf8'),
+  ) as {
+    bin?: Record<string, string>
+    dependencies?: Record<string, string>
+    exports?: Record<string, unknown>
+    main?: string
+    module?: string
+    types?: string
+  }
+  if (manifest.bin?.mppx !== './dist/bin.js')
+    throw new Error(`Expected the mppx binary to target dist/bin.js, got ${manifest.bin?.mppx}`)
+  if (manifest.bin?.['mppx.src']) throw new Error('Published manifest includes mppx.src')
+  if (manifest.dependencies?.incur) throw new Error('Published manifest includes incur')
+  if (JSON.stringify(manifest.exports).includes('"src"'))
+    throw new Error('Published exports include a src condition')
+
+  const packageRoot = path.join(extractDirectory, 'package')
+  const missingTargets = packageTargets({
+    bin: manifest.bin,
+    exports: manifest.exports,
+    main: manifest.main,
+    module: manifest.module,
+    types: manifest.types,
+  }).filter((target) => !fs.existsSync(path.join(packageRoot, target)))
+  if (missingTargets.length > 0)
+    throw new Error(
+      `Published manifest targets missing files:\n${missingTargets.map((file) => `- ${file}`).join('\n')}`,
+    )
+
+  const packedBytes = fs.statSync(pack.filename).size
+  const unpackedBytes = pack.files.reduce(
+    (total, file) => total + fs.statSync(path.join(root, file.path)).size,
+    0,
+  )
+  const metrics = { fileCount: paths.length, packedBytes, unpackedBytes }
+
+  for (const [metric, value] of Object.entries(metrics)) {
+    const limit = limits[metric as keyof typeof limits]
+    if (value > limit)
+      throw new Error(`${metric} ${value.toLocaleString()} exceeds ${limit.toLocaleString()}`)
+  }
+
+  console.log(
+    `package: ${metrics.fileCount} files, ${metrics.packedBytes.toLocaleString()} B packed, ${metrics.unpackedBytes.toLocaleString()} B unpacked`,
+  )
+} finally {
+  if (fs.existsSync(path.join(root, 'package.tmp.json')))
+    run('pnpm', ['exec', 'zile', 'publish:post'])
+  fs.rmSync(temporaryDirectory, { force: true, recursive: true })
+}

--- a/scripts/prepare:publish.ts
+++ b/scripts/prepare:publish.ts
@@ -1,0 +1,10 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const packageJsonPath = path.resolve(import.meta.dirname, '../package.json')
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+
+delete packageJson.bin?.['mppx.src']
+delete packageJson.exports?.['./cli/plugins']?.src
+
+fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`)

--- a/scripts/prepare:publish.ts
+++ b/scripts/prepare:publish.ts
@@ -4,7 +4,26 @@ import path from 'node:path'
 const packageJsonPath = path.resolve(import.meta.dirname, '../package.json')
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
 
+/** Remove development-only source conditions from a package exports tree. */
+function removeSourceConditions(value: unknown): void {
+  if (!value || typeof value !== 'object') return
+  if (Array.isArray(value)) {
+    for (const item of value) removeSourceConditions(item)
+    return
+  }
+
+  const conditions = value as Record<string, unknown>
+  delete conditions.src
+  for (const child of Object.values(conditions)) removeSourceConditions(child)
+}
+
 delete packageJson.bin?.['mppx.src']
-delete packageJson.exports?.['./cli/plugins']?.src
+removeSourceConditions(packageJson.exports)
+packageJson.files = [
+  'CHANGELOG.md',
+  'dist/**/*.d.ts',
+  'dist/**/*.js',
+  'dist/cli/THIRD-PARTY-LICENSES.txt',
+]
 
 fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`)

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -46,10 +46,12 @@ import {
 } from './utils.js'
 import validate from './validate/index.js'
 
-const packageJson = createRequire(import.meta.url)('../../package.json') as {
-  name: string
-  version: string
-}
+declare const __MPPX_CLI_VERSION__: string
+
+const version =
+  typeof __MPPX_CLI_VERSION__ === 'string'
+    ? __MPPX_CLI_VERSION__
+    : (createRequire(import.meta.url)('../../package.json') as { version: string }).version
 
 const accountSummarySchema = z.object({
   address: z.string(),
@@ -213,7 +215,7 @@ function findService(
 
 const cli = Cli.create('mppx', {
   mcp: { tools: { discovery: 'direct' } },
-  version: packageJson.version,
+  version,
   description: 'Make HTTP requests with automatic payment handling',
   usage: [{ suffix: '<url> [options]' }],
   args: z.object({
@@ -260,11 +262,7 @@ const cli = Cli.create('mppx', {
       .describe('Session selection: auto, new, or channel ID'),
     silent: z.boolean().default(false).describe('Silent mode (suppress progress and info)'),
     slippage: z.number().optional().describe('Tempo auto-swap max slippage percentage'),
-    userAgent: z
-      .string()
-      .optional()
-      .default(`${packageJson.name}/${packageJson.version}`)
-      .describe('Set User-Agent header'),
+    userAgent: z.string().optional().default(`mppx/${version}`).describe('Set User-Agent header'),
     verbose: z
       .number()
       .default(0)

--- a/src/cli/plugins/tempo.ts
+++ b/src/cli/plugins/tempo.ts
@@ -1,6 +1,5 @@
 import * as child from 'node:child_process'
 import * as fs from 'node:fs'
-import { createRequire } from 'node:module'
 import * as os from 'node:os'
 import * as path from 'node:path'
 
@@ -36,7 +35,7 @@ import {
 } from '../utils.js'
 import { createPlugin, type Plugin } from './plugin.js'
 
-const packageJson = createRequire(import.meta.url)('../../../package.json') as { name: string }
+const packageName = 'mppx'
 const booleanOption = z.union([
   z.boolean(),
   z.literal('true').transform(() => true),
@@ -1094,7 +1093,7 @@ function fallbackFromTempo(): string | undefined {
       for (const block of stdout.split('keychain:')) {
         const serviceMatch = block.match(/"svce"<blob>="([^"]*)"/)
         const accountMatch = block.match(/"acct"<blob>="([^"]*)"/)
-        if (serviceMatch?.[1] === packageJson.name && accountMatch?.[1])
+        if (serviceMatch?.[1] === packageName && accountMatch?.[1])
           mppxAccounts.push(accountMatch[1])
       }
       if (mppxAccounts.length > 0) {


### PR DESCRIPTION
## Motivation

Keep `mppx` as a single install while avoiding the `incur` runtime dependency tree for library consumers.

## Summary

- Bundle the CLI and exported CLI plugins during builds and publish preparation
- Move `incur` to development dependencies
- Preserve the existing `mppx` binary and MCP behavior
- Include third-party license notices for bundled dependencies

## Key design considerations

- Runtime protocol dependencies remain external and deduplicable
- Published CLI entrypoints no longer expose source files that import `incur`
- The CLI version is injected at build time so the bundle does not depend on package-relative metadata paths

Related: https://github.com/wevm/mppx/issues/796