### PR TITLE
test: stabilize HTML fee payer flow

### DIFF
--- a/.changeset/tidy-html-fees.md
+++ b/.changeset/tidy-html-fees.md
@@ -1,0 +1,4 @@
+---
+---
+
+Stabilized the HTML test fee payer policy without changing the published package.

--- a/test/html/server.ts
+++ b/test/html/server.ts
@@ -29,7 +29,9 @@ export async function startServer(port: number): Promise<HtmlTestServer> {
 
   const createTokenUrl = '/stripe/create-spt'
   const feePayerPolicy = {
-    maxFeePerGas: 200_000_000_000n,
+    // Moderato fee estimates can spike above 600 gwei. Keep this live-network
+    // test focused on the HTML payment flow while maxTotalFee bounds exposure.
+    maxFeePerGas: 1_000_000_000_000n,
     maxPriorityFeePerGas: 200_000_000_000n,
     maxTotalFee: 500_000_000_000_000_000n,
   }


### PR DESCRIPTION
## Why

The live Moderato fee estimate exceeded the HTML test fixture’s per-gas sponsor limit, causing the same Tempo HTML failures on `main` and PR #839.

## What

Raised the test-only `maxFeePerGas` limit to cover observed network spikes while retaining the existing `maxTotalFee` exposure bound. Added an empty changeset because shipped behavior is unchanged.