### PR TITLE
fix: use patch bump for CLI bundling

### DIFF
--- a/.changeset/dist-only-package.md
+++ b/.changeset/dist-only-package.md
@@ -1,5 +1,5 @@
 ---
-'mppx': minor
+'mppx': patch
 ---
 
 Bundled the CLI runtime and removed source files, source maps, and source export conditions from the published package.


### PR DESCRIPTION
## Motivation

Keep the CLI bundling release within the project’s pre-v1 patch versioning policy.

## Summary

- Changed the CLI bundling changeset from a minor bump to a patch bump.

## Key design considerations

- Left the changeset description and implementation unchanged.