### PR TITLE
feat(stripe): mark machine payment intents

### DIFF
--- a/.changeset/fuzzy-ravens-pay.md
+++ b/.changeset/fuzzy-ravens-pay.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added a machine-payment metadata field to every Stripe PaymentIntent created by mppx.

--- a/src/stripe/internal/constants.ts
+++ b/src/stripe/internal/constants.ts
@@ -5,3 +5,6 @@
  * Bump this when upgrading to a newer Stripe API version.
  */
 export const stripePreviewVersion = '2026-07-29.preview'
+
+/** Metadata identifying a Stripe PaymentIntent as a machine payment. */
+export const machinePaymentMetadata = { machine_payment: 'true' } as const

--- a/src/stripe/server/Charge.test.ts
+++ b/src/stripe/server/Charge.test.ts
@@ -213,6 +213,7 @@ describe('stripe.charge with client', () => {
 
     const [params] = create.mock.calls[0]!
     expect(params.metadata).toMatchObject({ plan: 'enterprise', request_id: 'req_123' })
+    expect(params.metadata).toHaveProperty('machine_payment', 'true')
     expect(params.metadata).not.toHaveProperty('mpp_is_mpp')
     expect(params.metadata).not.toHaveProperty('mpp_version')
   })

--- a/src/stripe/server/Charge.ts
+++ b/src/stripe/server/Charge.ts
@@ -10,7 +10,7 @@ import type { ConfiguredDefaults, LooseOmit, MaybePromise, OneOf } from '../../i
 import * as Method from '../../Method.js'
 import type * as Html from '../../server/internal/html/config.ts'
 import type * as z from '../../zod.js'
-import { stripePreviewVersion } from '../internal/constants.js'
+import { machinePaymentMetadata, stripePreviewVersion } from '../internal/constants.js'
 import type {
   StripeClient,
   CreatePaymentMethodFromElements,
@@ -184,6 +184,7 @@ export function charge<const parameters extends charge.Parameters>(parameters: p
         ...buildAnalytics({ credential }),
         ...userMetadata,
         ...paymentIntentOptions?.metadata,
+        ...machinePaymentMetadata,
       }
       const settlement = validateConnectSettlement({
         amount: resolvedRequest.amount,

--- a/src/stripe/server/Methods.test.ts
+++ b/src/stripe/server/Methods.test.ts
@@ -75,7 +75,9 @@ describe('stripe.create() defaultMethods', () => {
     })
 
     expect(client.paymentIntents.create).toHaveBeenCalledWith(
-      expect.objectContaining({ metadata: { agent_id: 'test-agent', request_id: 'req_123' } }),
+      expect.objectContaining({
+        metadata: { agent_id: 'test-agent', machine_payment: 'true', request_id: 'req_123' },
+      }),
       expect.anything(),
     )
   })

--- a/src/stripe/server/internal/record-payment.ts
+++ b/src/stripe/server/internal/record-payment.ts
@@ -1,3 +1,4 @@
+import { machinePaymentMetadata } from '../../internal/constants.js'
 import type { StripeClient } from '../../internal/types.js'
 import type { stripe } from '../Methods.js'
 import { createPaymentIntent, type ConnectConfig } from './request.js'
@@ -51,7 +52,7 @@ export function recordCryptoPayment(
           },
         },
       },
-      ...(metadata && { metadata }),
+      metadata: { ...metadata, ...machinePaymentMetadata },
     },
     {
       idempotencyKey: reference,


### PR DESCRIPTION
Add metadata.machine_payment=true to Stripe PaymentIntents created through shared payment tokens and crypto payment recording.

This will help users identify machine payments.