### PR TITLE
fix: isolate concurrent HTML builds

### DIFF
--- a/.changeset/fuzzy-cats-build.md
+++ b/.changeset/fuzzy-cats-build.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed concurrent HTML builds sharing a temporary directory.

--- a/scripts/build:html.ts
+++ b/scripts/build:html.ts
@@ -1,10 +1,11 @@
 import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
 
 import { build } from 'rolldown'
 
 const root = path.resolve(import.meta.dirname, '..')
-const outDir = path.resolve(root, '.tmp/html-build')
+const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mppx-html-build-'))
 const defaultMode = process.env.TEST ? 'test' : 'production'
 const stripeMode = process.env.STRIPE_HTML_MODE ?? defaultMode
 const formatBundleSize = (bytes: number) =>


### PR DESCRIPTION
## Motivation

Concurrent HTML builds reused `.tmp/html-build`, allowing one process to remove another process's output directory. Fixes #761.

## Summary

- Created a unique OS temporary directory for each HTML builder process
- Added a patch changeset

## Key design considerations

- Preserved the existing per-bundle cleanup and generated outputs while isolating intermediate files