### PR TITLE
fix(tempo): harden machine-token session flows

### DIFF
--- a/.changeset/machine-token-hardening.md
+++ b/.changeset/machine-token-hardening.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Hardened machine-token session flows after #800: kept stored machine channels instead of evicting them on failed retries, advertised close snapshots for signature-verified close credentials, accepted sponsored fees in the payment currency alongside a configured `feeToken`, and restored balance-aware fee-token selection for direct-channel settlement.

--- a/src/tempo/internal/machine-token-session.ts
+++ b/src/tempo/internal/machine-token-session.ts
@@ -86,6 +86,23 @@ export function resolveFeeToken(parameters: {
   return parameters.paymentToken
 }
 
+/**
+ * Resolves the fee tokens accepted for direct-rail sponsored transactions.
+ * Clients released before the fee-token advertisement always pay sponsored
+ * fees in the payment token, so it stays accepted alongside a configured
+ * override. Machine-rail routes post-date the advertisement and pin a single
+ * token via {@link resolveFeeToken}.
+ */
+export function allowedSponsoredFeeTokens(parameters: {
+  chainId: number | undefined
+  override?: Address | undefined
+  paymentToken: Address
+}): readonly Address[] {
+  const feeToken = resolveFeeToken(parameters)
+  if (isAddressEqual(feeToken, parameters.paymentToken)) return [feeToken]
+  return [feeToken, parameters.paymentToken]
+}
+
 /** Returns whether an account has enough of a TIP-20 token for an operation. */
 export async function hasSufficientBalance(
   client: Client,

--- a/src/tempo/session/client/ChannelOps.ts
+++ b/src/tempo/session/client/ChannelOps.ts
@@ -15,6 +15,7 @@ import { Transaction } from 'viem/tempo'
 
 import type { Challenge } from '../../../Challenge.js'
 import * as Credential from '../../../Credential.js'
+import * as MachineTokenSession from '../../internal/machine-token-session.js'
 import * as Channel from '../precompile/Channel.js'
 import { escrowAbi } from '../precompile/escrow.abi.js'
 import { tip20ChannelEscrow } from '../precompile/Protocol.js'
@@ -157,6 +158,32 @@ export function serializeCredential(
 /** Case-insensitive EVM address equality. */
 export function isSameAddress(a: Address, b: Address): boolean {
   return a.toLowerCase() === b.toLowerCase()
+}
+
+/** Returns whether a stored entry funds a machine-token session channel. */
+export function isMachineChannel(entry: Pick<ChannelEntry, 'chainId' | 'descriptor' | 'escrow'>) {
+  return (
+    isSameAddress(entry.escrow, tip20ChannelEscrow) &&
+    MachineTokenSession.matchDeployment({
+      chainId: entry.chainId,
+      descriptor: entry.descriptor,
+    }) !== undefined
+  )
+}
+
+/**
+ * Returns whether a stored entry's logical payment scope differs from its
+ * on-chain descriptor. Such entries cannot be re-derived from a challenge, so
+ * their descriptor is the only local copy — even when the deployment table no
+ * longer recognizes the route (for example after a rotation).
+ */
+export function hasRewrittenScope(entry: Pick<ChannelEntry, 'descriptor' | 'paymentScope'>) {
+  const scope = entry.paymentScope
+  if (!scope) return false
+  return (
+    !isSameAddress(scope.payee, entry.descriptor.payee) ||
+    !isSameAddress(scope.token, entry.descriptor.token)
+  )
 }
 
 /**

--- a/src/tempo/session/client/SessionManager.test.ts
+++ b/src/tempo/session/client/SessionManager.test.ts
@@ -757,6 +757,45 @@ describe('Session', () => {
       expect(map.get(entryKey(seeded))).toMatchObject({ channelId: machineChannelId })
     })
 
+    test('keeps a rewritten-scope channel from a rotated deployment', async () => {
+      // Opened against a deployment the current table no longer lists: only the
+      // differing payment scope marks the entry as non-derivable.
+      const rotatedDescriptor = {
+        ...machineDescriptor,
+        operator: '0x00000000000000000000000000000000000000AA' as Address,
+        token: '0x20c0000000000000000000000000000000000009' as Address,
+      }
+      const seeded = channelEntry({
+        channelId: Channel.computeId({
+          ...rotatedDescriptor,
+          chainId: 4217,
+          escrow: tip20ChannelEscrow,
+        }),
+        descriptor: rotatedDescriptor,
+        paymentScope: {
+          payee: storedDescriptor.payee,
+          token: storedDescriptor.token,
+        },
+      })
+      const { store, delete: remove, map } = makeChannelStore([seeded])
+      const mockFetch = vi.fn().mockImplementation((_input, init?: RequestInit) => {
+        const authorization = new Headers(init?.headers).get(Constants.Headers.authorization)
+        if (!authorization) return Promise.resolve(make402Response())
+        throw new Error('unexpected credential for a rotated machine channel')
+      })
+      const s = sessionManager({
+        account,
+        client,
+        fetch: mockFetch as typeof globalThis.fetch,
+        maxDeposit: '10',
+        channelStore: store,
+      })
+
+      await expect(s.fetch('https://api.example.com/data')).rejects.toThrow()
+      expect(remove).not.toHaveBeenCalled()
+      expect(map.get(entryKey(seeded))).toMatchObject({ channelId: seeded.channelId })
+    })
+
     test('keeps a persisted channel after its committed top-up when the paid retry fails', async () => {
       const seeded = channelEntry({ cumulativeAmount: 10_000_000n, deposit: 10_000_000n })
       const { store, delete: remove, map } = makeChannelStore([seeded])

--- a/src/tempo/session/client/SessionManager.test.ts
+++ b/src/tempo/session/client/SessionManager.test.ts
@@ -725,6 +725,38 @@ describe('Session', () => {
       expect(s.channelId).not.toBe(storedChannelId)
     })
 
+    test('keeps a stored machine channel instead of retrying without it', async () => {
+      const seeded = channelEntry({
+        channelId: machineChannelId,
+        descriptor: machineDescriptor,
+        paymentScope: {
+          payee: storedDescriptor.payee,
+          token: storedDescriptor.token,
+        },
+      })
+      const { store, delete: remove, map } = makeChannelStore([seeded])
+      const mockFetch = vi.fn().mockImplementation((_input, init?: RequestInit) => {
+        const authorization = new Headers(init?.headers).get(Constants.Headers.authorization)
+        if (!authorization) return Promise.resolve(make402Response())
+        throw new Error('unexpected credential for a machine channel the challenge disowned')
+      })
+      const s = sessionManager({
+        account,
+        client,
+        fetch: mockFetch as typeof globalThis.fetch,
+        maxDeposit: '10',
+        channelStore: store,
+      })
+
+      // The challenge no longer advertises `machineTokenEnabled`; evicting the
+      // entry would discard the only copy of the channel descriptor.
+      await expect(s.fetch('https://api.example.com/data')).rejects.toThrow(
+        /machine-token channel is not bound/i,
+      )
+      expect(remove).not.toHaveBeenCalled()
+      expect(map.get(entryKey(seeded))).toMatchObject({ channelId: machineChannelId })
+    })
+
     test('keeps a persisted channel after its committed top-up when the paid retry fails', async () => {
       const seeded = channelEntry({ cumulativeAmount: 10_000_000n, deposit: 10_000_000n })
       const { store, delete: remove, map } = makeChannelStore([seeded])

--- a/src/tempo/session/client/SessionManager.test.ts
+++ b/src/tempo/session/client/SessionManager.test.ts
@@ -725,75 +725,52 @@ describe('Session', () => {
       expect(s.channelId).not.toBe(storedChannelId)
     })
 
-    test('keeps a stored machine channel instead of retrying without it', async () => {
-      const seeded = channelEntry({
-        channelId: machineChannelId,
-        descriptor: machineDescriptor,
-        paymentScope: {
-          payee: storedDescriptor.payee,
-          token: storedDescriptor.token,
-        },
-      })
-      const { store, delete: remove, map } = makeChannelStore([seeded])
-      const mockFetch = vi.fn().mockImplementation((_input, init?: RequestInit) => {
-        const authorization = new Headers(init?.headers).get(Constants.Headers.authorization)
-        if (!authorization) return Promise.resolve(make402Response())
-        throw new Error('unexpected credential for a machine channel the challenge disowned')
-      })
-      const s = sessionManager({
-        account,
-        client,
-        fetch: mockFetch as typeof globalThis.fetch,
-        maxDeposit: '10',
-        channelStore: store,
-      })
-
-      // The challenge no longer advertises `machineTokenEnabled`; evicting the
-      // entry would discard the only copy of the channel descriptor.
-      await expect(s.fetch('https://api.example.com/data')).rejects.toThrow(
-        /machine-token channel is not bound/i,
-      )
-      expect(remove).not.toHaveBeenCalled()
-      expect(map.get(entryKey(seeded))).toMatchObject({ channelId: machineChannelId })
-    })
-
-    test('keeps a rewritten-scope channel from a rotated deployment', async () => {
-      // Opened against a deployment the current table no longer lists: only the
-      // differing payment scope marks the entry as non-derivable.
+    // The retry after a failed paid request must never evict entries whose
+    // descriptor is the only local copy (machine-rail, or any rewritten scope
+    // the current deployment table no longer recognizes).
+    test('keeps non-derivable channels instead of retrying without them', async () => {
       const rotatedDescriptor = {
         ...machineDescriptor,
         operator: '0x00000000000000000000000000000000000000AA' as Address,
         token: '0x20c0000000000000000000000000000000000009' as Address,
       }
-      const seeded = channelEntry({
-        channelId: Channel.computeId({
-          ...rotatedDescriptor,
-          chainId: 4217,
-          escrow: tip20ChannelEscrow,
+      const paymentScope = {
+        payee: storedDescriptor.payee,
+        token: storedDescriptor.token,
+      }
+      const variants = [
+        // The challenge no longer advertises `machineTokenEnabled`.
+        channelEntry({ channelId: machineChannelId, descriptor: machineDescriptor, paymentScope }),
+        // Opened against a deployment the current table no longer lists.
+        channelEntry({
+          channelId: Channel.computeId({
+            ...rotatedDescriptor,
+            chainId: 4217,
+            escrow: tip20ChannelEscrow,
+          }),
+          descriptor: rotatedDescriptor,
+          paymentScope,
         }),
-        descriptor: rotatedDescriptor,
-        paymentScope: {
-          payee: storedDescriptor.payee,
-          token: storedDescriptor.token,
-        },
-      })
-      const { store, delete: remove, map } = makeChannelStore([seeded])
-      const mockFetch = vi.fn().mockImplementation((_input, init?: RequestInit) => {
-        const authorization = new Headers(init?.headers).get(Constants.Headers.authorization)
-        if (!authorization) return Promise.resolve(make402Response())
-        throw new Error('unexpected credential for a rotated machine channel')
-      })
-      const s = sessionManager({
-        account,
-        client,
-        fetch: mockFetch as typeof globalThis.fetch,
-        maxDeposit: '10',
-        channelStore: store,
-      })
+      ]
+      for (const seeded of variants) {
+        const { store, delete: remove, map } = makeChannelStore([seeded])
+        const mockFetch = vi.fn().mockImplementation((_input, init?: RequestInit) => {
+          const authorization = new Headers(init?.headers).get(Constants.Headers.authorization)
+          if (!authorization) return Promise.resolve(make402Response())
+          throw new Error('unexpected credential for a non-derivable machine channel')
+        })
+        const s = sessionManager({
+          account,
+          client,
+          fetch: mockFetch as typeof globalThis.fetch,
+          maxDeposit: '10',
+          channelStore: store,
+        })
 
-      await expect(s.fetch('https://api.example.com/data')).rejects.toThrow()
-      expect(remove).not.toHaveBeenCalled()
-      expect(map.get(entryKey(seeded))).toMatchObject({ channelId: seeded.channelId })
+        await expect(s.fetch('https://api.example.com/data')).rejects.toThrow()
+        expect(remove).not.toHaveBeenCalled()
+        expect(map.get(entryKey(seeded))).toMatchObject({ channelId: seeded.channelId })
+      }
     })
 
     test('keeps a persisted channel after its committed top-up when the paid retry fails', async () => {

--- a/src/tempo/session/client/SessionManager.ts
+++ b/src/tempo/session/client/SessionManager.ts
@@ -137,6 +137,17 @@ function isZeroAmountChargeChallenge(challenge: Challenge.Challenge) {
   }
 }
 
+/** Returns whether a stored entry funds a machine-token session channel. */
+function isMachineChannel(entry: Pick<ChannelEntry, 'chainId' | 'descriptor' | 'escrow'>) {
+  return (
+    entry.escrow.toLowerCase() === tip20ChannelEscrow.toLowerCase() &&
+    MachineTokenSession.matchDeployment({
+      chainId: entry.chainId,
+      descriptor: entry.descriptor,
+    }) !== undefined
+  )
+}
+
 function requestInitWithSessionHint(
   input: RequestInfo | URL,
   init: RequestInit | undefined,
@@ -560,12 +571,7 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
     const snapshot = applySnapshot
       ? applyCloseSnapshot(target, challenge)
       : validateCloseSnapshot(target.channel, challenge)
-    const machineSession =
-      target.channel.escrow.toLowerCase() === tip20ChannelEscrow.toLowerCase() &&
-      MachineTokenSession.matchDeployment({
-        chainId: target.channel.chainId,
-        descriptor: target.channel.descriptor,
-      }) !== undefined
+    const machineSession = isMachineChannel(target.channel)
     const closeAmount = snapshot
       ? machineSession
         ? snapshot.spent > snapshot.settled
@@ -729,6 +735,10 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
       async function retryWithoutResumed(): Promise<boolean> {
         const resumed = use.resumed
         if (!canRetryResumed || !resumed) return false
+        // A machine-token entry holds the only local copy of its channel
+        // descriptor; evicting it would strand the deposit, so fail loudly
+        // instead of retrying without it.
+        if (resumed.opened && isMachineChannel(resumed)) return false
         canRetryResumed = false
         await ignoreChannel(resumed)
         effectiveInit = requestInitWithSessionHint(input, init, undefined)

--- a/src/tempo/session/client/SessionManager.ts
+++ b/src/tempo/session/client/SessionManager.ts
@@ -148,6 +148,21 @@ function isMachineChannel(entry: Pick<ChannelEntry, 'chainId' | 'descriptor' | '
   )
 }
 
+/**
+ * Returns whether a stored entry's logical payment scope differs from its
+ * on-chain descriptor. Such entries cannot be re-derived from a challenge, so
+ * their descriptor is the only copy — even when the deployment table no longer
+ * recognizes the route (for example after a rotation).
+ */
+function hasRewrittenScope(entry: Pick<ChannelEntry, 'descriptor' | 'paymentScope'>) {
+  const scope = entry.paymentScope
+  if (!scope) return false
+  return (
+    scope.payee.toLowerCase() !== entry.descriptor.payee.toLowerCase() ||
+    scope.token.toLowerCase() !== entry.descriptor.token.toLowerCase()
+  )
+}
+
 function requestInitWithSessionHint(
   input: RequestInfo | URL,
   init: RequestInit | undefined,
@@ -738,7 +753,8 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
         // A machine-token entry holds the only local copy of its channel
         // descriptor; evicting it would strand the deposit, so fail loudly
         // instead of retrying without it.
-        if (resumed.opened && isMachineChannel(resumed)) return false
+        if (resumed.opened && (isMachineChannel(resumed) || hasRewrittenScope(resumed)))
+          return false
         canRetryResumed = false
         await ignoreChannel(resumed)
         effectiveInit = requestInitWithSessionHint(input, init, undefined)

--- a/src/tempo/session/client/SessionManager.ts
+++ b/src/tempo/session/client/SessionManager.ts
@@ -11,14 +11,12 @@ import * as Account from '../../../viem/Account.js'
 import * as Client from '../../../viem/Client.js'
 import { charge as chargePlugin } from '../../client/Charge.js'
 import * as defaults from '../../internal/defaults.js'
-import * as MachineTokenSession from '../../internal/machine-token-session.js'
-import type { ChannelEntry } from '../client/ChannelOps.js'
+import { hasRewrittenScope, isMachineChannel, type ChannelEntry } from '../client/ChannelOps.js'
 import { createChannelStore, entryKey, type ChannelStore } from '../client/ChannelStore.js'
 import { hydrateSessionSnapshot, type SessionContext } from '../client/CredentialState.js'
 import { session as sessionPlugin } from '../client/Session.js'
 import * as Channel from '../precompile/Channel.js'
 import { deserializeSessionReceipt } from '../precompile/Protocol.js'
-import { tip20ChannelEscrow } from '../precompile/Protocol.js'
 import type { SessionReceipt } from '../precompile/Protocol.js'
 import {
   deserializeSnapshot as deserializeSessionSnapshot,
@@ -135,32 +133,6 @@ function isZeroAmountChargeChallenge(challenge: Challenge.Challenge) {
   } catch {
     return false
   }
-}
-
-/** Returns whether a stored entry funds a machine-token session channel. */
-function isMachineChannel(entry: Pick<ChannelEntry, 'chainId' | 'descriptor' | 'escrow'>) {
-  return (
-    entry.escrow.toLowerCase() === tip20ChannelEscrow.toLowerCase() &&
-    MachineTokenSession.matchDeployment({
-      chainId: entry.chainId,
-      descriptor: entry.descriptor,
-    }) !== undefined
-  )
-}
-
-/**
- * Returns whether a stored entry's logical payment scope differs from its
- * on-chain descriptor. Such entries cannot be re-derived from a challenge, so
- * their descriptor is the only copy — even when the deployment table no longer
- * recognizes the route (for example after a rotation).
- */
-function hasRewrittenScope(entry: Pick<ChannelEntry, 'descriptor' | 'paymentScope'>) {
-  const scope = entry.paymentScope
-  if (!scope) return false
-  return (
-    scope.payee.toLowerCase() !== entry.descriptor.payee.toLowerCase() ||
-    scope.token.toLowerCase() !== entry.descriptor.token.toLowerCase()
-  )
 }
 
 function requestInitWithSessionHint(
@@ -453,9 +425,7 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
       })) ?? defaultAccount
     const hydrated = await hydrateSessionSnapshot({ account, client, snapshot })
     const entry =
-      paymentScope &&
-      (paymentScope.payee.toLowerCase() !== hydrated.entry.descriptor.payee.toLowerCase() ||
-        paymentScope.token.toLowerCase() !== hydrated.entry.descriptor.token.toLowerCase())
+      paymentScope && hasRewrittenScope({ descriptor: hydrated.entry.descriptor, paymentScope })
         ? { ...hydrated.entry, paymentScope }
         : hydrated.entry
     assertVoucherWithinLocalLimit(entry.cumulativeAmount)

--- a/src/tempo/session/server/CredentialVerification.ts
+++ b/src/tempo/session/server/CredentialVerification.ts
@@ -95,7 +95,7 @@ export function validateChannelDescriptor(
 }
 
 type ResolvedCredentialRoute = {
-  allowedFeeTokens: readonly [Address]
+  allowedFeeTokens: readonly Address[]
   expectedOperator: Address
   machineRouter?: Address | undefined
   payment: ChallengePaymentFields
@@ -124,19 +124,27 @@ async function resolveCredentialRoute(parameters: {
     isAddressEqual(descriptor.token, request.currency) &&
     isAddressEqual(descriptor.operator, expectedOperator)
 
-  const allowedFeeTokens = (paymentToken: Address): readonly [Address] => [
-    MachineTokenSession.resolveFeeToken({
+  const allowedFeeTokens = (paymentToken: Address): readonly Address[] => {
+    const feeToken = MachineTokenSession.resolveFeeToken({
       chainId,
       override: parameters.feeToken,
       paymentToken,
-    }),
-  ]
-  if (direct)
+    })
+    return [feeToken]
+  }
+  if (direct) {
+    const [feeToken] = allowedFeeTokens(request.currency)
     return {
-      allowedFeeTokens: allowedFeeTokens(request.currency),
+      // Clients released before the fee-token advertisement pay sponsored fees
+      // in the payment currency; keep accepting it alongside an override.
+      allowedFeeTokens:
+        feeToken && !isAddressEqual(feeToken, request.currency)
+          ? [feeToken, request.currency]
+          : allowedFeeTokens(request.currency),
       expectedOperator,
       payment: request,
     }
+  }
   if (payload.action !== 'close' && !MachineTokenSession.isEnabledChallenge(challenge))
     throw new VerificationFailedError({ reason: 'credential descriptor does not match challenge' })
 

--- a/src/tempo/session/server/CredentialVerification.ts
+++ b/src/tempo/session/server/CredentialVerification.ts
@@ -124,27 +124,16 @@ async function resolveCredentialRoute(parameters: {
     isAddressEqual(descriptor.token, request.currency) &&
     isAddressEqual(descriptor.operator, expectedOperator)
 
-  const allowedFeeTokens = (paymentToken: Address): readonly Address[] => {
-    const feeToken = MachineTokenSession.resolveFeeToken({
-      chainId,
-      override: parameters.feeToken,
-      paymentToken,
-    })
-    return [feeToken]
-  }
-  if (direct) {
-    const [feeToken] = allowedFeeTokens(request.currency)
+  if (direct)
     return {
-      // Clients released before the fee-token advertisement pay sponsored fees
-      // in the payment currency; keep accepting it alongside an override.
-      allowedFeeTokens:
-        feeToken && !isAddressEqual(feeToken, request.currency)
-          ? [feeToken, request.currency]
-          : allowedFeeTokens(request.currency),
+      allowedFeeTokens: MachineTokenSession.allowedSponsoredFeeTokens({
+        chainId,
+        override: parameters.feeToken,
+        paymentToken: request.currency,
+      }),
       expectedOperator,
       payment: request,
     }
-  }
   if (payload.action !== 'close' && !MachineTokenSession.isEnabledChallenge(challenge))
     throw new VerificationFailedError({ reason: 'credential descriptor does not match challenge' })
 
@@ -161,7 +150,13 @@ async function resolveCredentialRoute(parameters: {
     })
 
   return {
-    allowedFeeTokens: allowedFeeTokens(route.token),
+    allowedFeeTokens: [
+      MachineTokenSession.resolveFeeToken({
+        chainId,
+        override: parameters.feeToken,
+        paymentToken: route.token,
+      }),
+    ],
     expectedOperator: route.operator,
     machineRouter: route.operator,
     payment: { ...request, currency: route.token, recipient: route.payee },
@@ -1188,7 +1183,12 @@ async function handleCloseCredential(
   let txHash: Hex | undefined
   let receipt: Awaited<ReturnType<typeof Chain.waitForSuccessfulReceipt>>
   try {
-    const transactionOptions = resolveChannelTransactionOptions(channel, parameters, account)
+    const transactionOptions = resolveChannelTransactionOptions(
+      channel,
+      parameters,
+      account,
+      machineRouter,
+    )
     if (machineRouter) {
       if (!authorizationSignature || !refundSignature)
         throw new VerificationFailedError({

--- a/src/tempo/session/server/RequestState.test.ts
+++ b/src/tempo/session/server/RequestState.test.ts
@@ -402,8 +402,8 @@ describe('SessionSnapshotHints', () => {
       expect(resolved).toBeUndefined()
     })
 
-    test('advertises a close snapshot once the close voucher signature verifies', async () => {
-      const verify = vi.spyOn(Voucher, 'verifyVoucher').mockReturnValue(true)
+    test('advertises a close snapshot only when the close voucher signature verifies', async () => {
+      const verify = vi.spyOn(Voucher, 'verifyVoucher')
       try {
         // A machine-rail channel: stored payee/token differ from the challenge
         // scope, so the snapshot needs the alternate-rail matcher.
@@ -412,31 +412,38 @@ describe('SessionSnapshotHints', () => {
           token: '0x20c0000000000000000000000000000000000009' as Address,
         })
         const matchPaymentFields = vi.fn().mockResolvedValue(true)
-        const resolved = await resolveSessionPaymentRequest({
-          credential: {
-            challenge: {},
-            payload: {
-              action: 'close',
-              channelId,
-              cumulativeAmount: '500',
-              signature: `0x${'44'.repeat(64)}`,
-            },
-          } as Credential.Credential,
-          decimals: 0,
-          getClient: async () => ({ chain: { id: 4217 } }),
-          matchSnapshotPaymentFields: matchPaymentFields,
-          request: {
-            amount: '1',
-            chainId: 4217,
-            currency: descriptor.token,
+        const resolve = () =>
+          resolveSessionPaymentRequest({
+            credential: {
+              challenge: {},
+              payload: {
+                action: 'close',
+                channelId,
+                cumulativeAmount: '500',
+                descriptor,
+                signature: `0x${'44'.repeat(64)}`,
+              },
+            } as Credential.Credential,
             decimals: 0,
-            escrowContract,
-            recipient: descriptor.payee,
-            unitType: 'request',
-          },
-          store: store(machineChannel),
-        })
+            getClient: async () => ({ chain: { id: 4217 } }),
+            matchSnapshotPaymentFields: matchPaymentFields,
+            request: {
+              amount: '1',
+              chainId: 4217,
+              currency: descriptor.token,
+              decimals: 0,
+              escrowContract,
+              recipient: descriptor.payee,
+              unitType: 'request',
+            },
+            store: store(machineChannel),
+          })
 
+        verify.mockReturnValue(false)
+        expect((await resolve()).sessionSnapshot).toBeUndefined()
+
+        verify.mockReturnValue(true)
+        const resolved = await resolve()
         expect(verify).toHaveBeenCalledWith(
           escrowContract,
           4217,
@@ -448,42 +455,9 @@ describe('SessionSnapshotHints', () => {
         expect(matchPaymentFields).toHaveBeenCalledWith(
           expect.objectContaining({ channelId }),
           expect.objectContaining({ recipient: descriptor.payee }),
-          { activeRoute: false },
+          { action: 'close' },
         )
         expect(resolved.sessionSnapshot).toMatchObject({ channelId, spent: '300' })
-      } finally {
-        verify.mockRestore()
-      }
-    })
-
-    test('ignores close credential channel IDs when the voucher signature fails', async () => {
-      const verify = vi.spyOn(Voucher, 'verifyVoucher').mockReturnValue(false)
-      try {
-        const resolved = await resolveSessionPaymentRequest({
-          credential: {
-            challenge: {},
-            payload: {
-              action: 'close',
-              channelId,
-              cumulativeAmount: '500',
-              signature: `0x${'44'.repeat(64)}`,
-            },
-          } as Credential.Credential,
-          decimals: 0,
-          getClient: async () => ({ chain: { id: 4217 } }),
-          request: {
-            amount: '1',
-            chainId: 4217,
-            currency: descriptor.token,
-            decimals: 0,
-            escrowContract,
-            recipient: descriptor.payee,
-            unitType: 'request',
-          },
-          store: store(channel()),
-        })
-
-        expect(resolved.sessionSnapshot).toBeUndefined()
       } finally {
         verify.mockRestore()
       }

--- a/src/tempo/session/server/RequestState.test.ts
+++ b/src/tempo/session/server/RequestState.test.ts
@@ -402,10 +402,17 @@ describe('SessionSnapshotHints', () => {
       expect(resolved).toBeUndefined()
     })
 
-    test('trusts a close credential channel ID once its voucher signature verifies', async () => {
+    test('advertises a close snapshot once the close voucher signature verifies', async () => {
       const verify = vi.spyOn(Voucher, 'verifyVoucher').mockReturnValue(true)
       try {
-        const resolved = await resolveSessionChannelId({
+        // A machine-rail channel: stored payee/token differ from the challenge
+        // scope, so the snapshot needs the alternate-rail matcher.
+        const machineChannel = channel({
+          payee: `0x${'99'.repeat(20)}` as Address,
+          token: '0x20c0000000000000000000000000000000000009' as Address,
+        })
+        const matchPaymentFields = vi.fn().mockResolvedValue(true)
+        const resolved = await resolveSessionPaymentRequest({
           credential: {
             challenge: {},
             payload: {
@@ -415,23 +422,35 @@ describe('SessionSnapshotHints', () => {
               signature: `0x${'44'.repeat(64)}`,
             },
           } as Credential.Credential,
+          decimals: 0,
+          getClient: async () => ({ chain: { id: 4217 } }),
+          matchSnapshotPaymentFields: matchPaymentFields,
           request: {
             amount: '1',
+            chainId: 4217,
             currency: descriptor.token,
             decimals: 0,
+            escrowContract,
             recipient: descriptor.payee,
             unitType: 'request',
           },
-          store: store(channel()),
+          store: store(machineChannel),
         })
 
-        expect(resolved).toBe(channelId)
         expect(verify).toHaveBeenCalledWith(
           escrowContract,
           4217,
           { channelId, cumulativeAmount: 500n, signature: `0x${'44'.repeat(64)}` },
           descriptor.authorizedSigner,
         )
+        // Close credentials accept retired routes, so the recovery snapshot is
+        // matched without requiring an active route or `machineTokenEnabled`.
+        expect(matchPaymentFields).toHaveBeenCalledWith(
+          expect.objectContaining({ channelId }),
+          expect.objectContaining({ recipient: descriptor.payee }),
+          { activeRoute: false },
+        )
+        expect(resolved.sessionSnapshot).toMatchObject({ channelId, spent: '300' })
       } finally {
         verify.mockRestore()
       }
@@ -440,7 +459,7 @@ describe('SessionSnapshotHints', () => {
     test('ignores close credential channel IDs when the voucher signature fails', async () => {
       const verify = vi.spyOn(Voucher, 'verifyVoucher').mockReturnValue(false)
       try {
-        const resolved = await resolveSessionChannelId({
+        const resolved = await resolveSessionPaymentRequest({
           credential: {
             challenge: {},
             payload: {
@@ -450,17 +469,21 @@ describe('SessionSnapshotHints', () => {
               signature: `0x${'44'.repeat(64)}`,
             },
           } as Credential.Credential,
+          decimals: 0,
+          getClient: async () => ({ chain: { id: 4217 } }),
           request: {
             amount: '1',
+            chainId: 4217,
             currency: descriptor.token,
             decimals: 0,
+            escrowContract,
             recipient: descriptor.payee,
             unitType: 'request',
           },
           store: store(channel()),
         })
 
-        expect(resolved).toBeUndefined()
+        expect(resolved.sessionSnapshot).toBeUndefined()
       } finally {
         verify.mockRestore()
       }

--- a/src/tempo/session/server/RequestState.test.ts
+++ b/src/tempo/session/server/RequestState.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test, vi } from 'vp/test'
 
 import type * as Credential from '../../../Credential.js'
 import type { SessionCredentialPayload } from '../precompile/Protocol.js'
+import * as Voucher from '../precompile/Voucher.js'
 import type * as ChannelStore from './ChannelStore.js'
 import {
   requireSessionCredentialAction,
@@ -399,6 +400,70 @@ describe('SessionSnapshotHints', () => {
       })
 
       expect(resolved).toBeUndefined()
+    })
+
+    test('trusts a close credential channel ID once its voucher signature verifies', async () => {
+      const verify = vi.spyOn(Voucher, 'verifyVoucher').mockReturnValue(true)
+      try {
+        const resolved = await resolveSessionChannelId({
+          credential: {
+            challenge: {},
+            payload: {
+              action: 'close',
+              channelId,
+              cumulativeAmount: '500',
+              signature: `0x${'44'.repeat(64)}`,
+            },
+          } as Credential.Credential,
+          request: {
+            amount: '1',
+            currency: descriptor.token,
+            decimals: 0,
+            recipient: descriptor.payee,
+            unitType: 'request',
+          },
+          store: store(channel()),
+        })
+
+        expect(resolved).toBe(channelId)
+        expect(verify).toHaveBeenCalledWith(
+          escrowContract,
+          4217,
+          { channelId, cumulativeAmount: 500n, signature: `0x${'44'.repeat(64)}` },
+          descriptor.authorizedSigner,
+        )
+      } finally {
+        verify.mockRestore()
+      }
+    })
+
+    test('ignores close credential channel IDs when the voucher signature fails', async () => {
+      const verify = vi.spyOn(Voucher, 'verifyVoucher').mockReturnValue(false)
+      try {
+        const resolved = await resolveSessionChannelId({
+          credential: {
+            challenge: {},
+            payload: {
+              action: 'close',
+              channelId,
+              cumulativeAmount: '500',
+              signature: `0x${'44'.repeat(64)}`,
+            },
+          } as Credential.Credential,
+          request: {
+            amount: '1',
+            currency: descriptor.token,
+            decimals: 0,
+            recipient: descriptor.payee,
+            unitType: 'request',
+          },
+          store: store(channel()),
+        })
+
+        expect(resolved).toBeUndefined()
+      } finally {
+        verify.mockRestore()
+      }
     })
 
     test('uses custom resolver when no explicit channel ID is present', async () => {

--- a/src/tempo/session/server/RequestState.ts
+++ b/src/tempo/session/server/RequestState.ts
@@ -20,7 +20,12 @@ import {
   type RequestBodyProbe,
 } from '../../server/internal/request-body.js'
 import type * as PrecompileChain from '../precompile/Chain.js'
-import { tip20ChannelEscrow, type SessionCredentialPayload } from '../precompile/Protocol.js'
+import {
+  tip20ChannelEscrow,
+  uint96,
+  type SessionCredentialPayload,
+} from '../precompile/Protocol.js'
+import * as Voucher from '../precompile/Voucher.js'
 import type { SessionSnapshot } from '../Snapshot.js'
 import * as ChannelStore from './ChannelStore.js'
 import { requireSessionCredentialAction } from './CredentialVerification.js'
@@ -119,6 +124,34 @@ function normalizeResolvedSessionChannelId(value: string | null | undefined): He
   return ChannelStore.normalizeChannelId(value)
 }
 
+/** Returns a close credential's channel ID once its voucher signature verifies. */
+async function verifiedCloseCredentialChannelId(
+  credential: Credential.Credential | null | undefined,
+  store: ChannelStore.ChannelStore,
+): Promise<Hex | undefined> {
+  const payload = credential?.payload
+  if (!isObject(payload) || payload.action !== 'close') return undefined
+  const channelId = getCredentialChannelId(credential)
+  if (!channelId || typeof payload.signature !== 'string') return undefined
+  const channel = await store.getChannel(channelId)
+  if (!channel || !ChannelStore.isPrecompileState(channel)) return undefined
+  try {
+    const verified = Voucher.verifyVoucher(
+      channel.escrowContract,
+      channel.chainId,
+      {
+        channelId,
+        cumulativeAmount: uint96(BigInt(payload.cumulativeAmount as string)),
+        signature: payload.signature as Hex,
+      },
+      channel.authorizedSigner,
+    )
+    return verified ? channelId : undefined
+  } catch {
+    return undefined
+  }
+}
+
 /** Resolves the channel ID used to build server-side session bootstrap hints. */
 export async function resolveSessionChannelId(parameters: {
   capturedRequest?: RequestBodyProbe | undefined
@@ -131,6 +164,12 @@ export async function resolveSessionChannelId(parameters: {
   const { capturedRequest, credential, request, resolveChannelId, source, store } = parameters
   const explicitChannelId = normalizeSessionChannelId(request.channelId)
   if (explicitChannelId) return explicitChannelId
+  // A close credential names the channel it settles; advertising that channel's
+  // snapshot on the retry challenge lets clients without a configured
+  // `resolveChannelId` learn the exact capture amount a machine-token close
+  // voucher must match. Only trusted once the voucher signature verifies.
+  const closeChannelId = await verifiedCloseCredentialChannelId(credential, store)
+  if (closeChannelId) return closeChannelId
   if (!resolveChannelId) return undefined
   return normalizeResolvedSessionChannelId(
     await resolveChannelId({

--- a/src/tempo/session/server/RequestState.ts
+++ b/src/tempo/session/server/RequestState.ts
@@ -28,7 +28,10 @@ import {
 import * as Voucher from '../precompile/Voucher.js'
 import type { SessionSnapshot } from '../Snapshot.js'
 import * as ChannelStore from './ChannelStore.js'
-import { requireSessionCredentialAction } from './CredentialVerification.js'
+import {
+  requireSessionCredentialAction,
+  requireSessionCredentialPayload,
+} from './CredentialVerification.js'
 import {
   resolveCredentialFeePayer,
   resolveRequestFeePayer,
@@ -40,6 +43,8 @@ import {
 export type ResolveSessionSnapshotParameters = {
   /** Raw request amount that must be covered by the next voucher. */
   amount: bigint
+  /** Already-loaded channel for `channelId`, skipping the store read. */
+  channel?: ChannelStore.State | null | undefined
   /** Channel ID from credential or challenge request, when available. */
   channelId: Hex | undefined
   /** Payment fields the reusable channel must match before it is advertised. */
@@ -62,21 +67,17 @@ export type SessionSnapshotPaymentFields = {
   recipient: Address
 }
 
-/** Validates an alternate channel descriptor against the logical session payment fields. */
+/**
+ * Validates an alternate channel descriptor against the logical session payment
+ * fields. `options.action` names the credential the snapshot serves: close
+ * credentials accept retired routes, so their recovery snapshots match
+ * inactive routes too.
+ */
 export type MatchSessionSnapshotPaymentFields = (
   channel: ChannelStore.StoredPrecompileChannel,
   expected: SessionSnapshotPaymentFields,
-  options?: MatchSessionSnapshotPaymentFieldsOptions | undefined,
+  options?: { action?: SessionCredentialPayload['action'] | undefined } | undefined,
 ) => MaybePromise<boolean>
-
-/** Options for alternate-rail snapshot matching. */
-export type MatchSessionSnapshotPaymentFieldsOptions = {
-  /**
-   * Whether the route must still be actively bound. Close credentials accept
-   * retired routes, so their recovery snapshots must too (default: `true`).
-   */
-  activeRoute?: boolean | undefined
-}
 
 /** Request metadata available to `resolveChannelId` without exposing a mutable `Request`. */
 export type SessionChannelIdRequest = {
@@ -134,29 +135,28 @@ function normalizeResolvedSessionChannelId(value: string | null | undefined): He
   return ChannelStore.normalizeChannelId(value)
 }
 
-/** Returns a close credential's channel ID once its voucher signature verifies. */
-async function verifiedCloseCredentialChannelId(
+/** Returns a close credential's channel once its voucher signature verifies. */
+async function verifiedCloseCredentialChannel(
   credential: Credential.Credential | null | undefined,
   store: ChannelStore.ChannelStore,
-): Promise<Hex | undefined> {
-  const payload = credential?.payload
-  if (!isObject(payload) || payload.action !== 'close') return undefined
-  const channelId = getCredentialChannelId(credential)
-  if (!channelId || typeof payload.signature !== 'string') return undefined
-  const channel = await store.getChannel(channelId)
-  if (!channel || !ChannelStore.isPrecompileState(channel)) return undefined
+): Promise<{ channelId: Hex; channel: ChannelStore.StoredPrecompileChannel } | undefined> {
   try {
+    const payload = requireSessionCredentialPayload(credential?.payload)
+    if (payload.action !== 'close') return undefined
+    const channelId = payload.channelId
+    const channel = await store.getChannel(channelId)
+    if (!channel || !ChannelStore.isPrecompileState(channel)) return undefined
     const verified = Voucher.verifyVoucher(
       channel.escrowContract,
       channel.chainId,
       {
         channelId,
-        cumulativeAmount: uint96(BigInt(payload.cumulativeAmount as string)),
-        signature: payload.signature as Hex,
+        cumulativeAmount: uint96(BigInt(payload.cumulativeAmount)),
+        signature: payload.signature,
       },
       channel.authorizedSigner,
     )
-    return verified ? channelId : undefined
+    return verified ? { channelId, channel } : undefined
   } catch {
     return undefined
   }
@@ -192,7 +192,8 @@ export async function resolveSessionSnapshot(
 ): Promise<SessionSnapshot | undefined> {
   const { amount, channelId, expected, matchPaymentFields, store } = parameters
   if (!channelId) return undefined
-  const channel = await store.getChannel(ChannelStore.normalizeChannelId(channelId))
+  const channel =
+    parameters.channel ?? (await store.getChannel(ChannelStore.normalizeChannelId(channelId)))
   if (!channel || !ChannelStore.isPrecompileState(channel)) return undefined
   if (channel.finalized) return undefined
   if (channel.closeRequestedAt !== 0n) return undefined
@@ -485,9 +486,9 @@ export async function resolveSessionPaymentRequest(
   // `resolveChannelId` learn the exact capture amount a machine-token close
   // voucher must match. Only trusted once the voucher signature verifies, and
   // matched with close semantics so retired routes stay closable.
-  const closeChannelId = await verifiedCloseCredentialChannelId(credential, store)
+  const verifiedClose = await verifiedCloseCredentialChannel(credential, store)
   const channelId =
-    closeChannelId ??
+    verifiedClose?.channelId ??
     (await resolveSessionChannelId({
       capturedRequest,
       credential,
@@ -498,6 +499,7 @@ export async function resolveSessionPaymentRequest(
     }))
   const sessionSnapshot = await resolveSessionSnapshot({
     amount: capturedRequest && !isSessionContentRequest(capturedRequest) ? 0n : requestAmount,
+    channel: verifiedClose?.channel,
     channelId,
     expected: {
       chainId,
@@ -506,12 +508,14 @@ export async function resolveSessionPaymentRequest(
       recipient: readChallengeAddress(request.recipient, 'recipient'),
     },
     matchPaymentFields:
-      closeChannelId && matchSnapshotPaymentFields
+      matchSnapshotPaymentFields && (verifiedClose || request.machineTokenEnabled)
         ? (channel, expected) =>
-            matchSnapshotPaymentFields(channel, expected, { activeRoute: false })
-        : request.machineTokenEnabled
-          ? matchSnapshotPaymentFields
-          : undefined,
+            matchSnapshotPaymentFields(
+              channel,
+              expected,
+              verifiedClose ? { action: 'close' } : undefined,
+            )
+        : undefined,
     store,
   })
   const { operator: _operator, ...requestWithoutOperator } = request

--- a/src/tempo/session/server/RequestState.ts
+++ b/src/tempo/session/server/RequestState.ts
@@ -66,7 +66,17 @@ export type SessionSnapshotPaymentFields = {
 export type MatchSessionSnapshotPaymentFields = (
   channel: ChannelStore.StoredPrecompileChannel,
   expected: SessionSnapshotPaymentFields,
+  options?: MatchSessionSnapshotPaymentFieldsOptions | undefined,
 ) => MaybePromise<boolean>
+
+/** Options for alternate-rail snapshot matching. */
+export type MatchSessionSnapshotPaymentFieldsOptions = {
+  /**
+   * Whether the route must still be actively bound. Close credentials accept
+   * retired routes, so their recovery snapshots must too (default: `true`).
+   */
+  activeRoute?: boolean | undefined
+}
 
 /** Request metadata available to `resolveChannelId` without exposing a mutable `Request`. */
 export type SessionChannelIdRequest = {
@@ -164,12 +174,6 @@ export async function resolveSessionChannelId(parameters: {
   const { capturedRequest, credential, request, resolveChannelId, source, store } = parameters
   const explicitChannelId = normalizeSessionChannelId(request.channelId)
   if (explicitChannelId) return explicitChannelId
-  // A close credential names the channel it settles; advertising that channel's
-  // snapshot on the retry challenge lets clients without a configured
-  // `resolveChannelId` learn the exact capture amount a machine-token close
-  // voucher must match. Only trusted once the voucher signature verifies.
-  const closeChannelId = await verifiedCloseCredentialChannelId(credential, store)
-  if (closeChannelId) return closeChannelId
   if (!resolveChannelId) return undefined
   return normalizeResolvedSessionChannelId(
     await resolveChannelId({
@@ -476,14 +480,22 @@ export async function resolveSessionPaymentRequest(
   )
   const operator = resolveRequestOperator(request.operator)
   const requestAmount = parseUnits(request.amount, decimals)
-  const channelId = await resolveSessionChannelId({
-    capturedRequest,
-    credential,
-    request,
-    resolveChannelId,
-    source,
-    store,
-  })
+  // A close credential names the channel it settles; advertising that channel's
+  // snapshot on the retry challenge lets clients without a configured
+  // `resolveChannelId` learn the exact capture amount a machine-token close
+  // voucher must match. Only trusted once the voucher signature verifies, and
+  // matched with close semantics so retired routes stay closable.
+  const closeChannelId = await verifiedCloseCredentialChannelId(credential, store)
+  const channelId =
+    closeChannelId ??
+    (await resolveSessionChannelId({
+      capturedRequest,
+      credential,
+      request,
+      resolveChannelId,
+      source,
+      store,
+    }))
   const sessionSnapshot = await resolveSessionSnapshot({
     amount: capturedRequest && !isSessionContentRequest(capturedRequest) ? 0n : requestAmount,
     channelId,
@@ -493,7 +505,13 @@ export async function resolveSessionPaymentRequest(
       escrowContract,
       recipient: readChallengeAddress(request.recipient, 'recipient'),
     },
-    matchPaymentFields: request.machineTokenEnabled ? matchSnapshotPaymentFields : undefined,
+    matchPaymentFields:
+      closeChannelId && matchSnapshotPaymentFields
+        ? (channel, expected) =>
+            matchSnapshotPaymentFields(channel, expected, { activeRoute: false })
+        : request.machineTokenEnabled
+          ? matchSnapshotPaymentFields
+          : undefined,
     store,
   })
   const { operator: _operator, ...requestWithoutOperator } = request

--- a/src/tempo/session/server/Session.test.ts
+++ b/src/tempo/session/server/Session.test.ts
@@ -1019,6 +1019,38 @@ describe('precompile server session unit guardrails', () => {
     expect(rpcCalls).toEqual([])
   })
 
+  test('accepts sponsored fees in the payment currency alongside a configured fee token', async () => {
+    const { method, rpcCalls } = createServer({
+      feePayer: payer,
+      feeToken: defaults.tokens.pathUsd,
+    })
+    // Clients released before the fee-token advertisement always pay sponsored
+    // open/top-up fees in the payment currency.
+    const payload = await createSponsoredOpenPayload(token)
+    const request = Methods.session.schema.request.parse(
+      await method.request!({
+        credential: null,
+        request: {
+          amount: '100',
+          currency: token,
+          decimals: 0,
+          recipient: payee,
+          unitType: 'request',
+        },
+      } as never),
+    )
+
+    await method.validate!({
+      credential: {
+        challenge: { ...makeChallenge(payload.channelId), request },
+        payload,
+      },
+      request: request as unknown as VerifyRequest,
+    })
+
+    expect(rpcCalls).toEqual([])
+  })
+
   test('rejects sponsored credentials that exceed the fee-payer policy during validation', async () => {
     const { method, rpcCalls } = createServer({
       feePayer: payer,

--- a/src/tempo/session/server/Session.test.ts
+++ b/src/tempo/session/server/Session.test.ts
@@ -1016,34 +1016,14 @@ describe('precompile server session unit guardrails', () => {
     })
 
     expect(request.methodDetails.feeToken).toBe(feeToken)
-    expect(rpcCalls).toEqual([])
-  })
 
-  test('accepts sponsored fees in the payment currency alongside a configured fee token', async () => {
-    const { method, rpcCalls } = createServer({
-      feePayer: payer,
-      feeToken: defaults.tokens.pathUsd,
-    })
     // Clients released before the fee-token advertisement always pay sponsored
-    // open/top-up fees in the payment currency.
-    const payload = await createSponsoredOpenPayload(token)
-    const request = Methods.session.schema.request.parse(
-      await method.request!({
-        credential: null,
-        request: {
-          amount: '100',
-          currency: token,
-          decimals: 0,
-          recipient: payee,
-          unitType: 'request',
-        },
-      } as never),
-    )
-
+    // open/top-up fees in the payment currency; both stay accepted.
+    const legacyPayload = await createSponsoredOpenPayload(token)
     await method.validate!({
       credential: {
-        challenge: { ...makeChallenge(payload.channelId), request },
-        payload,
+        challenge: { ...makeChallenge(legacyPayload.channelId), request },
+        payload: legacyPayload,
       },
       request: request as unknown as VerifyRequest,
     })

--- a/src/tempo/session/server/Session.ts
+++ b/src/tempo/session/server/Session.ts
@@ -347,6 +347,7 @@ export function session<const parameters extends session.Parameters>(
   const matchSnapshotPaymentFields: MatchSessionSnapshotPaymentFields = async (
     channel,
     expected,
+    options,
   ) => {
     if (
       channel.chainId !== expected.chainId ||
@@ -355,7 +356,7 @@ export function session<const parameters extends session.Parameters>(
     )
       return false
     return !!(await MachineTokenSession.matchRoute(await getClient({ chainId: expected.chainId }), {
-      active: true,
+      active: options?.activeRoute ?? true,
       chainId: expected.chainId,
       descriptor: channel.descriptor,
       merchant: expected.recipient,

--- a/src/tempo/session/server/Session.ts
+++ b/src/tempo/session/server/Session.ts
@@ -356,7 +356,7 @@ export function session<const parameters extends session.Parameters>(
     )
       return false
     return !!(await MachineTokenSession.matchRoute(await getClient({ chainId: expected.chainId }), {
-      active: options?.activeRoute ?? true,
+      active: options?.action !== 'close',
       chainId: expected.chainId,
       descriptor: channel.descriptor,
       merchant: expected.recipient,

--- a/src/tempo/session/server/Settlement.test.ts
+++ b/src/tempo/session/server/Settlement.test.ts
@@ -1,4 +1,4 @@
-import type { Hex } from 'viem'
+import { zeroAddress, type Address, type Hex } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { describe, expect, test, vi } from 'vp/test'
 
@@ -174,26 +174,35 @@ describe('FeePayerResolution', () => {
       ).toBe(defaultFeePayer)
     })
 
-    test('derives settlement fee tokens from the channel token', () => {
+    test('derives settlement fee tokens from the channel rail', () => {
       const chainId = defaults.chainId.mainnet
+      const deployment = defaults.machineToken[chainId]
+      const descriptor = (overrides: { operator: Address; token: Address }) => ({
+        authorizedSigner: defaultFeePayer.address,
+        expiringNonceHash: `0x${'11'.repeat(32)}` as Hex,
+        payee: requestFeePayer.address,
+        payer: defaultFeePayer.address,
+        salt: `0x${'22'.repeat(32)}` as Hex,
+        ...overrides,
+      })
+      const machineChannel = {
+        chainId,
+        descriptor: descriptor({ operator: deployment.swap, token: deployment.token }),
+        token: deployment.token,
+      }
+      const directChannel = {
+        chainId,
+        descriptor: descriptor({ operator: zeroAddress, token: defaults.tokens.usdc }),
+        token: defaults.tokens.usdc,
+      }
       expect(
-        resolveChannelTransactionOptions(
-          {
-            chainId,
-            token: defaults.machineToken[chainId].token,
-          },
-          undefined,
-          defaultFeePayer,
-        ),
+        resolveChannelTransactionOptions(machineChannel, undefined, defaultFeePayer),
       ).toMatchObject({
         candidateFeeTokens: [defaults.tokens.pathUsd],
         feeToken: defaults.tokens.pathUsd,
       })
       const directOptions = resolveChannelTransactionOptions(
-        {
-          chainId,
-          token: defaults.tokens.usdc,
-        },
+        directChannel,
         { feePayer: true },
         defaultFeePayer,
       )
@@ -204,12 +213,23 @@ describe('FeePayerResolution', () => {
       // Direct channels leave the fee token unset so balance-aware selection
       // can pick a funded candidate.
       expect(directOptions).not.toHaveProperty('feeToken')
+      // A direct channel denominated in the machine token is still direct.
+      const machineCurrencyDirect = resolveChannelTransactionOptions(
+        {
+          chainId,
+          descriptor: descriptor({ operator: zeroAddress, token: deployment.token }),
+          token: deployment.token,
+        },
+        undefined,
+        defaultFeePayer,
+      )
+      expect(machineCurrencyDirect).toMatchObject({
+        candidateFeeTokens: [deployment.token],
+      })
+      expect(machineCurrencyDirect).not.toHaveProperty('feeToken')
       expect(
         resolveChannelTransactionOptions(
-          {
-            chainId,
-            token: defaults.tokens.usdc,
-          },
+          directChannel,
           { feeToken: defaults.tokens.pathUsd },
           defaultFeePayer,
         ),

--- a/src/tempo/session/server/Settlement.test.ts
+++ b/src/tempo/session/server/Settlement.test.ts
@@ -1,4 +1,4 @@
-import { zeroAddress, type Address, type Hex } from 'viem'
+import type { Hex } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { describe, expect, test, vi } from 'vp/test'
 
@@ -177,26 +177,15 @@ describe('FeePayerResolution', () => {
     test('derives settlement fee tokens from the channel rail', () => {
       const chainId = defaults.chainId.mainnet
       const deployment = defaults.machineToken[chainId]
-      const descriptor = (overrides: { operator: Address; token: Address }) => ({
-        authorizedSigner: defaultFeePayer.address,
-        expiringNonceHash: `0x${'11'.repeat(32)}` as Hex,
-        payee: requestFeePayer.address,
-        payer: defaultFeePayer.address,
-        salt: `0x${'22'.repeat(32)}` as Hex,
-        ...overrides,
-      })
-      const machineChannel = {
-        chainId,
-        descriptor: descriptor({ operator: deployment.swap, token: deployment.token }),
-        token: deployment.token,
-      }
-      const directChannel = {
-        chainId,
-        descriptor: descriptor({ operator: zeroAddress, token: defaults.tokens.usdc }),
-        token: defaults.tokens.usdc,
-      }
+      const machineChannel = { chainId, token: deployment.token }
+      const directChannel = { chainId, token: defaults.tokens.usdc }
       expect(
-        resolveChannelTransactionOptions(machineChannel, undefined, defaultFeePayer),
+        resolveChannelTransactionOptions(
+          machineChannel,
+          undefined,
+          defaultFeePayer,
+          deployment.swap,
+        ),
       ).toMatchObject({
         candidateFeeTokens: [defaults.tokens.pathUsd],
         feeToken: defaults.tokens.pathUsd,
@@ -205,6 +194,7 @@ describe('FeePayerResolution', () => {
         directChannel,
         { feePayer: true },
         defaultFeePayer,
+        undefined,
       )
       expect(directOptions).toMatchObject({
         candidateFeeTokens: [defaults.tokens.usdc],
@@ -213,25 +203,12 @@ describe('FeePayerResolution', () => {
       // Direct channels leave the fee token unset so balance-aware selection
       // can pick a funded candidate.
       expect(directOptions).not.toHaveProperty('feeToken')
-      // A direct channel denominated in the machine token is still direct.
-      const machineCurrencyDirect = resolveChannelTransactionOptions(
-        {
-          chainId,
-          descriptor: descriptor({ operator: zeroAddress, token: deployment.token }),
-          token: deployment.token,
-        },
-        undefined,
-        defaultFeePayer,
-      )
-      expect(machineCurrencyDirect).toMatchObject({
-        candidateFeeTokens: [deployment.token],
-      })
-      expect(machineCurrencyDirect).not.toHaveProperty('feeToken')
       expect(
         resolveChannelTransactionOptions(
           directChannel,
           { feeToken: defaults.tokens.pathUsd },
           defaultFeePayer,
+          undefined,
         ),
       ).toMatchObject({
         candidateFeeTokens: [defaults.tokens.pathUsd],

--- a/src/tempo/session/server/Settlement.test.ts
+++ b/src/tempo/session/server/Settlement.test.ts
@@ -189,19 +189,33 @@ describe('FeePayerResolution', () => {
         candidateFeeTokens: [defaults.tokens.pathUsd],
         feeToken: defaults.tokens.pathUsd,
       })
+      const directOptions = resolveChannelTransactionOptions(
+        {
+          chainId,
+          token: defaults.tokens.usdc,
+        },
+        { feePayer: true },
+        defaultFeePayer,
+      )
+      expect(directOptions).toMatchObject({
+        candidateFeeTokens: [defaults.tokens.usdc],
+        feePayer: true,
+      })
+      // Direct channels leave the fee token unset so balance-aware selection
+      // can pick a funded candidate.
+      expect(directOptions).not.toHaveProperty('feeToken')
       expect(
         resolveChannelTransactionOptions(
           {
             chainId,
             token: defaults.tokens.usdc,
           },
-          { feePayer: true },
+          { feeToken: defaults.tokens.pathUsd },
           defaultFeePayer,
         ),
       ).toMatchObject({
-        candidateFeeTokens: [defaults.tokens.usdc],
-        feePayer: true,
-        feeToken: defaults.tokens.usdc,
+        candidateFeeTokens: [defaults.tokens.pathUsd],
+        feeToken: defaults.tokens.pathUsd,
       })
     })
   })

--- a/src/tempo/session/server/Settlement.ts
+++ b/src/tempo/session/server/Settlement.ts
@@ -413,17 +413,25 @@ export function assertSettlementSender(parameters: SettlementSenderParameters) {
  * fee token unset so balance-aware selection can pick a funded candidate.
  */
 export function resolveChannelTransactionOptions(
-  channel: Pick<ChannelStore.StoredPrecompileChannel, 'chainId' | 'token'>,
+  channel: Pick<ChannelStore.StoredPrecompileChannel, 'chainId' | 'descriptor' | 'token'>,
   options: SettlementTransactionOptions | undefined,
   account: viem_Account | undefined,
 ): Chain.ChannelTransactionOptions | undefined {
   if (!account) return undefined
-  const feeToken = MachineTokenSession.resolveFeeToken({
-    chainId: channel.chainId,
-    override: options?.feeToken,
-    paymentToken: channel.token,
-  })
-  const pinned = options?.feeToken !== undefined || !isAddressEqual(feeToken, channel.token)
+  const machine =
+    MachineTokenSession.matchDeployment({
+      chainId: channel.chainId,
+      descriptor: channel.descriptor,
+    }) !== undefined
+  const feeToken =
+    options?.feeToken ??
+    (machine
+      ? MachineTokenSession.resolveFeeToken({
+          chainId: channel.chainId,
+          paymentToken: channel.token,
+        })
+      : channel.token)
+  const pinned = options?.feeToken !== undefined || machine
   return {
     account,
     ...(options?.feePayer ? { feePayer: options.feePayer } : {}),

--- a/src/tempo/session/server/Settlement.ts
+++ b/src/tempo/session/server/Settlement.ts
@@ -408,8 +408,9 @@ export function assertSettlementSender(parameters: SettlementSenderParameters) {
 }
 
 /**
- * Assembles transaction options for settle/close transactions. Direct
- * channels pay fees in their payment token; machine channels use PathUSD.
+ * Assembles transaction options for settle/close transactions. Machine
+ * channels pin PathUSD (or an explicit override); direct channels leave the
+ * fee token unset so balance-aware selection can pick a funded candidate.
  */
 export function resolveChannelTransactionOptions(
   channel: Pick<ChannelStore.StoredPrecompileChannel, 'chainId' | 'token'>,
@@ -422,11 +423,12 @@ export function resolveChannelTransactionOptions(
     override: options?.feeToken,
     paymentToken: channel.token,
   })
+  const pinned = options?.feeToken !== undefined || !isAddressEqual(feeToken, channel.token)
   return {
     account,
     ...(options?.feePayer ? { feePayer: options.feePayer } : {}),
     ...(options?.feePayerPolicy ? { feePayerPolicy: options.feePayerPolicy } : {}),
-    feeToken,
+    ...(pinned ? { feeToken } : {}),
     candidateFeeTokens: options?.candidateFeeTokens ?? [feeToken],
   }
 }

--- a/src/tempo/session/server/Settlement.ts
+++ b/src/tempo/session/server/Settlement.ts
@@ -411,33 +411,29 @@ export function assertSettlementSender(parameters: SettlementSenderParameters) {
  * Assembles transaction options for settle/close transactions. Machine
  * channels pin PathUSD (or an explicit override); direct channels leave the
  * fee token unset so balance-aware selection can pick a funded candidate.
+ * The rail comes from the caller so fee pinning always matches dispatch.
  */
 export function resolveChannelTransactionOptions(
-  channel: Pick<ChannelStore.StoredPrecompileChannel, 'chainId' | 'descriptor' | 'token'>,
+  channel: Pick<ChannelStore.StoredPrecompileChannel, 'chainId' | 'token'>,
   options: SettlementTransactionOptions | undefined,
   account: viem_Account | undefined,
+  machineRouter: Address | undefined,
 ): Chain.ChannelTransactionOptions | undefined {
   if (!account) return undefined
-  const machine =
-    MachineTokenSession.matchDeployment({
-      chainId: channel.chainId,
-      descriptor: channel.descriptor,
-    }) !== undefined
   const feeToken =
     options?.feeToken ??
-    (machine
+    (machineRouter
       ? MachineTokenSession.resolveFeeToken({
           chainId: channel.chainId,
           paymentToken: channel.token,
         })
-      : channel.token)
-  const pinned = options?.feeToken !== undefined || machine
+      : undefined)
   return {
     account,
     ...(options?.feePayer ? { feePayer: options.feePayer } : {}),
     ...(options?.feePayerPolicy ? { feePayerPolicy: options.feePayerPolicy } : {}),
-    ...(pinned ? { feeToken } : {}),
-    candidateFeeTokens: options?.candidateFeeTokens ?? [feeToken],
+    ...(feeToken ? { feeToken } : {}),
+    candidateFeeTokens: options?.candidateFeeTokens ?? [feeToken ?? channel.token],
   }
 }
 
@@ -489,7 +485,12 @@ export async function settle(
       sender: account?.address,
     })
   const amount = uint96(channel.highestVoucher.cumulativeAmount)
-  const transactionOptions = resolveChannelTransactionOptions(channel, options, account)
+  const transactionOptions = resolveChannelTransactionOptions(
+    channel,
+    options,
+    account,
+    machineRouter,
+  )
   let txHash: Hex
   if (machineRouter) {
     const authorizationSignature = channel.highestVoucher.authorizationSignature


### PR DESCRIPTION
## Why

The machine-token session flow introduced in #800 left several recovery and compatibility edge cases that could strand deposits, prevent cooperative closes, reject older sponsored clients, or disable balance-aware fee-token selection for direct channels.

## What

- Preserve opened machine and rewritten-scope channels when a resumed request fails instead of evicting their only stored descriptor.
- Advertise close snapshots only after verifying the close voucher signature, including for retired machine routes.
- Accept sponsored fees in the payment currency alongside a configured `feeToken` for direct channels.
- Pin settlement fee tokens only for machine channels or explicit overrides, restoring balance-aware selection for direct channels.
- Add focused regression coverage and a patch changeset.
