### PR TITLE
fix(tempo): preserve hosted session fee token

### DIFF
--- a/.changeset/hosted-session-fee-token.md
+++ b/.changeset/hosted-session-fee-token.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Preserved configured fee tokens for hosted server-driven Tempo session settlement and close transactions.

--- a/src/tempo/session/precompile/Chain.test.ts
+++ b/src/tempo/session/precompile/Chain.test.ts
@@ -336,7 +336,7 @@ describe('precompile receipt wait', () => {
 })
 
 describe('precompile server transactions', () => {
-  test('marks server transactions for hosted sponsorship and preserves the machine close ABI', async () => {
+  test('marks server transactions for hosted sponsorship and preserves their fee token', async () => {
     const rpcMethods: string[] = []
     const preparedRequests: Record<string, unknown>[] = []
     const signedRequests: Record<string, unknown>[] = []
@@ -365,11 +365,13 @@ describe('precompile server transactions', () => {
       {
         account: sender,
         feePayer: true,
+        feeToken: sourceToken,
       },
     )
     await Chain.settleOnChain(client, descriptor, 1n, `0x${'11'.repeat(65)}`, tip20ChannelEscrow, {
       account: sender,
       feePayer: true,
+      feeToken: sourceToken,
     })
     await Chain.closeMachineSessionOnChain(
       client,
@@ -379,11 +381,21 @@ describe('precompile server transactions', () => {
       `0x${'22'.repeat(65)}`,
       `0x${'33'.repeat(65)}`,
       '0x7777777777777777777777777777777777777777',
-      { account: sender, feePayer: true },
+      { account: sender, feePayer: true, feeToken: sourceToken },
     )
 
     expect(preparedRequests.map(({ feePayer }) => feePayer)).toEqual([true, true, true])
+    expect(preparedRequests.map(({ feeToken }) => feeToken)).toEqual([
+      sourceToken,
+      sourceToken,
+      sourceToken,
+    ])
     expect(signedRequests.map(({ feePayer }) => feePayer)).toEqual([true, true, true])
+    expect(signedRequests.map(({ feeToken }) => feeToken)).toEqual([
+      sourceToken,
+      sourceToken,
+      sourceToken,
+    ])
     expect(rpcMethods.filter((method) => method === 'eth_sendRawTransaction')).toHaveLength(3)
     expect(rpcMethods).not.toContain('eth_sendTransaction')
     expect(rpcMethods).not.toContain('eth_call')

--- a/src/tempo/session/precompile/Chain.ts
+++ b/src/tempo/session/precompile/Chain.ts
@@ -1311,6 +1311,7 @@ async function sendPrecompileTransaction(
       account,
       data,
       feePayer: true,
+      feeToken: options.feeToken,
       to,
     })
   }


### PR DESCRIPTION
## Why

Hosted server-driven Tempo session settlement and close transactions dropped the configured fee token while preparing the sponsored transaction. Machine-token closes therefore lost their required liquid fee token after credential verification and failed during transaction submission.

## What

- propagate the configured fee token through the hosted fee-payer transaction path
- cover direct close, settle, and machine-token close preparation and signing