### PR TITLE
fix(stripe): remove obsolete MPP metadata

### DIFF
--- a/.changeset/remove-stripe-mpp-metadata.md
+++ b/.changeset/remove-stripe-mpp-metadata.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Removed obsolete MPP version metadata from Stripe charge PaymentIntents.

--- a/src/stripe/server/Charge.test.ts
+++ b/src/stripe/server/Charge.test.ts
@@ -207,7 +207,8 @@ describe('stripe.charge with client', () => {
 
     const [params] = create.mock.calls[0]!
     expect(params.metadata).toMatchObject({ plan: 'pro' })
-    expect(params.metadata.mpp_is_mpp).toBe('true')
+    expect(params.metadata).not.toHaveProperty('mpp_is_mpp')
+    expect(params.metadata).not.toHaveProperty('mpp_version')
   })
 
   test('behavior: applies Connect settlement parameters in client call', async () => {

--- a/src/stripe/server/Charge.ts
+++ b/src/stripe/server/Charge.ts
@@ -432,8 +432,6 @@ function buildAnalytics(parameters: { credential: Credential.Credential }): Reco
   const { credential } = parameters
   const { challenge } = credential
   return {
-    mpp_version: '1',
-    mpp_is_mpp: 'true',
     mpp_intent: challenge.intent,
     mpp_challenge_id: challenge.id,
     mpp_server_id: challenge.realm,


### PR DESCRIPTION
We've gotten feedback that this metadata is ~confusing/~not useful. Let's remove the `mpp_is_mpp` and `mpp_version` metadata for now (I've left the challenge ID) while we are also thinking about what useful PI metadata we could provide overall (and now we can add it for those users using the stripe.defaultMethods() and other higher level SDK + Stripe things).