### PR TITLE
fix(tempo): route hosted fee payer through transport

### DIFF
--- a/.changeset/calm-feepayers-route.md
+++ b/.changeset/calm-feepayers-route.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Routed hosted Tempo fee-payer fills through the configured `withFeePayer` transport and broadcast completed transactions through the default RPC transport.

--- a/src/tempo/internal/fee-payer.test.ts
+++ b/src/tempo/internal/fee-payer.test.ts
@@ -504,7 +504,6 @@ describe('fillHostedFeePayerTransaction', () => {
   const hostedContext = {
     chainId: defaults.chainId.mainnet,
     details,
-    remoteFeePayer: { url: 'https://sponsor.example/tp_key' },
   } as const
 
   test('uses hosted fillTransaction and preserves sender-committed fields', async () => {
@@ -517,10 +516,8 @@ describe('fillHostedFeePayerTransaction', () => {
     )
     let realFeePayerSignature: ReturnType<typeof Secp256k1.sign> | undefined
 
-    const calls: { init?: RequestInit | undefined; input: RequestInfo | URL }[] = []
-    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      calls.push({ init, input })
-      const rpc = JSON.parse(init!.body as string).params[0]
+    const request = vi.fn(async (args: any) => {
+      const rpc = args.params[0]
       const quantity = (value: unknown) =>
         value === undefined ? undefined : BigInt(value as string)
       realFeePayerSignature = Secp256k1.sign({
@@ -556,38 +553,19 @@ describe('fillHostedFeePayerTransaction', () => {
         ),
         privateKey: sponsorPrivateKey,
       })
-      return new Response(
-        JSON.stringify(
-          {
-            result: {
-              tx: {
-                feePayerSignature: realFeePayerSignature,
-                feeToken: defaults.tokens.pathUsd,
-                gas: '0x1',
-                maxFeePerGas: '0x2',
-              },
-            },
-          },
-          (key, value) => {
-            if (key === 'yParity') return toHex(value)
-            return typeof value === 'bigint' ? toHex(value) : value
-          },
-        ),
-      )
+      return {
+        tx: {
+          feePayerSignature: realFeePayerSignature,
+          feeToken: defaults.tokens.pathUsd,
+          gas: '0x1',
+          maxFeePerGas: '0x2',
+        },
+      }
     })
-    vi.stubGlobal('fetch', fetchMock)
-
-    const remoteFeePayer = {
-      url: 'https://sponsor.example/tp_key',
-      headers: {
-        Authorization: 'Bearer test',
-        'Content-Type': 'text/plain',
-      },
-    } as const
     const result = await fillHostedFeePayerTransaction({
       allowedFeeTokens: defaultAllowedFeeTokens(defaults.chainId.mainnet),
       ...hostedContext,
-      remoteFeePayer,
+      request,
       transaction: hostedTransaction as any,
     })
 
@@ -595,18 +573,9 @@ describe('fillHostedFeePayerTransaction', () => {
     expect(result.feePayer.toLowerCase()).toBe(sponsorAddress.toLowerCase())
     const serialized = result.serializedTransaction
 
-    expect(fetchMock).toHaveBeenCalledOnce()
-    expect(calls[0]!.input).toBe('https://sponsor.example/tp_key')
-    const requestHeaders = new Headers(calls[0]!.init!.headers)
-    expect(requestHeaders.get('authorization')).toBe('Bearer test')
-    expect(requestHeaders.get('content-type')).toBe('application/json')
-    expect(remoteFeePayer.headers).toEqual({
-      Authorization: 'Bearer test',
-      'Content-Type': 'text/plain',
-    })
-    const body = JSON.parse(calls[0]!.init!.body as string)
+    expect(request).toHaveBeenCalledOnce()
+    const body = request.mock.calls[0]![0]
     expect(body).toMatchObject({
-      jsonrpc: '2.0',
       method: 'eth_fillTransaction',
     })
     expect(body.params[0]).toMatchObject({
@@ -638,102 +607,82 @@ describe('fillHostedFeePayerTransaction', () => {
   })
 
   test('error: requires hosted fee payer to return a feeToken', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () => new Response(JSON.stringify({ result: { tx: { feePayerSignature } } }))),
-    )
-
     await expect(
       fillHostedFeePayerTransaction({
         allowedFeeTokens: defaultAllowedFeeTokens(defaults.chainId.mainnet),
         ...hostedContext,
+        request: vi.fn(async () => ({ tx: { feePayerSignature } })),
         transaction: hostedTransaction as any,
       }),
     ).rejects.toThrow('did not return a feeToken')
   })
 
   test('error: rejects hosted feeToken outside the allowlist', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(
-        async () =>
-          new Response(
-            JSON.stringify({
-              result: { tx: { feePayerSignature, feeToken: swapTokenIn } },
-            }),
-          ),
-      ),
-    )
-
     await expect(
       fillHostedFeePayerTransaction({
         allowedFeeTokens: defaultAllowedFeeTokens(defaults.chainId.mainnet),
         ...hostedContext,
+        request: vi.fn(async () => ({
+          tx: { feePayerSignature, feeToken: swapTokenIn },
+        })),
         transaction: hostedTransaction as any,
       }),
     ).rejects.toThrow('feeToken is not allowed')
   })
 
   test('error: surfaces hosted fee payer errors', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(
-        async () =>
-          new Response(JSON.stringify({ error: { message: 'Invalid or revoked API key' } }), {
-            status: 401,
-          }),
-      ),
-    )
-
     await expect(
       fillHostedFeePayerTransaction({
         allowedFeeTokens: defaultAllowedFeeTokens(defaults.chainId.mainnet),
         ...hostedContext,
+        request: vi.fn(async () => {
+          throw new Error('Invalid or revoked API key')
+        }),
         transaction: hostedTransaction as any,
       }),
     ).rejects.toThrow('Invalid or revoked API key')
   })
 
   test('error: enforces sponsor policy before requesting hosted fill', async () => {
-    const fetchMock = vi.fn()
-    vi.stubGlobal('fetch', fetchMock)
+    const request = vi.fn()
 
     await expect(
       fillHostedFeePayerTransaction({
         allowedFeeTokens: defaultAllowedFeeTokens(defaults.chainId.mainnet),
         ...hostedContext,
         policy: { maxGas: hostedTransaction.gas - 1n },
+        request,
         transaction: hostedTransaction as any,
       }),
     ).rejects.toThrow('gas exceeds sponsor policy')
-    expect(fetchMock).not.toHaveBeenCalled()
+    expect(request).not.toHaveBeenCalled()
   })
 
   test('error: rejects non-empty access lists before requesting hosted fill', async () => {
-    const fetchMock = vi.fn()
-    vi.stubGlobal('fetch', fetchMock)
+    const request = vi.fn()
 
     await expect(
       fillHostedFeePayerTransaction({
         allowedFeeTokens: defaultAllowedFeeTokens(defaults.chainId.mainnet),
         ...hostedContext,
+        request,
         transaction: {
           ...hostedTransaction,
           accessList: [{ address: bogus, storageKeys: [] }],
         } as any,
       }),
     ).rejects.toThrow('accessList is not allowed')
-    expect(fetchMock).not.toHaveBeenCalled()
+    expect(request).not.toHaveBeenCalled()
   })
 
   test('error: rejects padded calldata before requesting hosted fill', async () => {
-    const fetchMock = vi.fn()
-    vi.stubGlobal('fetch', fetchMock)
+    const request = vi.fn()
 
     await expect(
       fillHostedFeePayerTransaction({
         allowedFeeTokens: defaultAllowedFeeTokens(defaults.chainId.mainnet),
         ...hostedContext,
+        request,
         transaction: {
           ...hostedTransaction,
           calls: [
@@ -745,7 +694,7 @@ describe('fillHostedFeePayerTransaction', () => {
         } as any,
       }),
     ).rejects.toThrow('calldata is not canonical')
-    expect(fetchMock).not.toHaveBeenCalled()
+    expect(request).not.toHaveBeenCalled()
   })
 })
 

--- a/src/tempo/internal/fee-payer.ts
+++ b/src/tempo/internal/fee-payer.ts
@@ -8,7 +8,6 @@ import { Abis, Addresses, Transaction } from 'viem/tempo'
 
 import * as TempoAddress_internal from './address.js'
 import * as defaults from './defaults.js'
-import * as RemoteFeePayer from './remote-fee-payer.js'
 import * as Selectors from './selectors.js'
 
 /** Returns true if the serialized transaction has a Tempo envelope prefix. */
@@ -45,13 +44,10 @@ export type Policy = {
 // Tempo transaction fields.
 type SponsoredTransaction = ReturnType<(typeof Transaction)['deserialize']>
 
-type HostedFeePayerFillResponse = {
-  error?: { message?: string | undefined } | undefined
-  result?: {
-    tx?: {
-      feePayerSignature?: unknown
-      feeToken?: unknown
-    }
+type HostedFeePayerFillResult = {
+  tx?: {
+    feePayerSignature?: unknown
+    feeToken?: unknown
   }
 }
 
@@ -172,8 +168,8 @@ function hostedFeePayerRequest(transaction: SponsoredTransaction) {
 }
 
 /**
- * Co-signs a sender-signed partial sponsorship envelope using a hosted
- * fee-payer endpoint without letting the endpoint mutate sender-committed
+ * Co-signs a sender-signed partial sponsorship envelope through a hosted
+ * fee-payer transport without letting the endpoint mutate sender-committed
  * transaction fields.
  *
  * @returns The serialized co-signed transaction plus the sponsor's recovered
@@ -185,19 +181,15 @@ export async function fillHostedFeePayerTransaction(parameters: {
   challengeExpires?: string | undefined
   chainId: number
   details: Record<string, string>
-  remoteFeePayer: RemoteFeePayer.Config
   policy?: Partial<Policy> | undefined
+  request: (args: {
+    method: 'eth_fillTransaction'
+    params: readonly [ReturnType<typeof hostedFeePayerRequest>]
+  }) => Promise<unknown>
   transaction: SponsoredTransaction
 }) {
-  const {
-    allowedFeeTokens,
-    challengeExpires,
-    chainId,
-    details,
-    remoteFeePayer,
-    policy,
-    transaction,
-  } = parameters
+  const { allowedFeeTokens, challengeExpires, chainId, details, policy, request, transaction } =
+    parameters
   assertTransactionPolicy({
     challengeExpires,
     chainId,
@@ -205,31 +197,13 @@ export async function fillHostedFeePayerTransaction(parameters: {
     policy,
     transaction,
   })
-  const response = await fetch(remoteFeePayer.url, {
-    body: JSON.stringify(
-      {
-        id: 1,
-        jsonrpc: '2.0',
-        method: 'eth_fillTransaction',
-        params: [hostedFeePayerRequest(transaction)],
-      },
-      (_key, value) => (typeof value === 'bigint' ? toHex(value) : value),
-    ),
-    headers: {
-      ...RemoteFeePayer.resolveHeaders(remoteFeePayer),
-      'content-type': 'application/json',
-    },
-    method: 'POST',
-  })
-  const payload = (await response.json().catch(async () => ({
-    error: { message: await response.text() },
-  }))) as HostedFeePayerFillResponse
-  const filled = payload.result?.tx
-  if (!response.ok || payload.error || !filled?.feePayerSignature)
-    throw new FeePayerValidationError(
-      payload.error?.message ?? 'hosted fee payer failed to sponsor transaction',
-      {},
-    )
+  const result = (await request({
+    method: 'eth_fillTransaction',
+    params: [hostedFeePayerRequest(transaction)],
+  })) as HostedFeePayerFillResult
+  const filled = result?.tx
+  if (!filled?.feePayerSignature)
+    throw new FeePayerValidationError('hosted fee payer failed to sponsor transaction', {})
   if (typeof filled.feeToken !== 'string')
     throw new FeePayerValidationError('hosted fee payer did not return a feeToken', {})
 

--- a/src/tempo/server/Charge.test.ts
+++ b/src/tempo/server/Charge.test.ts
@@ -2523,13 +2523,10 @@ describe('tempo', () => {
 
       const response = await mppx.fetch(httpServer.url)
       expect(response.status).toBe(200)
-      expect(feePayerRequests.map(({ method }) => method)).toEqual([
-        'eth_fillTransaction',
-        'eth_sendRawTransactionSync',
-      ])
-      expect(feePayerAuthorizations).toEqual(['Bearer test', 'Bearer test'])
+      expect(feePayerRequests.map(({ method }) => method)).toEqual(['eth_fillTransaction'])
+      expect(feePayerAuthorizations).toEqual(['Bearer test'])
       expect(feePayerHeaders).toEqual({ Authorization: 'Bearer test' })
-      expect(sequence).toEqual(['simulate', 'complete', 'simulate', 'relay-broadcast'])
+      expect(sequence).toEqual(['simulate', 'complete', 'simulate', 'broadcast'])
 
       const receipt = Receipt.fromResponse(response)
       expect(receipt.status).toBe('success')
@@ -2545,7 +2542,7 @@ describe('tempo', () => {
       const rejected = await mppx.fetch(httpServer.url)
 
       expect(rejected.status).not.toBe(200)
-      expect(feePayerRequests).toHaveLength(3)
+      expect(feePayerRequests).toHaveLength(2)
       expect(sequence.slice(0, 2)).toEqual(['simulate', 'complete'])
       expect(sequence).not.toContain('relay-broadcast')
 

--- a/src/tempo/server/Charge.ts
+++ b/src/tempo/server/Charge.ts
@@ -1,6 +1,5 @@
 import * as SignatureEnvelope from 'ox/tempo/SignatureEnvelope'
 import {
-  createClient,
   decodeFunctionData,
   formatUnits,
   keccak256,
@@ -532,13 +531,6 @@ export function charge<const parameters extends charge.Parameters>(
           let reservation: SponsorBudget.Handle | undefined
 
           try {
-            const broadcastClient =
-              remoteFeePayer && isFeePayerTx
-                ? createClient({
-                    chain: client.chain!,
-                    transport: Client.remoteFeePayerTransport(remoteFeePayer),
-                  })
-                : client
             const allowedFeeTokens = FeePayer.defaultAllowedFeeTokens(chainId)
             if (isFeePayerTx) FeePayer.assertAllowedFeeToken(transaction, allowedFeeTokens)
             const selectableFeeTokens = allowedFeeTokens as readonly `0x${string}`[]
@@ -591,8 +583,8 @@ export function charge<const parameters extends charge.Parameters>(
                       challengeExpires: expires,
                       chainId: chainId ?? client.chain!.id,
                       details: { amount, currency, recipient },
-                      remoteFeePayer,
                       policy: transactionFeePayerPolicy,
+                      request: (args) => client.request(args as never),
                       transaction,
                     })
                     return { ...hosted, transaction }
@@ -674,7 +666,7 @@ export function charge<const parameters extends charge.Parameters>(
 
             broadcastAttempted = true
             if (waitForConfirmation) {
-              const receipt = await sendRawTransactionSync(broadcastClient, {
+              const receipt = await sendRawTransactionSync(client, {
                 serializedTransaction: serializedTransaction_final,
               })
               if (reservation) await SponsorBudget.release(sponsorBudgetStore!, reservation)
@@ -698,7 +690,7 @@ export function charge<const parameters extends charge.Parameters>(
             // Optimistic path: broadcast without waiting for confirmation
             // (simulation above already ran). The returned receipt assumes
             // success — callers opt in via waitForConfirmation: false.
-            const reference = await sendRawTransaction(broadcastClient, {
+            const reference = await sendRawTransaction(client, {
               serializedTransaction: serializedTransaction_final,
             })
             if (reference.toLowerCase() !== finalHash.toLowerCase())


### PR DESCRIPTION
## Summary

- route hosted Tempo fee-payer fills through the client transport configured with `withFeePayer`
- broadcast the completed co-signed transaction through the default RPC transport
- update unit and integration coverage to assert sponsor-only fill routing and default-RPC broadcast

## Validation

- `pnpm check:types`
- `pnpm check:ci`
- focused transport and hosted-fill tests with `VITE_TEMPO_NETWORK=none`
- localnet-backed charge integration test added but not executed locally because Docker/Tempo RPC is unavailable in this sandbox

Prompted by: @jxom