### PR TITLE
feat: add deferred client payment preparation

### DIFF
--- a/.changeset/calm-pandas-prepare.md
+++ b/.changeset/calm-pandas-prepare.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added `preparePayment` for inspecting a selected client payment before creating and attaching its credential.

--- a/src/client/Mppx.test-d.ts
+++ b/src/client/Mppx.test-d.ts
@@ -73,7 +73,10 @@ describe('Mppx', () => {
       setCredential: (request, credential) => ({ ...request, credential }),
     })
     const mppx = Mppx.create({ methods: [charge()], transport })
-    const prepared = await mppx.preparePayment({ challenges: [] })
+    const prepared = await mppx.preparePayment(
+      { challenges: [] },
+      { request: { credential: 'existing' } },
+    )
 
     expectTypeOf(prepared.setCredential({}, 'credential')).toEqualTypeOf<Request>()
   })

--- a/src/client/Mppx.test-d.ts
+++ b/src/client/Mppx.test-d.ts
@@ -48,6 +48,36 @@ describe('Mppx', () => {
     expectTypeOf(mppx.createCredential).returns.toMatchTypeOf<Promise<string>>()
   })
 
+  test('prepares a typed deferred payment', async () => {
+    const method = charge()
+    const mppx = Mppx.create({ methods: [method] })
+
+    const prepared = await mppx.preparePayment({} as Response)
+
+    expectTypeOf(prepared.challenge).toEqualTypeOf<Challenge.Challenge>()
+    expectTypeOf(prepared.challenges).toEqualTypeOf<readonly Challenge.Challenge[]>()
+    expectTypeOf(prepared.method.intent).toEqualTypeOf<'charge'>()
+    expectTypeOf(prepared.createCredential({ account: {} as Account })).toEqualTypeOf<
+      Promise<string>
+    >()
+    expectTypeOf(prepared.setCredential({ headers: {} }, 'credential')).toEqualTypeOf<RequestInit>()
+  })
+
+  test('uses custom transport request and response types', async () => {
+    type Request = { credential?: string | undefined }
+    type Response = { challenges: Challenge.Challenge[] }
+    const transport = Transport.from<Request, Response>({
+      getChallenges: (response) => response.challenges,
+      isPaymentRequired: (response) => response.challenges.length > 0,
+      name: 'custom',
+      setCredential: (request, credential) => ({ ...request, credential }),
+    })
+    const mppx = Mppx.create({ methods: [charge()], transport })
+    const prepared = await mppx.preparePayment({ challenges: [] })
+
+    expectTypeOf(prepared.setCredential({}, 'credential')).toEqualTypeOf<Request>()
+  })
+
   test('has rawFetch with standard fetch signature', () => {
     const method = charge({
       account: {} as Account,

--- a/src/client/Mppx.test.ts
+++ b/src/client/Mppx.test.ts
@@ -2,6 +2,7 @@ import { Challenge, Credential, Errors, Mcp, Method, Receipt } from 'mppx'
 import { Mppx, Transport, tempo } from 'mppx/client'
 import { Mppx as Mppx_server, tempo as tempo_server } from 'mppx/server'
 import { Methods } from 'mppx/tempo'
+import { Header as x402_Header, Types as x402_Types, type PaymentRequired } from 'mppx/x402'
 import { afterEach, describe, expect, test, vi } from 'vp/test'
 import * as Http from '~test/Http.js'
 import { accounts, asset, client } from '~test/tempo/viem.js'
@@ -11,6 +12,7 @@ const secretKey = 'test-secret-key-test-secret-key-32'
 
 afterEach(() => {
   Mppx.restore()
+  vi.useRealTimers()
 })
 
 describe('Mppx.create', () => {
@@ -28,6 +30,7 @@ describe('Mppx.create', () => {
     expect(mppx.transport.name).toBe('http')
     expect(typeof mppx.createCredential).toBe('function')
     expect(typeof mppx.fetch).toBe('function')
+    expect(typeof mppx.preparePayment).toBe('function')
     expect(typeof mppx.rawFetch).toBe('function')
   })
 
@@ -111,6 +114,159 @@ describe('Mppx.create', () => {
     expect(mppx.methods[0]?.name).toBe('tempo')
     expect(mppx.methods[1]?.name).toBe('tempo')
     expect(mppx.methods[2]?.name).toBe('stripe')
+  })
+})
+
+describe('preparePayment', () => {
+  function paymentMethod(name = 'test') {
+    const createCredential = vi.fn(async ({ challenge }) =>
+      Credential.serialize({
+        challenge,
+        payload: { signature: '0xsignature', type: 'transaction' },
+      }),
+    )
+    const method = Method.toClient(
+      Method.from({
+        name,
+        intent: 'charge',
+        schema: Methods.charge.schema,
+      }),
+      { createCredential },
+    )
+    return { createCredential, method }
+  }
+
+  function paymentChallenge(id: string, name = 'test') {
+    return Challenge.from({
+      expires: new Date(Date.now() + 60_000).toISOString(),
+      id,
+      intent: 'charge',
+      method: name,
+      realm,
+      request: { amount: '100', currency: asset },
+    })
+  }
+
+  function paymentRequiredResponse(...challenges: Challenge.Challenge[]) {
+    return new Response(null, {
+      headers: { 'WWW-Authenticate': challenges.map(Challenge.serialize).join(', ') },
+      status: 402,
+    })
+  }
+
+  test('behavior: inspects a payment without signing and memoizes credential creation', async () => {
+    const { createCredential, method } = paymentMethod()
+    const mppx = Mppx.create({ methods: [method], polyfill: false })
+    const events: string[] = []
+    mppx.onChallengeReceived(({ challenge }) => {
+      events.push(`challenge:${challenge.id}`)
+    })
+    mppx.onCredentialCreated(({ challenge }) => {
+      events.push(`credential:${challenge.id}`)
+    })
+    const challenge = paymentChallenge('selected')
+
+    const prepared = await mppx.preparePayment(paymentRequiredResponse(challenge))
+
+    expect(createCredential).not.toHaveBeenCalled()
+    expect(events).toEqual([])
+    expect(prepared.challenge).toBe(prepared.challenges[0])
+    expect(prepared.challenge).toEqual(challenge)
+    expect(prepared.method.name).toBe('test')
+    expect(Object.isFrozen(prepared)).toBe(true)
+    expect(Object.isFrozen(prepared.challenge)).toBe(true)
+    expect(Object.isFrozen(prepared.challenges)).toBe(true)
+
+    const [first, second] = await Promise.all([
+      prepared.createCredential(),
+      prepared.createCredential(),
+    ])
+
+    expect(first).toBe(second)
+    expect(createCredential).toHaveBeenCalledTimes(1)
+    expect(events).toEqual(['challenge:selected', 'credential:selected'])
+  })
+
+  test('behavior: applies request-local challenge policy before preparation', async () => {
+    const { createCredential, method } = paymentMethod()
+    const mppx = Mppx.create({ methods: [method], polyfill: false })
+    const first = paymentChallenge('first')
+    const selected = paymentChallenge('selected')
+
+    const prepared = await mppx.preparePayment(paymentRequiredResponse(first, selected), {
+      orderChallenges: (candidates) =>
+        candidates.filter(({ challenge }) => challenge.id === 'selected'),
+    })
+
+    expect(prepared.challenge.id).toBe('selected')
+    expect(prepared.challenges.map(({ id }) => id)).toEqual(['first', 'selected'])
+    expect(createCredential).not.toHaveBeenCalled()
+  })
+
+  test('behavior: attaches Payment-auth credentials using Authorization', async () => {
+    const { method } = paymentMethod()
+    const mppx = Mppx.create({ methods: [method], polyfill: false })
+    const prepared = await mppx.preparePayment(
+      paymentRequiredResponse(paymentChallenge('payment-auth')),
+    )
+
+    const request = prepared.setCredential({}, 'Payment credential')
+    const headers = new Headers(request.headers)
+
+    expect(headers.get('Authorization')).toBe('Payment credential')
+    expect(headers.get(x402_Types.paymentSignatureHeader)).toBeNull()
+  })
+
+  test('behavior: attaches x402 credentials using PAYMENT-SIGNATURE', async () => {
+    const { method } = paymentMethod(x402_Types.paymentMethod)
+    const mppx = Mppx.create({ methods: [method], polyfill: false })
+    const paymentRequired = {
+      accepts: [
+        {
+          amount: '100',
+          asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+          maxTimeoutSeconds: 60,
+          network: 'eip155:84532',
+          payTo: '0x209693Bc6afc0C5328bA36FaF03C514EF312287C',
+          scheme: x402_Types.schemes[0],
+        },
+      ],
+      resource: { url: 'https://api.example.com/x402' },
+      x402Version: 2,
+    } satisfies PaymentRequired
+    const response = new Response(null, {
+      headers: { 'PAYMENT-REQUIRED': x402_Header.encodePaymentRequired(paymentRequired) },
+      status: 402,
+    })
+
+    const prepared = await mppx.preparePayment(response)
+    const request = prepared.setCredential({}, 'x402-signature')
+    const headers = new Headers(request.headers)
+
+    expect(prepared.challenge.method).toBe(x402_Types.paymentMethod)
+    expect(headers.get('Authorization')).toBeNull()
+    expect(headers.get(x402_Types.paymentSignatureHeader)).toBe('x402-signature')
+  })
+
+  test('behavior: rechecks expiration before deferred credential creation', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+    const { createCredential, method } = paymentMethod()
+    const mppx = Mppx.create({ methods: [method], polyfill: false })
+    const paymentFailed = vi.fn()
+    mppx.onPaymentFailed(paymentFailed)
+    const challenge = {
+      ...paymentChallenge('expiring'),
+      expires: '2026-01-01T00:00:01.000Z',
+    }
+    const prepared = await mppx.preparePayment(paymentRequiredResponse(challenge))
+
+    vi.setSystemTime(new Date('2026-01-01T00:00:02.000Z'))
+
+    await expect(prepared.createCredential()).rejects.toThrow(Errors.PaymentExpiredError)
+    expect(createCredential).not.toHaveBeenCalled()
+    expect(paymentFailed).toHaveBeenCalledOnce()
+    expect(paymentFailed.mock.calls[0]?.[0].challenge?.id).toBe('expiring')
   })
 })
 

--- a/src/client/Mppx.test.ts
+++ b/src/client/Mppx.test.ts
@@ -7,6 +7,8 @@ import { afterEach, describe, expect, test, vi } from 'vp/test'
 import * as Http from '~test/Http.js'
 import { accounts, asset, client } from '~test/tempo/viem.js'
 
+import * as x402_ChallengeBrand from '../x402/internal/ChallengeBrand.js'
+
 const realm = 'api.example.com'
 const secretKey = 'test-secret-key-test-secret-key-32'
 
@@ -203,6 +205,76 @@ describe('preparePayment', () => {
     expect(createCredential).not.toHaveBeenCalled()
   })
 
+  test('behavior: prepares a payment after the response body is consumed', async () => {
+    const { method } = paymentMethod()
+    const mppx = Mppx.create({ methods: [method], polyfill: false })
+    const response = new Response(JSON.stringify({ message: 'Payment required' }), {
+      headers: {
+        'content-type': 'application/json',
+        'WWW-Authenticate': Challenge.serialize(paymentChallenge('consumed')),
+      },
+      status: 402,
+    })
+    await response.json()
+
+    const prepared = await mppx.preparePayment(response)
+
+    expect(prepared.challenge.id).toBe('consumed')
+    await expect(prepared.createCredential()).resolves.toBeTypeOf('string')
+  })
+
+  test('behavior: signs the immutable challenge that was inspected', async () => {
+    const { createCredential, method } = paymentMethod()
+    const challenge = paymentChallenge('immutable')
+    const response = { challenges: [challenge] }
+    const transport = Transport.from<{ credential?: string | undefined }, typeof response>({
+      getChallenges: ({ challenges }) => challenges,
+      isPaymentRequired: ({ challenges }) => challenges.length > 0,
+      name: 'custom',
+      setCredential: (request, credential) => ({ ...request, credential }),
+    })
+    const mppx = Mppx.create({ methods: [method], polyfill: false, transport })
+    const prepared = await mppx.preparePayment(response)
+
+    const mutableRequest = challenge.request as { amount: string }
+    mutableRequest.amount = '999'
+    const credential = await prepared.createCredential()
+
+    expect(createCredential.mock.calls[0]?.[0].challenge).toBe(prepared.challenge)
+    expect(Credential.deserialize(credential).challenge.request.amount).toBe('100')
+  })
+
+  test('behavior: forwards request context for MCP-over-HTTP', async () => {
+    const { method } = paymentMethod()
+    const mppx = Mppx.create({ methods: [method], polyfill: false })
+    const challenge = paymentChallenge('mcp-http')
+    const request = {
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: {} }),
+      headers: { accept: 'application/json, text/event-stream' },
+      method: 'POST',
+    } satisfies RequestInit
+    const response = new Response(
+      JSON.stringify({
+        error: {
+          code: Mcp.paymentRequiredCode,
+          data: { challenges: [challenge] },
+          message: 'Payment Required',
+        },
+        id: 1,
+        jsonrpc: '2.0',
+      }),
+      { headers: { 'content-type': 'application/json' } },
+    )
+
+    const prepared = await mppx.preparePayment(response, { request })
+
+    expect(prepared.challenge.id).toBe('mcp-http')
+    const credential = await prepared.createCredential()
+    const authenticated = prepared.setCredential(request, credential)
+    const body = JSON.parse(authenticated.body as string)
+    expect(body.params._meta[Mcp.credentialMetaKey]).toBeDefined()
+  })
+
   test('behavior: attaches Payment-auth credentials using Authorization', async () => {
     const { method } = paymentMethod()
     const mppx = Mppx.create({ methods: [method], polyfill: false })
@@ -218,7 +290,7 @@ describe('preparePayment', () => {
   })
 
   test('behavior: attaches x402 credentials using PAYMENT-SIGNATURE', async () => {
-    const { method } = paymentMethod(x402_Types.paymentMethod)
+    const { createCredential, method } = paymentMethod(x402_Types.paymentMethod)
     const mppx = Mppx.create({ methods: [method], polyfill: false })
     const paymentRequired = {
       accepts: [
@@ -244,6 +316,9 @@ describe('preparePayment', () => {
     const headers = new Headers(request.headers)
 
     expect(prepared.challenge.method).toBe(x402_Types.paymentMethod)
+    expect(x402_ChallengeBrand.is(prepared.challenge)).toBe(true)
+    await prepared.createCredential()
+    expect(createCredential.mock.calls[0]?.[0].challenge).toBe(prepared.challenge)
     expect(headers.get('Authorization')).toBeNull()
     expect(headers.get(x402_Types.paymentSignatureHeader)).toBe('x402-signature')
   })

--- a/src/client/Mppx.ts
+++ b/src/client/Mppx.ts
@@ -57,22 +57,23 @@ export type Mppx<
    *
    * @example
    * ```ts
-   * const response = await mppx.rawFetch('/resource')
-   * const payment = await mppx.preparePayment(response)
+   * const request = { method: 'POST' }
+   * const response = await mppx.rawFetch('/resource', request)
+   * const payment = await mppx.preparePayment(response, { request })
    * inspect(payment.challenge)
    * const credential = await payment.createCredential()
-   * const init = payment.setCredential({}, credential)
+   * const init = payment.setCredential(request, credential)
    * ```
    */
   preparePayment: (
     response: Transport.ResponseOf<transport>,
-    options?: preparePayment.Options<FlattenMethods<methods>> | undefined,
+    options?: preparePayment.Options<FlattenMethods<methods>, transport> | undefined,
   ) => Promise<PreparedPayment<FlattenMethods<methods>, transport>>
   /** Creates a credential from a payment-required response by routing to the correct method. */
   createCredential: (
     response: Transport.ResponseOf<transport>,
     context?: AnyContextFor<FlattenMethods<methods>> | undefined,
-    options?: createCredential.Options<FlattenMethods<methods>> | undefined,
+    options?: createCredential.Options<FlattenMethods<methods>, transport> | undefined,
   ) => Promise<string>
   /** Register a client event handler by canonical event name. */
   on<name extends Fetch.ClientEventName<FlattenMethods<methods>, EventResponseOf<transport>>>(
@@ -221,10 +222,13 @@ export function create<
 
   async function preparePayment(
     response: Transport.ResponseOf<transport>,
-    options?: preparePayment.Options<FlattenMethods<methods>>,
+    options?: preparePayment.Options<FlattenMethods<methods>, transport>,
   ): Promise<PreparedPayment<FlattenMethods<methods>, transport>> {
     const eventResponse = snapshotResponse(response)
-    const challenges = await transport.getChallenges(response as never)
+    const challenges = await transport.getChallenges(response as never, options?.request as never)
+    const challengeSnapshots = Object.freeze(
+      challenges.map((candidate) => snapshotValue(candidate)),
+    )
     const preferences = resolveChallengePreferences(acceptPayment.entries, options?.acceptPayment)
 
     let challenge: Challenge.Challenge | undefined
@@ -241,7 +245,10 @@ export function create<
           `No method found for challenges: ${challenges.map((challenge) => `${challenge.method}.${challenge.intent}`).join(', ')}. Available: ${methods.map((m) => `${m.name}.${m.intent}`).join(', ')}`,
         )
 
-      challenge = selected.challenge
+      // Signing must use what the caller inspects, while attachment needs the adapter's original
+      // object identity to retain protocol provenance.
+      const transportChallenge = selected.challenge
+      challenge = challengeSnapshots[selected.index]!
       mi = selected.method as FlattenMethods<methods>[number]
       if (challenge.expires) Expires.assert(challenge.expires, challenge.id)
 
@@ -298,18 +305,14 @@ export function create<
           }
         },
       )
-      const challengeSnapshots = Object.freeze(
-        challenges.map((candidate) => snapshotValue(candidate)),
-      )
-
       return Object.freeze({
-        challenge: challengeSnapshots[selected.index]!,
+        challenge: selectedChallenge,
         challenges: challengeSnapshots,
         createCredential: createPreparedCredential,
         method: snapshotMethod(selectedMethod),
         setCredential(request: Transport.RequestOf<transport>, credential: string) {
           Fetch.validateCredentialHeaderValue(credential)
-          return transport.setCredential(request, credential, { challenge: selectedChallenge })
+          return transport.setCredential(request, credential, { challenge: transportChallenge })
         },
       })
     } catch (error) {
@@ -341,7 +344,7 @@ export function create<
     async createCredential(
       response: Transport.ResponseOf<transport>,
       context?: AnyContextFor<FlattenMethods<methods>>,
-      options?: createCredential.Options<FlattenMethods<methods>>,
+      options?: createCredential.Options<FlattenMethods<methods>, transport>,
     ) {
       const prepared = await preparePayment(response, options)
       return prepared.createCredential(context)
@@ -351,16 +354,23 @@ export function create<
 
 export declare namespace preparePayment {
   /** Options for selecting a payment without creating its credential. */
-  type Options<methods extends readonly Method.AnyClient[] = readonly Method.AnyClient[]> =
-    createCredential.Options<methods>
+  type Options<
+    methods extends readonly Method.AnyClient[] = readonly Method.AnyClient[],
+    transport extends Transport.AnyTransport = Transport.Transport,
+  > = createCredential.Options<methods, transport>
 }
 
 export declare namespace createCredential {
-  type Options<methods extends readonly Method.AnyClient[] = readonly Method.AnyClient[]> = {
+  type Options<
+    methods extends readonly Method.AnyClient[] = readonly Method.AnyClient[],
+    transport extends Transport.AnyTransport = Transport.Transport,
+  > = {
     /** Request-local Accept-Payment override for manual rawFetch + createCredential flows. */
     acceptPayment?: string | readonly AcceptPayment.Entry[] | undefined
     /** Request-local challenge filtering and sorting. */
     orderChallenges?: AcceptPayment.OrderChallenges<methods> | undefined
+    /** Request that produced the response, when challenge extraction depends on both values. */
+    request?: Transport.RequestOf<transport> | undefined
   }
 }
 
@@ -516,13 +526,31 @@ function snapshotMethod<method extends Method.AnyClient>(method: method): method
 }
 
 function snapshotResponse<response>(response: response): response {
-  if (response instanceof Response) return response.clone() as response
+  if (response instanceof Response) {
+    try {
+      return response.clone() as response
+    } catch {
+      // A consumed body cannot be cloned, but status and headers are sufficient for event context.
+      return new Response(null, {
+        headers: response.headers,
+        status: response.status,
+        statusText: response.statusText,
+      }) as response
+    }
+  }
   return snapshotValue(response)
 }
 
 function snapshotValue<value>(value: value): value {
   try {
-    return deepFreeze(structuredClone(value))
+    const snapshot = structuredClone(value)
+    // Protocol adapters may attach non-enumerable symbol metadata to otherwise plain challenges.
+    if (value && snapshot && typeof value === 'object' && typeof snapshot === 'object')
+      for (const symbol of Object.getOwnPropertySymbols(value)) {
+        const descriptor = Object.getOwnPropertyDescriptor(value, symbol)
+        if (descriptor) Object.defineProperty(snapshot, symbol, descriptor)
+      }
+    return deepFreeze(snapshot)
   } catch {
     return freezeSnapshot(value)
   }

--- a/src/client/Mppx.ts
+++ b/src/client/Mppx.ts
@@ -14,6 +14,30 @@ type EventResponseOf<transport extends Transport.AnyTransport> =
   | Transport.ResponseOf<transport>
 
 /**
+ * A selected payment that can be inspected before its credential is created.
+ *
+ * Prepared payments retain transport-local protocol state and are not serializable.
+ */
+export type PreparedPayment<
+  methods extends readonly Method.AnyClient[] = readonly Method.AnyClient[],
+  transport extends Transport.AnyTransport = Transport.Transport,
+> = Readonly<{
+  /** The selected payment challenge. */
+  challenge: Challenge.Challenge
+  /** All supported payment challenges extracted from the response. */
+  challenges: readonly Challenge.Challenge[]
+  /** Creates the selected challenge's credential at most once. */
+  createCredential: (context?: AnyContextFor<methods> | undefined) => Promise<string>
+  /** The configured client method selected for the challenge. */
+  method: methods[number]
+  /** Attaches a credential using the protocol that produced the selected challenge. */
+  setCredential: (
+    request: Transport.RequestOf<transport>,
+    credential: string,
+  ) => Transport.RequestOf<transport>
+}>
+
+/**
  * Client-side payment handler.
  */
 export type Mppx<
@@ -28,6 +52,22 @@ export type Mppx<
   methods: FlattenMethods<methods>
   /** The transport used. */
   transport: transport
+  /**
+   * Selects a payment challenge without creating its credential.
+   *
+   * @example
+   * ```ts
+   * const response = await mppx.rawFetch('/resource')
+   * const payment = await mppx.preparePayment(response)
+   * inspect(payment.challenge)
+   * const credential = await payment.createCredential()
+   * const init = payment.setCredential({}, credential)
+   * ```
+   */
+  preparePayment: (
+    response: Transport.ResponseOf<transport>,
+    options?: preparePayment.Options<FlattenMethods<methods>> | undefined,
+  ) => Promise<PreparedPayment<FlattenMethods<methods>, transport>>
   /** Creates a credential from a payment-required response by routing to the correct method. */
   createCredential: (
     response: Transport.ResponseOf<transport>,
@@ -179,6 +219,114 @@ export function create<
     return events.on('payment.response', handler)
   }
 
+  async function preparePayment(
+    response: Transport.ResponseOf<transport>,
+    options?: preparePayment.Options<FlattenMethods<methods>>,
+  ): Promise<PreparedPayment<FlattenMethods<methods>, transport>> {
+    const eventResponse = snapshotResponse(response)
+    const challenges = await transport.getChallenges(response as never)
+    const preferences = resolveChallengePreferences(acceptPayment.entries, options?.acceptPayment)
+
+    let challenge: Challenge.Challenge | undefined
+    let mi: FlattenMethods<methods>[number] | undefined
+    try {
+      const candidates = AcceptPayment.selectChallengeCandidates(challenges, methods, preferences)
+      const orderedCandidates = await resolveChallengeOrder(
+        candidates,
+        options?.orderChallenges ?? orderChallenges,
+      )
+      const selected = orderedCandidates[0]
+      if (!selected)
+        throw new Error(
+          `No method found for challenges: ${challenges.map((challenge) => `${challenge.method}.${challenge.intent}`).join(', ')}. Available: ${methods.map((m) => `${m.name}.${m.intent}`).join(', ')}`,
+        )
+
+      challenge = selected.challenge
+      mi = selected.method as FlattenMethods<methods>[number]
+      if (challenge.expires) Expires.assert(challenge.expires, challenge.id)
+
+      const selectedChallenge = challenge
+      const selectedMethod = mi
+      const createPreparedCredential = memoizeCreateCredential<FlattenMethods<methods>>(
+        async (context) => {
+          try {
+            if (selectedChallenge.expires)
+              Expires.assert(selectedChallenge.expires, selectedChallenge.id)
+
+            const createCredential = memoizeCreateCredential<FlattenMethods<methods>>(
+              (overrideContext) =>
+                createCredentialForMethod(
+                  selectedChallenge,
+                  selectedMethod,
+                  overrideContext ?? context,
+                ),
+            )
+            const eventCredential = await events.emit(
+              'challenge.received',
+              createChallengeReceivedPayload({
+                challenge: selectedChallenge,
+                challenges,
+                createCredential,
+                method: selectedMethod,
+                response: eventResponse,
+              }),
+            )
+            const credential = eventCredential ?? (await createCredential())
+            Fetch.validateCredentialHeaderValue(credential)
+            await events.emit(
+              'credential.created',
+              createCredentialCreatedPayload({
+                challenge: selectedChallenge,
+                credential,
+                method: selectedMethod,
+                response: eventResponse,
+              }),
+            )
+            return credential
+          } catch (error) {
+            await events.emit(
+              'payment.failed',
+              createPaymentFailedPayload({
+                challenge: selectedChallenge,
+                challenges,
+                error,
+                method: selectedMethod,
+                response: eventResponse,
+              }),
+            )
+            throw error
+          }
+        },
+      )
+      const challengeSnapshots = Object.freeze(
+        challenges.map((candidate) => snapshotValue(candidate)),
+      )
+
+      return Object.freeze({
+        challenge: challengeSnapshots[selected.index]!,
+        challenges: challengeSnapshots,
+        createCredential: createPreparedCredential,
+        method: snapshotMethod(selectedMethod),
+        setCredential(request: Transport.RequestOf<transport>, credential: string) {
+          Fetch.validateCredentialHeaderValue(credential)
+          return transport.setCredential(request, credential, { challenge: selectedChallenge })
+        },
+      })
+    } catch (error) {
+      await events.emit(
+        'payment.failed',
+        createPaymentFailedPayload({
+          challenge,
+          challenges,
+          error,
+          method: mi,
+          response: eventResponse,
+        }),
+      )
+      throw error
+    }
+  }
+
   return {
     fetch,
     rawFetch,
@@ -189,74 +337,22 @@ export function create<
     onCredentialCreated,
     onPaymentFailed,
     onPaymentResponse,
+    preparePayment,
     async createCredential(
       response: Transport.ResponseOf<transport>,
-      context?: unknown,
+      context?: AnyContextFor<FlattenMethods<methods>>,
       options?: createCredential.Options<FlattenMethods<methods>>,
     ) {
-      const challenges = await transport.getChallenges(response as never)
-      const preferences = resolveChallengePreferences(acceptPayment.entries, options?.acceptPayment)
-
-      let challenge: Challenge.Challenge | undefined
-      let mi: FlattenMethods<methods>[number] | undefined
-      try {
-        const candidates = AcceptPayment.selectChallengeCandidates(challenges, methods, preferences)
-        const orderedCandidates = await resolveChallengeOrder(
-          candidates,
-          options?.orderChallenges ?? orderChallenges,
-        )
-        const selected = orderedCandidates[0]
-        if (!selected)
-          throw new Error(
-            `No method found for challenges: ${challenges.map((challenge) => `${challenge.method}.${challenge.intent}`).join(', ')}. Available: ${methods.map((m) => `${m.name}.${m.intent}`).join(', ')}`,
-          )
-
-        const selectedChallenge = selected.challenge
-        challenge = selectedChallenge
-        mi = selected.method as FlattenMethods<methods>[number]
-        if (challenge.expires) Expires.assert(challenge.expires, challenge.id)
-
-        const createCredential = memoizeCreateCredential(
-          (overrideContext?: AnyContextFor<FlattenMethods<methods>>) =>
-            createCredentialForMethod(selectedChallenge, mi!, overrideContext ?? context),
-        )
-        const eventCredential = await events.emit(
-          'challenge.received',
-          createChallengeReceivedPayload({
-            challenge: selectedChallenge,
-            challenges,
-            createCredential,
-            method: mi,
-            response,
-          }),
-        )
-        const credential = eventCredential ?? (await createCredential())
-        Fetch.validateCredentialHeaderValue(credential)
-        await events.emit(
-          'credential.created',
-          createCredentialCreatedPayload({
-            challenge: selectedChallenge,
-            credential,
-            method: mi,
-            response,
-          }),
-        )
-        return credential
-      } catch (error) {
-        await events.emit(
-          'payment.failed',
-          createPaymentFailedPayload({
-            challenge,
-            challenges,
-            error,
-            method: mi,
-            response,
-          }),
-        )
-        throw error
-      }
+      const prepared = await preparePayment(response, options)
+      return prepared.createCredential(context)
     },
   }
+}
+
+export declare namespace preparePayment {
+  /** Options for selecting a payment without creating its credential. */
+  type Options<methods extends readonly Method.AnyClient[] = readonly Method.AnyClient[]> =
+    createCredential.Options<methods>
 }
 
 export declare namespace createCredential {


### PR DESCRIPTION
## Motivation

Applications may need to inspect and authorize a selected payment before creating a credential, while preserving MPPx challenge selection and protocol-specific credential attachment.

## Summary

- Add `mppx.preparePayment(response, options?)`, returning a typed `PreparedPayment`.
- Expose the selected `challenge` and `method`, all supported `challenges`, memoized `createCredential(context?)`, and protocol-aware `setCredential(request, credential)`.
- Accept `options.request` when challenge extraction depends on the request/response pair, including MCP-over-HTTP.
- Keep `createCredential()` as the convenience path over the new primitive.
- Add a patch changeset.

## Key design considerations

- Preparation uses existing `Accept-Payment`, `orderChallenges`, transport, expiration, validation, and event behavior.
- Signing remains deferred until `createCredential()` and expiration is checked again at that point.
- The credential signs the immutable challenge exposed for inspection while transport-local provenance is retained for attachment.
- Consumed HTTP response bodies remain valid for header-based challenge preparation.
- `PreparedPayment` is immutable and runtime-only because it retains transport-local protocol state.
- Usage:

```ts
const request = { method: 'POST' }
const response = await mppx.rawFetch('/resource', request)
const payment = await mppx.preparePayment(response, {
  request,
  orderChallenges: (candidates) =>
    candidates.filter(({ challenge }) => approvedIds.has(challenge.id)),
})

inspect(payment.challenge)

const credential = await payment.createCredential()
const init = payment.setCredential(request, credential)
const result = await mppx.rawFetch('/resource', init)
```
