### PR TITLE
fix: align MCP payment error codes with spec

### DIFF
--- a/.changeset/tidy-mcp-error-codes.md
+++ b/.changeset/tidy-mcp-error-codes.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed MCP payment errors to use the specification-defined JSON-RPC codes and retry verification challenges.

--- a/src/Errors.test.ts
+++ b/src/Errors.test.ts
@@ -7,6 +7,7 @@ import {
   ChannelNotFoundError,
   DeltaTooSmallError,
   InsufficientBalanceError,
+  InternalPaymentError,
   InvalidChallengeError,
   InvalidPayloadError,
   InvalidSignatureError,
@@ -146,6 +147,19 @@ describe('VerificationFailedError', () => {
     const error = new VerificationFailedError({ details: {} })
 
     expect(error.toProblemDetails()).not.toHaveProperty('details')
+  })
+})
+
+describe('InternalPaymentError', () => {
+  test('default', () => {
+    expect(errorSnapshot(new InternalPaymentError())).toMatchInlineSnapshot(`
+      {
+        "message": "An internal payment error occurred.",
+        "name": "InternalPaymentError",
+        "status": 500,
+        "type": "https://paymentauth.org/problems/internal-payment-error",
+      }
+    `)
   })
 })
 

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -144,6 +144,20 @@ export declare namespace VerificationFailedError {
 }
 
 /**
+ * Payment processing failed because of an unexpected internal error.
+ */
+export class InternalPaymentError extends PaymentError {
+  override readonly name = 'InternalPaymentError'
+  readonly title = 'Internal Payment Error'
+  override readonly status = 500
+  readonly type = 'https://paymentauth.org/problems/internal-payment-error'
+
+  constructor() {
+    super('An internal payment error occurred.')
+  }
+}
+
+/**
  * Payment requires additional action (e.g., 3DS authentication).
  */
 export class PaymentActionRequiredError extends PaymentError {

--- a/src/Mcp.ts
+++ b/src/Mcp.ts
@@ -1,6 +1,6 @@
 import type * as Challenge from './Challenge.js'
 import type * as Credential from './Credential.js'
-import type * as Errors from './Errors.js'
+import * as Errors from './Errors.js'
 import type { OneOf } from './internal/types.js'
 import type * as core_Receipt from './Receipt.js'
 
@@ -9,6 +9,26 @@ export const paymentRequiredCode = -32042
 
 /** MCP JSON-RPC error code for payment verification failed. */
 export const paymentVerificationFailedCode = -32043
+
+/** JSON-RPC error code for invalid parameters. */
+export const invalidParamsCode = -32602
+
+/** JSON-RPC error code for internal errors. */
+export const internalErrorCode = -32603
+
+/**
+ * Maps a payment error to its MCP JSON-RPC error code.
+ */
+export function errorCode(error?: Errors.PaymentError): number {
+  if (!error || error instanceof Errors.PaymentRequiredError) return paymentRequiredCode
+  if (
+    error instanceof Errors.MalformedCredentialError ||
+    error instanceof Errors.InvalidPayloadError
+  )
+    return invalidParamsCode
+  if (error instanceof Errors.InternalPaymentError) return internalErrorCode
+  return paymentVerificationFailedCode
+}
 
 /** MCP metadata key for credentials. */
 export const credentialMetaKey = 'org.paymentauth/credential'

--- a/src/client/internal/protocols/Mcp.test.ts
+++ b/src/client/internal/protocols/Mcp.test.ts
@@ -55,6 +55,15 @@ describe('mcp HTTP protocol', () => {
     expect(await getChallengeIds(jsonResponse(paymentRequired))).toEqual([challenge.id])
   })
 
+  test('extracts retry challenges from payment verification errors', async () => {
+    const response = jsonResponse({
+      ...paymentRequired,
+      error: { ...paymentRequired.error, code: Mcp.paymentVerificationFailedCode },
+    })
+
+    expect(await getChallengeIds(response)).toEqual([challenge.id])
+  })
+
   test('extracts all valid payment challenges', async () => {
     const alternate = { ...challenge, id: 'alternate' }
     const response = jsonResponse({

--- a/src/client/internal/protocols/Mcp.ts
+++ b/src/client/internal/protocols/Mcp.ts
@@ -87,7 +87,11 @@ export function paymentRequiredData(
 ): PaymentRequiredData | undefined {
   if (!message) return undefined
   if ('error' in message) {
-    if (message.error?.code !== Mcp.paymentRequiredCode) return undefined
+    if (
+      message.error?.code !== Mcp.paymentRequiredCode &&
+      message.error?.code !== Mcp.paymentVerificationFailedCode
+    )
+      return undefined
     return paymentRequiredDataFromValue(message.error.data)
   }
   return paymentRequiredDataFromValue(message.result?._meta?.[Mcp.paymentRequiredMetaKey])

--- a/src/mcp/client/McpClient.integration.test.ts
+++ b/src/mcp/client/McpClient.integration.test.ts
@@ -218,7 +218,7 @@ describe.runIf(isLocalnet)('McpClient.wrap integration', () => {
         expect(mismatch.content).toEqual([
           {
             type: 'text',
-            text: expect.stringContaining('challenge does not match route'),
+            text: expect.stringContaining('credential amount does not match'),
           },
         ])
 

--- a/src/mcp/client/McpClient.integration.test.ts
+++ b/src/mcp/client/McpClient.integration.test.ts
@@ -208,19 +208,19 @@ describe.runIf(isLocalnet)('McpClient.wrap integration', () => {
         const openReceipt = opened.receipt as SessionReceipt | undefined
         expect(openReceipt?.acceptedCumulative).toBe(chargeAmountRaw.toString())
 
-        const mismatch = await getPaymentRequiredError(
+        const mismatch = await callToolWithCredential(
           harness.sdkClient,
           'session_tool_double',
           openCredential,
         )
 
-        expect(mismatch.data.problem?.type).toBe(
-          'https://paymentauth.org/problems/invalid-challenge',
-        )
-        expect(mismatch.data.challenges).toHaveLength(1)
-        expect(mismatch.data.challenges[0]?.method).toBe('tempo')
-        expect(mismatch.data.challenges[0]?.intent).toBe('session')
-        expect(mismatch.data.challenges[0]?.request.amount).toBe(doubleSessionAmountRaw.toString())
+        expect(mismatch.isError).toBe(true)
+        expect(mismatch.content).toEqual([
+          {
+            type: 'text',
+            text: expect.stringContaining('challenge does not match route'),
+          },
+        ])
 
         const channel = await harness.sessionStore.getChannel(openReceipt!.channelId)
         expect(channel?.highestVoucherAmount).toBe(chargeAmountRaw)
@@ -414,13 +414,6 @@ type WrappedClient = {
 
 type SessionMethod = ReturnType<typeof tempo_session_client>
 type SessionChallenge = Parameters<SessionMethod['createCredential']>[0]['challenge']
-type PaymentRequiredMcpError = Error & {
-  data: {
-    challenges: SessionChallenge[]
-    problem?: { type?: string | undefined } | undefined
-  }
-}
-
 type Scenario = {
   name: string
   run: (harness: Harness) => Promise<void>
@@ -599,21 +592,6 @@ async function callToolWithCredential(
     ...result,
     receipt: result._meta?.[core_Mcp.receiptMetaKey] as McpClient.CallToolResult['receipt'],
   }
-}
-
-async function getPaymentRequiredError(
-  client: Client,
-  toolName: string,
-  serializedCredential: string,
-): Promise<PaymentRequiredMcpError> {
-  try {
-    await callToolWithCredential(client, toolName, serializedCredential)
-  } catch (error) {
-    if (!McpClient.isPaymentRequiredError(error)) throw error
-    return error as unknown as PaymentRequiredMcpError
-  }
-
-  throw new Error(`Expected ${toolName} to return a payment-required error`)
 }
 
 async function getTokenBalance(account: Address): Promise<bigint> {

--- a/src/mcp/client/McpClient.test.ts
+++ b/src/mcp/client/McpClient.test.ts
@@ -433,17 +433,21 @@ describe('McpClient.wrap (in-place)', () => {
 })
 
 describe('isPaymentRequiredError', () => {
-  test('returns true for McpError with payment code and challenges', () => {
-    const error = new McpError(core_Mcp.paymentRequiredCode, 'Payment Required', {
-      httpStatus: 402,
-      challenges: [{ id: 'test', method: 'tempo', intent: 'charge', realm: 'test', request: {} }],
-    })
-    expect(McpClient.isPaymentRequiredError(error)).toBe(true)
-  })
+  test.each([core_Mcp.paymentRequiredCode, core_Mcp.paymentVerificationFailedCode])(
+    'returns true for MCP payment error code %s with challenges',
+    (code) => {
+      const error = new McpError(code, 'Payment Required', {
+        httpStatus: 402,
+        challenges: [{ id: 'test', method: 'tempo', intent: 'charge', realm: 'test', request: {} }],
+      })
+      expect(McpClient.isPaymentRequiredError(error)).toBe(true)
+    },
+  )
 
   test('returns false for McpError with wrong code', () => {
     const error = new McpError(-32600, 'Invalid Request', {
-      challenges: [{ id: 'test', method: 'tempo' }],
+      httpStatus: 402,
+      challenges: [{ id: 'test', method: 'tempo', intent: 'charge', realm: 'test', request: {} }],
     })
     expect(McpClient.isPaymentRequiredError(error)).toBe(false)
   })

--- a/src/mcp/client/McpClient.test.ts
+++ b/src/mcp/client/McpClient.test.ts
@@ -307,6 +307,79 @@ describe('McpClient.wrap (in-place)', () => {
     expect(createCredential).toHaveBeenCalledOnce()
   })
 
+  test('behavior: retries a verification challenge from a credential-bearing call', async () => {
+    const challenge = createChallenge()
+    const createCredential = vi.fn(async ({ challenge }) =>
+      Credential.serialize({
+        challenge,
+        payload: { signature: '0xsignature', type: 'transaction' },
+      }),
+    )
+    const rawCallTool = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new McpError(core_Mcp.paymentRequiredCode, 'Payment Required', {
+          httpStatus: 402,
+          challenges: [challenge],
+        }),
+      )
+      .mockRejectedValueOnce(
+        new McpError(core_Mcp.paymentVerificationFailedCode, 'Verification Failed', {
+          httpStatus: 402,
+          challenges: [challenge],
+        }),
+      )
+      .mockResolvedValueOnce({
+        _meta: { [core_Mcp.receiptMetaKey]: createReceipt(challenge) },
+        content: [{ type: 'text', text: 'Premium tool executed' }],
+      })
+    const wrapped = McpClient.wrap(
+      { callTool: rawCallTool as Client['callTool'] },
+      { methods: [Method.toClient(Methods.charge, { createCredential })] },
+    )
+
+    const result = await wrapped.callTool({ name: 'premium_tool', arguments: {} })
+
+    expect(result.content).toEqual([{ type: 'text', text: 'Premium tool executed' }])
+    expect(result.receipt?.status).toBe('success')
+    expect(rawCallTool).toHaveBeenCalledTimes(3)
+    expect(createCredential).toHaveBeenCalledTimes(2)
+  })
+
+  test('behavior: limits repeated payment verification attempts', async () => {
+    const challenge = createChallenge()
+    const createCredential = vi.fn(async ({ challenge }) =>
+      Credential.serialize({
+        challenge,
+        payload: { signature: '0xsignature', type: 'transaction' },
+      }),
+    )
+    const verificationError = new McpError(
+      core_Mcp.paymentVerificationFailedCode,
+      'Verification Failed',
+      { httpStatus: 402, challenges: [challenge] },
+    )
+    const rawCallTool = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new McpError(core_Mcp.paymentRequiredCode, 'Payment Required', {
+          httpStatus: 402,
+          challenges: [challenge],
+        }),
+      )
+      .mockRejectedValue(verificationError)
+    const wrapped = McpClient.wrap(
+      { callTool: rawCallTool as Client['callTool'] },
+      { methods: [Method.toClient(Methods.charge, { createCredential })] },
+    )
+
+    await expect(wrapped.callTool({ name: 'premium_tool', arguments: {} })).rejects.toBe(
+      verificationError,
+    )
+    expect(rawCallTool).toHaveBeenCalledTimes(4)
+    expect(createCredential).toHaveBeenCalledTimes(3)
+  })
+
   test('behavior: preserves the MCP SDK callTool argument shape', async () => {
     const rawCallTool = vi.fn(async () => ({
       content: [{ type: 'text' as const, text: 'Free tool executed' }],

--- a/src/mcp/client/McpClient.ts
+++ b/src/mcp/client/McpClient.ts
@@ -18,6 +18,7 @@ type CallToolRequestOptions = Parameters<Client['callTool']>[2]
 type PaymentRequiredData = NonNullable<core_Mcp.ErrorObject['data']>
 
 const MPPX_MCP_CLIENT_WRAPPER = Symbol.for('mppx.mcp.client.wrapper')
+const maxPaymentAttempts = 3
 
 export type OnPaymentRequired = (challenge: Challenge.Challenge) => boolean | Promise<boolean>
 
@@ -201,7 +202,8 @@ function createPaymentAwareCallTool<methods extends Methods>(
     call: CallToolCall,
     paymentRequired: PaymentRequiredData,
     cause: unknown,
-  ) => {
+    attemptsRemaining = maxPaymentAttempts,
+  ): Promise<CallToolResult> => {
     const challenges = paymentRequired.challenges
     const candidates = AcceptPayment.selectChallengeCandidates(
       challenges,
@@ -236,19 +238,33 @@ function createPaymentAwareCallTool<methods extends Methods>(
     })
     const parsed = Credential.deserialize(credential)
 
-    const retryResult = await callTool(
-      {
-        ...params,
-        _meta: {
-          ...params._meta,
-          [core_Mcp.credentialMetaKey]: parsed,
+    try {
+      const retryResult = await callTool(
+        {
+          ...params,
+          _meta: {
+            ...params._meta,
+            [core_Mcp.credentialMetaKey]: parsed,
+          },
         },
-      },
-      call.resultSchema,
-      call.requestOptions,
-    )
+        call.resultSchema,
+        call.requestOptions,
+      )
 
-    return withReceipt(retryResult)
+      const nextPaymentRequired = getPaymentRequiredMeta(retryResult)
+      if (nextPaymentRequired && attemptsRemaining > 1)
+        return retryWithPayment(
+          params,
+          call,
+          nextPaymentRequired,
+          retryResult,
+          attemptsRemaining - 1,
+        )
+      return withReceipt(retryResult)
+    } catch (error) {
+      if (!isPaymentRequiredError(error) || attemptsRemaining <= 1) throw error
+      return retryWithPayment(params, call, error.data, error, attemptsRemaining - 1)
+    }
   }
 
   return async (params, call) => {

--- a/src/mcp/client/McpClient.ts
+++ b/src/mcp/client/McpClient.ts
@@ -151,7 +151,9 @@ export function isPaymentRequiredError(
 ): error is McpError & { data: PaymentRequiredData } {
   if (typeof error !== 'object' || error === null) return false
   if (!('code' in error) || !('message' in error)) return false
-  if ((error as { code: unknown }).code !== core_Mcp.paymentRequiredCode) return false
+  const code = (error as { code: unknown }).code
+  if (code !== core_Mcp.paymentRequiredCode && code !== core_Mcp.paymentVerificationFailedCode)
+    return false
   return isPaymentRequiredData((error as { data?: unknown }).data)
 }
 

--- a/src/mcp/server/Transport.test.ts
+++ b/src/mcp/server/Transport.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, test } from 'vp/test'
 
 import type { Challenge } from '../../Challenge.js'
-import type { Credential } from '../../Credential.js'
-import { VerificationFailedError } from '../../Errors.js'
+import { type Credential, InvalidCredentialEncodingError } from '../../Credential.js'
+import {
+  InternalPaymentError,
+  InvalidPayloadError,
+  MalformedCredentialError,
+  PaymentRequiredError,
+  VerificationFailedError,
+} from '../../Errors.js'
 import * as Mcp from '../../Mcp.js'
 import { type Extra, mcpSdk } from './Transport.js'
 
@@ -65,7 +71,7 @@ describe('mcpSdk', () => {
       expect(result).toBeNull()
     })
 
-    test('returns null when credential metadata is malformed', () => {
+    test('throws when credential metadata is malformed', () => {
       const transport = mcpSdk()
       const extra = {
         _meta: {
@@ -73,7 +79,7 @@ describe('mcpSdk', () => {
         },
       } as Extra
 
-      expect(transport.getCredential(extra)).toBeNull()
+      expect(() => transport.getCredential(extra)).toThrow(InvalidCredentialEncodingError)
     })
   })
 
@@ -87,7 +93,7 @@ describe('mcpSdk', () => {
 
       expect(result).toBeInstanceOf(Error)
       const err = result as any
-      expect(err.code).toBe(Mcp.paymentRequiredCode)
+      expect(err.code).toBe(Mcp.paymentVerificationFailedCode)
       expect(err.message).toContain('Payment Required')
       expect(err.data?.httpStatus).toBe(402)
       expect(err.data?.challenges).toEqual([challenge])
@@ -108,6 +114,43 @@ describe('mcpSdk', () => {
       expect(err.data?.problem).toBeDefined()
       expect(err.data?.problem?.type).toBe(error.type)
       expect(err.data?.problem?.challengeId).toBe(challenge.id)
+    })
+
+    test.each([
+      {
+        code: Mcp.paymentRequiredCode,
+        error: new PaymentRequiredError(),
+        name: 'payment required',
+      },
+      {
+        code: Mcp.paymentVerificationFailedCode,
+        error: new VerificationFailedError(),
+        name: 'verification failed',
+      },
+      {
+        code: Mcp.invalidParamsCode,
+        error: new MalformedCredentialError(),
+        name: 'malformed credential',
+      },
+      {
+        code: Mcp.invalidParamsCode,
+        error: new InvalidPayloadError(),
+        name: 'invalid payload',
+      },
+      {
+        code: Mcp.internalErrorCode,
+        error: new InternalPaymentError(),
+        name: 'internal payment error',
+      },
+    ])('uses $code for $name', async ({ code, error }) => {
+      const result = await mcpSdk().respondChallenge({
+        challenge,
+        error,
+        input: {} as Extra,
+      })
+
+      expect(result.code).toBe(code)
+      expect((result.data as { httpStatus?: number } | undefined)?.httpStatus).toBe(error.status)
     })
 
     test('uses default message when no error provided', async () => {

--- a/src/mcp/server/Transport.test.ts
+++ b/src/mcp/server/Transport.test.ts
@@ -93,7 +93,7 @@ describe('mcpSdk', () => {
 
       expect(result).toBeInstanceOf(Error)
       const err = result as any
-      expect(err.code).toBe(Mcp.paymentVerificationFailedCode)
+      expect(err.code).toBe(Mcp.paymentRequiredCode)
       expect(err.message).toContain('Payment Required')
       expect(err.data?.httpStatus).toBe(402)
       expect(err.data?.challenges).toEqual([challenge])
@@ -109,7 +109,7 @@ describe('mcpSdk', () => {
       })
 
       const err = result as any
-      expect(err.code).toBe(Mcp.paymentRequiredCode)
+      expect(err.code).toBe(Mcp.paymentVerificationFailedCode)
       expect(err.message).toContain('verification failed')
       expect(err.data?.problem).toBeDefined()
       expect(err.data?.problem?.type).toBe(error.type)

--- a/src/mcp/server/Transport.ts
+++ b/src/mcp/server/Transport.ts
@@ -1,6 +1,6 @@
 import type { CallToolResult, McpError } from '@modelcontextprotocol/sdk/types.js'
 
-import type * as Credential from '../../Credential.js'
+import * as Credential from '../../Credential.js'
 import * as core_Mcp from '../../Mcp.js'
 import * as Transport from '../../server/Transport.js'
 import * as McpCredential from '../internal/Credential.js'
@@ -25,7 +25,7 @@ export type McpSdk = Transport.Transport<Extra, McpError, CallToolResult>
  * MCP SDK transport for server-side payment handling with `@modelcontextprotocol/sdk`.
  *
  * - Reads credentials from `_meta["org.paymentauth/credential"]`
- * - Issues challenges as `McpError` with code `-32042` and challenge in `error.data`
+ * - Maps payment errors to their specification-defined JSON-RPC codes
  * - Attaches receipts via `_meta["org.paymentauth/receipt"]` on tool results
  *
  * @example
@@ -64,7 +64,11 @@ export function mcpSdk(): McpSdk {
     },
 
     getCredential(extra) {
-      return McpCredential.parse(extra._meta?.[core_Mcp.credentialMetaKey])?.value ?? null
+      const value = extra._meta?.[core_Mcp.credentialMetaKey]
+      if (value === undefined) return null
+      const parsed = McpCredential.parse(value)
+      if (!parsed) throw new Credential.InvalidCredentialEncodingError()
+      return parsed.value
     },
 
     async respondChallenge({ challenge, error }) {
@@ -80,8 +84,8 @@ export function mcpSdk(): McpSdk {
           throw err
         }
       }
-      return new McpErrorClass(core_Mcp.paymentRequiredCode, error?.message ?? 'Payment Required', {
-        httpStatus: 402,
+      return new McpErrorClass(core_Mcp.errorCode(error), error?.message ?? 'Payment Required', {
+        httpStatus: error?.status ?? 402,
         challenges: [challenge],
         ...(error && { problem: error.toProblemDetails(challenge.id) }),
       })

--- a/src/proxy/Proxy.test.ts
+++ b/src/proxy/Proxy.test.ts
@@ -1032,7 +1032,10 @@ describe.runIf(isLocalnet)('plain HTTP session proxy', () => {
     const replay = await fetch(`${proxyServer.url}/api/v1/scrape`, {
       headers: { Authorization: authorization },
     })
-    expect(replay.status).toBe(402)
+    expect(replay.status).toBe(500)
+    expect(await replay.json()).toMatchObject({
+      type: 'https://paymentauth.org/problems/internal-payment-error',
+    })
     expect(replay.headers.get('Payment-Receipt')).toBeNull()
   })
 })

--- a/src/server/Mppx.test.ts
+++ b/src/server/Mppx.test.ts
@@ -5306,8 +5306,8 @@ describe('realm auto-detection', () => {
       recipient: '0x0000000000000000000000000000000000000002',
     })
 
-    // Simulate a non-HTTP input with no .url — should warn and use fallback
-    const result = await handle({} as any)
+    // Simulate a request-shaped input with no .url — should use fallback
+    const result = await handle({ body: null, headers: new Headers(), method: 'GET' } as any)
     expect(result.status).toBe(402)
     if (result.status !== 402) throw new Error()
     const challenge = Challenge.fromResponse(result.challenge)

--- a/src/server/Mppx.test.ts
+++ b/src/server/Mppx.test.ts
@@ -1,6 +1,6 @@
 import * as http from 'node:http'
 
-import { Challenge, Constants, Credential, Errors, Method, Receipt, z } from 'mppx'
+import { Challenge, Constants, Credential, Errors, Mcp, Method, Receipt, z } from 'mppx'
 import {
   Mppx as Mppx_client,
   session as tempo_session_client,
@@ -220,7 +220,7 @@ describe('request handler', () => {
     `)
   })
 
-  test('returns sanitized malformed credential error for unexpected transport failures', async () => {
+  test('returns sanitized internal error for unexpected transport failures', async () => {
     const baseTransport = Transport.http()
     const transport = Transport.from({
       ...baseTransport,
@@ -243,9 +243,10 @@ describe('request handler', () => {
 
     expect(result.status).toBe(402)
     if (result.status !== 402) throw new Error()
+    expect(result.challenge.status).toBe(500)
 
     const body = (await result.challenge.json()) as { detail: string }
-    expect(body.detail).toBe('Credential is malformed.')
+    expect(body.detail).toBe('An internal payment error occurred.')
     expect(body.detail).not.toContain('secret-key')
     expect(body.detail).not.toContain('rpc.example.com')
   })
@@ -813,7 +814,7 @@ describe('request handler', () => {
     expect(body.detail).not.toContain('invalidField')
   })
 
-  test('returns sanitized verification error for unexpected verifier failures', async () => {
+  test('returns sanitized internal error for unexpected verifier failures', async () => {
     const leakingMethod = Method.toServer(
       Method.from({
         name: 'mock',
@@ -853,17 +854,19 @@ describe('request handler', () => {
       payload: { token: 'valid' },
     })
 
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
     const result = await handle(
       new Request('https://example.com/resource', {
         headers: { Authorization: Credential.serialize(credential) },
       }),
-    )
+    ).finally(() => consoleError.mockRestore())
 
     expect(result.status).toBe(402)
     if (result.status !== 402) throw new Error()
+    expect(result.challenge.status).toBe(500)
 
     const body = (await result.challenge.json()) as { detail: string }
-    expect(body.detail).toBe('Payment verification failed.')
+    expect(body.detail).toBe('An internal payment error occurred.')
     expect(body.detail).not.toContain('infura')
     expect(body.detail).not.toContain('secret-key')
   })
@@ -5427,6 +5430,58 @@ describe('challenge', () => {
     expires: new Date(Date.now() + 60_000).toISOString(),
     recipient: '0x0000000000000000000000000000000000000002',
   }
+
+  test('maps unexpected MCP verification failures to internal errors', async () => {
+    const internalMethod = Method.toServer(mockCharge, {
+      async verify() {
+        throw new Error('processor unavailable')
+      },
+    })
+    const mppx = Mppx.create({
+      methods: [internalMethod],
+      realm,
+      secretKey,
+      transport: Transport.mcp(),
+    })
+    const input: Mcp.JsonRpcRequest = {
+      id: 1,
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      params: {},
+    }
+    const first = await mppx.alpha.charge(challengeOpts)(input)
+    expect(first.status).toBe(402)
+    if (first.status !== 402 || !('error' in first.challenge) || !first.challenge.error)
+      throw new Error()
+    const challenge = first.challenge.error.data?.challenges[0]
+    if (!challenge) throw new Error()
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      const result = await mppx.alpha.charge(challengeOpts)({
+        ...input,
+        params: {
+          _meta: {
+            [Mcp.credentialMetaKey]: Credential.from({
+              challenge,
+              payload: { token: 'valid' },
+            }),
+          },
+        },
+      })
+
+      expect(result.status).toBe(402)
+      if (result.status !== 402 || !('error' in result.challenge) || !result.challenge.error)
+        throw new Error()
+      const error = result.challenge.error
+      expect(error.code).toBe(Mcp.internalErrorCode)
+      expect(error.data?.httpStatus).toBe(500)
+      expect(error.data?.problem?.detail).toBe('An internal payment error occurred.')
+      expect(error.data?.problem?.detail).not.toContain('processor unavailable')
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
 
   test('mppx.challenge.alpha.charge returns a valid Challenge object', async () => {
     const mppx = Mppx.create({

--- a/src/server/Mppx.ts
+++ b/src/server/Mppx.ts
@@ -1187,9 +1187,12 @@ function createMethodFn(parameters: createMethodFn.Parameters): createMethodFn.R
       // Credential was provided but malformed
       if (credentialError) {
         const reason = getSafeCredentialReason(credentialError)
-        const error = reason
-          ? new Errors.MalformedCredentialError({ reason })
-          : new Errors.InternalPaymentError()
+        const error =
+          credentialError instanceof Errors.PaymentError
+            ? credentialError
+            : reason
+              ? new Errors.MalformedCredentialError({ reason })
+              : new Errors.InternalPaymentError()
         await emitPaymentFailed({
           challenge,
           credential: null,

--- a/src/server/Mppx.ts
+++ b/src/server/Mppx.ts
@@ -850,7 +850,7 @@ export function create<
       const broadcast = mi.broadcast ?? mi.verify
       receipt = await broadcast({ credential: parsedCredential, envelope, request } as never)
     } catch (e) {
-      const error = e instanceof Errors.PaymentError ? e : new Errors.VerificationFailedError()
+      const error = e instanceof Errors.PaymentError ? e : new Errors.InternalPaymentError()
       await emitStandalonePaymentFailed({
         challenge: prepared.credential.challenge,
         credential: parsedCredential,
@@ -1187,7 +1187,9 @@ function createMethodFn(parameters: createMethodFn.Parameters): createMethodFn.R
       // Credential was provided but malformed
       if (credentialError) {
         const reason = getSafeCredentialReason(credentialError)
-        const error = new Errors.MalformedCredentialError(reason ? { reason } : {})
+        const error = reason
+          ? new Errors.MalformedCredentialError({ reason })
+          : new Errors.InternalPaymentError()
         await emitPaymentFailed({
           challenge,
           credential: null,
@@ -1275,8 +1277,7 @@ function createMethodFn(parameters: createMethodFn.Parameters): createMethodFn.R
           } catch (e) {
             if (!(e instanceof Errors.PaymentError))
               console.error('mppx: internal authorization error', e)
-            const error =
-              e instanceof Errors.PaymentError ? e : new Errors.VerificationFailedError()
+            const error = e instanceof Errors.PaymentError ? e : new Errors.InternalPaymentError()
             await emitPaymentFailed({
               challenge,
               credential: null,
@@ -1459,7 +1460,7 @@ function createMethodFn(parameters: createMethodFn.Parameters): createMethodFn.R
       } catch (e) {
         if (!(e instanceof Errors.PaymentError))
           console.error('mppx: internal verification error', e)
-        const error = e instanceof Errors.PaymentError ? e : new Errors.VerificationFailedError()
+        const error = e instanceof Errors.PaymentError ? e : new Errors.InternalPaymentError()
         await emitPaymentFailed({
           challenge,
           credential: parsedCredential,

--- a/src/server/Transport.test.ts
+++ b/src/server/Transport.test.ts
@@ -4,6 +4,13 @@ import { Methods } from 'mppx/tempo'
 import { describe, expect, test } from 'vp/test'
 
 import { BadRequestError, ChannelClosedError } from '../Errors.js'
+import {
+  InternalPaymentError,
+  InvalidPayloadError,
+  MalformedCredentialError,
+  PaymentRequiredError,
+  VerificationFailedError,
+} from '../Errors.js'
 
 const realm = 'api.example.com'
 const secretKey = 'test-secret-key-test-secret-key-32'
@@ -512,6 +519,21 @@ describe('mcp', () => {
 
       expect(transport.getCredential(mcpRequest)).toBeNull()
     })
+
+    test('throws when credential metadata is malformed', () => {
+      const transport = Transport.mcp()
+      const request = {
+        ...mcpRequest,
+        params: {
+          ...mcpRequest.params,
+          _meta: { [Mcp.credentialMetaKey]: { challenge: {}, payload: {} } },
+        },
+      } as Mcp.JsonRpcRequest
+
+      expect(() => transport.getCredential(request)).toThrow(
+        Credential.InvalidCredentialEncodingError,
+      )
+    })
   })
 
   describe('respondChallenge', () => {
@@ -545,6 +567,44 @@ describe('mcp', () => {
           "jsonrpc": "2.0",
         }
       `)
+    })
+
+    test.each([
+      {
+        code: Mcp.paymentRequiredCode,
+        error: new PaymentRequiredError(),
+        name: 'payment required',
+      },
+      {
+        code: Mcp.paymentVerificationFailedCode,
+        error: new VerificationFailedError(),
+        name: 'verification failed',
+      },
+      {
+        code: Mcp.invalidParamsCode,
+        error: new MalformedCredentialError(),
+        name: 'malformed credential',
+      },
+      {
+        code: Mcp.invalidParamsCode,
+        error: new InvalidPayloadError(),
+        name: 'invalid payload',
+      },
+      {
+        code: Mcp.internalErrorCode,
+        error: new InternalPaymentError(),
+        name: 'internal payment error',
+      },
+    ])('uses $code for $name', async ({ code, error }) => {
+      const response = await Transport.mcp().respondChallenge({
+        challenge,
+        error,
+        input: mcpRequest,
+      })
+      if (!response.error) throw new Error()
+
+      expect(response.error.code).toBe(code)
+      expect(response.error.data?.httpStatus).toBe(error.status)
     })
   })
 

--- a/src/server/Transport.ts
+++ b/src/server/Transport.ts
@@ -4,6 +4,7 @@ import * as Credential from '../Credential.js'
 import * as Errors from '../Errors.js'
 import type { Distribute, MaybePromise, UnionToIntersection } from '../internal/types.js'
 import * as core_Mcp from '../Mcp.js'
+import * as McpCredential from '../mcp/internal/Credential.js'
 import type * as Method from '../Method.js'
 import * as Receipt from '../Receipt.js'
 import * as Html from './internal/html/config.js'
@@ -264,9 +265,11 @@ export function mcp() {
 
     getCredential(request) {
       const meta = request.params?._meta
-      const credential = meta?.[core_Mcp.credentialMetaKey]
-      if (!credential) return null
-      return credential
+      const value = meta?.[core_Mcp.credentialMetaKey]
+      if (value === undefined) return null
+      const parsed = McpCredential.parse(value)
+      if (!parsed) throw new Credential.InvalidCredentialEncodingError()
+      return parsed.value
     },
 
     respondChallenge({ challenge, input, error }) {
@@ -274,7 +277,7 @@ export function mcp() {
         jsonrpc: '2.0',
         id: input.id,
         error: {
-          code: mcpErrorCode(error),
+          code: core_Mcp.errorCode(error),
           message: error?.message ?? 'Payment Required',
           data: {
             httpStatus: error?.status ?? 402,
@@ -305,14 +308,6 @@ export function mcp() {
       }
     },
   })
-}
-
-/** @internal */
-function mcpErrorCode(error?: Errors.PaymentError): number {
-  if (!error) return core_Mcp.paymentRequiredCode
-  if (error instanceof Errors.MalformedCredentialError) return -32602
-  if (error instanceof Errors.PaymentRequiredError) return core_Mcp.paymentRequiredCode
-  return core_Mcp.paymentVerificationFailedCode
 }
 
 export function safeUrl(url: string | URL | undefined): URL {

--- a/src/tempo/session/server/Session.test.ts
+++ b/src/tempo/session/server/Session.test.ts
@@ -2307,6 +2307,23 @@ describe('precompile server session unit guardrails', () => {
       expect(challenge.request.amount).toBe('0')
     })
 
+    test('malformed bootstrap payload returns an invalid-payload challenge', async () => {
+      const route = createBootstrapRoute({ rawStore: Store.memory() })
+      const challenge = Challenge.fromResponse(await bootstrapResponse(route))
+      const authorization = Credential.serialize({
+        challenge,
+        payload: { type: 'transaction' },
+      } as never)
+
+      const response = await bootstrapResponse(route, authorization)
+
+      expect(response.status).toBe(402)
+      expect(await response.json()).toMatchObject({
+        status: 402,
+        type: 'https://paymentauth.org/problems/invalid-payload',
+      })
+    })
+
     test('valid proof resolves channel by source and returns snapshot headers', async () => {
       const rawStore = Store.memory()
       const store = channelStore(rawStore)

--- a/src/tempo/session/server/Session.ts
+++ b/src/tempo/session/server/Session.ts
@@ -273,7 +273,7 @@ async function handleBootstrapPreflight(
   } catch (error) {
     return respondBootstrapChallenge(
       challenge,
-      error instanceof Errors.PaymentError ? error : new Errors.VerificationFailedError(),
+      error instanceof Errors.PaymentError ? error : new Errors.InternalPaymentError(),
     )
   }
 

--- a/src/tempo/session/server/Session.ts
+++ b/src/tempo/session/server/Session.ts
@@ -239,10 +239,12 @@ async function verifyBootstrapCredential(parameters: {
     })
   Expires.assert(credential.challenge.expires, credential.challenge.id)
   assertBootstrapChallengeMatches(challenge, credential.challenge)
+  const payload = Methods.charge.schema.credential.payload.safeParse(credential.payload)
+  if (!payload.success) throw new Errors.InvalidPayloadError()
   return charge.verify({
     credential: {
       ...credential,
-      payload: Methods.charge.schema.credential.payload.parse(credential.payload),
+      payload: payload.data,
     } as never,
     request: rawRequest,
   })

--- a/src/x402/mcp.test.ts
+++ b/src/x402/mcp.test.ts
@@ -13,7 +13,7 @@ const account = privateKeyToAccount(
   '0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
 )
 
-async function createHarness() {
+async function createHarness(options: { paymentIsValid?: boolean } = {}) {
   const calls: string[] = []
   const facilitator = {
     async getSupported() {
@@ -31,7 +31,9 @@ async function createHarness() {
     },
     async verify() {
       calls.push('verify')
-      return { isValid: true, payer: account.address }
+      return options.paymentIsValid === false
+        ? { invalidReason: 'invalid payment', isValid: false, payer: account.address }
+        : { isValid: true, payer: account.address }
     },
   }
   const server = new x402ResourceServer(facilitator).register(network, new ExactEvmScheme())
@@ -107,6 +109,29 @@ describe('x402 MCP compatibility', () => {
     expect(result.content).toEqual([{ text: 'result:mpp', type: 'text' }])
     expect(result.receipt?.reference).toBe(transaction)
     expect(calls).toEqual(['verify', 'settle'])
+  })
+
+  test('reports a rejected MPP credential as payment verification failed', async () => {
+    const { tool } = await createHarness({ paymentIsValid: false })
+    const sdkClient = {
+      callTool: (parameters: {
+        arguments?: Record<string, unknown>
+        _meta?: Record<string, unknown>
+      }) => tool((parameters.arguments ?? {}) as { query: string }, { _meta: parameters._meta }),
+    }
+    const client = McpClient.wrap(sdkClient as any, {
+      methods: [
+        evm.charge({
+          account,
+          authorization: { name: 'USDC', version: '2' },
+          maxAtomicAmount: '1000000',
+        }),
+      ],
+    })
+
+    await expect(
+      client.callTool({ arguments: { query: 'mpp' }, name: 'search' }),
+    ).rejects.toMatchObject({ code: -32043 })
   })
 
   test('returns facilitator failures as valid MCP tool errors', async () => {

--- a/src/x402/mcp.ts
+++ b/src/x402/mcp.ts
@@ -11,6 +11,7 @@ import {
 } from '@x402/mcp'
 
 import * as Challenge from '../Challenge.js'
+import * as Errors from '../Errors.js'
 import * as Negotiator from '../integrations/x402/Negotiator.js'
 import * as Mcp from '../Mcp.js'
 import * as McpCredential from '../mcp/internal/Credential.js'
@@ -86,7 +87,11 @@ export function mpp(
       if (result.status === 'unprotected') return x402Handler(arguments_, rawExtra)
       if (result.status === 'x402') return x402Handler(arguments_, rawExtra)
       if (result.status === 'handled') {
-        if (result.response.status === 402) throw createCombinedChallenge(result.response)
+        if (result.response.status === 402)
+          throw createCombinedChallenge(
+            result.response,
+            credential ? new Errors.VerificationFailedError() : undefined,
+          )
         return attachReceipt(
           await responseToToolResult(result.response.clone()),
           result.response,
@@ -160,11 +165,11 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
-function createCombinedChallenge(response: Response): McpError {
+function createCombinedChallenge(response: Response, error?: Errors.PaymentError): McpError {
   const challenges = Challenge.fromResponseList(response)
   const encoded = response.headers.get(paymentRequiredHeader)
   const x402 = encoded ? decodePaymentRequiredHeader(encoded) : undefined
-  return new McpError(Mcp.paymentRequiredCode, 'Payment Required', {
+  return new McpError(Mcp.errorCode(error), error?.title ?? 'Payment Required', {
     challenges,
     httpStatus: 402,
     ...(x402 ? { x402 } : {}),

--- a/src/x402/server/EvmCharge.test.ts
+++ b/src/x402/server/EvmCharge.test.ts
@@ -194,7 +194,9 @@ describe('x402 evm charge route binding', () => {
 
     expect(result.status).toBe(402)
     if (result.status !== 402) throw new Error()
-    expect(readError(result.challenge)).toBe('Credential is malformed.')
+    expect(readError(result.challenge)).toBe(
+      'Payment verification failed: x402 payment payload resource does not match route resource.',
+    )
     expect(reached).toEqual([])
   })
 


### PR DESCRIPTION
## Motivation

MCP payment failures were collapsed into Payment Required errors, preventing clients from distinguishing missing credentials, rejected credentials, malformed inputs, and processor failures.

Fixes [#840](https://github.com/wevm/mppx/issues/840).

## Summary

- mapped MCP payment failures to the specification-defined JSON-RPC error codes
- rejected malformed MCP credential metadata as Invalid Params
- represented unexpected payment processing failures as sanitized Internal Error responses
- handled payment verification retry challenges in both MCP client transports
- added protocol mapping and retry coverage

## Key design considerations

- centralized error-code selection so raw JSON-RPC and MCP SDK transports cannot drift
- mapped invalid credential payload schemas to Invalid Params alongside malformed credential envelopes
- retained fresh challenges for retryable verification failures while keeping internal failure details private