### PR TITLE
feat(tempo): support remote fee payer headers

### DIFF
--- a/.changeset/tidy-feepayers-authenticate.md
+++ b/.changeset/tidy-feepayers-authenticate.md
@@ -2,4 +2,4 @@
 'mppx': patch
 ---
 
-Added HTTP headers to hosted Tempo fee-payer configuration.
+Added HTTP headers to remote Tempo fee-payer configuration.

--- a/.changeset/tidy-feepayers-authenticate.md
+++ b/.changeset/tidy-feepayers-authenticate.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added HTTP headers to hosted Tempo fee-payer configuration.

--- a/src/stripe/server/Methods.test-d.ts
+++ b/src/stripe/server/Methods.test-d.ts
@@ -25,7 +25,10 @@ test('tempo.session() accepts getClient, feePayer, store without casts', () => {
   const session = mp.tempo.session({
     recipient: addr,
     getClient: () => ({}) as Client,
-    feePayer: 'https://api.tempo.xyz/rpc/sponsor?key=test',
+    feePayer: {
+      url: 'https://api.tempo.xyz/rpc/sponsor',
+      headers: { Authorization: 'Bearer test' },
+    },
     store: {} as AtomicStore,
     sse: true,
     settlementSchedule: { amount: '0.01' },

--- a/src/tempo/internal/account.test.ts
+++ b/src/tempo/internal/account.test.ts
@@ -11,23 +11,23 @@ const feePayer = privateKeyToAccount(
 )
 
 describe('resolve', () => {
-  test('normalizes hosted fee-payer string shorthand', () => {
+  test('normalizes remote fee-payer string shorthand', () => {
     expect(Account.resolve({ feePayer: 'https://sponsor.example' })).toMatchObject({
       feePayer: undefined,
-      hostedFeePayer: { url: 'https://sponsor.example' },
+      remoteFeePayer: { url: 'https://sponsor.example' },
     })
   })
 
-  test('preserves hosted fee-payer headers without classifying them as an account', () => {
-    const hostedFeePayer = {
+  test('preserves remote fee-payer headers without classifying them as an account', () => {
+    const remoteFeePayer = {
       url: 'https://sponsor.example',
       headers: { Authorization: 'Bearer test' },
     } as const
 
-    const resolved = Account.resolve({ feePayer: hostedFeePayer })
+    const resolved = Account.resolve({ feePayer: remoteFeePayer })
 
     expect(resolved.feePayer).toBeUndefined()
-    expect(resolved.hostedFeePayer).toBe(hostedFeePayer)
+    expect(resolved.remoteFeePayer).toBe(remoteFeePayer)
   })
 
   test('preserves local account and account-sponsored modes', () => {

--- a/src/tempo/internal/account.test.ts
+++ b/src/tempo/internal/account.test.ts
@@ -1,0 +1,37 @@
+import { privateKeyToAccount } from 'viem/accounts'
+import { describe, expect, test } from 'vp/test'
+
+import * as Account from './account.js'
+
+const account = privateKeyToAccount(
+  '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+)
+const feePayer = privateKeyToAccount(
+  '0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d',
+)
+
+describe('resolve', () => {
+  test('normalizes hosted fee-payer string shorthand', () => {
+    expect(Account.resolve({ feePayer: 'https://sponsor.example' })).toMatchObject({
+      feePayer: undefined,
+      hostedFeePayer: { url: 'https://sponsor.example' },
+    })
+  })
+
+  test('preserves hosted fee-payer headers without classifying them as an account', () => {
+    const hostedFeePayer = {
+      url: 'https://sponsor.example',
+      headers: { Authorization: 'Bearer test' },
+    } as const
+
+    const resolved = Account.resolve({ feePayer: hostedFeePayer })
+
+    expect(resolved.feePayer).toBeUndefined()
+    expect(resolved.hostedFeePayer).toBe(hostedFeePayer)
+  })
+
+  test('preserves local account and account-sponsored modes', () => {
+    expect(Account.resolve({ account, feePayer }).feePayer).toBe(feePayer)
+    expect(Account.resolve({ account, feePayer: true }).feePayer).toBe(account)
+  })
+})

--- a/src/tempo/internal/account.ts
+++ b/src/tempo/internal/account.ts
@@ -1,7 +1,7 @@
 import type { Account, Address } from 'viem'
 import type { Account as TempoAccount } from 'viem/tempo'
 
-import * as HostedFeePayer from './hosted-fee-payer.js'
+import * as RemoteFeePayer from './remote-fee-payer.js'
 
 /** Returns whether an account is a Tempo access-key account. */
 export function isAccessKeyAccount(
@@ -21,10 +21,10 @@ export function getAccountSignerAddress(account: Account): Address {
  * Accepts either `account` or `recipient` as the parameter name. When the value
  * is an `Account`, its address is extracted. If `feePayer` is `true`, the
  * account also acts as the fee payer. Alternatively, a separate `Account`
- * can be provided as the fee payer, or hosted fee-payer configuration (used
+ * can be provided as the fee payer, or remote fee-payer configuration (used
  * with `withFeePayer` transport wrapping).
  *
- * @returns Resolved account, local fee payer, hosted fee payer, and recipient.
+ * @returns Resolved account, local fee payer, remote fee payer, and recipient.
  */
 export function resolve(parameters: resolve.Parameters) {
   const feePayerInput = parameters.feePayer
@@ -37,13 +37,13 @@ export function resolve(parameters: resolve.Parameters) {
     if (typeof parameters.account === 'object') return parameters.account.address
     return parameters.account
   })()
-  const hostedFeePayer = HostedFeePayer.from(feePayerInput)
+  const remoteFeePayer = RemoteFeePayer.from(feePayerInput)
   const feePayer = ((): Account | undefined => {
     if (typeof parameters.account === 'object' && feePayerInput === true) return parameters.account
-    if (typeof feePayerInput === 'object' && !HostedFeePayer.is(feePayerInput)) return feePayerInput
+    if (typeof feePayerInput === 'object' && !RemoteFeePayer.is(feePayerInput)) return feePayerInput
     return undefined
   })()
-  return { account, feePayer, hostedFeePayer, recipient: recipient as Address | undefined }
+  return { account, feePayer, remoteFeePayer, recipient: recipient as Address | undefined }
 }
 
 export declare namespace resolve {
@@ -51,7 +51,10 @@ export declare namespace resolve {
     recipient?: Address | undefined
     /** Account or address that performs payment operations / receives payment. */
     account?: Account | Address | undefined
-    /** When `true`, the account also sponsors fees. An `Account` or hosted fee-payer configuration can also be provided. */
-    feePayer?: Account | HostedFeePayer.Config | string | true | undefined
+    /**
+     * When `true`, the account also sponsors fees. An `Account` or remote fee-payer
+     * configuration can also be provided. A string is shorthand for its URL.
+     */
+    feePayer?: Account | RemoteFeePayer.Config | string | true | undefined
   }
 }

--- a/src/tempo/internal/account.ts
+++ b/src/tempo/internal/account.ts
@@ -3,6 +3,11 @@ import type { Account as TempoAccount } from 'viem/tempo'
 
 import * as RemoteFeePayer from './remote-fee-payer.js'
 
+/** Returns whether a value is a viem account. */
+export function is(value: unknown): value is Account {
+  return typeof value === 'object' && value !== null && 'address' in value
+}
+
 /** Returns whether an account is a Tempo access-key account. */
 export function isAccessKeyAccount(
   account: Account,
@@ -27,22 +32,15 @@ export function getAccountSignerAddress(account: Account): Address {
  * @returns Resolved account, local fee payer, remote fee payer, and recipient.
  */
 export function resolve(parameters: resolve.Parameters) {
-  const feePayerInput = parameters.feePayer
-  const account = (() => {
-    if (typeof parameters.account === 'object') return parameters.account
-    return undefined
-  })()
-  const recipient = (() => {
-    if (parameters.recipient) return parameters.recipient
-    if (typeof parameters.account === 'object') return parameters.account.address
-    return parameters.account
-  })()
-  const remoteFeePayer = RemoteFeePayer.from(feePayerInput)
-  const feePayer = ((): Account | undefined => {
-    if (typeof parameters.account === 'object' && feePayerInput === true) return parameters.account
-    if (typeof feePayerInput === 'object' && !RemoteFeePayer.is(feePayerInput)) return feePayerInput
-    return undefined
-  })()
+  const account = is(parameters.account) ? parameters.account : undefined
+  const recipient = parameters.recipient ?? account?.address ?? parameters.account
+  const remoteFeePayer = RemoteFeePayer.from(parameters.feePayer)
+  const feePayer =
+    parameters.feePayer === true
+      ? account
+      : is(parameters.feePayer)
+        ? parameters.feePayer
+        : undefined
   return { account, feePayer, remoteFeePayer, recipient: recipient as Address | undefined }
 }
 

--- a/src/tempo/internal/account.ts
+++ b/src/tempo/internal/account.ts
@@ -1,6 +1,8 @@
 import type { Account, Address } from 'viem'
 import type { Account as TempoAccount } from 'viem/tempo'
 
+import * as HostedFeePayer from './hosted-fee-payer.js'
+
 /** Returns whether an account is a Tempo access-key account. */
 export function isAccessKeyAccount(
   account: Account,
@@ -19,12 +21,13 @@ export function getAccountSignerAddress(account: Account): Address {
  * Accepts either `account` or `recipient` as the parameter name. When the value
  * is an `Account`, its address is extracted. If `feePayer` is `true`, the
  * account also acts as the fee payer. Alternatively, a separate `Account`
- * can be provided as the fee payer, or a URL string pointing to a fee payer
- * relay service (used with `withFeePayer` transport wrapping).
+ * can be provided as the fee payer, or hosted fee-payer configuration (used
+ * with `withFeePayer` transport wrapping).
  *
- * @returns An object with `account`, `feePayer`, `feePayerUrl`, and `recipient`.
+ * @returns Resolved account, local fee payer, hosted fee payer, and recipient.
  */
 export function resolve(parameters: resolve.Parameters) {
+  const feePayerInput = parameters.feePayer
   const account = (() => {
     if (typeof parameters.account === 'object') return parameters.account
     return undefined
@@ -34,15 +37,13 @@ export function resolve(parameters: resolve.Parameters) {
     if (typeof parameters.account === 'object') return parameters.account.address
     return parameters.account
   })()
-  const feePayerUrl = typeof parameters.feePayer === 'string' ? parameters.feePayer : undefined
-  const feePayer = (() => {
-    if (typeof parameters.feePayer === 'string') return undefined
-    if (typeof parameters.account === 'object' && parameters.feePayer === true)
-      return parameters.account
-    if (typeof parameters.feePayer === 'object') return parameters.feePayer
+  const hostedFeePayer = HostedFeePayer.from(feePayerInput)
+  const feePayer = ((): Account | undefined => {
+    if (typeof parameters.account === 'object' && feePayerInput === true) return parameters.account
+    if (typeof feePayerInput === 'object' && !HostedFeePayer.is(feePayerInput)) return feePayerInput
     return undefined
   })()
-  return { account, feePayer, feePayerUrl, recipient: recipient as Address | undefined }
+  return { account, feePayer, hostedFeePayer, recipient: recipient as Address | undefined }
 }
 
 export declare namespace resolve {
@@ -50,7 +51,7 @@ export declare namespace resolve {
     recipient?: Address | undefined
     /** Account or address that performs payment operations / receives payment. */
     account?: Account | Address | undefined
-    /** When `true`, the account also sponsors fees. An `Account` object or URL string can also be provided as a dedicated fee payer. */
-    feePayer?: Account | string | true | undefined
+    /** When `true`, the account also sponsors fees. An `Account` or hosted fee-payer configuration can also be provided. */
+    feePayer?: Account | HostedFeePayer.Config | string | true | undefined
   }
 }

--- a/src/tempo/internal/fee-payer.test.ts
+++ b/src/tempo/internal/fee-payer.test.ts
@@ -586,8 +586,7 @@ describe('fillHostedFeePayerTransaction', () => {
     } as const
     const result = await fillHostedFeePayerTransaction({
       allowedFeeTokens: defaultAllowedFeeTokens(defaults.chainId.mainnet),
-      chainId: hostedContext.chainId,
-      details: hostedContext.details,
+      ...hostedContext,
       remoteFeePayer,
       transaction: hostedTransaction as any,
     })

--- a/src/tempo/internal/fee-payer.test.ts
+++ b/src/tempo/internal/fee-payer.test.ts
@@ -504,6 +504,7 @@ describe('fillHostedFeePayerTransaction', () => {
   const hostedContext = {
     chainId: defaults.chainId.mainnet,
     details,
+    hostedFeePayer: { url: 'https://sponsor.example/tp_key' },
   } as const
 
   test('uses hosted fillTransaction and preserves sender-committed fields', async () => {
@@ -576,11 +577,19 @@ describe('fillHostedFeePayerTransaction', () => {
     })
     vi.stubGlobal('fetch', fetchMock)
 
+    const hostedFeePayer = {
+      url: 'https://sponsor.example/tp_key',
+      headers: {
+        Authorization: 'Bearer test',
+        'Content-Type': 'text/plain',
+      },
+    } as const
     const result = await fillHostedFeePayerTransaction({
       allowedFeeTokens: defaultAllowedFeeTokens(defaults.chainId.mainnet),
-      ...hostedContext,
+      chainId: hostedContext.chainId,
+      details: hostedContext.details,
+      hostedFeePayer,
       transaction: hostedTransaction as any,
-      url: 'https://sponsor.example/tp_key',
     })
 
     expect(result.feeToken).toBe(defaults.tokens.pathUsd)
@@ -589,6 +598,13 @@ describe('fillHostedFeePayerTransaction', () => {
 
     expect(fetchMock).toHaveBeenCalledOnce()
     expect(calls[0]!.input).toBe('https://sponsor.example/tp_key')
+    const requestHeaders = new Headers(calls[0]!.init!.headers)
+    expect(requestHeaders.get('authorization')).toBe('Bearer test')
+    expect(requestHeaders.get('content-type')).toBe('application/json')
+    expect(hostedFeePayer.headers).toEqual({
+      Authorization: 'Bearer test',
+      'Content-Type': 'text/plain',
+    })
     const body = JSON.parse(calls[0]!.init!.body as string)
     expect(body).toMatchObject({
       jsonrpc: '2.0',
@@ -633,7 +649,6 @@ describe('fillHostedFeePayerTransaction', () => {
         allowedFeeTokens: defaultAllowedFeeTokens(defaults.chainId.mainnet),
         ...hostedContext,
         transaction: hostedTransaction as any,
-        url: 'https://sponsor.example/tp_key',
       }),
     ).rejects.toThrow('did not return a feeToken')
   })
@@ -656,7 +671,6 @@ describe('fillHostedFeePayerTransaction', () => {
         allowedFeeTokens: defaultAllowedFeeTokens(defaults.chainId.mainnet),
         ...hostedContext,
         transaction: hostedTransaction as any,
-        url: 'https://sponsor.example/tp_key',
       }),
     ).rejects.toThrow('feeToken is not allowed')
   })
@@ -677,7 +691,6 @@ describe('fillHostedFeePayerTransaction', () => {
         allowedFeeTokens: defaultAllowedFeeTokens(defaults.chainId.mainnet),
         ...hostedContext,
         transaction: hostedTransaction as any,
-        url: 'https://sponsor.example/tp_key',
       }),
     ).rejects.toThrow('Invalid or revoked API key')
   })
@@ -692,7 +705,6 @@ describe('fillHostedFeePayerTransaction', () => {
         ...hostedContext,
         policy: { maxGas: hostedTransaction.gas - 1n },
         transaction: hostedTransaction as any,
-        url: 'https://sponsor.example/tp_key',
       }),
     ).rejects.toThrow('gas exceeds sponsor policy')
     expect(fetchMock).not.toHaveBeenCalled()
@@ -710,7 +722,6 @@ describe('fillHostedFeePayerTransaction', () => {
           ...hostedTransaction,
           accessList: [{ address: bogus, storageKeys: [] }],
         } as any,
-        url: 'https://sponsor.example/tp_key',
       }),
     ).rejects.toThrow('accessList is not allowed')
     expect(fetchMock).not.toHaveBeenCalled()
@@ -733,7 +744,6 @@ describe('fillHostedFeePayerTransaction', () => {
             },
           ],
         } as any,
-        url: 'https://sponsor.example/tp_key',
       }),
     ).rejects.toThrow('calldata is not canonical')
     expect(fetchMock).not.toHaveBeenCalled()

--- a/src/tempo/internal/fee-payer.test.ts
+++ b/src/tempo/internal/fee-payer.test.ts
@@ -504,7 +504,7 @@ describe('fillHostedFeePayerTransaction', () => {
   const hostedContext = {
     chainId: defaults.chainId.mainnet,
     details,
-    hostedFeePayer: { url: 'https://sponsor.example/tp_key' },
+    remoteFeePayer: { url: 'https://sponsor.example/tp_key' },
   } as const
 
   test('uses hosted fillTransaction and preserves sender-committed fields', async () => {
@@ -577,7 +577,7 @@ describe('fillHostedFeePayerTransaction', () => {
     })
     vi.stubGlobal('fetch', fetchMock)
 
-    const hostedFeePayer = {
+    const remoteFeePayer = {
       url: 'https://sponsor.example/tp_key',
       headers: {
         Authorization: 'Bearer test',
@@ -588,7 +588,7 @@ describe('fillHostedFeePayerTransaction', () => {
       allowedFeeTokens: defaultAllowedFeeTokens(defaults.chainId.mainnet),
       chainId: hostedContext.chainId,
       details: hostedContext.details,
-      hostedFeePayer,
+      remoteFeePayer,
       transaction: hostedTransaction as any,
     })
 
@@ -601,7 +601,7 @@ describe('fillHostedFeePayerTransaction', () => {
     const requestHeaders = new Headers(calls[0]!.init!.headers)
     expect(requestHeaders.get('authorization')).toBe('Bearer test')
     expect(requestHeaders.get('content-type')).toBe('application/json')
-    expect(hostedFeePayer.headers).toEqual({
+    expect(remoteFeePayer.headers).toEqual({
       Authorization: 'Bearer test',
       'Content-Type': 'text/plain',
     })

--- a/src/tempo/internal/fee-payer.ts
+++ b/src/tempo/internal/fee-payer.ts
@@ -8,7 +8,7 @@ import { Abis, Addresses, Transaction } from 'viem/tempo'
 
 import * as TempoAddress_internal from './address.js'
 import * as defaults from './defaults.js'
-import * as HostedFeePayer from './hosted-fee-payer.js'
+import * as RemoteFeePayer from './remote-fee-payer.js'
 import * as Selectors from './selectors.js'
 
 /** Returns true if the serialized transaction has a Tempo envelope prefix. */
@@ -185,7 +185,7 @@ export async function fillHostedFeePayerTransaction(parameters: {
   challengeExpires?: string | undefined
   chainId: number
   details: Record<string, string>
-  hostedFeePayer: HostedFeePayer.Config
+  remoteFeePayer: RemoteFeePayer.Config
   policy?: Partial<Policy> | undefined
   transaction: SponsoredTransaction
 }) {
@@ -194,7 +194,7 @@ export async function fillHostedFeePayerTransaction(parameters: {
     challengeExpires,
     chainId,
     details,
-    hostedFeePayer,
+    remoteFeePayer,
     policy,
     transaction,
   } = parameters
@@ -205,7 +205,7 @@ export async function fillHostedFeePayerTransaction(parameters: {
     policy,
     transaction,
   })
-  const response = await fetch(hostedFeePayer.url, {
+  const response = await fetch(remoteFeePayer.url, {
     body: JSON.stringify(
       {
         id: 1,
@@ -216,7 +216,7 @@ export async function fillHostedFeePayerTransaction(parameters: {
       (_key, value) => (typeof value === 'bigint' ? toHex(value) : value),
     ),
     headers: {
-      ...HostedFeePayer.resolveHeaders(hostedFeePayer),
+      ...RemoteFeePayer.resolveHeaders(remoteFeePayer),
       'content-type': 'application/json',
     },
     method: 'POST',

--- a/src/tempo/internal/fee-payer.ts
+++ b/src/tempo/internal/fee-payer.ts
@@ -8,6 +8,7 @@ import { Abis, Addresses, Transaction } from 'viem/tempo'
 
 import * as TempoAddress_internal from './address.js'
 import * as defaults from './defaults.js'
+import * as HostedFeePayer from './hosted-fee-payer.js'
 import * as Selectors from './selectors.js'
 
 /** Returns true if the serialized transaction has a Tempo envelope prefix. */
@@ -184,12 +185,19 @@ export async function fillHostedFeePayerTransaction(parameters: {
   challengeExpires?: string | undefined
   chainId: number
   details: Record<string, string>
+  hostedFeePayer: HostedFeePayer.Config
   policy?: Partial<Policy> | undefined
   transaction: SponsoredTransaction
-  url: string
 }) {
-  const { allowedFeeTokens, challengeExpires, chainId, details, policy, transaction, url } =
-    parameters
+  const {
+    allowedFeeTokens,
+    challengeExpires,
+    chainId,
+    details,
+    hostedFeePayer,
+    policy,
+    transaction,
+  } = parameters
   assertTransactionPolicy({
     challengeExpires,
     chainId,
@@ -197,7 +205,7 @@ export async function fillHostedFeePayerTransaction(parameters: {
     policy,
     transaction,
   })
-  const response = await fetch(url, {
+  const response = await fetch(hostedFeePayer.url, {
     body: JSON.stringify(
       {
         id: 1,
@@ -207,7 +215,10 @@ export async function fillHostedFeePayerTransaction(parameters: {
       },
       (_key, value) => (typeof value === 'bigint' ? toHex(value) : value),
     ),
-    headers: { 'content-type': 'application/json' },
+    headers: {
+      ...HostedFeePayer.resolveHeaders(hostedFeePayer),
+      'content-type': 'application/json',
+    },
     method: 'POST',
   })
   const payload = (await response.json().catch(async () => ({

--- a/src/tempo/internal/hosted-fee-payer.ts
+++ b/src/tempo/internal/hosted-fee-payer.ts
@@ -1,0 +1,26 @@
+/** Configuration for a hosted Tempo fee-payer service. */
+export type Config = Readonly<{
+  headers?: Readonly<Record<string, string>> | undefined
+  url: string
+}>
+
+/** Returns whether a value is hosted fee-payer configuration. */
+export function is(value: unknown): value is Config {
+  return (
+    typeof value === 'object' && value !== null && 'url' in value && typeof value.url === 'string'
+  )
+}
+
+/** Normalizes hosted fee-payer string and object inputs. */
+export function from(value: unknown): Config | undefined {
+  if (typeof value === 'string') return { url: value }
+  if (is(value)) return value
+  return undefined
+}
+
+/** Returns a cloned header record while reserving JSON content type for MPPX. */
+export function resolveHeaders(config: Config): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(config.headers ?? {}).filter(([name]) => name.toLowerCase() !== 'content-type'),
+  )
+}

--- a/src/tempo/internal/remote-fee-payer.ts
+++ b/src/tempo/internal/remote-fee-payer.ts
@@ -1,17 +1,17 @@
-/** Configuration for a hosted Tempo fee-payer service. */
+/** Configuration for a remote Tempo fee-payer service. */
 export type Config = Readonly<{
   headers?: Readonly<Record<string, string>> | undefined
   url: string
 }>
 
-/** Returns whether a value is hosted fee-payer configuration. */
+/** Returns whether a value is remote fee-payer configuration. */
 export function is(value: unknown): value is Config {
   return (
     typeof value === 'object' && value !== null && 'url' in value && typeof value.url === 'string'
   )
 }
 
-/** Normalizes hosted fee-payer string and object inputs. */
+/** Normalizes remote fee-payer string and object inputs. */
 export function from(value: unknown): Config | undefined {
   if (typeof value === 'string') return { url: value }
   if (is(value)) return value

--- a/src/tempo/server/Charge.test.ts
+++ b/src/tempo/server/Charge.test.ts
@@ -2648,8 +2648,10 @@ describe('tempo', () => {
       httpServer.close()
     })
 
-    test('behavior: fee payer URL (withFeePayer transport)', async () => {
+    test('behavior: hosted fee-payer configuration (withFeePayer transport)', async () => {
       const feePayerRequests: any[] = []
+      const feePayerAuthorizations: (string | undefined)[] = []
+      const feePayerHeaders = { Authorization: 'Bearer test' }
       const sequence: string[] = []
       let rejectFinalSimulation = false
       let simulations = 0
@@ -2673,6 +2675,7 @@ describe('tempo', () => {
         for await (const chunk of req) requestBody += chunk
         const request = JSON.parse(requestBody)
         feePayerRequests.push(request)
+        feePayerAuthorizations.push(req.headers.authorization)
 
         if (request.method === 'eth_sendRawTransactionSync') {
           sequence.push('relay-broadcast')
@@ -2699,7 +2702,7 @@ describe('tempo', () => {
       const serverWithFeePayer = Mppx_server.create({
         methods: [
           tempo_server.charge({
-            feePayer: feePayerServer.url,
+            feePayer: { url: feePayerServer.url, headers: feePayerHeaders },
             getClient: () => interceptingClient,
             currency: asset,
           }),
@@ -2730,12 +2733,22 @@ describe('tempo', () => {
         res.end('OK')
       })
 
+      const challengeResponse = await fetch(httpServer.url)
+      const challenge = Challenge.fromResponse(challengeResponse, {
+        methods: [tempo_client.charge()],
+      })
+      expect(challenge.request.methodDetails?.feePayer).toBe(true)
+      expect(JSON.stringify(challenge)).not.toContain(feePayerServer.url)
+      expect(JSON.stringify(challenge)).not.toContain('Bearer test')
+
       const response = await mppx.fetch(httpServer.url)
       expect(response.status).toBe(200)
       expect(feePayerRequests.map(({ method }) => method)).toEqual([
         'eth_fillTransaction',
         'eth_sendRawTransactionSync',
       ])
+      expect(feePayerAuthorizations).toEqual(['Bearer test', 'Bearer test'])
+      expect(feePayerHeaders).toEqual({ Authorization: 'Bearer test' })
       expect(sequence).toEqual(['simulate', 'complete', 'simulate', 'relay-broadcast'])
 
       const receipt = Receipt.fromResponse(response)

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -34,9 +34,9 @@ import * as Charge_internal from '../internal/charge.js'
 import * as defaults from '../internal/defaults.js'
 import * as FeePayer from '../internal/fee-payer.js'
 import { resolveFeeToken } from '../internal/fee-token.js'
-import * as HostedFeePayer from '../internal/hosted-fee-payer.js'
 import * as MachineTokenCharge from '../internal/machine-token-charge.js'
 import * as Proof from '../internal/proof.js'
+import * as RemoteFeePayer from '../internal/remote-fee-payer.js'
 import * as Selectors from '../internal/selectors.js'
 import type * as types from '../internal/types.js'
 import * as Methods from '../Methods.js'
@@ -112,13 +112,13 @@ export function charge<const parameters extends charge.Parameters>(
       })
     : undefined
 
-  const { recipient, feePayer, hostedFeePayer } = Account.resolve(parameters)
-  if (configuredFeeToken && hostedFeePayer)
+  const { recipient, feePayer, remoteFeePayer } = Account.resolve(parameters)
+  if (configuredFeeToken && remoteFeePayer)
     throw new Error('`feeToken` can only be configured for a local fee payer.')
 
   const getClient = Client.getResolver({
     chain: { ...tempo_chain, experimental_preconfirmationTime: 500 },
-    hostedFeePayer,
+    remoteFeePayer,
     getClient: parameters.getClient,
     rpcUrl: defaults.rpcUrl,
   })
@@ -308,7 +308,7 @@ export function charge<const parameters extends charge.Parameters>(
     const isFeePayerTx =
       methodDetails?.feePayer === true &&
       requestAllowsFeePayer &&
-      !!(typeof request.feePayer === 'object' ? request.feePayer : feePayer || hostedFeePayer)
+      !!(typeof request.feePayer === 'object' ? request.feePayer : feePayer || remoteFeePayer)
     const transfers = getExpectedTransfers({ amount, memo, methodDetails, recipient })
     const machineTokenRoute = machineTokenEnabled
       ? MachineTokenCharge.matchRoute({
@@ -473,11 +473,11 @@ export function charge<const parameters extends charge.Parameters>(
       const resolvedFeePayer = (() => {
         if (request.feePayer === false) return credential ? false : undefined
         const account =
-          typeof request.feePayer === 'object' && !HostedFeePayer.is(request.feePayer)
+          typeof request.feePayer === 'object' && !RemoteFeePayer.is(request.feePayer)
             ? request.feePayer
             : feePayer
-        const requested = account ?? feePayer ?? hostedFeePayer
-        if (credential) return account ?? (hostedFeePayer ? true : undefined)
+        const requested = account ?? feePayer ?? remoteFeePayer
+        if (credential) return account ?? (remoteFeePayer ? true : undefined)
         if (requested) return true
         return undefined
       })()
@@ -522,7 +522,7 @@ export function charge<const parameters extends charge.Parameters>(
       const validated = await validateCredential(credential, request, context)
       const feePayerAccount =
         methodDetails?.feePayer === true && requestAllowsFeePayer
-          ? typeof request.feePayer === 'object' && !HostedFeePayer.is(request.feePayer)
+          ? typeof request.feePayer === 'object' && !RemoteFeePayer.is(request.feePayer)
             ? request.feePayer
             : feePayer
           : undefined
@@ -574,12 +574,12 @@ export function charge<const parameters extends charge.Parameters>(
 
           try {
             const broadcastClient =
-              hostedFeePayer && isFeePayerTx
+              remoteFeePayer && isFeePayerTx
                 ? createClient({
                     chain: client.chain!,
-                    transport: http(hostedFeePayer.url, {
+                    transport: http(remoteFeePayer.url, {
                       fetchOptions: {
-                        headers: HostedFeePayer.resolveHeaders(hostedFeePayer),
+                        headers: RemoteFeePayer.resolveHeaders(remoteFeePayer),
                       },
                     }),
                   })
@@ -626,7 +626,7 @@ export function charge<const parameters extends charge.Parameters>(
                   sponsor: completed.feePayer,
                 }
               }
-              if (hostedFeePayer && isFeePayerTx) {
+              if (remoteFeePayer && isFeePayerTx) {
                 const completed = await FeePayer.preflightSponsorship({
                   transaction,
                   simulate: (request) => viem_call(client, request as never),
@@ -636,7 +636,7 @@ export function charge<const parameters extends charge.Parameters>(
                       challengeExpires: expires,
                       chainId: chainId ?? client.chain!.id,
                       details: { amount, currency, recipient },
-                      hostedFeePayer,
+                      remoteFeePayer,
                       policy: transactionFeePayerPolicy,
                       transaction,
                     })

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -34,6 +34,7 @@ import * as Charge_internal from '../internal/charge.js'
 import * as defaults from '../internal/defaults.js'
 import * as FeePayer from '../internal/fee-payer.js'
 import { resolveFeeToken } from '../internal/fee-token.js'
+import * as HostedFeePayer from '../internal/hosted-fee-payer.js'
 import * as MachineTokenCharge from '../internal/machine-token-charge.js'
 import * as Proof from '../internal/proof.js'
 import * as Selectors from '../internal/selectors.js'
@@ -111,13 +112,13 @@ export function charge<const parameters extends charge.Parameters>(
       })
     : undefined
 
-  const { recipient, feePayer, feePayerUrl } = Account.resolve(parameters)
-  if (configuredFeeToken && feePayerUrl)
+  const { recipient, feePayer, hostedFeePayer } = Account.resolve(parameters)
+  if (configuredFeeToken && hostedFeePayer)
     throw new Error('`feeToken` can only be configured for a local fee payer.')
 
   const getClient = Client.getResolver({
     chain: { ...tempo_chain, experimental_preconfirmationTime: 500 },
-    feePayerUrl,
+    hostedFeePayer,
     getClient: parameters.getClient,
     rpcUrl: defaults.rpcUrl,
   })
@@ -307,7 +308,7 @@ export function charge<const parameters extends charge.Parameters>(
     const isFeePayerTx =
       methodDetails?.feePayer === true &&
       requestAllowsFeePayer &&
-      !!(typeof request.feePayer === 'object' ? request.feePayer : feePayer || feePayerUrl)
+      !!(typeof request.feePayer === 'object' ? request.feePayer : feePayer || hostedFeePayer)
     const transfers = getExpectedTransfers({ amount, memo, methodDetails, recipient })
     const machineTokenRoute = machineTokenEnabled
       ? MachineTokenCharge.matchRoute({
@@ -471,9 +472,12 @@ export function charge<const parameters extends charge.Parameters>(
 
       const resolvedFeePayer = (() => {
         if (request.feePayer === false) return credential ? false : undefined
-        const account = typeof request.feePayer === 'object' ? request.feePayer : feePayer
-        const requested = account ?? feePayer ?? feePayerUrl
-        if (credential) return account ?? (feePayerUrl ? true : undefined)
+        const account =
+          typeof request.feePayer === 'object' && !HostedFeePayer.is(request.feePayer)
+            ? request.feePayer
+            : feePayer
+        const requested = account ?? feePayer ?? hostedFeePayer
+        if (credential) return account ?? (hostedFeePayer ? true : undefined)
         if (requested) return true
         return undefined
       })()
@@ -518,7 +522,7 @@ export function charge<const parameters extends charge.Parameters>(
       const validated = await validateCredential(credential, request, context)
       const feePayerAccount =
         methodDetails?.feePayer === true && requestAllowsFeePayer
-          ? typeof request.feePayer === 'object'
+          ? typeof request.feePayer === 'object' && !HostedFeePayer.is(request.feePayer)
             ? request.feePayer
             : feePayer
           : undefined
@@ -570,8 +574,15 @@ export function charge<const parameters extends charge.Parameters>(
 
           try {
             const broadcastClient =
-              feePayerUrl && isFeePayerTx
-                ? createClient({ chain: client.chain!, transport: http(feePayerUrl) })
+              hostedFeePayer && isFeePayerTx
+                ? createClient({
+                    chain: client.chain!,
+                    transport: http(hostedFeePayer.url, {
+                      fetchOptions: {
+                        headers: HostedFeePayer.resolveHeaders(hostedFeePayer),
+                      },
+                    }),
+                  })
                 : client
             const allowedFeeTokens = FeePayer.defaultAllowedFeeTokens(chainId)
             if (isFeePayerTx) FeePayer.assertAllowedFeeToken(transaction, allowedFeeTokens)
@@ -615,7 +626,7 @@ export function charge<const parameters extends charge.Parameters>(
                   sponsor: completed.feePayer,
                 }
               }
-              if (feePayerUrl && isFeePayerTx) {
+              if (hostedFeePayer && isFeePayerTx) {
                 const completed = await FeePayer.preflightSponsorship({
                   transaction,
                   simulate: (request) => viem_call(client, request as never),
@@ -625,9 +636,9 @@ export function charge<const parameters extends charge.Parameters>(
                       challengeExpires: expires,
                       chainId: chainId ?? client.chain!.id,
                       details: { amount, currency, recipient },
+                      hostedFeePayer,
                       policy: transactionFeePayerPolicy,
                       transaction,
-                      url: feePayerUrl,
                     })
                     return { ...hosted, transaction }
                   },

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -3,7 +3,6 @@ import {
   createClient,
   decodeFunctionData,
   formatUnits,
-  http,
   keccak256,
   parseEventLogs,
   type TransactionReceipt,
@@ -36,7 +35,6 @@ import * as FeePayer from '../internal/fee-payer.js'
 import { resolveFeeToken } from '../internal/fee-token.js'
 import * as MachineTokenCharge from '../internal/machine-token-charge.js'
 import * as Proof from '../internal/proof.js'
-import * as RemoteFeePayer from '../internal/remote-fee-payer.js'
 import * as Selectors from '../internal/selectors.js'
 import type * as types from '../internal/types.js'
 import * as Methods from '../Methods.js'
@@ -308,7 +306,7 @@ export function charge<const parameters extends charge.Parameters>(
     const isFeePayerTx =
       methodDetails?.feePayer === true &&
       requestAllowsFeePayer &&
-      !!(typeof request.feePayer === 'object' ? request.feePayer : feePayer || remoteFeePayer)
+      !!(Account.is(request.feePayer) ? request.feePayer : feePayer || remoteFeePayer)
     const transfers = getExpectedTransfers({ amount, memo, methodDetails, recipient })
     const machineTokenRoute = machineTokenEnabled
       ? MachineTokenCharge.matchRoute({
@@ -472,14 +470,9 @@ export function charge<const parameters extends charge.Parameters>(
 
       const resolvedFeePayer = (() => {
         if (request.feePayer === false) return credential ? false : undefined
-        const account =
-          typeof request.feePayer === 'object' && !RemoteFeePayer.is(request.feePayer)
-            ? request.feePayer
-            : feePayer
-        const requested = account ?? feePayer ?? remoteFeePayer
+        const account = Account.is(request.feePayer) ? request.feePayer : feePayer
         if (credential) return account ?? (remoteFeePayer ? true : undefined)
-        if (requested) return true
-        return undefined
+        return account || remoteFeePayer ? true : undefined
       })()
 
       return {
@@ -522,7 +515,7 @@ export function charge<const parameters extends charge.Parameters>(
       const validated = await validateCredential(credential, request, context)
       const feePayerAccount =
         methodDetails?.feePayer === true && requestAllowsFeePayer
-          ? typeof request.feePayer === 'object' && !RemoteFeePayer.is(request.feePayer)
+          ? Account.is(request.feePayer)
             ? request.feePayer
             : feePayer
           : undefined
@@ -577,11 +570,7 @@ export function charge<const parameters extends charge.Parameters>(
               remoteFeePayer && isFeePayerTx
                 ? createClient({
                     chain: client.chain!,
-                    transport: http(remoteFeePayer.url, {
-                      fetchOptions: {
-                        headers: RemoteFeePayer.resolveHeaders(remoteFeePayer),
-                      },
-                    }),
+                    transport: Client.remoteFeePayerTransport(remoteFeePayer),
                   })
                 : client
             const allowedFeeTokens = FeePayer.defaultAllowedFeeTokens(chainId)

--- a/src/tempo/session/server/Session.ts
+++ b/src/tempo/session/server/Session.ts
@@ -338,7 +338,6 @@ export function session<const parameters extends session.Parameters>(
   const { account, feePayer, remoteFeePayer, recipient } = Account.resolve(parameters)
   const configuredFeePayer =
     feePayer ?? (remoteFeePayer || parameters.feePayer === true ? true : undefined)
-  const settlementFeePayer = configuredFeePayer
   const getClient = Client.getResolver({
     chain: tempo_chain,
     remoteFeePayer,
@@ -370,7 +369,7 @@ export function session<const parameters extends session.Parameters>(
       account,
       channel,
       client: await getClient({ chainId: channel.chainId }),
-      ...(settlementFeePayer ? { feePayer: settlementFeePayer } : {}),
+      ...(configuredFeePayer ? { feePayer: configuredFeePayer } : {}),
       feePayerPolicy: parameters.feePayerPolicy,
       feeToken: parameters.feeToken,
       onSessionSettlement,

--- a/src/tempo/session/server/Session.ts
+++ b/src/tempo/session/server/Session.ts
@@ -335,12 +335,13 @@ export function session<const parameters extends session.Parameters>(
 
   const store = ChannelStore.fromStore(rawStore)
   const lastOnChainVerified = new Map<Hex, number>()
-  const { account, feePayer, feePayerUrl, recipient } = Account.resolve(parameters)
-  const configuredFeePayer = feePayer ?? feePayerUrl
-  const settlementFeePayer = feePayer ?? (feePayerUrl ? true : undefined)
+  const { account, feePayer, hostedFeePayer, recipient } = Account.resolve(parameters)
+  const configuredFeePayer =
+    feePayer ?? (hostedFeePayer || parameters.feePayer === true ? true : undefined)
+  const settlementFeePayer = configuredFeePayer
   const getClient = Client.getResolver({
     chain: tempo_chain,
-    feePayerUrl,
+    hostedFeePayer,
     getClient: parameters.getClient,
     rpcUrl: defaults.rpcUrl,
   })
@@ -561,7 +562,7 @@ export function session<const parameters extends session.Parameters>(
         matchSnapshotPaymentFields,
         parameterChainId: parameters.chainId,
         parameterEscrowContract: parameters.escrowContract,
-        parameterFeePayer: parameters.feePayer,
+        parameterFeePayer: configuredFeePayer,
         request,
         resolveChannelId: parameters.resolveChannelId,
         store,

--- a/src/tempo/session/server/Session.ts
+++ b/src/tempo/session/server/Session.ts
@@ -335,13 +335,13 @@ export function session<const parameters extends session.Parameters>(
 
   const store = ChannelStore.fromStore(rawStore)
   const lastOnChainVerified = new Map<Hex, number>()
-  const { account, feePayer, hostedFeePayer, recipient } = Account.resolve(parameters)
+  const { account, feePayer, remoteFeePayer, recipient } = Account.resolve(parameters)
   const configuredFeePayer =
-    feePayer ?? (hostedFeePayer || parameters.feePayer === true ? true : undefined)
+    feePayer ?? (remoteFeePayer || parameters.feePayer === true ? true : undefined)
   const settlementFeePayer = configuredFeePayer
   const getClient = Client.getResolver({
     chain: tempo_chain,
-    hostedFeePayer,
+    remoteFeePayer,
     getClient: parameters.getClient,
     rpcUrl: defaults.rpcUrl,
   })

--- a/src/viem/Client.test.ts
+++ b/src/viem/Client.test.ts
@@ -83,7 +83,7 @@ describe('getResolver', () => {
     )
   })
 
-  test('behavior: wraps custom client transports with a hosted fee payer', async () => {
+  test('behavior: wraps custom client transports with a remote fee payer', async () => {
     const defaultRequests: string[] = []
     const headers = { Authorization: 'Bearer test' }
     const client = createClient({
@@ -107,7 +107,7 @@ describe('getResolver', () => {
 
     const getClient = Client.getResolver({
       chain: tempoLocalnet,
-      hostedFeePayer: { url: 'https://sponsor.example', headers },
+      remoteFeePayer: { url: 'https://sponsor.example', headers },
       getClient: () => client,
       rpcUrl: { [tempoLocalnet.id]: 'https://rpc.example.com' },
     })
@@ -127,7 +127,7 @@ describe('getResolver', () => {
     expect(defaultRequests).toEqual([])
   })
 
-  test('behavior: sends hosted headers only to the hosted fee-payer URL', async () => {
+  test('behavior: sends remote fee-payer headers only to its URL', async () => {
     const calls: { headers: Headers; url: string }[] = []
     vi.stubGlobal(
       'fetch',
@@ -144,7 +144,7 @@ describe('getResolver', () => {
     )
 
     const getClient = Client.getResolver({
-      hostedFeePayer: {
+      remoteFeePayer: {
         url: 'https://sponsor.example',
         headers: { Authorization: 'Bearer test' },
       },

--- a/src/viem/Client.test.ts
+++ b/src/viem/Client.test.ts
@@ -85,6 +85,7 @@ describe('getResolver', () => {
 
   test('behavior: wraps custom client transports with a hosted fee payer', async () => {
     const defaultRequests: string[] = []
+    const headers = { Authorization: 'Bearer test' }
     const client = createClient({
       chain: tempoLocalnet,
       transport: custom({
@@ -106,7 +107,7 @@ describe('getResolver', () => {
 
     const getClient = Client.getResolver({
       chain: tempoLocalnet,
-      feePayerUrl: 'https://sponsor.example',
+      hostedFeePayer: { url: 'https://sponsor.example', headers },
       getClient: () => client,
       rpcUrl: { [tempoLocalnet.id]: 'https://rpc.example.com' },
     })
@@ -119,7 +120,49 @@ describe('getResolver', () => {
     expect(result).toEqual({ source: 'relay' })
     expect(fetchMock).toHaveBeenCalledOnce()
     expect(String(fetchMock.mock.calls[0]?.[0])).toBe('https://sponsor.example/')
+    expect(new Headers(fetchMock.mock.calls[0]?.[1]?.headers).get('authorization')).toBe(
+      'Bearer test',
+    )
+    expect(headers).toEqual({ Authorization: 'Bearer test' })
     expect(defaultRequests).toEqual([])
+  })
+
+  test('behavior: sends hosted headers only to the hosted fee-payer URL', async () => {
+    const calls: { headers: Headers; url: string }[] = []
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input)
+        calls.push({ headers: new Headers(init?.headers), url })
+        const request = JSON.parse(String(init?.body)) as { id: number; jsonrpc: string }
+        return Response.json({
+          id: request.id,
+          jsonrpc: request.jsonrpc,
+          result: url.startsWith('https://sponsor.example') ? {} : '0x2a',
+        })
+      }),
+    )
+
+    const getClient = Client.getResolver({
+      hostedFeePayer: {
+        url: 'https://sponsor.example',
+        headers: { Authorization: 'Bearer test' },
+      },
+      rpcUrl,
+    })
+    const resolved = await getClient({ chainId: 42 })
+
+    await resolved.request({ method: 'eth_chainId' })
+    await resolved.request({
+      method: 'eth_fillTransaction',
+      params: [{ feePayer: true }],
+    } as never)
+
+    expect(calls).toHaveLength(2)
+    expect(calls[0]?.url).toBe('https://rpc.example.com/')
+    expect(calls[0]?.headers.get('authorization')).toBeNull()
+    expect(calls[1]?.url).toBe('https://sponsor.example/')
+    expect(calls[1]?.headers.get('authorization')).toBe('Bearer test')
   })
 })
 

--- a/src/viem/Client.ts
+++ b/src/viem/Client.ts
@@ -3,7 +3,7 @@ import { withFeePayer } from 'viem/tempo'
 import { tempo as tempoMainnetChain, tempoModerato } from 'viem/tempo/chains'
 
 import type { MaybePromise } from '../internal/types.js'
-import * as HostedFeePayer from '../tempo/internal/hosted-fee-payer.js'
+import * as RemoteFeePayer from '../tempo/internal/remote-fee-payer.js'
 
 const knownTempoChains: Record<number, Chain> = {
   [tempoMainnetChain.id]: tempoMainnetChain,
@@ -14,33 +14,33 @@ export function getResolver(
   parameters: getResolver.Parameters & {
     /** Default chain to use if not provided. */
     chain?: Chain | undefined
-    /** Hosted fee-payer configuration. When set, the transport is wrapped with `withFeePayer`. */
-    hostedFeePayer?: HostedFeePayer.Config | undefined
+    /** Remote fee-payer configuration. When set, the transport is wrapped with `withFeePayer`. */
+    remoteFeePayer?: RemoteFeePayer.Config | undefined
     /** RPC URLs keyed by chain ID. */
     rpcUrl?: ({ [chainId: number]: string } & object) | undefined
   },
 ): (parameters: { chainId?: number | undefined }) => MaybePromise<Client> {
-  const { chain, getClient, hostedFeePayer, rpcUrl } = parameters
+  const { chain, getClient, remoteFeePayer, rpcUrl } = parameters
 
   if (getClient) {
     // When a default chain with serializers is provided (e.g. Tempo chain config),
     // ensure user-provided clients inherit those serializers. Without this, clients
     // created without the Tempo chain config will use the default viem serializer,
     // causing errors like "maxFeePerGas is not a valid Legacy Transaction attribute".
-    if (!chain?.serializers && !hostedFeePayer) return getClient
+    if (!chain?.serializers && !remoteFeePayer) return getClient
     return async (params) => {
       const client = await getClient(params)
       let resolvedClient = client
 
       // Wrap the client's transport with `withFeePayer` when a fee payer URL is provided.
-      if (hostedFeePayer && client.transport.key !== 'feePayer') {
+      if (remoteFeePayer && client.transport.key !== 'feePayer') {
         const request = client.request.bind(client)
         // The supplied client already owns retries. Keep the relay middleware retry-free so
         // failures are not retried once per nested transport layer.
         const feePayerTransport = withFeePayer(
           custom({ request: (args) => request(args as never) }, { retryCount: 0 }),
-          http(hostedFeePayer.url, {
-            fetchOptions: { headers: HostedFeePayer.resolveHeaders(hostedFeePayer) },
+          http(remoteFeePayer.url, {
+            fetchOptions: { headers: RemoteFeePayer.resolveHeaders(remoteFeePayer) },
             retryCount: client.transport.retryCount,
           }),
         )({
@@ -81,11 +81,11 @@ export function getResolver(
     const resolvedChainId = chainId || Number(Object.keys(rpcUrl)[0])!
     const url = rpcUrl[resolvedChainId as keyof typeof rpcUrl]
     if (!url) throw new Error(`No \`rpcUrl\` configured for \`chainId\` (${resolvedChainId}).`)
-    const transport = hostedFeePayer
+    const transport = remoteFeePayer
       ? withFeePayer(
           http(url),
-          http(hostedFeePayer.url, {
-            fetchOptions: { headers: HostedFeePayer.resolveHeaders(hostedFeePayer) },
+          http(remoteFeePayer.url, {
+            fetchOptions: { headers: RemoteFeePayer.resolveHeaders(remoteFeePayer) },
           }),
         )
       : http(url)

--- a/src/viem/Client.ts
+++ b/src/viem/Client.ts
@@ -10,6 +10,17 @@ const knownTempoChains: Record<number, Chain> = {
   [tempoModerato.id]: tempoModerato,
 }
 
+/** Creates an HTTP transport for a configured remote fee-payer service. */
+export function remoteFeePayerTransport(
+  config: RemoteFeePayer.Config,
+  options: { retryCount?: number | undefined } = {},
+) {
+  return http(config.url, {
+    fetchOptions: { headers: RemoteFeePayer.resolveHeaders(config) },
+    ...options,
+  })
+}
+
 export function getResolver(
   parameters: getResolver.Parameters & {
     /** Default chain to use if not provided. */
@@ -39,8 +50,7 @@ export function getResolver(
         // failures are not retried once per nested transport layer.
         const feePayerTransport = withFeePayer(
           custom({ request: (args) => request(args as never) }, { retryCount: 0 }),
-          http(remoteFeePayer.url, {
-            fetchOptions: { headers: RemoteFeePayer.resolveHeaders(remoteFeePayer) },
+          remoteFeePayerTransport(remoteFeePayer, {
             retryCount: client.transport.retryCount,
           }),
         )({
@@ -82,12 +92,7 @@ export function getResolver(
     const url = rpcUrl[resolvedChainId as keyof typeof rpcUrl]
     if (!url) throw new Error(`No \`rpcUrl\` configured for \`chainId\` (${resolvedChainId}).`)
     const transport = remoteFeePayer
-      ? withFeePayer(
-          http(url),
-          http(remoteFeePayer.url, {
-            fetchOptions: { headers: RemoteFeePayer.resolveHeaders(remoteFeePayer) },
-          }),
-        )
+      ? withFeePayer(http(url), remoteFeePayerTransport(remoteFeePayer))
       : http(url)
     return createClient({
       chain: (knownTempoChains[resolvedChainId] ?? { ...chain, id: resolvedChainId }) as never,

--- a/src/viem/Client.ts
+++ b/src/viem/Client.ts
@@ -3,6 +3,7 @@ import { withFeePayer } from 'viem/tempo'
 import { tempo as tempoMainnetChain, tempoModerato } from 'viem/tempo/chains'
 
 import type { MaybePromise } from '../internal/types.js'
+import * as HostedFeePayer from '../tempo/internal/hosted-fee-payer.js'
 
 const knownTempoChains: Record<number, Chain> = {
   [tempoMainnetChain.id]: tempoMainnetChain,
@@ -13,32 +14,35 @@ export function getResolver(
   parameters: getResolver.Parameters & {
     /** Default chain to use if not provided. */
     chain?: Chain | undefined
-    /** Fee payer relay URL. When set, the transport is wrapped with `withFeePayer`. */
-    feePayerUrl?: string | undefined
+    /** Hosted fee-payer configuration. When set, the transport is wrapped with `withFeePayer`. */
+    hostedFeePayer?: HostedFeePayer.Config | undefined
     /** RPC URLs keyed by chain ID. */
     rpcUrl?: ({ [chainId: number]: string } & object) | undefined
   },
 ): (parameters: { chainId?: number | undefined }) => MaybePromise<Client> {
-  const { chain, feePayerUrl, getClient, rpcUrl } = parameters
+  const { chain, getClient, hostedFeePayer, rpcUrl } = parameters
 
   if (getClient) {
     // When a default chain with serializers is provided (e.g. Tempo chain config),
     // ensure user-provided clients inherit those serializers. Without this, clients
     // created without the Tempo chain config will use the default viem serializer,
     // causing errors like "maxFeePerGas is not a valid Legacy Transaction attribute".
-    if (!chain?.serializers && !feePayerUrl) return getClient
+    if (!chain?.serializers && !hostedFeePayer) return getClient
     return async (params) => {
       const client = await getClient(params)
       let resolvedClient = client
 
       // Wrap the client's transport with `withFeePayer` when a fee payer URL is provided.
-      if (feePayerUrl && client.transport.key !== 'feePayer') {
+      if (hostedFeePayer && client.transport.key !== 'feePayer') {
         const request = client.request.bind(client)
         // The supplied client already owns retries. Keep the relay middleware retry-free so
         // failures are not retried once per nested transport layer.
         const feePayerTransport = withFeePayer(
           custom({ request: (args) => request(args as never) }, { retryCount: 0 }),
-          http(feePayerUrl, { retryCount: client.transport.retryCount }),
+          http(hostedFeePayer.url, {
+            fetchOptions: { headers: HostedFeePayer.resolveHeaders(hostedFeePayer) },
+            retryCount: client.transport.retryCount,
+          }),
         )({
           account: client.account,
           chain: client.chain,
@@ -77,7 +81,14 @@ export function getResolver(
     const resolvedChainId = chainId || Number(Object.keys(rpcUrl)[0])!
     const url = rpcUrl[resolvedChainId as keyof typeof rpcUrl]
     if (!url) throw new Error(`No \`rpcUrl\` configured for \`chainId\` (${resolvedChainId}).`)
-    const transport = feePayerUrl ? withFeePayer(http(url), http(feePayerUrl)) : http(url)
+    const transport = hostedFeePayer
+      ? withFeePayer(
+          http(url),
+          http(hostedFeePayer.url, {
+            fetchOptions: { headers: HostedFeePayer.resolveHeaders(hostedFeePayer) },
+          }),
+        )
+      : http(url)
     return createClient({
       chain: (knownTempoChains[resolvedChainId] ?? { ...chain, id: resolvedChainId }) as never,
       transport,


### PR DESCRIPTION
## Summary

- accept remote Tempo fee-payer configuration with a URL and static HTTP headers
- send configured headers only to remote fee-payer fill and broadcast requests
- preserve string URL shorthand, local account, and boolean fee-payer modes without exposing remote configuration in challenges

## Validation

- `VITE_TEMPO_NETWORK=none pnpm exec vp test --run src/tempo/internal/account.test.ts src/viem/Client.test.ts src/tempo/internal/fee-payer.test.ts`
- `pnpm check:ci`
- `pnpm check:types`
- `pnpm build`
- `pnpm check:package`
