### PR TITLE
fix(tempo): preserve explicit charge amount for mpp sessions

### DIFF
--- a/.changeset/fuzzy-chairs-pay.md
+++ b/.changeset/fuzzy-chairs-pay.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed explicit session stream charges being discarded by prepaid units.

--- a/src/tempo/session/server/MeteredStream.ts
+++ b/src/tempo/session/server/MeteredStream.ts
@@ -42,7 +42,7 @@ export type MeteredStreamOptions = {
   onChargeCommitted?: ((channel: ChannelStore.State) => MaybePromise<unknown>) | undefined
   /** Store polling interval when `waitForUpdate` is unavailable. */
   pollIntervalMs: number
-  /** Pre-authorized units that may be emitted without reserving new voucher headroom. */
+  /** Pre-authorized implicit tick-cost units that may be emitted without a new reservation. */
   prepaidUnits?: number | undefined
   /** Optional abort signal for stream cancellation. */
   signal?: AbortSignal | undefined
@@ -58,23 +58,25 @@ export async function* meterIterable(options: MeteredStreamOptions): AsyncGenera
   let reservedAmount = 0n
   let reservedUnits = 0
 
-  const charge = async (amount = options.tickCost) => {
-    if (prepaidUnits > 0) {
+  const charge = async (amount?: bigint) => {
+    if (amount === undefined && prepaidUnits > 0) {
       prepaidUnits -= 1
       return
     }
 
+    const resolvedAmount = amount ?? options.tickCost
+
     await reserveChargeOrWait({
       store: options.store,
       channelId: options.channelId,
-      amount,
+      amount: resolvedAmount,
       reservedAmount,
       emit: options.emitNeedVoucher,
       formatNeedVoucher: options.formatNeedVoucher,
       pollIntervalMs: options.pollIntervalMs,
       signal: options.signal,
     })
-    reservedAmount += amount
+    reservedAmount += resolvedAmount
     reservedUnits += 1
   }
 

--- a/src/tempo/session/server/Session.test.ts
+++ b/src/tempo/session/server/Session.test.ts
@@ -2369,6 +2369,7 @@ describe('precompile server session unit guardrails', () => {
       options: {
         amount?: string
         chunkDelayMs?: number
+        explicitCharge?: bigint
         maxDeposit?: bigint
         onSessionSettlement?: session.Parameters['onSessionSettlement']
         settlementSchedule?: session.Parameters['settlementSchedule']
@@ -2471,6 +2472,11 @@ describe('precompile server session unit guardrails', () => {
 
           currentPayload = undefined
           return result.withReceipt(async function* (stream) {
+            if (options.explicitCharge !== undefined) {
+              await stream.charge(options.explicitCharge)
+              yield 'chunk-1'
+              return
+            }
             await stream.charge()
             yield 'chunk-1'
             if (options.chunkDelayMs)
@@ -2523,6 +2529,32 @@ describe('precompile server session unit guardrails', () => {
       expect(channelId).toBeTruthy()
       const persisted = await channelStore(harness.rawStore).getChannel(channelId!)
       expect(persisted?.finalized).toBe(true)
+    })
+
+    test('captures an explicit stream charge after a prepaid request tick', async () => {
+      const harness = createManagedSseFetch({ explicitCharge: 4014n, maxDeposit: 4015n })
+      const manager = precompileSessionManager({
+        account: payer,
+        client: createSigningClient(),
+        decimals: 0,
+        fetch: harness.fetch,
+        maxDeposit: '4015',
+      })
+
+      const chunks: string[] = []
+      for await (const chunk of await manager.sse('https://api.example.com/stream')) {
+        chunks.push(chunk)
+      }
+
+      expect(chunks).toEqual(['chunk-1'])
+      expect(harness.voucherPosts).toBeGreaterThan(0)
+
+      const closeReceipt = await manager.close()
+      expect(closeReceipt?.acceptedCumulative).toBe('4015')
+      expect(closeReceipt?.spent).toBe('4015')
+
+      const persisted = await channelStore(harness.rawStore).getChannel(manager.channelId!)
+      expect(persisted).toMatchObject({ finalized: true, spent: 4015n, units: 2 })
     })
 
     test.each([

--- a/src/tempo/session/server/Sse.test.ts
+++ b/src/tempo/session/server/Sse.test.ts
@@ -288,6 +288,32 @@ describe('serve', () => {
     expect(committed).toEqual([{ spent: 2000000n, units: 2 }])
   })
 
+  test('uses the provided amount for an explicit charge when a prepaid unit exists', async () => {
+    const storage = memoryStore()
+    await seedChannel(storage, 4015n)
+    await storage.updateChannel(channelId, (current) =>
+      current ? { ...current, spent: 1n, units: 1 } : current,
+    )
+
+    const stream = serve({
+      store: storage,
+      channelId,
+      challengeId,
+      tickCost: 1n,
+      generate: async function* (stream) {
+        await stream.charge(4014n)
+        yield 'charged'
+      },
+      prepaidUnits: 1,
+    })
+
+    await readStream(stream)
+
+    const channel = await storage.getChannel(channelId)
+    expect(channel!.spent).toBe(4015n)
+    expect(channel!.units).toBe(2)
+  })
+
   test('runs the post-commit hook before emitting each charged value', async () => {
     const storage = memoryStore()
     const committed: Array<{ spent: bigint; units: number }> = []


### PR DESCRIPTION
## Summary
`stream.charge()` charges the configured tick cost. `stream.charge(amount)` charges the provided raw-unit amount when the corresponding value is emitted.

This PR fixes a bug where an existing prepaid request tick could discard an explicit `amount`.
- Before: accepted cumulative `4015`, spent `1`, close capture `1`
- After: accepted cumulative `4015`, spent `4015`, close capture `4015`