### PR TITLE
docs: add contract-qualified preparePayment example

### DIFF
--- a/.changeset/contract-qualified-prepare.md
+++ b/.changeset/contract-qualified-prepare.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added a contract-qualified preparePayment example that binds a request and OpenAPI 3.1 success contract before creating a credential.

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,7 @@ Standalone, runnable examples demonstrating the mppx HTTP 402 payment flow.
 | [stripe](./stripe/)                           | Stripe SPT charge with automatic client              |
 | [subscription](./subscription/)               | Daily news subscription using Tempo access keys      |
 | [web-bot-auth](./web-bot-auth/)               | Web Bot Auth with automatic MPP payment retry        |
+| [prepared-payment](./prepared-payment/)       | Qualify a request and OpenAPI 3.1 contract           |
 | [x402-mpp](./x402-mpp/)                       | Server route supporting x402 and mpp payments        |
 
 ## Running Examples

--- a/examples/prepared-payment/README.md
+++ b/examples/prepared-payment/README.md
@@ -1,0 +1,59 @@
+# Contract-qualified preparePayment
+
+An application example that qualifies an exact HTTP request and a bounded OpenAPI 3.1 success contract before calling the exported preparePayment().createCredential() path.
+
+## Official seam
+
+Use the real exported path:
+
+1. rawFetch(frozen request)
+2. preparePayment(response, { request })
+3. inspect the immutable selected challenge
+4. qualify the request and OpenAPI 3.1 contract
+5. createCredential()
+6. setCredential(exact request, result)
+7. stop. Do not send the authenticated request.
+
+Use Mppx.create().preparePayment(). A fake fetch may be injected with
+polyfill: false so rawFetch never hits a network.
+
+## Buyer-side binding, not MPP HTTP binding
+
+MPP binds the selected challenge fields only. MPP does not
+cryptographically bind the HTTP method, path, query, or output contract.
+
+This example records local authorization evidence for:
+
+- the exact uppercase HTTP method
+- the byte-exact absolute URL, including query order
+- the inspected challenge id plus amount, currency, and any present
+  chain / network / recipient terms
+- the SHA-256 digest of the frozen OpenAPI document bytes
+- the exact operation, successful status, media type, and schema pointer
+- the buyer-required output paths
+
+It does not read `_mppx_scope`, `opaque`, or any other server-private field.
+
+## Fail-closed OpenAPI 3.1 qualifier
+
+The qualifier accepts only directly represented OpenAPI 3.1 forms it can prove.
+It rejects, and must not sign, when it sees:
+
+- openapi other than 3.1.x, or an unknown jsonSchemaDialect
+- dollar-ref, including dynamic or recursive refs
+- composition (allOf, oneOf, anyOf, not)
+- more than one applicable 2xx status or success media type
+- a media type other than application/json
+- path templating or a non-unique path/method pair
+- a missing buyer-required output path
+- another unsupported schema representation
+
+The extract fixture is modeled on a live zero-spend probe of GET /extract?url=https%3A%2F%2Fexample.com.
+It uses one evm/charge offer and a JSON 200 schema that requires ok, url, and title.
+
+## Running
+
+The oracle is `src/client/prepared-payment.example.test.ts`.
+
+`pnpm dev` only runs the local fake 402 demo that stops after attachment.
+No wallet. No network.

--- a/examples/prepared-payment/package.json
+++ b/examples/prepared-payment/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "prepared-payment",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "check:types": "tsgo -p tsconfig.json",
+    "dev": "tsx src/demo.ts"
+  },
+  "dependencies": {
+    "@types/node": "26.2.0",
+    "@typescript/native-preview": "7.0.0-dev.20260707.2",
+    "mppx": "latest",
+    "tsx": "4.23.12",
+    "typescript": "catalog:"
+  }
+}

--- a/examples/prepared-payment/src/attach.ts
+++ b/examples/prepared-payment/src/attach.ts
@@ -1,0 +1,92 @@
+import {
+  qualifyPreparedPayment,
+  type ContractRequirement,
+  type FrozenRequest,
+  type QualifiedAuthorization,
+  type SelectedChallenge,
+} from './qualify.js'
+
+/** Minimal `preparePayment` surface used by this example. */
+export type PreparePaymentClient = {
+  preparePayment: (
+    response: Response,
+    options?: { request?: RequestInit },
+  ) => Promise<{
+    challenge: SelectedChallenge
+    createCredential: () => Promise<string>
+    setCredential: (request: RequestInit, credential: string) => RequestInit
+  }>
+}
+
+export type AttachQualifiedCredentialOptions = {
+  mppx: PreparePaymentClient
+  request: FrozenRequest
+  response: Response
+  openApiDocument: string | Uint8Array
+  required: ContractRequirement
+}
+
+export type AttachedQualifiedCredential = {
+  authorization: QualifiedAuthorization
+  credential: string
+  authenticatedRequest: RequestInit
+  sent: false
+}
+
+/** Thrown when buyer-side qualification fails before credential creation. */
+export class QualificationError extends Error {
+  override readonly name = 'QualificationError'
+  readonly reason: string
+
+  constructor(reason: string) {
+    super('Prepared payment failed buyer qualification: ' + reason)
+    this.reason = reason
+  }
+}
+
+/**
+ * Qualifies a prepared payment, creates one credential, attaches it to the
+ * frozen request, and stops.
+ *
+ * Never sends the authenticated request. MPP binds the selected challenge
+ * fields only; this helper adds buyer-side application binding before
+ * `createCredential()`.
+ */
+export async function attachQualifiedCredential(
+  options: AttachQualifiedCredentialOptions,
+): Promise<AttachedQualifiedCredential> {
+  const requestInit = toRequestInit(options.request)
+  const prepared = await options.mppx.preparePayment(options.response, {
+    request: requestInit,
+  })
+  const qualified = qualifyPreparedPayment({
+    request: options.request,
+    challenge: prepared.challenge,
+    openApiDocument: options.openApiDocument,
+    required: options.required,
+  })
+  if (!qualified.ok) throw new QualificationError(qualified.reason)
+
+  const credential = await prepared.createCredential()
+  const authenticatedRequest = prepared.setCredential(requestInit, credential)
+  return {
+    authorization: qualified.authorization,
+    credential,
+    authenticatedRequest,
+    sent: false,
+  }
+}
+
+/**
+ * Returns the `RequestInit` used with `preparePayment` and `setCredential`.
+ *
+ * The URL stays on the frozen request so attachment cannot retarget another
+ * resource.
+ */
+export function toRequestInit(request: FrozenRequest): RequestInit {
+  return {
+    method: request.method,
+    ...(request.headers !== undefined ? { headers: request.headers } : {}),
+    ...(request.body !== undefined ? { body: request.body } : {}),
+  }
+}

--- a/examples/prepared-payment/src/demo.ts
+++ b/examples/prepared-payment/src/demo.ts
@@ -1,0 +1,88 @@
+import { Challenge, Credential, Method } from 'mppx'
+import { Mppx } from 'mppx/client'
+import { Methods } from 'mppx/tempo'
+
+import { attachQualifiedCredential } from './attach.js'
+import { extractOpenApiDocument, extractRequirement, extractUrl } from './extract.js'
+
+/**
+ * No-network demo: qualify a fake 402, attach a fake credential, and stop.
+ *
+ * This script never sends an `Authorization: Payment` request, never opens a
+ * wallet, and never talks to Tempo or a seller.
+ */
+const createCredential = async ({ challenge }: { challenge: Challenge.Challenge }) =>
+  Credential.serialize({
+    challenge,
+    payload: { signature: '0xdemo', type: 'transaction' },
+  })
+
+const method = Method.toClient(
+  Method.from({
+    name: 'evm',
+    intent: 'charge',
+    schema: Methods.charge.schema,
+  }),
+  { createCredential },
+)
+
+const challenge = Challenge.from({
+  expires: new Date(Date.now() + 60_000).toISOString(),
+  id: extractRequirement.challenge.id,
+  intent: 'charge',
+  method: 'evm',
+  realm: 'seller.example',
+  request: {
+    amount: extractRequirement.challenge.amount,
+    currency: extractRequirement.challenge.currency,
+    chainId: extractRequirement.challenge.chainId,
+    recipient: extractRequirement.challenge.recipient,
+  },
+})
+
+let fetchCount = 0
+const fetch = async (_input: RequestInfo | URL, init?: RequestInit) => {
+  fetchCount += 1
+  const headers = new Headers(init?.headers)
+  if (headers.has('Authorization')) {
+    throw new Error('demo refused to send a credential-bearing request')
+  }
+  return new Response(null, {
+    headers: { 'WWW-Authenticate': Challenge.serialize(challenge) },
+    status: 402,
+  })
+}
+
+const mppx = Mppx.create({
+  fetch: fetch as typeof globalThis.fetch,
+  methods: [method],
+  polyfill: false,
+})
+
+const request = {
+  method: extractRequirement.method,
+  url: extractUrl,
+}
+
+const response = await mppx.rawFetch(request.url, { method: request.method })
+const attached = await attachQualifiedCredential({
+  mppx,
+  request,
+  response,
+  openApiDocument: extractOpenApiDocument,
+  required: extractRequirement,
+})
+
+const authorization = new Headers(attached.authenticatedRequest.headers).get('Authorization')
+
+console.log('qualified', {
+  method: attached.authorization.method,
+  url: attached.authorization.url,
+  challengeId: attached.authorization.challengeId,
+  openApiDigest: attached.authorization.openApiDigest,
+  schemaPointer: attached.authorization.schemaPointer,
+})
+console.log('authorization', authorization)
+console.log('sent', attached.sent)
+console.log('rawFetchCount', fetchCount)
+console.log('stopped without sending the credential-bearing request')

--- a/examples/prepared-payment/src/extract.ts
+++ b/examples/prepared-payment/src/extract.ts
@@ -1,0 +1,92 @@
+import { digestOpenApiDocument } from './openapi.js'
+import type { ChallengeTerms, ContractRequirement } from './qualify.js'
+
+/**
+ * Frozen extract operation modeled on a live zero-spend HTTP 402 probe.
+ *
+ * The live seller advertised `GET /extract?url=https%3A%2F%2Fexample.com` with
+ * one MPP evm/charge offer. This example never calls that seller.
+ */
+export const extractMethod = 'GET'
+
+export const extractUrl = 'https://seller.example/extract?url=https%3A%2F%2Fexample.com'
+
+export const extractOperationPath = '/extract'
+
+export const extractSuccessStatus = '200'
+
+export const extractMediaType = 'application/json'
+
+export const extractRequiredOutputPaths = ['ok', 'url', 'title'] as const
+
+export const extractChallengeTerms = {
+  amount: '5000',
+  currency: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+  chainId: 8453,
+  recipient: '0x209693Bc6afc0C5328bA36FaF03C514EF312287C',
+  id: 'extract-charge',
+} satisfies ChallengeTerms
+
+/**
+ * Directly represented OpenAPI 3.1 document for `GET /extract`.
+ *
+ * The operation requires query `url`. The JSON 200 schema requires `ok`,
+ * `url`, and `title`. No `$ref`, composition, or extra success representation.
+ */
+export const extractOpenApiDocumentObject = {
+  openapi: '3.1.0',
+  info: {
+    title: 'Extract',
+    version: '1.0.0',
+  },
+  paths: {
+    '/extract': {
+      get: {
+        operationId: 'extract',
+        parameters: [
+          {
+            name: 'url',
+            in: 'query',
+            required: true,
+            schema: { type: 'string' },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Extracted page metadata',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  required: ['ok', 'url', 'title'],
+                  properties: {
+                    ok: { type: 'boolean' },
+                    url: { type: 'string' },
+                    title: { type: 'string' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+} as const
+
+/** Frozen OpenAPI 3.1 document bytes used for the digest and qualifier. */
+export const extractOpenApiDocument = JSON.stringify(extractOpenApiDocumentObject)
+
+export const extractOpenApiDigest = digestOpenApiDocument(extractOpenApiDocument)
+
+export const extractRequirement = {
+  method: extractMethod,
+  url: extractUrl,
+  challenge: extractChallengeTerms,
+  openApiDigest: extractOpenApiDigest,
+  operationPath: extractOperationPath,
+  operationMethod: 'get',
+  successStatus: extractSuccessStatus,
+  mediaType: extractMediaType,
+  requiredOutputPaths: extractRequiredOutputPaths,
+} satisfies ContractRequirement

--- a/examples/prepared-payment/src/index.ts
+++ b/examples/prepared-payment/src/index.ts
@@ -1,0 +1,34 @@
+export {
+  attachQualifiedCredential,
+  QualificationError,
+  toRequestInit,
+  type AttachQualifiedCredentialOptions,
+  type AttachedQualifiedCredential,
+  type PreparePaymentClient,
+} from './attach.js'
+export {
+  extractChallengeTerms,
+  extractMediaType,
+  extractMethod,
+  extractOpenApiDigest,
+  extractOpenApiDocument,
+  extractOpenApiDocumentObject,
+  extractOperationPath,
+  extractRequiredOutputPaths,
+  extractRequirement,
+  extractSuccessStatus,
+  extractUrl,
+} from './extract.js'
+export { digestOpenApiDocument, openApi31Dialect } from './openapi.js'
+export {
+  qualifyPreparedPayment,
+  type ChallengeTerms,
+  type ContractRequirement,
+  type FrozenRequest,
+  type QualifiedAuthorization,
+  type QualifyFailure,
+  type QualifyInput,
+  type QualifyResult,
+  type QualifySuccess,
+  type SelectedChallenge,
+} from './qualify.js'

--- a/examples/prepared-payment/src/openapi.ts
+++ b/examples/prepared-payment/src/openapi.ts
@@ -1,0 +1,15 @@
+import { createHash } from 'node:crypto'
+
+/** Default JSON Schema dialect advertised by OpenAPI 3.1. */
+export const openApi31Dialect = 'https://spec.openapis.org/oas/3.1/dialect/base'
+
+/**
+ * Returns the stable SHA-256 hex digest of frozen OpenAPI document bytes.
+ *
+ * The digest is buyer-side authorization evidence. It is not an MPP field and
+ * is not written into a payment challenge.
+ */
+export function digestOpenApiDocument(document: string | Uint8Array): string {
+  const bytes = typeof document === 'string' ? new TextEncoder().encode(document) : document
+  return createHash('sha256').update(bytes).digest('hex')
+}

--- a/examples/prepared-payment/src/qualify.ts
+++ b/examples/prepared-payment/src/qualify.ts
@@ -1,0 +1,343 @@
+import { digestOpenApiDocument, openApi31Dialect } from './openapi.js'
+
+/** Buyer-authorized challenge identity and economic or network terms. */
+export type ChallengeTerms = {
+  id: string
+  amount: string
+  currency: string
+  chainId?: number
+  network?: string
+  recipient?: string
+}
+
+/** Frozen HTTP request the buyer is willing to authenticate. */
+export type FrozenRequest = {
+  method: string
+  url: string
+  headers?: HeadersInit
+  body?: BodyInit | null
+}
+
+/** Buyer-owned request, challenge, and OpenAPI 3.1 success contract. */
+export type ContractRequirement = {
+  method: string
+  url: string
+  challenge: ChallengeTerms
+  openApiDigest?: string
+  operationPath: string
+  operationMethod: string
+  successStatus: string
+  mediaType: string
+  requiredOutputPaths: readonly string[]
+}
+
+/** Selected challenge fields the qualifier is allowed to read. */
+export type SelectedChallenge = {
+  id: string
+  request: Record<string, unknown>
+}
+
+export type QualifyInput = {
+  request: FrozenRequest
+  challenge: SelectedChallenge
+  openApiDocument: string | Uint8Array
+  required: ContractRequirement
+}
+
+/**
+ * Buyer-side authorization evidence recorded after every gate passes.
+ *
+ * MPP binds challenge fields only. This object is application evidence; it is
+ * not a protocol-level binding of the HTTP request or output contract.
+ */
+export type QualifiedAuthorization = {
+  method: string
+  url: string
+  challengeId: string
+  challengeTerms: ChallengeTerms
+  openApiDigest: string
+  operationPath: string
+  operationMethod: string
+  successStatus: string
+  mediaType: string
+  schemaPointer: string
+  requiredOutputPaths: readonly string[]
+}
+
+export type QualifySuccess = {
+  ok: true
+  authorization: QualifiedAuthorization
+}
+
+export type QualifyFailure = {
+  ok: false
+  reason: string
+}
+
+export type QualifyResult = QualifySuccess | QualifyFailure
+
+const httpMethods = new Set(['get', 'put', 'post', 'delete', 'patch', 'options', 'head', 'trace'])
+
+const unsupportedSchemaKeys = new Set([
+  '$ref',
+  '$dynamicRef',
+  '$recursiveRef',
+  'allOf',
+  'oneOf',
+  'anyOf',
+  'not',
+  'if',
+  'then',
+  'else',
+  'dependentSchemas',
+  'patternProperties',
+  'prefixItems',
+  'unevaluatedProperties',
+  'unevaluatedItems',
+  'discriminator',
+  '$defs',
+  'definitions',
+])
+
+/**
+ * Qualifies an inspected payment challenge against a frozen request and a
+ * bounded OpenAPI 3.1 success contract.
+ *
+ * Fail closed: unsupported `$ref`, composition, dialects, extra success
+ * representations, templated paths, or missing required output paths do not
+ * authorize credential creation. This is buyer-side application binding.
+ * MPP does not cryptographically bind HTTP method, path, query, or the output
+ * contract.
+ */
+export function qualifyPreparedPayment(input: QualifyInput): QualifyResult {
+  const { request, challenge, required } = input
+  if (request.method !== request.method.toUpperCase() || request.method !== required.method) {
+    return fail('http method mismatch')
+  }
+  if (request.url !== required.url) return fail('url mismatch')
+
+  let parsedUrl: URL
+  try {
+    parsedUrl = new URL(request.url)
+  } catch {
+    return fail('url mismatch')
+  }
+  if (parsedUrl.pathname !== required.operationPath) return fail('path mismatch')
+
+  const selectedTerms = selectedChallengeTerms(challenge)
+  if (!selectedTerms) return fail('challenge terms mismatch')
+  if (selectedTerms.id !== required.challenge.id) return fail('challenge id mismatch')
+  if (!challengeTermsMatch(selectedTerms, required.challenge)) {
+    return fail('challenge terms mismatch')
+  }
+
+  const documentText = toDocumentText(input.openApiDocument)
+  const digest = digestOpenApiDocument(input.openApiDocument)
+  if (required.openApiDigest && required.openApiDigest !== digest) {
+    return fail('openapi digest mismatch')
+  }
+
+  let document: unknown
+  try {
+    document = JSON.parse(documentText)
+  } catch {
+    return fail('openapi parse error')
+  }
+  if (!isRecord(document)) return fail('openapi parse error')
+
+  const version = document.openapi
+  if (typeof version !== 'string' || !/^3\.1(\.\d+)?$/.test(version)) {
+    return fail('unsupported openapi version')
+  }
+  if (document.jsonSchemaDialect !== undefined && document.jsonSchemaDialect !== openApi31Dialect) {
+    return fail('unsupported json schema dialect')
+  }
+
+  if (required.operationPath.includes('{') || required.operationPath.includes('}')) {
+    return fail('unsupported path templating')
+  }
+  if (required.operationMethod !== required.method.toLowerCase()) {
+    return fail('ambiguous operation')
+  }
+
+  const paths = document.paths
+  if (!isRecord(paths)) return fail('operation not found')
+
+  let matchingLiteralPaths = 0
+  for (const pathKey of Object.keys(paths)) {
+    if (pathKey === required.operationPath && !pathKey.includes('{') && !pathKey.includes('}')) {
+      matchingLiteralPaths += 1
+    }
+  }
+  if (matchingLiteralPaths !== 1) return fail('ambiguous operation')
+
+  const pathItem = paths[required.operationPath]
+  if (!isRecord(pathItem)) return fail('operation not found')
+  const pathRefReason = unsupportedReason(
+    pathItem,
+    '#/paths/' + encodePointerToken(required.operationPath),
+  )
+  if (pathRefReason) return fail(pathRefReason)
+
+  const methodKeys = Object.keys(pathItem).filter((key) => httpMethods.has(key.toLowerCase()))
+  const matchingMethods = methodKeys.filter((key) => key.toLowerCase() === required.operationMethod)
+  if (matchingMethods.length !== 1) return fail('ambiguous operation')
+
+  const operation = pathItem[matchingMethods[0]!]
+  if (!isRecord(operation)) return fail('operation not found')
+  const operationPointer =
+    '#/paths/' +
+    encodePointerToken(required.operationPath) +
+    '/' +
+    encodePointerToken(matchingMethods[0]!)
+  const operationReason = unsupportedReason(operation, operationPointer)
+  if (operationReason) return fail(operationReason)
+
+  const responses = operation.responses
+  if (!isRecord(responses)) return fail('success status mismatch')
+  const successKeys = Object.keys(responses).filter(isSuccessStatusKey)
+  if (successKeys.length === 0) return fail('success status mismatch')
+  if (successKeys.length !== 1) return fail('extra success status')
+  if (successKeys[0] !== required.successStatus) return fail('success status mismatch')
+
+  const successResponse = responses[successKeys[0]!]
+  if (!isRecord(successResponse)) return fail('success status mismatch')
+  const responsePointer = operationPointer + '/responses/' + encodePointerToken(successKeys[0]!)
+  const responseReason = unsupportedReason(successResponse, responsePointer)
+  if (responseReason) return fail(responseReason)
+
+  const content = successResponse.content
+  if (!isRecord(content)) return fail('media type mismatch')
+  const mediaTypes = Object.keys(content)
+  if (mediaTypes.length === 0) return fail('media type mismatch')
+  if (mediaTypes.length !== 1) return fail('extra success media type')
+  if (mediaTypes[0] !== 'application/json') return fail('unsupported media type')
+  if (mediaTypes[0] !== required.mediaType) return fail('media type mismatch')
+
+  const media = content[mediaTypes[0]!]
+  if (!isRecord(media)) return fail('media type mismatch')
+  const mediaPointer = responsePointer + '/content/' + encodePointerToken(mediaTypes[0]!)
+  const mediaReason = unsupportedReason(media, mediaPointer)
+  if (mediaReason) return fail(mediaReason)
+
+  const schema = media.schema
+  if (!isRecord(schema)) return fail('unsupported schema representation')
+  const schemaPointer = mediaPointer + '/schema'
+  const schemaReason = unsupportedReason(schema, schemaPointer)
+  if (schemaReason) return fail(schemaReason)
+  if (schema.type !== 'object') return fail('unsupported schema representation')
+
+  for (const outputPath of required.requiredOutputPaths) {
+    if (!hasRequiredOutputPath(schema, outputPath)) return fail('missing required output path')
+  }
+
+  return {
+    ok: true,
+    authorization: {
+      method: required.method,
+      url: required.url,
+      challengeId: selectedTerms.id,
+      challengeTerms: selectedTerms,
+      openApiDigest: digest,
+      operationPath: required.operationPath,
+      operationMethod: required.operationMethod,
+      successStatus: required.successStatus,
+      mediaType: required.mediaType,
+      schemaPointer,
+      requiredOutputPaths: required.requiredOutputPaths,
+    },
+  }
+}
+
+function fail(reason: string): QualifyFailure {
+  return { ok: false, reason }
+}
+
+function toDocumentText(document: string | Uint8Array): string {
+  return typeof document === 'string' ? document : new TextDecoder().decode(document)
+}
+
+function selectedChallengeTerms(challenge: SelectedChallenge): ChallengeTerms | undefined {
+  const request = challenge.request
+  if (typeof request.amount !== 'string' || typeof request.currency !== 'string') return undefined
+  const details = isRecord(request.methodDetails) ? request.methodDetails : undefined
+  const chainId = firstDefined(request.chainId, details?.chainId)
+  const network = firstDefined(request.network, details?.network)
+  const recipient = firstDefined(request.recipient, details?.recipient)
+  if (chainId !== undefined && typeof chainId !== 'number') return undefined
+  if (network !== undefined && typeof network !== 'string') return undefined
+  if (recipient !== undefined && typeof recipient !== 'string') return undefined
+  return {
+    id: challenge.id,
+    amount: request.amount,
+    currency: request.currency,
+    ...(typeof chainId === 'number' ? { chainId } : {}),
+    ...(typeof network === 'string' ? { network } : {}),
+    ...(typeof recipient === 'string' ? { recipient } : {}),
+  }
+}
+
+function challengeTermsMatch(selected: ChallengeTerms, required: ChallengeTerms): boolean {
+  return (
+    selected.amount === required.amount &&
+    selected.currency === required.currency &&
+    selected.chainId === required.chainId &&
+    selected.network === required.network &&
+    selected.recipient === required.recipient
+  )
+}
+
+function firstDefined(left: unknown, right: unknown): unknown {
+  return left !== undefined ? left : right
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function isSuccessStatusKey(key: string): boolean {
+  return /^2\d\d$/.test(key) || key.toUpperCase() === '2XX'
+}
+
+function encodePointerToken(token: string): string {
+  return token.replace(/~/g, '~0').replace(/\//g, '~1')
+}
+
+function unsupportedReason(value: unknown, pointer: string): string | undefined {
+  if (Array.isArray(value)) {
+    for (const [index, item] of value.entries()) {
+      const reason = unsupportedReason(item, pointer + '/' + index)
+      if (reason) return reason
+    }
+    return undefined
+  }
+  if (!isRecord(value)) return undefined
+  for (const key of Object.keys(value)) {
+    if (key === '$ref' || key === '$dynamicRef' || key === '$recursiveRef') {
+      return 'unsupported $ref'
+    }
+    if (key === 'allOf' || key === 'oneOf' || key === 'anyOf' || key === 'not') {
+      return 'unsupported composition'
+    }
+    if (unsupportedSchemaKeys.has(key) && key.startsWith('$') === false) {
+      return 'unsupported schema representation'
+    }
+    const reason = unsupportedReason(value[key], pointer + '/' + encodePointerToken(key))
+    if (reason) return reason
+  }
+  return undefined
+}
+
+function hasRequiredOutputPath(schema: Record<string, unknown>, outputPath: string): boolean {
+  if (!outputPath) return false
+  let current: Record<string, unknown> | undefined = schema
+  for (const segment of outputPath.split('.')) {
+    if (!current || current.type !== 'object') return false
+    const required: unknown = current.required
+    if (!Array.isArray(required) || !required.includes(segment)) return false
+    const properties: unknown = current.properties
+    if (!isRecord(properties) || !isRecord(properties[segment])) return false
+    current = properties[segment]
+  }
+  return true
+}

--- a/examples/prepared-payment/tsconfig.json
+++ b/examples/prepared-payment/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "types": ["node"],
+    "noEmit": true,
+    "paths": {
+      "mppx": ["../../src/index.ts"],
+      "mppx/*": ["../../src/*/index.ts"]
+    }
+  },
+  "include": ["src/**/*"]
+}

--- a/src/client/prepared-payment.example.test.ts
+++ b/src/client/prepared-payment.example.test.ts
@@ -1,0 +1,396 @@
+import { Challenge, Credential, Errors, Method } from 'mppx'
+import { Mppx } from 'mppx/client'
+import { Methods } from 'mppx/tempo'
+import { afterEach, describe, expect, test, vi } from 'vp/test'
+
+import {
+  attachQualifiedCredential,
+  QualificationError,
+  toRequestInit,
+} from '../../examples/prepared-payment/src/attach.js'
+import {
+  extractOpenApiDocument,
+  extractOpenApiDocumentObject,
+  extractRequirement,
+  extractUrl,
+} from '../../examples/prepared-payment/src/extract.js'
+import { digestOpenApiDocument } from '../../examples/prepared-payment/src/openapi.js'
+import {
+  qualifyPreparedPayment,
+  type ContractRequirement,
+} from '../../examples/prepared-payment/src/qualify.js'
+
+afterEach(() => {
+  Mppx.restore()
+  vi.useRealTimers()
+})
+
+function paymentMethod() {
+  const createCredential = vi.fn(async ({ challenge }) =>
+    Credential.serialize({
+      challenge,
+      payload: { signature: '0xsignature', type: 'transaction' },
+    }),
+  )
+  const method = Method.toClient(
+    Method.from({
+      name: 'evm',
+      intent: 'charge',
+      schema: Methods.charge.schema,
+    }),
+    { createCredential },
+  )
+  return { createCredential, method }
+}
+
+function paymentChallenge(overrides: Record<string, unknown> = {}) {
+  return Challenge.from({
+    expires: new Date(Date.now() + 60_000).toISOString(),
+    id: extractRequirement.challenge.id,
+    intent: 'charge',
+    method: 'evm',
+    realm: 'seller.example',
+    request: {
+      amount: extractRequirement.challenge.amount,
+      currency: extractRequirement.challenge.currency,
+      chainId: extractRequirement.challenge.chainId,
+      recipient: extractRequirement.challenge.recipient,
+    },
+    ...overrides,
+  })
+}
+
+function frozenRequest(url = extractUrl, method = extractRequirement.method) {
+  return { method, url }
+}
+
+function createClient(
+  method: ReturnType<typeof paymentMethod>['method'],
+  challenge: Challenge.Challenge,
+) {
+  const fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const headers = new Headers(init?.headers)
+    if (headers.has('Authorization')) {
+      throw new Error('test refused to send an authenticated request')
+    }
+    return new Response(null, {
+      headers: { 'WWW-Authenticate': Challenge.serialize(challenge) },
+      status: 402,
+    })
+  })
+  const mppx = Mppx.create({
+    fetch: fetch as typeof globalThis.fetch,
+    methods: [method],
+    polyfill: false,
+  })
+  return { fetch, mppx }
+}
+
+function mutateDocument(
+  mutate: (document: Record<string, any>) => void,
+  base: unknown = extractOpenApiDocumentObject,
+) {
+  const document = structuredClone(base)
+  mutate(document as Record<string, any>)
+  return JSON.stringify(document)
+}
+
+describe('prepared-payment example', () => {
+  test('behavior: qualifies the frozen request and attaches one credential without sending', async () => {
+    const { createCredential, method } = paymentMethod()
+    const challenge = paymentChallenge()
+    const { fetch, mppx } = createClient(method, challenge)
+    const request = frozenRequest()
+
+    const response = await mppx.rawFetch(request.url, toRequestInit(request))
+    const attached = await attachQualifiedCredential({
+      mppx,
+      request,
+      response,
+      openApiDocument: extractOpenApiDocument,
+      required: extractRequirement,
+    })
+
+    expect(createCredential).toHaveBeenCalledTimes(1)
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(attached.sent).toBe(false)
+    expect(attached.authorization.method).toBe('GET')
+    expect(attached.authorization.url).toBe(extractUrl)
+    expect(attached.authorization.challengeId).toBe(extractRequirement.challenge.id)
+    expect(attached.authorization.openApiDigest).toBe(digestOpenApiDocument(extractOpenApiDocument))
+    expect(attached.authorization.schemaPointer).toBe(
+      '#/paths/~1extract/get/responses/200/content/application~1json/schema',
+    )
+    const authorization = new Headers(attached.authenticatedRequest.headers).get('Authorization')
+    expect(authorization).toMatch(/^Payment /)
+    expect(authorization).toBe(attached.credential)
+    expect(attached.authenticatedRequest.method).toBe(request.method)
+  })
+
+  async function expectNoSign(
+    request: { method: string; url: string },
+    required: ContractRequirement,
+    openApiDocument = extractOpenApiDocument,
+    challenge = paymentChallenge(),
+  ) {
+    const { createCredential, method } = paymentMethod()
+    const { fetch, mppx } = createClient(method, challenge)
+    const response = await mppx.rawFetch(request.url, toRequestInit(request))
+    await expect(
+      attachQualifiedCredential({
+        mppx,
+        request,
+        response,
+        openApiDocument,
+        required,
+      }),
+    ).rejects.toThrow(QualificationError)
+    expect(createCredential).toHaveBeenCalledTimes(0)
+    expect(fetch).toHaveBeenCalledTimes(1)
+  }
+
+  test('behavior: method mismatch does not create a credential', async () => {
+    await expectNoSign({ method: 'POST', url: extractUrl }, extractRequirement)
+  })
+
+  test('behavior: path mismatch does not create a credential', async () => {
+    await expectNoSign(
+      { method: 'GET', url: 'https://seller.example/other?url=https%3A%2F%2Fexample.com' },
+      extractRequirement,
+    )
+  })
+
+  test('behavior: query value mismatch does not create a credential', async () => {
+    await expectNoSign(
+      { method: 'GET', url: 'https://seller.example/extract?url=https%3A%2F%2Fother.example' },
+      extractRequirement,
+    )
+  })
+
+  test('behavior: query order mismatch does not create a credential', async () => {
+    const url = 'https://seller.example/extract?url=https%3A%2F%2Fexample.com&fresh=1'
+    const reordered = 'https://seller.example/extract?fresh=1&url=https%3A%2F%2Fexample.com'
+    await expectNoSign({ method: 'GET', url: reordered }, { ...extractRequirement, url })
+  })
+
+  test('behavior: selected challenge id mismatch does not create a credential', async () => {
+    await expectNoSign(frozenRequest(), {
+      ...extractRequirement,
+      challenge: { ...extractRequirement.challenge, id: 'other-id' },
+    })
+  })
+
+  test('behavior: challenge economic term mismatch does not create a credential', async () => {
+    await expectNoSign(frozenRequest(), {
+      ...extractRequirement,
+      challenge: { ...extractRequirement.challenge, amount: '1' },
+    })
+  })
+
+  test('behavior: challenge network term mismatch does not create a credential', async () => {
+    await expectNoSign(frozenRequest(), {
+      ...extractRequirement,
+      challenge: {
+        ...extractRequirement.challenge,
+        recipient: '0x0000000000000000000000000000000000000001',
+      },
+    })
+  })
+
+  test('behavior: OpenAPI version mismatch does not create a credential', async () => {
+    const document = mutateDocument((current) => {
+      current.openapi = '3.0.3'
+    })
+    await expectNoSign(
+      frozenRequest(),
+      {
+        ...extractRequirement,
+        openApiDigest: digestOpenApiDocument(document),
+      },
+      document,
+    )
+  })
+
+  test('behavior: unknown OpenAPI dialect does not create a credential', async () => {
+    const document = mutateDocument((current) => {
+      current.jsonSchemaDialect = 'https://json-schema.org/draft/2020-12/schema'
+    })
+    await expectNoSign(
+      frozenRequest(),
+      {
+        ...extractRequirement,
+        openApiDigest: digestOpenApiDocument(document),
+      },
+      document,
+    )
+  })
+
+  test('behavior: missing required output path does not create a credential', async () => {
+    await expectNoSign(frozenRequest(), {
+      ...extractRequirement,
+      requiredOutputPaths: ['ok', 'url', 'title', 'missing'],
+    })
+  })
+
+  test('behavior: extra successful status does not create a credential', async () => {
+    const document = mutateDocument((current) => {
+      current.paths['/extract'].get.responses['201'] = {
+        description: 'Created',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              required: ['ok', 'url', 'title'],
+              properties: {
+                ok: { type: 'boolean' },
+                url: { type: 'string' },
+                title: { type: 'string' },
+              },
+            },
+          },
+        },
+      }
+    })
+    await expectNoSign(
+      frozenRequest(),
+      {
+        ...extractRequirement,
+        openApiDigest: digestOpenApiDocument(document),
+      },
+      document,
+    )
+  })
+
+  test('behavior: media type mismatch does not create a credential', async () => {
+    const document = mutateDocument((current) => {
+      const content = current.paths['/extract'].get.responses['200'].content
+      content['text/plain'] = content['application/json']
+      delete content['application/json']
+    })
+    await expectNoSign(
+      frozenRequest(),
+      {
+        ...extractRequirement,
+        openApiDigest: digestOpenApiDocument(document),
+      },
+      document,
+    )
+  })
+
+  test('behavior: unsupported schema composition does not create a credential', async () => {
+    const document = mutateDocument((current) => {
+      const schema =
+        current.paths['/extract'].get.responses['200'].content['application/json'].schema
+      current.paths['/extract'].get.responses['200'].content['application/json'].schema = {
+        oneOf: [schema],
+      }
+    })
+    await expectNoSign(
+      frozenRequest(),
+      {
+        ...extractRequirement,
+        openApiDigest: digestOpenApiDocument(document),
+      },
+      document,
+    )
+  })
+
+  test('behavior: unsupported dollar-ref does not create a credential', async () => {
+    const document = mutateDocument((current) => {
+      current.paths['/extract'].get.responses['200'].content['application/json'].schema = {
+        $ref: '#/components/schemas/Extract',
+      }
+    })
+    await expectNoSign(
+      frozenRequest(),
+      {
+        ...extractRequirement,
+        openApiDigest: digestOpenApiDocument(document),
+      },
+      document,
+    )
+  })
+
+  test('behavior: extra success media type does not create a credential', async () => {
+    const document = mutateDocument((current) => {
+      current.paths['/extract'].get.responses['200'].content['text/plain'] = {
+        schema: { type: 'string' },
+      }
+    })
+    await expectNoSign(
+      frozenRequest(),
+      {
+        ...extractRequirement,
+        openApiDigest: digestOpenApiDocument(document),
+      },
+      document,
+    )
+  })
+
+  test('behavior: preparation alone does not create a credential', async () => {
+    const { createCredential, method } = paymentMethod()
+    const { fetch, mppx } = createClient(method, paymentChallenge())
+    const request = frozenRequest()
+    const response = await mppx.rawFetch(request.url, toRequestInit(request))
+    const prepared = await mppx.preparePayment(response, { request: toRequestInit(request) })
+
+    expect(Object.isFrozen(prepared)).toBe(true)
+    expect(Object.isFrozen(prepared.challenge)).toBe(true)
+    expect(prepared.challenge.id).toBe(extractRequirement.challenge.id)
+    expect(createCredential).toHaveBeenCalledTimes(0)
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  test('behavior: repeated createCredential after qualify invokes the creator once', async () => {
+    const { createCredential, method } = paymentMethod()
+    const { fetch, mppx } = createClient(method, paymentChallenge())
+    const request = frozenRequest()
+    const response = await mppx.rawFetch(request.url, toRequestInit(request))
+    const prepared = await mppx.preparePayment(response, { request: toRequestInit(request) })
+    const qualified = qualifyPreparedPayment({
+      request,
+      challenge: prepared.challenge,
+      openApiDocument: extractOpenApiDocument,
+      required: extractRequirement,
+    })
+    expect(qualified.ok).toBe(true)
+
+    const [first, second] = await Promise.all([
+      prepared.createCredential(),
+      prepared.createCredential(),
+    ])
+    const third = await prepared.createCredential()
+
+    expect(first).toBe(second)
+    expect(second).toBe(third)
+    expect(createCredential).toHaveBeenCalledTimes(1)
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  test('behavior: rechecks expiration before deferred credential creation', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+    const { createCredential, method } = paymentMethod()
+    const challenge = paymentChallenge({
+      expires: '2026-01-01T00:00:01.000Z',
+    })
+    const { fetch, mppx } = createClient(method, challenge)
+    const request = frozenRequest()
+    const response = await mppx.rawFetch(request.url, toRequestInit(request))
+    const prepared = await mppx.preparePayment(response, { request: toRequestInit(request) })
+    const qualified = qualifyPreparedPayment({
+      request,
+      challenge: prepared.challenge,
+      openApiDocument: extractOpenApiDocument,
+      required: extractRequirement,
+    })
+    expect(qualified.ok).toBe(true)
+    expect(createCredential).toHaveBeenCalledTimes(0)
+
+    vi.setSystemTime(new Date('2026-01-01T00:00:02.000Z'))
+
+    await expect(prepared.createCredential()).rejects.toThrow(Errors.PaymentExpiredError)
+    expect(createCredential).toHaveBeenCalledTimes(0)
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary

- add a bounded example that uses the exported `preparePayment()` seam to inspect an immutable selected challenge before credential creation
- qualify one frozen HTTP request and a deliberately narrow OpenAPI 3.1 success contract before calling `createCredential()`
- attach the credential to the original request and stop without sending an authenticated request
- add a focused oracle test covering exact matches, hostile mismatches, expiry, preparation without signing, and concurrent credential creation

## Boundary

MPP binds the selected challenge fields. This example records buyer-side application evidence for the HTTP request and output contract. It does not claim that MPP cryptographically binds the HTTP method, URL, query, body, or OpenAPI contract.

The change is example, documentation, changeset, and focused test only. It does not modify MPPx core, exports, transport, or credential semantics.

## Validation

```text
VITE_TEMPO_NETWORK=none vp test src/client/prepared-payment.example.test.ts --project node
19 passed
```

An independent controller replay also exercised 19 matching, mismatch, expiry, and concurrency cases against the real exported `Mppx.create().preparePayment()` path. Every mismatch and preparation-only case kept credential creation at zero. The matching and concurrent paths created one credential and sent no authenticated request.

AI assistance: implementation used Grok Bot. I independently reviewed the exact tree, replayed the load-bearing tests, and signed this commit.
