### PR TITLE
fix(tempo): support hosted fee payer for session settlement

### DIFF
--- a/.changeset/hosted-session-settlement.md
+++ b/.changeset/hosted-session-settlement.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed hosted fee-payer sponsorship for server-driven session settlement and close transactions.

--- a/src/tempo/PublicExports.test-d.ts
+++ b/src/tempo/PublicExports.test-d.ts
@@ -76,7 +76,7 @@ test('tempo session chain exports canonical transaction options', () => {
   expectTypeOf<ChannelTransactionOptions>().toEqualTypeOf<{
     account?: import('viem').Account | undefined
     candidateFeeTokens?: readonly import('viem').Address[] | undefined
-    feePayer?: import('viem').Account | undefined
+    feePayer?: import('viem').Account | true | undefined
     feePayerPolicy?: Partial<import('./internal/fee-payer.js').Policy> | undefined
     feeToken?: import('viem').Address | undefined
   }>()

--- a/src/tempo/session/precompile/Chain.test.ts
+++ b/src/tempo/session/precompile/Chain.test.ts
@@ -333,6 +333,49 @@ describe('precompile receipt wait', () => {
 })
 
 describe('precompile server transactions', () => {
+  test('marks server-driven close and settle transactions for hosted fee-payer sponsorship', async () => {
+    const rpcMethods: string[] = []
+    const preparedRequests: Record<string, unknown>[] = []
+    const signedRequests: Record<string, unknown>[] = []
+    const sender = {
+      ...feePayer,
+      async signTransaction(transaction: Record<string, unknown>) {
+        signedRequests.push(transaction)
+        return `0x76${'00'.repeat(32)}` as `0x${string}`
+      },
+    }
+    const prepare = async (parameters: Record<string, unknown>) => {
+      preparedRequests.push(parameters)
+      return parameters
+    }
+    const client = createMockClient({ rpcMethods }).extend(() => ({
+      prepareTransactionRequest: prepare as never,
+    }))
+
+    await Chain.closeOnChain(
+      client,
+      descriptor,
+      1n,
+      1n,
+      `0x${'11'.repeat(65)}`,
+      tip20ChannelEscrow,
+      {
+        account: sender,
+        feePayer: true,
+      },
+    )
+    await Chain.settleOnChain(client, descriptor, 1n, `0x${'11'.repeat(65)}`, tip20ChannelEscrow, {
+      account: sender,
+      feePayer: true,
+    })
+
+    expect(preparedRequests.map(({ feePayer }) => feePayer)).toEqual([true, true])
+    expect(signedRequests.map(({ feePayer }) => feePayer)).toEqual([true, true])
+    expect(rpcMethods.filter((method) => method === 'eth_sendRawTransaction')).toHaveLength(2)
+    expect(rpcMethods).not.toContain('eth_sendTransaction')
+    expect(rpcMethods).not.toContain('eth_call')
+  })
+
   test('does not add a fee-payer signature when the sender and fee payer are the same account', async () => {
     const rpcMethods: string[] = []
     const client = createMockClient({ rpcMethods })

--- a/src/tempo/session/precompile/Chain.ts
+++ b/src/tempo/session/precompile/Chain.ts
@@ -391,8 +391,8 @@ export type ChannelTransactionOptions = {
   account?: Account | undefined
   /** Candidate fee tokens used when resolving a fee token for fee-sponsored transactions. */
   candidateFeeTokens?: readonly Address[] | undefined
-  /** Fee-payer account used to co-sign Tempo fee-sponsored transactions. */
-  feePayer?: Account | undefined
+  /** Fee-payer account, or `true` when the client transport uses a configured hosted fee-payer service. */
+  feePayer?: Account | true | undefined
   /** Optional fee-payer gas and total-fee limits enforced before co-signing. */
   feePayerPolicy?: Partial<FeePayer.Policy> | undefined
   /** Explicit fee token for the transaction. */
@@ -600,17 +600,19 @@ function sendPrecompileContractCall(
   parameters: {
     account?: Account | undefined
     data: Hex
+    feePayer?: true | undefined
     feeToken?: Address | undefined
     to: Address
   },
 ): Promise<Hex> {
-  const { account, data, feeToken, to } = parameters
+  const { account, data, feePayer, feeToken, to } = parameters
   // `feeToken` is Tempo-specific and not represented on viem's base
   // transaction request type.
   return sendViemTransaction(client, {
     ...(account ? { account } : {}),
     to,
     data,
+    ...(feePayer ? { feePayer } : {}),
     ...(feeToken ? { feeToken } : {}),
   } as never)
 }
@@ -1216,15 +1218,26 @@ async function sendPrecompileTransaction(
   options?: ChannelTransactionOptions,
 ): Promise<Hex> {
   const account = options?.account ?? client.account
+  const feePayer = options?.feePayer
   const selfSponsored =
-    account && options?.feePayer && isAddressEqual(account.address, options.feePayer.address)
+    account && typeof feePayer === 'object' && isAddressEqual(account.address, feePayer.address)
 
-  if (options?.feePayer && !selfSponsored) {
+  if (feePayer === true) {
+    if (!account) throw new Error(`Cannot ${label} precompile channel: no account available.`)
+    return sendPrecompileContractCall(client, {
+      account,
+      data,
+      feePayer: true,
+      to,
+    })
+  }
+
+  if (feePayer && !selfSponsored) {
     if (!account) throw new Error(`Cannot ${label} precompile channel: no account available.`)
     const feeToken =
       options.feeToken ??
       (await resolveFeeToken({
-        account: options.feePayer.address,
+        account: feePayer.address,
         candidateTokens: options.candidateFeeTokens,
         client,
       }))
@@ -1238,7 +1251,7 @@ async function sendPrecompileTransaction(
     const serialized = await signTempoTransaction(client, {
       ...prepared,
       account,
-      feePayer: options.feePayer,
+      feePayer,
     })
     const receipt = await sendRawTransactionSync(client, {
       serializedTransaction: serialized as Transaction.TransactionSerializedTempo,

--- a/src/tempo/session/server/CredentialVerification.ts
+++ b/src/tempo/session/server/CredentialVerification.ts
@@ -1028,7 +1028,7 @@ async function handleCloseCredential(
       account
         ? {
             account,
-            ...(typeof parameters.feePayer === 'object' ? { feePayer: parameters.feePayer } : {}),
+            ...(parameters.feePayer ? { feePayer: parameters.feePayer } : {}),
             ...(parameters.feePayerPolicy ? { feePayerPolicy: parameters.feePayerPolicy } : {}),
             ...(parameters.feeToken ? { feeToken: parameters.feeToken } : {}),
             candidateFeeTokens: [channel.token],

--- a/src/tempo/session/server/Session.ts
+++ b/src/tempo/session/server/Session.ts
@@ -329,6 +329,7 @@ export function session<const parameters extends session.Parameters>(
   const lastOnChainVerified = new Map<Hex, number>()
   const { account, feePayer, feePayerUrl, recipient } = Account.resolve(parameters)
   const configuredFeePayer = feePayer ?? feePayerUrl
+  const settlementFeePayer = feePayer ?? (feePayerUrl ? true : undefined)
   const getClient = Client.getResolver({
     chain: tempo_chain,
     feePayerUrl,
@@ -341,7 +342,7 @@ export function session<const parameters extends session.Parameters>(
       account,
       channel,
       client: await getClient({ chainId: channel.chainId }),
-      ...(feePayer ? { feePayer } : {}),
+      ...(settlementFeePayer ? { feePayer: settlementFeePayer } : {}),
       feePayerPolicy: parameters.feePayerPolicy,
       feeToken: parameters.feeToken,
       onSessionSettlement,
@@ -463,7 +464,7 @@ export function session<const parameters extends session.Parameters>(
         maybeSettleScheduled({
           account,
           client: context.client,
-          ...(typeof context.feePayer === 'object' ? { feePayer: context.feePayer } : {}),
+          ...(context.feePayer ? { feePayer: context.feePayer } : {}),
           feePayerPolicy: parameters.feePayerPolicy,
           feeToken: parameters.feeToken,
           onSessionSettlement,

--- a/src/tempo/session/server/Settlement.test.ts
+++ b/src/tempo/session/server/Settlement.test.ts
@@ -103,6 +103,13 @@ describe('FeePayerResolution', () => {
           requestFeePayer: false,
         }),
       ).toBe(false)
+
+      expect(
+        resolveRequestFeePayer({
+          credential: credential(),
+          parameterFeePayer: feePayerUrl,
+        }),
+      ).toBe(true)
     })
 
     test('allows credential fee sponsorship only when method details and request permit it', () => {

--- a/src/tempo/session/server/Settlement.ts
+++ b/src/tempo/session/server/Settlement.ts
@@ -92,14 +92,9 @@ export function resolveRequestFeePayer(
   if (requestFeePayer === false) return credential ? false : undefined
 
   const account = typeof requestFeePayer === 'object' ? requestFeePayer : defaultFeePayer
-  if (credential) return account ?? undefined
-  if (
-    account ||
-    defaultFeePayer ||
-    parameterFeePayer === true ||
-    typeof parameterFeePayer === 'string'
-  )
-    return true
+  const hosted = parameterFeePayer === true || typeof parameterFeePayer === 'string'
+  if (credential) return account ?? (hosted ? true : undefined)
+  if (account || hosted) return true
   return undefined
 }
 
@@ -352,8 +347,8 @@ export type SettlementTransactionOptions = {
   candidateFeeTokens?: readonly Address[] | undefined
   /** TIP20EscrowChannel precompile address override. */
   escrowContract?: Address | undefined
-  /** Optional fee-payer account for sponsored settlement. */
-  feePayer?: viem_Account | undefined
+  /** Fee-payer account, or `true` when the client transport uses a configured hosted fee-payer service. */
+  feePayer?: viem_Account | true | undefined
   /** Optional policy for sponsored settlement. */
   feePayerPolicy?: Partial<FeePayer.Policy> | undefined
   /** Optional fee token override for settlement. */
@@ -370,8 +365,8 @@ export type MaybeSettleScheduledParameters = {
   channel: ChannelStore.State
   /** viem client used to settle on-chain. */
   client: Chain.TransactionClient
-  /** Optional fee-payer account for sponsored settlement. */
-  feePayer?: viem_Account | undefined
+  /** Fee-payer account, or `true` when the client transport uses a configured hosted fee-payer service. */
+  feePayer?: viem_Account | true | undefined
   /** Optional policy for sponsored settlement. */
   feePayerPolicy?: Partial<FeePayer.Policy> | undefined
   /** Optional fee token override for settlement. */


### PR DESCRIPTION
## What changed
- Preserve hosted fee-payer during session close and scheduled settlement
- Allow server-built transactions to carry `feePayer: true`

## Why
A fee-payer URL worked for buyer-signed open and top-up transactions, but server-driven close and settlement dropped the resolved hosted mode. The operator then attempted to pay its own gas, causing zero-balance operators to fail despite a configured hosted fee-payer service.