### PR TITLE
fix(x402): bind scoped charges the way x402 does, not mppx-only

### DIFF
--- a/.changeset/x402-scoped-route-binding.md
+++ b/.changeset/x402-scoped-route-binding.md
@@ -1,0 +1,34 @@
+---
+'mppx': patch
+---
+
+Fixed scoped EVM charges rejecting every spec-compliant x402 client, which made
+each route served through `Proxy` unpayable over x402.
+
+A route scope lands in `challenge.meta`, and the x402 path treated any route
+metadata as a demand for mppx's own `extensions.mppx` binding plus an EIP-3009
+nonce equal to an unexported `sha256(accepted | resource | extensions)`. That
+derivation is not part of the x402 spec, so a client mppx did not write cannot
+produce it: the charge re-challenged forever with `Credential is malformed.`
+`Proxy` attaches a derived scope to every charge it serves, so this applied to
+everything behind it whether or not an operator set `scope`.
+
+Such a credential is now bound the way x402 itself binds — by comparing the
+echoed `resource` and `accepted` — instead of being rejected. A credential that
+does carry `extensions.mppx` is still verified in full, including the
+route-bound nonce, so mppx's own client is unaffected. Body binding is unchanged:
+`challenge.digest` is verified against the request body either way.
+
+The trade is that route scope on the x402 rail is advisory for clients that don't
+implement mppx's binding. `resource` and `accepted` sit outside the EIP-3009
+signature, so two charges sharing a URL and a price are no longer distinguishable
+by scope alone. Cross-URL reuse is still refused. Operators who need scope
+enforced can restore the previous behaviour per method:
+
+```ts
+evm({
+  currency: evm.assets.base.USDC,
+  recipient,
+  x402: { facilitator, routeBinding: 'required' },
+})
+```

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -25,4 +25,4 @@ jobs:
       - name: Prerelease
         run: |
           pnpm run build
-          pnpm exec pkg-pr-new publish
+          pnpm exec pkg-pr-new publish --pnpm

--- a/src/x402/CoinbaseClient.integration.test.ts
+++ b/src/x402/CoinbaseClient.integration.test.ts
@@ -2,15 +2,19 @@ import { once } from 'node:events'
 import { readFile } from 'node:fs/promises'
 import type { IncomingMessage } from 'node:http'
 
+import { x402Client, x402HTTPClient } from '@x402/core/client'
 import { x402Facilitator } from '@x402/core/facilitator'
 import { HTTPFacilitatorClient, x402ResourceServer } from '@x402/core/server'
 import type { PaymentPayload, PaymentRequirements } from '@x402/core/types'
 import { toFacilitatorEvmSigner } from '@x402/evm'
+import { ExactEvmScheme as ExactEvmClient } from '@x402/evm/exact/client'
 import { ExactEvmScheme as ExactEvmFacilitator } from '@x402/evm/exact/facilitator'
 import { ExactEvmScheme as ExactEvmServer } from '@x402/evm/exact/server'
 import { paymentMiddleware } from '@x402/express'
 import express from 'express'
-import { evm as evmClient, Mppx } from 'mppx/client'
+import { evm as evmClient, Mppx as ClientMppx } from 'mppx/client'
+import { Proxy } from 'mppx/proxy'
+import { evm as evmServer, Mppx as ServerMppx } from 'mppx/server'
 import type { Abi, Address, Hex } from 'viem'
 import {
   createClient,
@@ -78,6 +82,68 @@ type CoinbaseHarness = {
 }
 
 describeLocalnet('Coinbase x402 client interoperability', () => {
+  test(
+    'pays an automatically scoped mppx proxy with the Coinbase client',
+    { timeout: 60_000 },
+    async () => {
+      const harness = await setupCoinbaseHarness()
+
+      try {
+        const proxy = createMppxProxy(harness)
+        const url = 'https://example.com/proxy/coinbase/paid'
+        const challenge = await proxy.fetch(new Request(url))
+        expect(challenge.status).toBe(402)
+
+        const client = new x402Client().register(network, new ExactEvmClient(payer))
+        const httpClient = new x402HTTPClient(client)
+        const paymentRequired = httpClient.getPaymentRequiredResponse((name) =>
+          challenge.headers.get(name),
+        )
+        const paymentPayload = await httpClient.createPaymentPayload(paymentRequired)
+        const headers = httpClient.encodePaymentSignatureHeader(paymentPayload)
+        const credential = new Headers(headers).get(Types.paymentSignatureHeader)
+        expect(credential).toBeTruthy()
+
+        const decodedPayload = Header.decodePaymentSignature(credential!)
+        expect(decodedPayload.extensions).toEqual(paymentRequired.extensions)
+        expect(decodedPayload.extensions?.mppx?.info).toMatchObject({
+          _mppx_scope: 'GET /proxy/coinbase/paid',
+          method: 'GET',
+        })
+        expect(decodedPayload.extensions?.mppx?.info.nonce).toBeUndefined()
+        if (!('authorization' in decodedPayload.payload)) throw new Error()
+        expect(decodedPayload.payload.authorization.nonce).toMatch(/^0x[0-9a-f]{64}$/)
+
+        const payerBefore = await balanceOf(harness.artifact, harness.token, payer.address)
+        const recipientBefore = await balanceOf(harness.artifact, harness.token, recipient.address)
+        const response = await proxy.fetch(new Request(url, { headers }))
+
+        expect(response.status).toBe(200)
+        expect(await response.text()).toBe('paid by Coinbase')
+        const paymentResponseHeader = response.headers.get(Types.paymentResponseHeader)
+        expect(paymentResponseHeader).toBeTruthy()
+        const paymentResponse = Header.decodePaymentResponse(paymentResponseHeader!)
+        const receipt = await waitForTransactionReceipt(payerClient, {
+          hash: paymentResponse.transaction as Hex,
+        })
+        expect(receipt.status).toBe('success')
+        expect(await balanceOf(harness.artifact, harness.token, payer.address)).toBe(
+          payerBefore - paymentAmount,
+        )
+        expect(await balanceOf(harness.artifact, harness.token, recipient.address)).toBe(
+          recipientBefore + paymentAmount,
+        )
+        expect(harness.facilitator.stats).toEqual({
+          settleRequests: 1,
+          supportedRequests: 1,
+          verifyRequests: 1,
+        })
+      } finally {
+        closeCoinbaseHarness(harness)
+      }
+    },
+  )
+
   test('pays a Coinbase resource server with the mppx client', { timeout: 60_000 }, async () => {
     const harness = await setupCoinbaseHarness()
 
@@ -324,7 +390,7 @@ function createMppxClient(token: Address) {
     transfer: { name: 'USDC', type: 'eip3009', version: '2' },
   })
 
-  return Mppx.create({
+  return ClientMppx.create({
     methods: [
       evmClient.charge({
         account: payer,
@@ -338,6 +404,39 @@ function createMppxClient(token: Address) {
         (a, b) => Number(ChallengeBrand.is(b.challenge)) - Number(ChallengeBrand.is(a.challenge)),
       ),
     polyfill: false,
+  })
+}
+
+function createMppxProxy(harness: CoinbaseHarness): Proxy.Proxy {
+  const asset = evmServer.assets.define({
+    address: harness.token,
+    decimals: 6,
+    network,
+    transfer: { name: 'USDC', type: 'eip3009', version: '2' },
+  })
+  const payment = ServerMppx.create({
+    methods: [
+      evmServer.charge({
+        currency: asset,
+        recipient: recipient.address,
+        x402: { facilitator: harness.facilitator.url },
+      }),
+    ],
+    secretKey: 'coinbase-x402-integration-secret-key',
+  })
+
+  return Proxy.create({
+    basePath: '/proxy',
+    async fetch() {
+      return new Response('paid by Coinbase')
+    },
+    services: [
+      {
+        baseUrl: 'https://upstream.example.com',
+        id: 'coinbase',
+        routes: { 'GET /paid': payment.charge({ amount: '0.01' }) },
+      },
+    ],
   })
 }
 

--- a/src/x402/Exact.e2e.test.ts
+++ b/src/x402/Exact.e2e.test.ts
@@ -322,6 +322,12 @@ describe('x402 exact e2e', () => {
     }
     expect(verifyCalls).toBe(2)
 
+    // A scoped charge at the same URL accepts the same standard credential.
+    // Nothing a spec-compliant client echoes can distinguish two charges that
+    // share a URL and a price: `resource` and `accepted` are equal, and neither
+    // is covered by the EIP-3009 signature. Scope on the x402 rail is therefore
+    // advisory unless the client implements mppx's own binding — which is what
+    // `routeBinding: 'required'` demands, asserted below.
     const scopedRoute = payment.evm.charge({
       amount: '0.01',
       scope: 'POST /body',
@@ -333,8 +339,46 @@ describe('x402 exact e2e', () => {
         method: 'POST',
       }),
     )
-    expect(scopedResult.status).toBe(402)
-    expect(verifyCalls).toBe(2)
+    expect(scopedResult.status).toBe(200)
+    expect(verifyCalls).toBe(3)
+
+    const strict = ServerMppx.create({
+      methods: [
+        evm.charge({
+          currency: evm.assets.baseSepolia.USDC,
+          recipient: accounts[0].address,
+          x402: {
+            facilitator: {
+              async verify() {
+                verifyCalls++
+                return { isValid: true }
+              },
+              async settle(paymentPayload: Types.PaymentPayload) {
+                return {
+                  network: paymentPayload.accepted.network,
+                  success: true,
+                  transaction,
+                }
+              },
+            },
+            routeBinding: 'required',
+          },
+        }),
+      ],
+      secretKey,
+    })
+    const strictResult = await strict.evm.charge({
+      amount: '0.01',
+      scope: 'POST /body',
+    })(
+      new Request('https://example.com/body', {
+        body,
+        headers: { [Types.paymentSignatureHeader]: paymentSignatures[0]! },
+        method: 'POST',
+      }),
+    )
+    expect(strictResult.status).toBe(402)
+    expect(verifyCalls).toBe(3)
   })
 
   test('serves tempo and x402 from one composed live endpoint', async () => {

--- a/src/x402/server/EvmCharge.test.ts
+++ b/src/x402/server/EvmCharge.test.ts
@@ -169,6 +169,31 @@ describe('x402 evm charge route binding', () => {
     expect(reached).toEqual([])
   })
 
+  test('a scoped charge accepts an enriched echoed resource', async () => {
+    const { mppx, reached } = createMppx()
+    const route = mppx.evm.charge({ amount: '0.25', scope })
+
+    const challenged = await route(request(url))
+    if (challenged.status !== 402) throw new Error()
+    const challenge = readChallenge(challenged.challenge)
+
+    // Only the URL is load-bearing. A client that round-trips the resource with
+    // descriptive fields filled in has still bound the route, so rejecting it
+    // would cost interop and buy nothing.
+    const result = await route(
+      request(
+        url,
+        await thirdPartyCredential({
+          accepted: challenge.accepts[0]!,
+          resource: { ...challenge.resource, description: 'A paid route.' },
+        }),
+      ),
+    )
+
+    expect(result.status).toBe(200)
+    expect(reached).toEqual(['verify', 'settle'])
+  })
+
   test('a scoped charge rejects a credential minted for another route', async () => {
     const { mppx, reached } = createMppx()
     const route = mppx.evm.charge({ amount: '0.25', scope })

--- a/src/x402/server/EvmCharge.test.ts
+++ b/src/x402/server/EvmCharge.test.ts
@@ -5,6 +5,8 @@ import { Header as x402_Header, Types as x402_Types, type PaymentPayload } from 
 import { privateKeyToAccount } from 'viem/accounts'
 import { describe, expect, test } from 'vp/test'
 
+import * as RouteBinding from '../internal/RouteBinding.js'
+
 const transaction = `0x${'1'.repeat(64)}`
 /** Pays. */
 const account = privateKeyToAccount(
@@ -108,6 +110,31 @@ async function thirdPartyCredential(parameters: {
     payload: { authorization, signature },
     ...(parameters.resource ? { resource: parameters.resource } : {}),
     x402Version: 2,
+  })
+}
+
+function routeBoundExtensions(
+  extensions: x402_Types.Extensions,
+  info?: Record<string, unknown> | undefined,
+): x402_Types.Extensions {
+  const mppx = extensions.mppx!
+  return {
+    ...extensions,
+    mppx: {
+      ...mppx,
+      info: { ...mppx.info, nonce: 'client-salt', ...info },
+    },
+  }
+}
+
+async function routeBoundCredential(parameters: {
+  accepted: x402_Types.PaymentRequirements
+  extensions: x402_Types.Extensions
+  resource: x402_Types.ResourceInfo
+}): Promise<string> {
+  return thirdPartyCredential({
+    ...parameters,
+    nonce: RouteBinding.nonce(parameters),
   })
 }
 
@@ -222,6 +249,28 @@ describe('x402 evm charge route binding', () => {
     expect(reached).toEqual([])
   })
 
+  test('a scoped charge rejects altered payment requirements', async () => {
+    const { mppx, reached } = createMppx()
+    const route = mppx.evm.charge({ amount: '0.25', scope })
+
+    const challenged = await route(request(url))
+    if (challenged.status !== 402) throw new Error()
+    const challenge = readChallenge(challenged.challenge)
+
+    const result = await route(
+      request(
+        url,
+        await thirdPartyCredential({
+          accepted: { ...challenge.accepts[0]!, amount: '1' },
+          resource: challenge.resource,
+        }),
+      ),
+    )
+
+    expect(result.status).toBe(402)
+    expect(reached).toEqual([])
+  })
+
   test('an unscoped charge is payable by a third-party client', async () => {
     const { mppx, reached } = createMppx()
     const route = mppx.evm.charge({ amount: '0.25' })
@@ -242,6 +291,28 @@ describe('x402 evm charge route binding', () => {
 
     expect(result.status).toBe(200)
     expect(reached).toEqual(['verify', 'settle'])
+  })
+
+  test('an unscoped charge rejects an unrelated resource', async () => {
+    const { mppx, reached } = createMppx()
+    const route = mppx.evm.charge({ amount: '0.25' })
+
+    const challenged = await route(request('https://example.com/paid'))
+    if (challenged.status !== 402) throw new Error()
+    const challenge = readChallenge(challenged.challenge)
+
+    const result = await route(
+      request(
+        'https://example.com/paid',
+        await thirdPartyCredential({
+          accepted: challenge.accepts[0]!,
+          resource: { ...challenge.resource, url: 'https://example.com/other' },
+        }),
+      ),
+    )
+
+    expect(result.status).toBe(402)
+    expect(reached).toEqual([])
   })
 
   test('a credential claiming mppx binding is still verified in full', async () => {
@@ -270,6 +341,63 @@ describe('x402 evm charge route binding', () => {
         }),
       ),
     )
+
+    expect(result.status).toBe(402)
+    expect(reached).toEqual([])
+  })
+
+  test('a valid mppx-bound credential remains payable', async () => {
+    const { mppx, reached } = createMppx({ routeBinding: 'required' })
+    const route = mppx.evm.charge({ amount: '0.25', scope })
+
+    const challenged = await route(request(url))
+    if (challenged.status !== 402) throw new Error()
+    const challenge = readChallenge(challenged.challenge)
+    const parameters = {
+      accepted: challenge.accepts[0]!,
+      extensions: routeBoundExtensions(challenge.extensions!),
+      resource: challenge.resource,
+    }
+
+    const result = await route(request(url, await routeBoundCredential(parameters)))
+
+    expect(result.status).toBe(200)
+    expect(reached).toEqual(['verify', 'settle'])
+  })
+
+  test('a bound credential rejects a mismatched resource', async () => {
+    const { mppx, reached } = createMppx()
+    const route = mppx.evm.charge({ amount: '0.25', scope })
+
+    const challenged = await route(request(url))
+    if (challenged.status !== 402) throw new Error()
+    const challenge = readChallenge(challenged.challenge)
+    const parameters = {
+      accepted: challenge.accepts[0]!,
+      extensions: routeBoundExtensions(challenge.extensions!),
+      resource: { ...challenge.resource, url: 'https://example.com/other' },
+    }
+
+    const result = await route(request(url, await routeBoundCredential(parameters)))
+
+    expect(result.status).toBe(402)
+    expect(reached).toEqual([])
+  })
+
+  test('a bound credential rejects altered route extensions', async () => {
+    const { mppx, reached } = createMppx()
+    const route = mppx.evm.charge({ amount: '0.25', scope })
+
+    const challenged = await route(request(url))
+    if (challenged.status !== 402) throw new Error()
+    const challenge = readChallenge(challenged.challenge)
+    const parameters = {
+      accepted: challenge.accepts[0]!,
+      extensions: routeBoundExtensions(challenge.extensions!, { _mppx_scope: 'GET /other' }),
+      resource: challenge.resource,
+    }
+
+    const result = await route(request(url, await routeBoundCredential(parameters)))
 
     expect(result.status).toBe(402)
     expect(reached).toEqual([])

--- a/src/x402/server/EvmCharge.test.ts
+++ b/src/x402/server/EvmCharge.test.ts
@@ -60,9 +60,9 @@ function readError(response: Response) {
 
 /**
  * Builds the credential a spec-compliant third-party x402 wallet produces: the
- * advertised `accepted` and `resource` echoed back, a nonce of its own choosing,
- * and no `extensions.mppx` — which is mppx's own binding, and unpublished, so a
- * client mppx did not write cannot compute it.
+ * advertised `accepted`, `resource`, and optional extensions echoed back, with
+ * a nonce of its own choosing. A client mppx did not write cannot compute the
+ * unpublished route-bound nonce.
  */
 async function thirdPartyCredential(parameters: {
   accepted: x402_Types.PaymentRequirements
@@ -121,7 +121,7 @@ describe('x402 evm charge route binding', () => {
   const url = 'https://example.com/paid-scoped'
   const scope = 'GET /paid-scoped'
 
-  test('a scoped charge is payable by a third-party client', async () => {
+  test('a scoped charge accepts a standard extension echo without a bound nonce', async () => {
     const { mppx, reached } = createMppx()
     const route = mppx.evm.charge({ amount: '0.25', scope })
 
@@ -136,12 +136,14 @@ describe('x402 evm charge route binding', () => {
       _mppx_scope: scope,
       method: 'GET',
     })
+    expect(challenge.extensions?.mppx?.info.nonce).toBeUndefined()
 
     const result = await route(
       request(
         url,
         await thirdPartyCredential({
           accepted: challenge.accepts[0]!,
+          extensions: challenge.extensions,
           resource: challenge.resource,
         }),
       ),
@@ -210,6 +212,7 @@ describe('x402 evm charge route binding', () => {
         url,
         await thirdPartyCredential({
           accepted: challenge.accepts[0]!,
+          extensions: challenge.extensions,
           resource: challenge.resource,
         }),
       ),

--- a/src/x402/server/EvmCharge.test.ts
+++ b/src/x402/server/EvmCharge.test.ts
@@ -1,0 +1,353 @@
+import { Types as evm_Types } from 'mppx/evm'
+import { Proxy } from 'mppx/proxy'
+import { evm, Mppx } from 'mppx/server'
+import { Header as x402_Header, Types as x402_Types, type PaymentPayload } from 'mppx/x402'
+import { privateKeyToAccount } from 'viem/accounts'
+import { describe, expect, test } from 'vp/test'
+
+const transaction = `0x${'1'.repeat(64)}`
+/** Pays. */
+const account = privateKeyToAccount(
+  '0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+)
+/** Gets paid. Derived rather than written out so the two are known to differ. */
+const recipient = privateKeyToAccount(`0x${'42'.repeat(32)}`).address
+const secretKey = 'test-secret-key-test-secret-key-32'
+
+/** Records how far a credential got before settlement. */
+function createFacilitator() {
+  const reached: string[] = []
+  return {
+    reached,
+    facilitator: {
+      async verify() {
+        reached.push('verify')
+        return { isValid: true }
+      },
+      async settle(_payload: PaymentPayload, requirements: x402_Types.PaymentRequirements) {
+        reached.push('settle')
+        return { network: requirements.network, success: true, transaction }
+      },
+    },
+  }
+}
+
+function createMppx(options?: { routeBinding?: 'required' | 'resource' | undefined }) {
+  const { facilitator, reached } = createFacilitator()
+  const mppx = Mppx.create({
+    methods: [
+      evm({
+        currency: evm.assets.baseSepolia.USDC,
+        recipient,
+        x402: {
+          facilitator,
+          ...(options?.routeBinding ? { routeBinding: options.routeBinding } : {}),
+        },
+      }),
+    ],
+    secretKey,
+  })
+  return { mppx, reached }
+}
+
+function readChallenge(response: Response) {
+  return x402_Header.decodePaymentRequired(response.headers.get(x402_Types.paymentRequiredHeader)!)
+}
+
+function readError(response: Response) {
+  return readChallenge(response).error
+}
+
+/**
+ * Builds the credential a spec-compliant third-party x402 wallet produces: the
+ * advertised `accepted` and `resource` echoed back, a nonce of its own choosing,
+ * and no `extensions.mppx` — which is mppx's own binding, and unpublished, so a
+ * client mppx did not write cannot compute it.
+ */
+async function thirdPartyCredential(parameters: {
+  accepted: x402_Types.PaymentRequirements
+  extensions?: x402_Types.Extensions | undefined
+  nonce?: `0x${string}` | undefined
+  resource?: x402_Types.ResourceInfo | undefined
+}): Promise<string> {
+  const { accepted } = parameters
+  const now = Math.floor(Date.now() / 1000)
+  const authorization = {
+    from: account.address,
+    nonce: parameters.nonce ?? (`0x${'ab'.repeat(32)}` as const),
+    to: accepted.payTo as `0x${string}`,
+    validAfter: (now - 600).toString(),
+    validBefore: (now + accepted.maxTimeoutSeconds).toString(),
+    value: accepted.amount,
+  }
+
+  const signature = await account.signTypedData({
+    domain: evm_Types.authorizationDomain({
+      authorization: {
+        name: accepted.extra!.name as string,
+        version: accepted.extra!.version as string,
+      },
+      chainId: Number(accepted.network.slice('eip155:'.length)),
+      currency: accepted.asset as `0x${string}`,
+    }),
+    message: {
+      from: authorization.from,
+      nonce: authorization.nonce,
+      to: authorization.to,
+      validAfter: BigInt(authorization.validAfter),
+      validBefore: BigInt(authorization.validBefore),
+      value: BigInt(authorization.value),
+    },
+    primaryType: 'TransferWithAuthorization',
+    types: evm_Types.authorizationTypes,
+  })
+
+  return x402_Header.encodePaymentSignature({
+    accepted,
+    ...(parameters.extensions ? { extensions: parameters.extensions } : {}),
+    payload: { authorization, signature },
+    ...(parameters.resource ? { resource: parameters.resource } : {}),
+    x402Version: 2,
+  })
+}
+
+function request(url: string, credential?: string) {
+  return new Request(url, {
+    ...(credential ? { headers: { [x402_Types.paymentSignatureHeader]: credential } } : {}),
+  })
+}
+
+describe('x402 evm charge route binding', () => {
+  const url = 'https://example.com/paid-scoped'
+  const scope = 'GET /paid-scoped'
+
+  test('a scoped charge is payable by a third-party client', async () => {
+    const { mppx, reached } = createMppx()
+    const route = mppx.evm.charge({ amount: '0.25', scope })
+
+    const challenged = await route(request(url))
+    expect(challenged.status).toBe(402)
+    if (challenged.status !== 402) throw new Error()
+    const challenge = readChallenge(challenged.challenge)
+
+    // The challenge still advertises the binding mppx prefers, so an mppx client
+    // keeps producing it. Not producing it is no longer fatal.
+    expect(challenge.extensions?.mppx?.info).toMatchObject({
+      _mppx_scope: scope,
+      method: 'GET',
+    })
+
+    const result = await route(
+      request(
+        url,
+        await thirdPartyCredential({
+          accepted: challenge.accepts[0]!,
+          resource: challenge.resource,
+        }),
+      ),
+    )
+
+    expect(result.status).toBe(200)
+    expect(reached).toEqual(['verify', 'settle'])
+  })
+
+  test('a scoped charge still requires the resource to be echoed', async () => {
+    const { mppx, reached } = createMppx()
+    const route = mppx.evm.charge({ amount: '0.25', scope })
+
+    const challenged = await route(request(url))
+    if (challenged.status !== 402) throw new Error()
+    const challenge = readChallenge(challenged.challenge)
+
+    const result = await route(
+      request(url, await thirdPartyCredential({ accepted: challenge.accepts[0]! })),
+    )
+
+    expect(result.status).toBe(402)
+    if (result.status !== 402) throw new Error()
+    expect(readError(result.challenge)).toBe('Credential is malformed.')
+    expect(reached).toEqual([])
+  })
+
+  test('a scoped charge rejects a credential minted for another route', async () => {
+    const { mppx, reached } = createMppx()
+    const route = mppx.evm.charge({ amount: '0.25', scope })
+    const other = mppx.evm.charge({ amount: '0.25', scope: 'GET /other' })
+
+    const challenged = await other(request('https://example.com/other'))
+    if (challenged.status !== 402) throw new Error()
+    const challenge = readChallenge(challenged.challenge)
+
+    // Same price, same rail, different route: the echoed resource is what makes
+    // this distinguishable, so the credential does not travel.
+    const result = await route(
+      request(
+        url,
+        await thirdPartyCredential({
+          accepted: challenge.accepts[0]!,
+          resource: challenge.resource,
+        }),
+      ),
+    )
+
+    expect(result.status).toBe(402)
+    expect(reached).toEqual([])
+  })
+
+  test('an unscoped charge is payable by a third-party client', async () => {
+    const { mppx, reached } = createMppx()
+    const route = mppx.evm.charge({ amount: '0.25' })
+
+    const challenged = await route(request('https://example.com/paid'))
+    if (challenged.status !== 402) throw new Error()
+    const challenge = readChallenge(challenged.challenge)
+
+    const result = await route(
+      request(
+        'https://example.com/paid',
+        await thirdPartyCredential({
+          accepted: challenge.accepts[0]!,
+          resource: challenge.resource,
+        }),
+      ),
+    )
+
+    expect(result.status).toBe(200)
+    expect(reached).toEqual(['verify', 'settle'])
+  })
+
+  test('a credential claiming mppx binding is still verified in full', async () => {
+    const { mppx, reached } = createMppx()
+    const route = mppx.evm.charge({ amount: '0.25', scope })
+
+    const challenged = await route(request(url))
+    if (challenged.status !== 402) throw new Error()
+    const challenge = readChallenge(challenged.challenge)
+
+    // `extensions.mppx.info.nonce` present means the client claims to have bound
+    // the route into the EIP-3009 nonce. That claim is checked against the
+    // derivation, so a wrong nonce is rejected rather than downgraded.
+    const result = await route(
+      request(
+        url,
+        await thirdPartyCredential({
+          accepted: challenge.accepts[0]!,
+          extensions: {
+            mppx: {
+              ...challenge.extensions!.mppx!,
+              info: { ...challenge.extensions!.mppx!.info, nonce: 'client-salt' },
+            },
+          },
+          resource: challenge.resource,
+        }),
+      ),
+    )
+
+    expect(result.status).toBe(402)
+    expect(reached).toEqual([])
+  })
+
+  test("`routeBinding: 'required'` keeps a scoped charge mppx-only", async () => {
+    const { mppx, reached } = createMppx({ routeBinding: 'required' })
+    const route = mppx.evm.charge({ amount: '0.25', scope })
+
+    const challenged = await route(request(url))
+    if (challenged.status !== 402) throw new Error()
+    const challenge = readChallenge(challenged.challenge)
+
+    const result = await route(
+      request(
+        url,
+        await thirdPartyCredential({
+          accepted: challenge.accepts[0]!,
+          resource: challenge.resource,
+        }),
+      ),
+    )
+
+    expect(result.status).toBe(402)
+    expect(reached).toEqual([])
+  })
+
+  test("`routeBinding: 'required'` leaves an unscoped charge payable", async () => {
+    const { mppx, reached } = createMppx({ routeBinding: 'required' })
+    const route = mppx.evm.charge({ amount: '0.25' })
+
+    const challenged = await route(request('https://example.com/paid'))
+    if (challenged.status !== 402) throw new Error()
+    const challenge = readChallenge(challenged.challenge)
+
+    const result = await route(
+      request(
+        'https://example.com/paid',
+        await thirdPartyCredential({
+          accepted: challenge.accepts[0]!,
+          resource: challenge.resource,
+        }),
+      ),
+    )
+
+    expect(result.status).toBe(200)
+    expect(reached).toEqual(['verify', 'settle'])
+  })
+})
+
+/**
+ * `Proxy` attaches a derived scope to every charge it serves, so before this it
+ * put each proxied route into the mppx-only binding mode with no way to opt out.
+ * Reselling an API is what `Proxy` is for, so this is the case that has to work
+ * without configuring anything.
+ */
+describe('x402 evm charge behind Proxy', () => {
+  const origin = 'https://example.com'
+  const basePath = '/__proxy'
+  const serviceId = 'local_free'
+  const proxyUrl = `${origin}${basePath}/${serviceId}/free`
+
+  function createProxy() {
+    const { mppx, reached } = createMppx()
+    const proxy = Proxy.create({
+      basePath,
+      async fetch() {
+        return Response.json({ free: true })
+      },
+      services: [
+        {
+          id: serviceId,
+          baseUrl: origin,
+          routes: { 'GET /free': mppx.charge({ amount: '0.25' }) },
+        },
+      ],
+    })
+    return { proxy, reached }
+  }
+
+  test('is payable by a third-party client with no configuration', async () => {
+    const { proxy, reached } = createProxy()
+
+    const challenged = await proxy.fetch(request(proxyUrl))
+    expect(challenged.status).toBe(402)
+    const challenge = readChallenge(challenged)
+
+    // No `scope` is set anywhere; `Proxy` derived one, and the challenge carries
+    // it as route metadata.
+    expect(challenge.extensions?.mppx?.info).toMatchObject({
+      _mppx_scope: `GET ${basePath}/${serviceId}/free`,
+      method: 'GET',
+    })
+
+    const response = await proxy.fetch(
+      request(
+        proxyUrl,
+        await thirdPartyCredential({
+          accepted: challenge.accepts[0]!,
+          resource: challenge.resource,
+        }),
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    expect(reached).toEqual(['verify', 'settle'])
+    expect(response.headers.get(x402_Types.paymentResponseHeader)).toBeTruthy()
+  })
+})

--- a/src/x402/server/EvmCharge.ts
+++ b/src/x402/server/EvmCharge.ts
@@ -164,9 +164,16 @@ export function createPath(config: ResolvedOptions): Path {
           })
       } else if (routeRequiresBinding) {
         // A scoped route still binds what x402 makes bindable: the resource must
-        // be echoed, not merely left out. `accepted` was compared above, and
-        // `challenge.digest` was verified against the body by assertBodyDigest().
-        if (!isDeepStrictEqual(paymentPayload.resource, expectedResource))
+        // be echoed, not merely left out, which is the one thing a scope can ask
+        // of a client that doesn't implement mppx's binding. `accepted` was
+        // compared above, and `challenge.digest` was verified against the body by
+        // assertBodyDigest().
+        //
+        // Only the URL is compared. `ResourceInfo` carries optional descriptive
+        // fields that mppx neither advertises nor attaches meaning to, so
+        // demanding their absence would reject a client echoing an enriched
+        // resource without binding anything in return.
+        if (paymentPayload.resource?.url !== expectedResource.url)
           throw new VerificationFailedError({
             reason: 'x402 payment payload resource does not match route resource',
           })

--- a/src/x402/server/EvmCharge.ts
+++ b/src/x402/server/EvmCharge.ts
@@ -40,12 +40,35 @@ export type Options = {
   fetch?: typeof globalThis.fetch | undefined
   /** Maximum time in seconds allowed for x402-compatible payment completion. @default 300 */
   maxTimeoutSeconds?: number | undefined
+  /**
+   * How a route-scoped charge binds an x402 credential to its route.
+   *
+   * - `'resource'` — accept either binding. A credential carrying
+   *   `extensions.mppx` is verified in full, including the route-bound nonce; one
+   *   without it is bound the way x402 itself binds, by comparing the echoed
+   *   `resource` and `accepted`. Any spec-compliant client can pay a scoped route.
+   * - `'required'` — every credential must carry `extensions.mppx` and the
+   *   route-bound nonce. Only clients that implement mppx's binding can pay.
+   *
+   * `'resource'` is weaker for clients that don't bind: `resource` sits outside
+   * the EIP-3009 signature, so a holder of a valid payload could re-present it at
+   * another route with identical `accepted`. It prevents honest cross-route reuse
+   * and client bugs, not an active attacker. Body binding is unaffected either
+   * way — `challenge.digest` is verified against the actual body.
+   *
+   * @default 'resource'
+   */
+  routeBinding?: RouteBindingMode | undefined
 }
+
+/** How a route-scoped charge binds an x402 credential to its route. */
+export type RouteBindingMode = 'required' | 'resource'
 
 export type ResolvedOptions = {
   authorization: Types.AuthorizationConfig
   facilitator?: x402_Types.Facilitator | undefined
   maxTimeoutSeconds: number
+  routeBinding: RouteBindingMode
 }
 
 export type Path = {
@@ -78,6 +101,7 @@ export function resolveOptions(parameters: {
         }
       : {}),
     maxTimeoutSeconds: parameters.options?.maxTimeoutSeconds ?? 300,
+    routeBinding: parameters.options?.routeBinding ?? 'resource',
   }
 }
 
@@ -117,7 +141,12 @@ export function createPath(config: ResolvedOptions): Path {
         challenge.digest !== undefined ||
         challenge.opaque !== undefined ||
         challenge.meta !== undefined
-      if (routeRequiresBinding && !isRouteBound)
+      // `extensions.mppx` binding is not part of the x402 spec, so a client mppx
+      // did not write cannot produce it. Requiring it makes every scoped route —
+      // and everything behind `Proxy`, which scopes what it serves — unpayable by
+      // third-party wallets. Under 'resource' such a credential falls through to
+      // the binding x402 itself defines instead of being rejected outright.
+      if (routeRequiresBinding && !isRouteBound && config.routeBinding === 'required')
         throw new VerificationFailedError({
           reason: 'x402 payment payload does not bind required route metadata',
         })
@@ -132,6 +161,14 @@ export function createPath(config: ResolvedOptions): Path {
         if (!containsExtensions(paymentPayload.extensions, expectedExtensions))
           throw new VerificationFailedError({
             reason: 'x402 payment payload extensions do not match route binding',
+          })
+      } else if (routeRequiresBinding) {
+        // A scoped route still binds what x402 makes bindable: the resource must
+        // be echoed, not merely left out. `accepted` was compared above, and
+        // `challenge.digest` was verified against the body by assertBodyDigest().
+        if (!isDeepStrictEqual(paymentPayload.resource, expectedResource))
+          throw new VerificationFailedError({
+            reason: 'x402 payment payload resource does not match route resource',
           })
       } else if (
         paymentPayload.resource !== undefined &&


### PR DESCRIPTION
When investigating using Proxy with the `evm.charge` method, I was unable to - hitting errors like "malformed credential" - due to x402 not official support for the same binding/scoping that MPP supports. That means that x402 clients that are not mppx written will not work.

I tested this in a repro repo: https://github.com/raubrey-stripe/mpp-x402-reference


### LLM Generated

A route scope lands in `challenge.meta`, and the x402 path read any route metadata as a demand for mppx's own `extensions.mppx` binding plus an EIP-3009 nonce equal to an unexported `sha256(accepted | resource | extensions)`. That derivation isn't in the x402 spec, so no third-party client could produce it and scoped charges re-challenged forever with `Credential is malformed.` `Proxy` attaches a derived scope to every charge it serves, so everything behind it was unpayable over x402 by default.

Such a credential now falls through to the binding x402 itself defines -- comparing the echoed `resource` and `accepted`. A credential that does carry `extensions.mppx` is still verified in full, so mppx's own client is unaffected, and `challenge.digest` is still checked against the body.

`x402: { routeBinding: 'required' }` restores the previous behaviour for operators who need scope enforced on the x402 rail.


Committed-By-Agent: claude