### PR TITLE
fix: format challenge escaping changeset

### DIFF
--- a/.changeset/witty-doors-wave.md
+++ b/.changeset/witty-doors-wave.md
@@ -1,5 +1,5 @@
 ---
-"mppx": patch
+'mppx': patch
 ---
 
 Escape characters above Latin-1 in challenge auth-params so serialized challenges are always valid HTTP header values. Previously a charge `description` containing an em dash, smart quote, or emoji made `Response` construction throw (`Cannot convert argument to a ByteString`) in fetch-compliant runtimes when the challenge was written to the `WWW-Authenticate` header.


### PR DESCRIPTION
## Motivation

Restore the failing formatting check on main.

## Summary

- Normalized the mppx changeset frontmatter to repository formatting conventions.

## Key design considerations

- Kept the fix scoped to the file reported by CI.