### PR TITLE
fix: escape non-Latin-1 characters in challenge auth-params

### DIFF
--- a/.changeset/witty-doors-wave.md
+++ b/.changeset/witty-doors-wave.md
@@ -1,0 +1,5 @@
+---
+"mppx": patch
+---
+
+Escape characters above Latin-1 in challenge auth-params so serialized challenges are always valid HTTP header values. Previously a charge `description` containing an em dash, smart quote, or emoji made `Response` construction throw (`Cannot convert argument to a ByteString`) in fetch-compliant runtimes when the challenge was written to the `WWW-Authenticate` header.

--- a/src/Challenge.test.ts
+++ b/src/Challenge.test.ts
@@ -508,6 +508,16 @@ describe('serialize', () => {
       escaped: 'Ends with slash \\\\',
       label: 'trailing backslash',
     },
+    {
+      description: '1 \u00d7 Classmatic \u2014 General Admission',
+      escaped: '1 \u00d7 Classmatic \\u2014 General Admission',
+      label: 'characters above Latin-1 (em dash)',
+    },
+    {
+      description: 'Tickets \ud83c\udf9f\ufe0f "VIP"',
+      escaped: 'Tickets \\ud83c\\udf9f\\ufe0f \\"VIP\\"',
+      label: 'surrogate pairs and quotes',
+    },
   ])('behavior: escapes quoted-string values: $label', ({ description, escaped }) => {
     const challenge = Challenge.from({
       id: 'abc123',
@@ -520,6 +530,25 @@ describe('serialize', () => {
 
     const header = Challenge.serialize(challenge)
     expect(header).toContain(`description="${escaped}"`)
+    expect(Challenge.deserialize(header).description).toBe(description)
+  })
+
+  test('behavior: serialized challenges are valid HTTP header values', () => {
+    const description = '1 \u00d7 Classmatic \u2014 General Admission \ud83c\udf9f\ufe0f'
+    const challenge = Challenge.from({
+      id: 'abc123',
+      realm: 'api.example.com',
+      method: 'tempo',
+      intent: 'charge',
+      request: { amount: '1000000' },
+      description,
+    })
+
+    const header = Challenge.serialize(challenge)
+    // Header values are ByteStrings: anything above 0xFF makes Response
+    // construction throw in fetch-compliant runtimes.
+    expect([...header].every((char) => char.charCodeAt(0) <= 0xff)).toBe(true)
+    expect(() => new Headers({ 'WWW-Authenticate': header })).not.toThrow()
     expect(Challenge.deserialize(header).description).toBe(description)
   })
 

--- a/src/Challenge.ts
+++ b/src/Challenge.ts
@@ -318,7 +318,15 @@ export function serialize(challenge: Challenge): string {
 /** @internal */
 function authParam(name: string, value: string): string {
   if (/[\r\n]/.test(value)) throw new Error('Invalid quoted-string value.')
-  return `${name}="${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+  const escaped = value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    // Header values must be ByteStrings (code points ≤ 0xFF): escape anything
+    // above Latin-1 (em dashes, smart quotes, emoji in descriptions) so the
+    // serialized challenge is always a legal header value instead of crashing
+    // Response construction.
+    .replace(/[\u0100-\uffff]/g, (char) => `\\u${char.charCodeAt(0).toString(16).padStart(4, '0')}`)
+  return `${name}="${escaped}"`
 }
 
 /**
@@ -431,7 +439,14 @@ function readQuotedAuthParamValue(
 
     if (escaped) {
       parts ??= []
-      parts.push(char)
+      // `\\uXXXX` unescapes characters above Latin-1. Unambiguous: serializers
+      // always double raw backslashes, so a bare `\\u` only ever comes from
+      // the unicode escape in `authParam`.
+      const hex = char === 'u' ? input.slice(i, i + 4) : undefined
+      if (hex && /^[0-9A-Fa-f]{4}$/.test(hex)) {
+        parts.push(String.fromCharCode(Number.parseInt(hex, 16)))
+        i += 4
+      } else parts.push(char)
       segmentStart = i
       escaped = false
       continue


### PR DESCRIPTION
### Problem

`Challenge.serialize` writes the charge `description` into the `WWW-Authenticate` header raw. Header values must be ByteStrings (code points ≤ 0xFF), so any description containing an em dash, smart quote, or emoji makes `Response` construction throw in fetch-compliant runtimes:

```
TypeError: Cannot convert argument to a ByteString because the character at index 858 has a value of 8212 which is greater than 255.
    at Object.respondChallenge (.../mppx.mjs:6295)
```

Minimal repro:

```ts
const challenge = Challenge.from({
  id: 'abc',
  realm: 'shop.example',
  method: 'stripe',
  intent: 'charge',
  request: { amount: '1400', currency: 'usd' },
  description: '1 × Classmatic — General Admission',
})
new Headers({ 'WWW-Authenticate': Challenge.serialize(challenge) }) // throws
```

We hit this in production: merchant product titles routinely contain em dashes, so any integrator passing a title through `charge({ description })` gets an opaque crash on the challenge response. (Existing serialize/deserialize tests pass because they never place the serialized value into a real `Headers`/`Response`.)

### Fix

`authParam` now escapes characters above Latin-1 as `\uXXXX` inside quoted strings, and the quoted-string parser decodes them. The escape is unambiguous with the existing convention: serializers always double raw backslashes, so a bare `\u` can only come from this encoding. Older parsers degrade to rendering the literal escape in the display-only description rather than failing.

- Round-trip covered in the existing `test.each` escape table (em dash, surrogate pairs + quotes).
- New test asserts serialized challenges are constructible as real header values.
- Fuzz suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)