### PR TITLE
feat(stripe): Add Stripe hosted feepayer to Stripe defaultMethods

### DIFF
--- a/.changeset/stripe-hosted-fee-payer.md
+++ b/.changeset/stripe-hosted-fee-payer.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added opt-in Stripe-hosted Tempo fee sponsorship to `stripe.create()` using the configured Stripe client.

--- a/src/stripe/internal/types.ts
+++ b/src/stripe/internal/types.ts
@@ -7,6 +7,12 @@ import * as StripeJsTypes from '../../stripe/server/internal/html/types.js'
  * Uses loose signatures so any Stripe SDK version is assignable.
  */
 export type StripeClient = {
+  /** Stripe-node request transport used for hosted fee-payer requests. */
+  _requestSender?:
+    | {
+        _request(...args: any[]): void
+      }
+    | undefined
   paymentIntents: {
     create(...args: any[]): Promise<{
       id: string

--- a/src/stripe/server/Methods.test-d.ts
+++ b/src/stripe/server/Methods.test-d.ts
@@ -55,6 +55,17 @@ test('tempo.session() accepts getClient, feePayer, store without casts', () => {
   expectTypeOf(session).toHaveProperty('intent')
 })
 
+test('stripe.create() accepts hosted fee-payer opt-in', () => {
+  const mp = stripe.create({
+    client: {} as any,
+    networkId: 'profile_x',
+    livemode: true,
+    hostedFeePayer: true,
+  })
+
+  expectTypeOf(mp.defaultMethods()).toHaveProperty('additional')
+})
+
 test('.charge() works with multiple charge methods (implicit compose)', async () => {
   const mp = stripe.create({ client: {} as any, networkId: 'profile_x', livemode: false })
   const methods = await mp.defaultMethods()

--- a/src/stripe/server/Methods.test.ts
+++ b/src/stripe/server/Methods.test.ts
@@ -19,6 +19,13 @@ function createMockStripeClient(): StripeClient {
   }
 }
 
+function createHostedFeePayerStripeClient(): StripeClient {
+  return {
+    ...createMockStripeClient(),
+    _requestSender: { _request: vi.fn() },
+  }
+}
+
 function findMethod(methods: readonly AnyServer[], name: string, intent: string) {
   return methods.find((m) => m.name === name && m.intent === intent)!
 }
@@ -80,6 +87,88 @@ describe('stripe.create() defaultMethods', () => {
       }),
       expect.anything(),
     )
+  })
+
+  test('uses Stripe feepayer when hostedFeePayer set', async () => {
+    const client = createHostedFeePayerStripeClient()
+    const methods = stripe({
+      client,
+      networkId: 'test-profile',
+      livemode: true,
+      hostedFeePayer: true,
+      depositAddresses: { tempo: '0xtempoaddr' },
+    }).defaultMethods()
+
+    const chargeRequest = await findMethod(methods, 'tempo', 'charge').request!({
+      request: {
+        amount: '10000',
+        currency: 'test-currency',
+        decimals: 6,
+        recipient: 'test-recipient',
+      },
+    } as never)
+
+    expect(chargeRequest.feePayer).toBe(true)
+    expect(JSON.stringify(chargeRequest)).not.toContain('mpp.stripe.com')
+  })
+
+  test('does not use Stripe feepayer when hostedFeePayer unset', async () => {
+    const client = createMockStripeClient()
+    const methods = stripe({
+      client,
+      networkId: 'test-profile',
+      livemode: true,
+      depositAddresses: { tempo: '0xtempoaddr' },
+    }).defaultMethods()
+
+    const request = await findMethod(methods, 'tempo', 'charge').request!({
+      request: {
+        amount: '10000',
+        currency: 'test-currency',
+        decimals: 6,
+        recipient: 'test-recipient',
+      },
+    } as never)
+
+    expect(request.feePayer).toBeUndefined()
+  })
+
+  test('rejects Stripe feepayer in test mode', () => {
+    const client = createHostedFeePayerStripeClient()
+
+    expect(() =>
+      stripe({
+        client,
+        networkId: 'test-profile',
+        livemode: false,
+        hostedFeePayer: true,
+      }),
+    ).toThrow('requires a live-mode integration')
+  })
+
+  test('rejects Stripe feepayer with Connect', () => {
+    const client = createHostedFeePayerStripeClient()
+
+    expect(() =>
+      stripe({
+        client,
+        networkId: 'test-profile',
+        livemode: true,
+        hostedFeePayer: true,
+        connect: { stripeAccount: 'acct_connected' },
+      }),
+    ).toThrow('does not support Connect account routing')
+  })
+
+  test('rejects Stripe feepayer without Stripe request transport', () => {
+    expect(() =>
+      stripe({
+        client: createMockStripeClient(),
+        networkId: 'test-profile',
+        livemode: true,
+        hostedFeePayer: true,
+      }),
+    ).toThrow('requires a compatible Stripe Node SDK client')
   })
 
   test.each(['tempo', 'spt'] as const)('exclude removes %s', async (excluded) => {

--- a/src/stripe/server/Methods.ts
+++ b/src/stripe/server/Methods.ts
@@ -9,6 +9,7 @@ import * as PaymentIntent from '../internal/payment-intent.js'
 import type { StripeClient } from '../internal/types.js'
 import { charge as charge_ } from './Charge.js'
 import { findOrCreateDepositAddress as _findOrCreateDepositAddress } from './internal/deposit-address.js'
+import * as HostedFeePayer from './internal/hosted-fee-payer.js'
 import { recordCryptoPayment } from './internal/record-payment.js'
 import { type ConnectConfig } from './internal/request.js'
 
@@ -29,6 +30,7 @@ export declare namespace stripe {
     client: StripeClient
     networkId: string
     livemode: boolean
+    hostedFeePayer?: boolean | undefined
     connect?: ConnectConfig
     depositAddresses?: Partial<Record<Network, string>> | ((network: Network) => Promise<string>)
     metadata?: Record<string, string> | undefined
@@ -189,12 +191,18 @@ class DefaultMethodsBuilder implements PromiseLike<DefaultMethods> {
  * ```
  */
 export function stripe<const P extends stripe.Parameters>(parameters: P): StripeMachinePayments<P> {
-  const { client, networkId, livemode, connect, depositAddresses, metadata } = parameters
+  const { client, networkId, livemode, hostedFeePayer, connect, depositAddresses, metadata } =
+    parameters
   if (!client.rawRequest)
     throw new Error('stripe.create() requires a Stripe SDK client with rawRequest() (v15+)')
+  if (hostedFeePayer && !livemode)
+    throw new Error('Stripe hosted fee payer requires a live-mode integration.')
+  if (hostedFeePayer && connect)
+    throw new Error('Stripe hosted fee payer does not support Connect account routing.')
   const tempoCurrency = (
     livemode ? tempoDefaults.tokens.usdc : tempoDefaults.tokens.pathUsd
   ) as `0x${string}`
+  const hostedTempoFeePayer = hostedFeePayer ? HostedFeePayer.create(client) : undefined
   const tempoPaymentHandler = createPaymentSuccessHandler(client, 'tempo', connect, metadata)
   const basePaymentHandler = createPaymentSuccessHandler(client, 'base', connect, metadata)
 
@@ -229,6 +237,7 @@ export function stripe<const P extends stripe.Parameters>(parameters: P): Stripe
         currency: tempoCurrency,
         recipient,
         ...(!livemode && { testnet: true }),
+        ...(hostedTempoFeePayer && { feePayer: hostedTempoFeePayer }),
         canOffer: cryptoCanOffer,
         onPaymentSuccess: handler,
         ...rest,
@@ -244,6 +253,7 @@ export function stripe<const P extends stripe.Parameters>(parameters: P): Stripe
       currency: tempoCurrency,
       recipient,
       ...(!livemode && { testnet: true }),
+      ...(hostedTempoFeePayer && { feePayer: hostedTempoFeePayer }),
       ...rest,
     } as tempoSession.Parameters) as Method.AnyServer
   }

--- a/src/stripe/server/internal/hosted-fee-payer.test.ts
+++ b/src/stripe/server/internal/hosted-fee-payer.test.ts
@@ -1,0 +1,104 @@
+import { Readable } from 'node:stream'
+
+import { describe, expect, test, vi } from 'vp/test'
+
+import type { StripeClient } from '../../internal/types.js'
+import * as HostedFeePayer from './hosted-fee-payer.js'
+
+function createClient(request: (...args: any[]) => void): StripeClient {
+  return {
+    _requestSender: { _request: request },
+    paymentIntents: {
+      create: vi.fn(async () => ({ id: 'pi_mock', status: 'succeeded' })),
+    },
+    rawRequest: vi.fn(),
+  }
+}
+
+function sendRequest(request: (...args: any[]) => void, body: unknown) {
+  const feePayer = HostedFeePayer.create(createClient(request))
+  return feePayer.fetch!(feePayer.url, {
+    body: JSON.stringify(body),
+    method: 'POST',
+  })
+}
+
+describe('Stripe hosted fee payer', () => {
+  test('forwards JSON-RPC through the configured Stripe client', async () => {
+    const rpcRequest = {
+      id: 1,
+      jsonrpc: '2.0',
+      method: 'eth_fillTransaction',
+      params: [{ from: '0xsender' }],
+    }
+    const request = vi.fn((...args: any[]) => {
+      const data = args[3]
+      const callback = args[7] as (error: unknown, response: unknown) => void
+      const processData = args[8] as (
+        method: string,
+        data: unknown,
+        headers: unknown,
+        callback: (error: unknown, body: string) => void,
+      ) => void
+
+      processData('POST', data, {}, (error, body) => {
+        expect(error).toBeNull()
+        expect(JSON.parse(body)).toEqual(rpcRequest)
+      })
+      callback(
+        null,
+        Readable.from([
+          JSON.stringify({ id: 1, jsonrpc: '2.0', result: { tx: { feeToken: '0xtoken' } } }),
+        ]),
+      )
+    })
+    const response = await sendRequest(request, rpcRequest)
+
+    expect(response.ok).toBe(true)
+    expect(await response.json()).toEqual({
+      id: 1,
+      jsonrpc: '2.0',
+      result: { tx: { feeToken: '0xtoken' } },
+    })
+    expect(request).toHaveBeenCalledOnce()
+    expect(request.mock.calls[0]?.slice(0, 4)).toEqual([
+      'POST',
+      'mpp.stripe.com',
+      '/tempo/feepayer',
+      rpcRequest,
+    ])
+    expect(request.mock.calls[0]?.[4]).toBeNull()
+    expect(request.mock.calls[0]?.[5]).toEqual({
+      headers: { 'Content-Type': 'application/json' },
+      settings: { maxNetworkRetries: 0 },
+      streaming: true,
+    })
+  })
+
+  test('returns Stripe request failures as JSON-RPC errors', async () => {
+    const request = vi.fn((...args: any[]) => {
+      const callback = args[7] as (error: unknown, response: unknown) => void
+      callback(
+        {
+          code: -32602,
+          message: 'unknown account',
+          statusCode: 400,
+        },
+        null,
+      )
+    })
+    const response = await sendRequest(request, {
+      id: 7,
+      jsonrpc: '2.0',
+      method: 'eth_fillTransaction',
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: { code: -32602, message: 'unknown account' },
+      id: 7,
+      jsonrpc: '2.0',
+    })
+    expect(request).toHaveBeenCalledOnce()
+  })
+})

--- a/src/stripe/server/internal/hosted-fee-payer.ts
+++ b/src/stripe/server/internal/hosted-fee-payer.ts
@@ -1,0 +1,84 @@
+import type * as RemoteFeePayer from '../../../tempo/internal/remote-fee-payer.js'
+import type { StripeClient } from '../../internal/types.js'
+
+const stripeFeepayerHost = 'mpp.stripe.com'
+const stripeFeepayerPath = '/tempo/feepayer'
+const url = `https://${stripeFeepayerHost}${stripeFeepayerPath}`
+
+type JsonRpcRequest = Record<string, unknown> & { id?: unknown }
+
+/**
+ * Creates an instance of a Stripe feepayer using an authenticated Stripe client.
+ *
+ * This compatibility path uses the Stripe client so that requests to the feepayer
+ * retain their authentication, timeouts, telemetry, and request events.
+ */
+export function create(client: StripeClient): RemoteFeePayer.Config {
+  const requestSender = client._requestSender
+  if (!requestSender?._request)
+    throw new Error('Stripe hosted fee payer requires a compatible Stripe Node SDK client.')
+  return { fetch: createFetch(requestSender), url }
+}
+
+function createFetch(
+  requestSender: NonNullable<StripeClient['_requestSender']>,
+): typeof globalThis.fetch {
+  return async (_url, request) => {
+    // Remote fee-payer requests must be JSON-RPC POST requests.
+    if (request?.method !== 'POST' || typeof request.body !== 'string')
+      throw new Error('Stripe hosted fee payer requires a JSON POST request.')
+
+    const body = JSON.parse(request.body) as JsonRpcRequest
+
+    try {
+      // Make the request to the feepayer through the Stripe client so that we can reuse auth and telemetry.
+      const stream = await new Promise<NodeJS.ReadableStream>((resolve, reject) => {
+        requestSender._request(
+          'POST',
+          stripeFeepayerHost,
+          stripeFeepayerPath,
+          body,
+          null,
+          {
+            headers: { 'Content-Type': 'application/json' },
+            settings: { maxNetworkRetries: 0 },
+            streaming: true,
+          },
+          ['mpp_feepayer'],
+          (error: unknown, response: unknown) =>
+            error ? reject(error) : resolve(response as NodeJS.ReadableStream),
+          (_method: string, data: unknown, _headers: unknown, callback: Function) =>
+            callback(null, JSON.stringify(data)),
+        )
+      })
+
+      return new Response(stream as unknown as BodyInit, {
+        headers: { 'Content-Type': 'application/json' },
+        status: 200,
+      })
+    } catch (error) {
+      // Convert Stripe transport failure into the JSON-RPC shape viem expects.
+      const stripeError = error as {
+        code?: unknown
+        message?: unknown
+        statusCode?: unknown
+      }
+      return Response.json(
+        {
+          error: {
+            code: typeof stripeError.code === 'number' ? stripeError.code : -32603,
+            message:
+              typeof stripeError.message === 'string'
+                ? stripeError.message
+                : 'Stripe fee-payer request failed',
+          },
+          id: body.id ?? null,
+          jsonrpc: '2.0',
+        },
+        {
+          status: typeof stripeError.statusCode === 'number' ? stripeError.statusCode : 502,
+        },
+      )
+    }
+  }
+}

--- a/src/tempo/internal/remote-fee-payer.ts
+++ b/src/tempo/internal/remote-fee-payer.ts
@@ -1,5 +1,7 @@
 /** Configuration for a remote Tempo fee-payer service. */
 export type Config = Readonly<{
+  /** Custom fetch implementation used only for fee-payer JSON-RPC transport. */
+  fetch?: typeof globalThis.fetch | undefined
   headers?: Readonly<Record<string, string>> | undefined
   url: string
 }>

--- a/src/viem/Client.test.ts
+++ b/src/viem/Client.test.ts
@@ -103,11 +103,9 @@ describe('getResolver', () => {
         result: { source: 'relay' },
       })
     })
-    vi.stubGlobal('fetch', fetchMock)
-
     const getClient = Client.getResolver({
       chain: tempoLocalnet,
-      remoteFeePayer: { url: 'https://sponsor.example', headers },
+      remoteFeePayer: { url: 'https://sponsor.example', fetch: fetchMock, headers },
       getClient: () => client,
       rpcUrl: { [tempoLocalnet.id]: 'https://rpc.example.com' },
     })

--- a/src/viem/Client.ts
+++ b/src/viem/Client.ts
@@ -16,6 +16,7 @@ export function remoteFeePayerTransport(
   options: { retryCount?: number | undefined } = {},
 ) {
   return http(config.url, {
+    fetchFn: config.fetch,
     fetchOptions: { headers: RemoteFeePayer.resolveHeaders(config) },
     ...options,
   })


### PR DESCRIPTION
## Summary
Stripe is standing up a hosted feepayer that is merchant authenticated via Stripe api key. Merchants using Stripe for MPP currently have the ability to instantiate the `stripe` client and pass it to `mppx` which abstracts away the complexity of making PaymentIntents, configuring payment methods, etc. 

This PR adds an optional param to the stripe`defaultMethods()` for opting in to using the new Stripe hosted feepayer.

## Note
The feepayer service is currently under construction and not yet rolled out to the public. Merchants interested in trying it can contact machine-payments@stripe.com