### PR TITLE
fix(discovery): ignore unknown fields next to offers in x-payment-info

### DIFF
--- a/.changeset/quiet-offers-ignore.md
+++ b/.changeset/quiet-offers-ignore.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Discovery: unknown fields next to `offers` in `x-payment-info` are ignored instead of failing validation (only the spec-defined flat fields conflict with `offers`).

--- a/src/discovery/Discovery.test.ts
+++ b/src/discovery/Discovery.test.ts
@@ -65,6 +65,20 @@ describe('PaymentInfo', () => {
     expect(result.success).toBe(false)
   })
 
+  test('ignores unknown fields next to offers', () => {
+    // Only the spec-defined flat fields conflict with `offers`; unknown
+    // extension keys are ignored, as documented on the schema.
+    const result = PaymentInfo.safeParse({
+      offers: [{ amount: '1000', intent: 'charge', method: 'tempo' }],
+      price: '0.001',
+      protocols: ['mpp'],
+    })
+    expect(result.success).toBe(true)
+    expect(result.data).toEqual({
+      offers: [{ amount: '1000', intent: 'charge', method: 'tempo' }],
+    })
+  })
+
   test('rejects malformed offers', () => {
     const result = PaymentInfo.safeParse({
       offers: [{ amount: '01', intent: 'charge', method: 'tempo' }],

--- a/src/discovery/Discovery.ts
+++ b/src/discovery/Discovery.ts
@@ -38,7 +38,8 @@ export const PaymentInfo = z.pipe(
     .check(
       z.refine(
         (value) =>
-          value.offers === undefined || Object.keys(value).every((key) => key === 'offers'),
+          value.offers === undefined ||
+          Object.keys(value).every((key) => key === 'offers' || !paymentInfoFieldNames.has(key)),
         'Cannot mix offers with flat payment info fields',
       ),
     ),

--- a/src/discovery/Validate.test.ts
+++ b/src/discovery/Validate.test.ts
@@ -169,6 +169,36 @@ describe('validate', () => {
     )
   })
 
+  test('accepts unknown fields next to offers', () => {
+    const errors = validate(
+      makeDoc({
+        paths: {
+          '/search': {
+            post: {
+              'x-payment-info': {
+                offers: [{ amount: '100', intent: 'charge', method: 'tempo' }],
+                price: '0.0001',
+              },
+              requestBody: {
+                content: { 'application/json': { schema: { type: 'object' } } },
+              },
+              responses: {
+                '200': { description: 'OK' },
+                '402': { description: 'Payment Required' },
+              },
+            },
+          },
+        },
+      }),
+    )
+
+    expect(errors).not.toContainEqual(
+      expect.objectContaining({
+        message: 'Cannot mix offers with flat payment info fields',
+      }),
+    )
+  })
+
   test('returns errors for empty offers arrays', () => {
     const errors = validate(
       makeDoc({


### PR DESCRIPTION
## Problem

`PaymentInfo` is documented as "unknown fields are ignored", but the mixed-shape refine rejects **any** key other than `offers` once `offers` is present:

```ts
value.offers === undefined || Object.keys(value).every((key) => key === 'offers')
```

So a discovery document that carries other `x-payment-info` extension keys next to `offers` (for example a registry-specific `price` or `protocols` field) fails `mppx discover validate` with `Cannot mix offers with flat payment info fields` on every operation, even though the `offers` array itself is well-formed and is exactly what mppx consumers read.

## Change

Only the spec-defined flat fields (`amount`, `currency`, `description`, `intent`, `method`) conflict with `offers`; unknown keys are ignored, matching the schema comment and the transform (which already drops everything but `offers` when `offers` is present).

```ts
Object.keys(value).every((key) => key === 'offers' || !paymentInfoFieldNames.has(key))
```

The existing behaviour for a real mix (flat `amount` + `offers`) is unchanged and still covered by the existing tests.

## Tests

- `Discovery.test.ts`: `ignores unknown fields next to offers` (parses, output is `{ offers }` only)
- `Validate.test.ts`: `accepts unknown fields next to offers` (no mixed-shape error)
- Both fail on `main` and pass with the change; the existing `rejects mixed shorthand and offers shapes` tests still pass.

Changeset: patch.