### PR TITLE
ci: guard published package size

### DIFF
--- a/.changeset/dist-only-package.md
+++ b/.changeset/dist-only-package.md
@@ -1,0 +1,5 @@
+---
+'mppx': minor
+---
+
+Removed source files, source maps, and source export conditions from the published package.

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Check types
         run: pnpm dev && pnpm exec tsx scripts/build:html.ts && pnpm check:types && pnpm check:types:html && pnpm check:types:examples
 
+      - name: Check package contents and size
+        run: pnpm check:package
+
   test:
     name: Test Runtime
     if: always()

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "changeset:version": "changeset version && vp fmt .",
     "check": "vp lint --fix && vp fmt --write .",
     "check:ci": "vp lint && vp fmt --check .",
+    "check:package": "node --import tsx scripts/check:package.ts",
     "check:types": "pnpm build:html && tsgo -b",
     "check:types:html": "tsgo -p src/tempo/server/internal/html/tsconfig.json && tsgo -p src/stripe/server/internal/html/tsconfig.json",
     "check:types:examples": "pnpm -r --filter './examples/**' run check:types",

--- a/scripts/check:package.ts
+++ b/scripts/check:package.ts
@@ -1,0 +1,120 @@
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+const root = path.resolve(import.meta.dirname, '..')
+const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'mppx-package-'))
+const limits = {
+  fileCount: 460,
+  packedBytes: 1_200_000,
+  unpackedBytes: 4_750_000,
+}
+
+/** Run a package validation command and fail with its exit status. */
+function run(command: string, args: string[], capture = false) {
+  const result = spawnSync(command, args, {
+    cwd: root,
+    encoding: 'utf8',
+    stdio: capture ? ['ignore', 'pipe', 'inherit'] : 'inherit',
+  })
+  if (result.error) throw result.error
+  if (result.status !== 0) throw new Error(`${command} exited with status ${result.status}`)
+  return result.stdout
+}
+
+/** Collect relative file targets from a package manifest field. */
+function packageTargets(value: unknown): string[] {
+  if (typeof value === 'string') return value.startsWith('./') ? [value.slice(2)] : []
+  if (!value || typeof value !== 'object') return []
+  return Object.values(value).flatMap(packageTargets)
+}
+
+try {
+  run(process.execPath, ['--import', 'tsx', 'scripts/build:html.ts'])
+  run('pnpm', ['exec', 'zile', 'publish:prepare'])
+  run(process.execPath, ['--import', 'tsx', 'scripts/build:cli.ts'])
+  run(process.execPath, ['--import', 'tsx', 'scripts/prepare:publish.ts'])
+
+  const pack = JSON.parse(
+    run('pnpm', ['pack', '--pack-destination', temporaryDirectory, '--json'], true),
+  ) as {
+    filename: string
+    files: { path: string }[]
+  }
+  const paths = pack.files.map((file) => file.path)
+  const allowedRootFiles = new Set(['CHANGELOG.md', 'LICENSE', 'README.md', 'package.json'])
+  const unexpected = paths.filter(
+    (file) => !file.startsWith('dist/') && !allowedRootFiles.has(file),
+  )
+  if (unexpected.length > 0)
+    throw new Error(
+      `Unexpected package files:\n${unexpected.map((file) => `- ${file}`).join('\n')}`,
+    )
+
+  const forbidden = paths.filter(
+    (file) =>
+      file.startsWith('src/') ||
+      file.includes('/node_modules/') ||
+      /(?:^|\/)node_modules\//.test(file) ||
+      /\.map$/.test(file) ||
+      /(?:^|\/)__tests__(?:\/|$)/.test(file) ||
+      /\.(?:test|spec)\.[cm]?[jt]sx?$/.test(file),
+  )
+  if (forbidden.length > 0)
+    throw new Error(`Forbidden package files:\n${forbidden.map((file) => `- ${file}`).join('\n')}`)
+
+  const extractDirectory = path.join(temporaryDirectory, 'extract')
+  fs.mkdirSync(extractDirectory)
+  run('tar', ['-xzf', pack.filename, '-C', extractDirectory])
+  const manifest = JSON.parse(
+    fs.readFileSync(path.join(extractDirectory, 'package/package.json'), 'utf8'),
+  ) as {
+    bin?: Record<string, string>
+    dependencies?: Record<string, string>
+    exports?: Record<string, unknown>
+    main?: string
+    module?: string
+    types?: string
+  }
+  if (manifest.bin?.mppx !== './dist/bin.js')
+    throw new Error(`Expected the mppx binary to target dist/bin.js, got ${manifest.bin?.mppx}`)
+  if (manifest.bin?.['mppx.src']) throw new Error('Published manifest includes mppx.src')
+  if (manifest.dependencies?.incur) throw new Error('Published manifest includes incur')
+  if (JSON.stringify(manifest.exports).includes('"src"'))
+    throw new Error('Published exports include a src condition')
+
+  const packageRoot = path.join(extractDirectory, 'package')
+  const missingTargets = packageTargets({
+    bin: manifest.bin,
+    exports: manifest.exports,
+    main: manifest.main,
+    module: manifest.module,
+    types: manifest.types,
+  }).filter((target) => !fs.existsSync(path.join(packageRoot, target)))
+  if (missingTargets.length > 0)
+    throw new Error(
+      `Published manifest targets missing files:\n${missingTargets.map((file) => `- ${file}`).join('\n')}`,
+    )
+
+  const packedBytes = fs.statSync(pack.filename).size
+  const unpackedBytes = pack.files.reduce(
+    (total, file) => total + fs.statSync(path.join(root, file.path)).size,
+    0,
+  )
+  const metrics = { fileCount: paths.length, packedBytes, unpackedBytes }
+
+  for (const [metric, value] of Object.entries(metrics)) {
+    const limit = limits[metric as keyof typeof limits]
+    if (value > limit)
+      throw new Error(`${metric} ${value.toLocaleString()} exceeds ${limit.toLocaleString()}`)
+  }
+
+  console.log(
+    `package: ${metrics.fileCount} files, ${metrics.packedBytes.toLocaleString()} B packed, ${metrics.unpackedBytes.toLocaleString()} B unpacked`,
+  )
+} finally {
+  if (fs.existsSync(path.join(root, 'package.tmp.json')))
+    run('pnpm', ['exec', 'zile', 'publish:post'])
+  fs.rmSync(temporaryDirectory, { force: true, recursive: true })
+}

--- a/scripts/prepare:publish.ts
+++ b/scripts/prepare:publish.ts
@@ -4,7 +4,26 @@ import path from 'node:path'
 const packageJsonPath = path.resolve(import.meta.dirname, '../package.json')
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
 
+/** Remove development-only source conditions from a package exports tree. */
+function removeSourceConditions(value: unknown): void {
+  if (!value || typeof value !== 'object') return
+  if (Array.isArray(value)) {
+    for (const item of value) removeSourceConditions(item)
+    return
+  }
+
+  const conditions = value as Record<string, unknown>
+  delete conditions.src
+  for (const child of Object.values(conditions)) removeSourceConditions(child)
+}
+
 delete packageJson.bin?.['mppx.src']
-delete packageJson.exports?.['./cli/plugins']?.src
+removeSourceConditions(packageJson.exports)
+packageJson.files = [
+  'CHANGELOG.md',
+  'dist/**/*.d.ts',
+  'dist/**/*.js',
+  'dist/cli/THIRD-PARTY-LICENSES.txt',
+]
 
 fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`)


### PR DESCRIPTION
## Motivation

Reduce install payload and prevent published-package size regressions.

## Summary

- Publish compiled JavaScript, declarations, changelog, and bundled CLI license notices only
- Remove source export conditions and the source-only binary from the published manifest
- Validate package contents, manifest targets, dependency boundaries, and size budgets in CI

## Key design considerations

- Source conditions remain available in the development manifest and are removed only during publish preparation
- The packed artifact drops from 1,280 to 445 files, from 2,344,721 B to 1,136,524 B packed, and from 10,908,401 B to 4,521,325 B unpacked
- CI allows roughly 5% headroom: 460 files, 1,200,000 B packed, and 4,750,000 B unpacked

Related: https://github.com/wevm/mppx/issues/796