### PR TITLE
Add request-scoped payment intent options

### DIFF
--- a/.changeset/callback-payment-intent-metadata.md
+++ b/.changeset/callback-payment-intent-metadata.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added request-scoped PaymentIntent metadata to Stripe machine payment charge handlers, and exposed pre-transform request input to payment-success callbacks.

--- a/src/Method.ts
+++ b/src/Method.ts
@@ -246,9 +246,10 @@ export type OnPaymentSuccessFn<method extends Method> = (parameters: {
   request: DeepReadonly<z.output<method['schema']['request']>>
   /**
    * Server-side request after defaults and request hooks, before the method
-   * request schema's output transforms.
+   * request schema's output transforms. Absent during standalone credential
+   * verification when no route options are supplied.
    */
-  requestInput: DeepReadonly<z.input<method['schema']['request']>>
+  requestInput?: DeepReadonly<z.input<method['schema']['request']>> | undefined
 }) => MaybePromise<void>
 
 export type ComposableHooks<method extends Method> = {

--- a/src/Method.ts
+++ b/src/Method.ts
@@ -242,7 +242,13 @@ export type CanOfferFn<method extends Method> = (parameters: {
 export type OnPaymentSuccessFn<method extends Method> = (parameters: {
   input?: globalThis.Request
   receipt: DeepReadonly<Receipt.Receipt>
+  /** Canonical payment request included in the challenge. */
   request: DeepReadonly<z.output<method['schema']['request']>>
+  /**
+   * Server-side request after defaults and request hooks, before the method
+   * request schema's output transforms.
+   */
+  requestInput: DeepReadonly<z.input<method['schema']['request']>>
 }) => MaybePromise<void>
 
 export type ComposableHooks<method extends Method> = {

--- a/src/server/Mppx.test.ts
+++ b/src/server/Mppx.test.ts
@@ -1243,7 +1243,6 @@ describe('server events', () => {
     const first = await handle(new Request('https://example.com/resource'))
     expect(first.status).toBe(402)
     if (first.status !== 402) throw new Error()
-
     const paid = await handle(
       new Request('https://example.com/resource', {
         headers: {
@@ -1932,9 +1931,10 @@ describe('server events', () => {
             amount: z.string(),
             currency: z.string(),
             decimals: z.number(),
+            inputOnly: z.optional(z.string()),
             recipient: z.string(),
           }),
-          z.transform(({ amount, currency, decimals, recipient }) => ({
+          z.transform(({ amount, currency, decimals, inputOnly: _, recipient }) => ({
             amount: String(Number(amount) * 10 ** decimals),
             currency,
             recipient,
@@ -1960,17 +1960,20 @@ describe('server events', () => {
       seen.eventAdmin = context.credential?.payload.admin
       seen.eventEnvelopeAmount = context.envelope?.request.amount
       seen.eventRequestAmount = context.request.amount
+      seen.eventRequestInput = context.requestInput.inputOnly
     })
     const handle = handler.charge({
       amount: '25',
       currency: '0x0000000000000000000000000000000000000001',
       decimals: 2,
       expires: new Date(Date.now() + 60_000).toISOString(),
+      inputOnly: 'server-only',
       recipient: '0x0000000000000000000000000000000000000002',
     })
     const first = await handle(new Request('https://example.com/resource'))
     expect(first.status).toBe(402)
     if (first.status !== 402) throw new Error()
+    expect(Challenge.fromResponse(first.challenge).request).not.toHaveProperty('inputOnly')
 
     const paid = await handle(
       new Request('https://example.com/resource', {
@@ -1990,6 +1993,7 @@ describe('server events', () => {
       eventAdmin: false,
       eventEnvelopeAmount: '2500',
       eventRequestAmount: '2500',
+      eventRequestInput: 'server-only',
       verifyAdmin: false,
       verifyEnvelopeAmount: '2500',
       verifyRequestAmount: '25',
@@ -1998,6 +2002,7 @@ describe('server events', () => {
 
   test('snapshots payment success payloads before listeners run', async () => {
     let mutationBlocked = false
+    let requestInputMutationBlocked = false
     const serverMethod = Method.toServer(eventCharge, {
       async verify() {
         return receipt('tx-original')
@@ -2013,6 +2018,11 @@ describe('server events', () => {
         ;(context.receipt as { reference: string }).reference = 'tx-mutated'
       } catch {
         mutationBlocked = true
+      }
+      try {
+        ;(context.requestInput as { amount: string }).amount = 'mutated'
+      } catch {
+        requestInputMutationBlocked = true
       }
     })
     const handle = handler.charge(options())
@@ -2037,6 +2047,7 @@ describe('server events', () => {
 
     const response = paid.withReceipt(Response.json({ ok: true }))
     expect(mutationBlocked).toBe(true)
+    expect(requestInputMutationBlocked).toBe(true)
     expect(Receipt.fromResponse(response).reference).toBe('tx-original')
   })
 })

--- a/src/server/Mppx.test.ts
+++ b/src/server/Mppx.test.ts
@@ -1243,6 +1243,7 @@ describe('server events', () => {
     const first = await handle(new Request('https://example.com/resource'))
     expect(first.status).toBe(402)
     if (first.status !== 402) throw new Error()
+
     const paid = await handle(
       new Request('https://example.com/resource', {
         headers: {

--- a/src/server/Mppx.test.ts
+++ b/src/server/Mppx.test.ts
@@ -1537,7 +1537,7 @@ describe('server events', () => {
     })
     handler.onPaymentSuccess((context) => {
       events.push(
-        `success:${context.receipt.reference}:${context.input}:${context.capturedRequest?.url.pathname}`,
+        `success:${context.receipt.reference}:${context.input}:${context.capturedRequest?.url.pathname}:${context.requestInput?.amount}`,
       )
     })
 
@@ -1554,7 +1554,41 @@ describe('server events', () => {
     )
 
     expect(result.reference).toBe('tx-standalone')
-    expect(events).toEqual(['success:tx-standalone:undefined:/standalone'])
+    expect(events).toEqual(['success:tx-standalone:undefined:/standalone:1000'])
+  })
+
+  test('omits request input from standalone verification without route options', async () => {
+    const successContexts: object[] = []
+    const serverMethod = Method.toServer(eventCharge, {
+      onPaymentSuccess(context) {
+        successContexts.push(context)
+      },
+      async verify() {
+        return receipt('tx-standalone')
+      },
+    })
+    const handler = Mppx.create({
+      methods: [serverMethod],
+      realm,
+      secretKey,
+    })
+    handler.onPaymentSuccess((context) => {
+      successContexts.push(context)
+    })
+
+    const first = await handler.charge(options())(new Request('https://example.com/resource'))
+    expect(first.status).toBe(402)
+    if (first.status !== 402) throw new Error()
+
+    await handler.verifyCredential(
+      Credential.from({
+        challenge: Challenge.fromResponse(first.challenge),
+        payload: { token: 'valid' },
+      }),
+    )
+
+    expect(successContexts).toHaveLength(2)
+    for (const context of successContexts) expect(context).not.toHaveProperty('requestInput')
   })
 
   test('per-method onPaymentSuccess hook fires on successful payment', async () => {
@@ -1961,7 +1995,7 @@ describe('server events', () => {
       seen.eventAdmin = context.credential?.payload.admin
       seen.eventEnvelopeAmount = context.envelope?.request.amount
       seen.eventRequestAmount = context.request.amount
-      seen.eventRequestInput = context.requestInput.inputOnly
+      seen.eventRequestInput = context.requestInput?.inputOnly
     })
     const handle = handler.charge({
       amount: '25',

--- a/src/server/Mppx.ts
+++ b/src/server/Mppx.ts
@@ -180,8 +180,11 @@ export type PaymentSuccessContext<
   receipt: Receipt.Receipt
   /** Canonical request represented by the challenge. */
   request: z.output<method['schema']['request']>
-  /** Resolved method input before request-schema output transforms. */
-  requestInput: z.input<method['schema']['request']>
+  /**
+   * Resolved method input before request-schema output transforms. Absent during
+   * standalone credential verification when no route options are supplied.
+   */
+  requestInput?: z.input<method['schema']['request']> | undefined
 }>
 
 /** Options for standalone credential verification. */
@@ -536,7 +539,7 @@ export function create<
             input: ctx.input,
             receipt: ctx.receipt,
             request: ctx.request,
-            requestInput: ctx.requestInput,
+            ...(ctx.requestInput !== undefined && { requestInput: ctx.requestInput }),
           })
         }
       }) as never)
@@ -803,6 +806,7 @@ export function create<
       parsedCredential,
       parsedRequest,
       request,
+      requestInput: shouldValidateRoute ? request : undefined,
     }
   }
 
@@ -824,7 +828,14 @@ export function create<
     options?: VerifyCredentialOptions,
   ): Promise<Receipt.Receipt> {
     const prepared = await prepareStandaloneCredential(input, options, { emitFailures: true })
-    const { method: mi, parsedCredential, parsedRequest, request, envelope } = prepared
+    const {
+      method: mi,
+      parsedCredential,
+      parsedRequest,
+      request,
+      requestInput,
+      envelope,
+    } = prepared
 
     const emitStandalonePaymentFailed = async (parameters: {
       challenge: Challenge.Challenge
@@ -875,7 +886,7 @@ export function create<
         method: mi,
         receipt,
         request: parsedRequest,
-        requestInput: request,
+        ...(requestInput !== undefined && { requestInput }),
       }) as never,
     )
 
@@ -1777,7 +1788,7 @@ function createPaymentSuccessContext(parameters: {
   method: Method.Method | ServerMethodDescriptor
   receipt: Receipt.Receipt
   request: Record<string, unknown>
-  requestInput: Record<string, unknown>
+  requestInput?: Record<string, unknown> | undefined
 }): PaymentSuccessContext {
   return Object.freeze({
     ...(parameters.capturedRequest
@@ -1790,7 +1801,9 @@ function createPaymentSuccessContext(parameters: {
     method: snapshotMethod(parameters.method),
     receipt: snapshotValue(parameters.receipt),
     request: snapshotValue(parameters.request),
-    requestInput: snapshotValue(parameters.requestInput),
+    ...(parameters.requestInput !== undefined && {
+      requestInput: snapshotValue(parameters.requestInput),
+    }),
   }) as never
 }
 

--- a/src/server/Mppx.ts
+++ b/src/server/Mppx.ts
@@ -178,7 +178,10 @@ export type PaymentSuccessContext<
   input?: Transport.InputOf<transport> | undefined
   method: ServerMethodDescriptor<method>
   receipt: Receipt.Receipt
+  /** Canonical request represented by the challenge. */
   request: z.output<method['schema']['request']>
+  /** Resolved method input before request-schema output transforms. */
+  requestInput: z.input<method['schema']['request']>
 }>
 
 /** Options for standalone credential verification. */
@@ -533,6 +536,7 @@ export function create<
             input: ctx.input,
             receipt: ctx.receipt,
             request: ctx.request,
+            requestInput: ctx.requestInput,
           })
         }
       }) as never)
@@ -871,6 +875,7 @@ export function create<
         method: mi,
         receipt,
         request: parsedRequest,
+        requestInput: request,
       }) as never,
     )
 
@@ -1266,6 +1271,7 @@ function createMethodFn(parameters: createMethodFn.Parameters): createMethodFn.R
                   method,
                   receipt: authorized.receipt,
                   request: parsedRequest,
+                  requestInput: request,
                 }) as never,
               )
               return success(authorized.receipt, {
@@ -1503,6 +1509,7 @@ function createMethodFn(parameters: createMethodFn.Parameters): createMethodFn.R
           method,
           receipt: receiptData,
           request: parsedRequest,
+          requestInput: request,
         }) as never,
       )
 
@@ -1770,6 +1777,7 @@ function createPaymentSuccessContext(parameters: {
   method: Method.Method | ServerMethodDescriptor
   receipt: Receipt.Receipt
   request: Record<string, unknown>
+  requestInput: Record<string, unknown>
 }): PaymentSuccessContext {
   return Object.freeze({
     ...(parameters.capturedRequest
@@ -1782,6 +1790,7 @@ function createPaymentSuccessContext(parameters: {
     method: snapshotMethod(parameters.method),
     receipt: snapshotValue(parameters.receipt),
     request: snapshotValue(parameters.request),
+    requestInput: snapshotValue(parameters.requestInput),
   }) as never
 }
 

--- a/src/stripe/Methods.test.ts
+++ b/src/stripe/Methods.test.ts
@@ -24,8 +24,10 @@ describe('charge', () => {
       networkId: 'profile_123',
       paymentMethodTypes: ['card'],
       metadata: { example: 'metadata' },
+      paymentIntentOptions: { metadata: { order: '123' } },
     })
     expect(result.success).toBe(true)
+    if (result.success) expect(result.data).not.toHaveProperty('paymentIntentOptions')
   })
 
   test('schema: rejects invalid request', () => {

--- a/src/stripe/Methods.ts
+++ b/src/stripe/Methods.ts
@@ -2,6 +2,7 @@ import { parseUnits } from 'viem'
 
 import * as Method from '../Method.js'
 import * as z from '../zod.js'
+import * as PaymentIntent from './internal/payment-intent.js'
 
 /**
  * Stripe charge intent for one-time payments via Shared Payment Tokens (SPTs).
@@ -27,18 +28,29 @@ export const charge = Method.from({
         externalId: z.optional(z.string()),
         metadata: z.optional(z.record(z.string(), z.string())),
         networkId: z.string(),
+        paymentIntentOptions: z.optional(PaymentIntent.Schema),
         paymentMethodTypes: z.array(z.string()).check(z.minLength(1)),
         recipient: z.optional(z.string()),
       }),
-      z.transform(({ amount, decimals, metadata, networkId, paymentMethodTypes, ...rest }) => ({
-        ...rest,
-        amount: parseUnits(amount, decimals).toString(),
-        methodDetails: {
+      z.transform(
+        ({
+          amount,
+          decimals,
+          metadata,
           networkId,
+          paymentIntentOptions: _,
           paymentMethodTypes,
-          ...(metadata !== undefined && { metadata }),
-        },
-      })),
+          ...rest
+        }) => ({
+          ...rest,
+          amount: parseUnits(amount, decimals).toString(),
+          methodDetails: {
+            networkId,
+            paymentMethodTypes,
+            ...(metadata !== undefined && { metadata }),
+          },
+        }),
+      ),
     ),
   },
 })

--- a/src/stripe/internal/payment-intent.ts
+++ b/src/stripe/internal/payment-intent.ts
@@ -1,0 +1,8 @@
+import * as z from '../../zod.js'
+
+/** Stripe PaymentIntent options accepted only by server-side method input. */
+export const Schema = z.object({
+  metadata: z.record(z.string(), z.string()),
+})
+
+export type Options = z.infer<typeof Schema>

--- a/src/stripe/server/Charge.test.ts
+++ b/src/stripe/server/Charge.test.ts
@@ -188,7 +188,12 @@ describe('stripe.charge with client', () => {
 
     httpServer = await Http.createServer(async (req, res) => {
       const result = await Mppx.toNodeListener(
-        server.charge({ amount: '1', currency: 'usd', decimals: 2 }),
+        server.charge({
+          amount: '1',
+          currency: 'usd',
+          decimals: 2,
+          paymentIntentOptions: { metadata: { plan: 'enterprise', request_id: 'req_123' } },
+        }),
       )(req, res)
       if (result.status === 402) return
       res.end('OK')
@@ -196,6 +201,7 @@ describe('stripe.charge with client', () => {
 
     const response = await fetch(httpServer.url)
     const challenge = Challenge.fromResponse(response)
+    expect(challenge.request).not.toHaveProperty('paymentIntentOptions')
     const credential = Credential.from({
       challenge,
       payload: { spt: 'spt_test_token' },
@@ -206,7 +212,7 @@ describe('stripe.charge with client', () => {
     })
 
     const [params] = create.mock.calls[0]!
-    expect(params.metadata).toMatchObject({ plan: 'pro' })
+    expect(params.metadata).toMatchObject({ plan: 'enterprise', request_id: 'req_123' })
     expect(params.metadata).not.toHaveProperty('mpp_is_mpp')
     expect(params.metadata).not.toHaveProperty('mpp_version')
   })

--- a/src/stripe/server/Charge.ts
+++ b/src/stripe/server/Charge.ts
@@ -152,12 +152,13 @@ export function charge<const parameters extends charge.Parameters>(parameters: p
 
     async verify({ credential, envelope, request }) {
       const { challenge } = credential
+      const { paymentIntentOptions, ...methodRequest } = request
       const resolvedRequest = (() => {
-        const parsed = Methods.charge.schema.request.safeParse(request)
+        const parsed = Methods.charge.schema.request.safeParse(methodRequest)
         if (parsed.success) return parsed.data
         // verifyCredential() passes the HMAC-bound challenge request, which is
         // already in canonical output form and should not be transformed again.
-        return request as unknown as z.output<typeof Methods.charge.schema.request>
+        return methodRequest as unknown as z.output<typeof Methods.charge.schema.request>
       })()
 
       Expires.assert(challenge.expires, challenge.id)
@@ -179,7 +180,11 @@ export function charge<const parameters extends charge.Parameters>(parameters: p
       const userMetadata = resolvedRequest.methodDetails?.metadata as
         | Record<string, string>
         | undefined
-      const resolvedMetadata = { ...buildAnalytics({ credential }), ...userMetadata }
+      const resolvedMetadata = {
+        ...buildAnalytics({ credential }),
+        ...userMetadata,
+        ...paymentIntentOptions?.metadata,
+      }
       const settlement = validateConnectSettlement({
         amount: resolvedRequest.amount,
         settlement:

--- a/src/stripe/server/Methods.test-d.ts
+++ b/src/stripe/server/Methods.test-d.ts
@@ -11,8 +11,24 @@ test('async defaultMethods() produces types compose can use', async () => {
   const mppx = Mppx.create({ methods, secretKey: 'test' })
 
   const result = await mppx.compose(
-    ['tempo/charge', { amount: '0.01', description: 'test' }],
-    ['stripe/charge', { amount: '0.50', currency: 'usd', decimals: 2, description: 'test' }],
+    [
+      'tempo/charge',
+      {
+        amount: '0.01',
+        description: 'test',
+        paymentIntentOptions: { metadata: { key: 'value' } },
+      },
+    ],
+    [
+      'stripe/charge',
+      {
+        amount: '0.50',
+        currency: 'usd',
+        decimals: 2,
+        description: 'test',
+        paymentIntentOptions: { metadata: { key: 'value' } },
+      },
+    ],
   )(new Request('http://localhost'))
 
   expectTypeOf(result.status).toEqualTypeOf<200 | 402>()

--- a/src/stripe/server/Methods.test.ts
+++ b/src/stripe/server/Methods.test.ts
@@ -71,10 +71,11 @@ describe('stripe.create() defaultMethods', () => {
     await tempoMethod.onPaymentSuccess!({
       receipt: { reference: '0xtx123' },
       request: { amount: '500000' },
+      requestInput: { paymentIntentOptions: { metadata: { request_id: 'req_123' } } },
     })
 
     expect(client.paymentIntents.create).toHaveBeenCalledWith(
-      expect.objectContaining({ metadata: { agent_id: 'test-agent' } }),
+      expect.objectContaining({ metadata: { agent_id: 'test-agent', request_id: 'req_123' } }),
       expect.anything(),
     )
   })

--- a/src/stripe/server/Methods.ts
+++ b/src/stripe/server/Methods.ts
@@ -444,7 +444,7 @@ function createPaymentSuccessHandler(
   connect?: ConnectConfig,
   metadata?: Record<string, string>,
 ) {
-  return (params: { receipt: any; request: any; requestInput: any }) => {
+  return (params: { receipt: any; request: any; requestInput?: any }) => {
     const { receipt, request, requestInput } = params
     if (receipt?.reference && request?.amount) {
       const resolvedMetadata = {

--- a/src/stripe/server/Methods.ts
+++ b/src/stripe/server/Methods.ts
@@ -4,6 +4,8 @@ import type * as Method from '../../Method.js'
 import * as tempoDefaults from '../../tempo/internal/defaults.js'
 import { charge as tempoCharge } from '../../tempo/server/Charge.js'
 import { session as tempoSession } from '../../tempo/session/server/Session.js'
+import * as z from '../../zod.js'
+import * as PaymentIntent from '../internal/payment-intent.js'
 import type { StripeClient } from '../internal/types.js'
 import { charge as charge_ } from './Charge.js'
 import { findOrCreateDepositAddress as _findOrCreateDepositAddress } from './internal/deposit-address.js'
@@ -222,14 +224,16 @@ export function stripe<const P extends stripe.Parameters>(parameters: P): Stripe
     const handler = callMetadata
       ? createPaymentSuccessHandler(client, 'tempo', connect, { ...metadata, ...callMetadata })
       : tempoPaymentHandler
-    return tempoCharge({
-      currency: tempoCurrency,
-      recipient,
-      ...(!livemode && { testnet: true }),
-      canOffer: cryptoCanOffer,
-      onPaymentSuccess: handler,
-      ...rest,
-    }) as Method.AnyServer
+    return withPaymentIntentInput(
+      tempoCharge({
+        currency: tempoCurrency,
+        recipient,
+        ...(!livemode && { testnet: true }),
+        canOffer: cryptoCanOffer,
+        onPaymentSuccess: handler,
+        ...rest,
+      }) as Method.AnyServer,
+    )
   }
 
   function makeTempoSession(
@@ -251,14 +255,16 @@ export function stripe<const P extends stripe.Parameters>(parameters: P): Stripe
     const handler = callMetadata
       ? createPaymentSuccessHandler(client, 'base', connect, { ...metadata, ...callMetadata })
       : basePaymentHandler
-    return evmCharge({
-      currency: livemode ? EvmAssets.base.USDC : EvmAssets.baseSepolia.USDC,
-      recipient,
-      x402,
-      canOffer: cryptoCanOffer,
-      onPaymentSuccess: handler,
-      ...rest,
-    }) as Method.AnyServer
+    return withPaymentIntentInput(
+      evmCharge({
+        currency: livemode ? EvmAssets.base.USDC : EvmAssets.baseSepolia.USDC,
+        recipient,
+        x402,
+        canOffer: cryptoCanOffer,
+        onPaymentSuccess: handler,
+        ...rest,
+      }) as Method.AnyServer,
+    )
   }
 
   const defaultMethodBuilders: Record<
@@ -326,7 +332,9 @@ export function stripe<const P extends stripe.Parameters>(parameters: P): Stripe
           const canOffer = m.canOffer
             ? (params: any) => cryptoCanOffer(params) && m.canOffer!(params)
             : cryptoCanOffer
-          result.push({ ...m, canOffer, onPaymentSuccess } as Method.AnyServer)
+          result.push(
+            withPaymentIntentInput({ ...m, canOffer, onPaymentSuccess } as Method.AnyServer),
+          )
         }
       }
     }
@@ -436,16 +444,51 @@ function createPaymentSuccessHandler(
   connect?: ConnectConfig,
   metadata?: Record<string, string>,
 ) {
-  return (params: { receipt: any; request: any }) => {
-    const { receipt, request } = params
+  return (params: { receipt: any; request: any; requestInput: any }) => {
+    const { receipt, request, requestInput } = params
     if (receipt?.reference && request?.amount) {
+      const resolvedMetadata = {
+        ...metadata,
+        ...requestInput?.paymentIntentOptions?.metadata,
+      }
       return recordCryptoPayment(client, {
         network,
         reference: receipt.reference,
         amount: String(request.amount),
         ...(connect && { connect }),
-        ...(metadata && { metadata }),
+        ...(Object.keys(resolvedMetadata).length > 0 && { metadata: resolvedMetadata }),
       })
     }
+  }
+}
+
+function withPaymentIntentInput(method: Method.AnyServer): Method.AnyServer {
+  const baseSchema = method.schema.request
+  const baseRequest = method.request
+
+  return {
+    ...method,
+    // Accept Stripe-only options without changing the canonical rail schema.
+    schema: {
+      ...method.schema,
+      request: z.pipe(
+        z.custom<
+          z.input<typeof baseSchema> & {
+            paymentIntentOptions?: PaymentIntent.Options | undefined
+          }
+        >(),
+        z.transform((input) => {
+          const { paymentIntentOptions, ...request } = input
+          z.optional(PaymentIntent.Schema).parse(paymentIntentOptions)
+          // Only the base schema's output is included in the challenge.
+          return baseSchema.parse(request)
+        }),
+      ),
+    },
+    async request(context: Method.RequestContext<Method.AnyServer>) {
+      const { paymentIntentOptions, ...request } = context.request
+      const resolved = baseRequest ? await baseRequest({ ...context, request }) : request
+      return { ...resolved, paymentIntentOptions }
+    },
   }
 }


### PR DESCRIPTION
### Summary
* Adds pre-transformation request to the input of payment success handlers
* Uses this information to allow passing payment intent configuration to all stripe methods without exposing them in the Challenge
* Adds payment intent configuration options to Stripe SPT charge method

### Validation
* `pnpm check:ci`
* `pnpm check:types`
* `pnpm build`
* `pnpm check:package`