### PR TITLE
fix(tempo): prefer payable charge challenges

### DIFF
--- a/.changeset/prefer-funded-tempo-charges.md
+++ b/.changeset/prefer-funded-tempo-charges.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Preferred funded Tempo charge currencies when servers offered multiple payment challenges.

--- a/.changeset/prefer-funded-tempo-charges.md
+++ b/.changeset/prefer-funded-tempo-charges.md
@@ -2,4 +2,4 @@
 'mppx': patch
 ---
 
-Preferred funded Tempo charge currencies when servers offered multiple payment challenges.
+Prefer Tempo charge challenges that can be funded directly or through auto-swap, including the fee-token requirement for unsponsored MACH.

--- a/src/Method.ts
+++ b/src/Method.ts
@@ -67,6 +67,7 @@ export type Client<
     method,
     context extends z.ZodMiniType ? z.output<context> : Record<never, never>
   >
+  getChallengePriority?: GetChallengePriorityFn | undefined
 }
 export type AnyClient = Client<any, any>
 
@@ -272,6 +273,17 @@ export type CreateCredentialFn<method extends Method, context = unknown> = (
 
 /** Predicate used when multiple client implementations share a wire method/intent. */
 export type CanHandleChallengeFn = (parameters: { challenge: Challenge.Challenge }) => boolean
+
+/**
+ * Returns a method-owned preference score for a supported challenge.
+ *
+ * Higher scores are preferred. The client only compares challenges handled by
+ * the same configured method, preserving protocol and `Accept-Payment` order
+ * across different payment methods.
+ */
+export type GetChallengePriorityFn = (parameters: {
+  challenge: Challenge.Challenge
+}) => MaybePromise<number>
 
 /** Request transform function for a single method. */
 export type RequestFn<method extends Method> = (
@@ -499,12 +511,13 @@ export function toClient<
   const method extends Method,
   const context extends z.ZodMiniType | undefined = undefined,
 >(method: method, options: toClient.Options<method, context>): Client<method, context> {
-  const { canHandleChallenge, context, createCredential } = options
+  const { canHandleChallenge, context, createCredential, getChallengePriority } = options
   return {
     ...method,
     canHandleChallenge,
     context,
     createCredential,
+    getChallengePriority,
   } as Client<method, context>
 }
 
@@ -516,6 +529,7 @@ export declare namespace toClient {
       method,
       context extends z.ZodMiniType ? z.output<context> : Record<never, never>
     >
+    getChallengePriority?: GetChallengePriorityFn | undefined
   }
 }
 

--- a/src/client/Mppx.test-d.ts
+++ b/src/client/Mppx.test-d.ts
@@ -225,6 +225,18 @@ describe('create.Config', () => {
 })
 
 describe('Method.toClient', () => {
+  test('getChallengePriority receives an untyped challenge and may be async', () => {
+    Method.toClient(Methods.charge, {
+      async createCredential() {
+        return 'Payment ...'
+      },
+      async getChallengePriority({ challenge }) {
+        expectTypeOf(challenge.request).toEqualTypeOf<Record<string, unknown>>()
+        return 1
+      },
+    })
+  })
+
   test('createCredential receives typed challenge', () => {
     Method.toClient(Methods.charge, {
       async createCredential({ challenge }) {

--- a/src/client/Mppx.test.ts
+++ b/src/client/Mppx.test.ts
@@ -205,6 +205,34 @@ describe('preparePayment', () => {
     expect(createCredential).not.toHaveBeenCalled()
   })
 
+  test('behavior: applies method-owned challenge priority by default', async () => {
+    const createCredential = vi.fn(async ({ challenge }) =>
+      Credential.serialize({
+        challenge,
+        payload: { signature: '0xsignature', type: 'transaction' },
+      }),
+    )
+    const method = Method.toClient(
+      Method.from({
+        name: 'test',
+        intent: 'charge',
+        schema: Methods.charge.schema,
+      }),
+      {
+        createCredential,
+        getChallengePriority: ({ challenge }) => (challenge.id === 'funded' ? 1 : -1),
+      },
+    )
+    const mppx = Mppx.create({ methods: [method], polyfill: false })
+
+    const prepared = await mppx.preparePayment(
+      paymentRequiredResponse(paymentChallenge('unfunded'), paymentChallenge('funded')),
+    )
+
+    expect(prepared.challenge.id).toBe('funded')
+    expect(createCredential).not.toHaveBeenCalled()
+  })
+
   test('behavior: prepares a payment after the response body is consumed', async () => {
     const { method } = paymentMethod()
     const mppx = Mppx.create({ methods: [method], polyfill: false })

--- a/src/client/Mppx.ts
+++ b/src/client/Mppx.ts
@@ -596,7 +596,8 @@ async function resolveChallengeOrder<methods extends readonly Method.AnyClient[]
   candidates: readonly AcceptPayment.ChallengeCandidate<methods[number]>[],
   orderChallenges: AcceptPayment.OrderChallenges<methods> | undefined,
 ): Promise<readonly AcceptPayment.ChallengeCandidate<methods[number]>[]> {
-  return orderChallenges ? orderChallenges(candidates) : candidates
+  const prioritized = await AcceptPayment.prioritizeChallengeCandidates(candidates)
+  return orderChallenges ? orderChallenges(prioritized) : prioritized
 }
 
 async function createCredentialForMethod(

--- a/src/client/internal/Fetch.test.ts
+++ b/src/client/internal/Fetch.test.ts
@@ -1856,6 +1856,56 @@ describe('Fetch.from: 402 retry path', () => {
     expect(createCredential.mock.calls[0]?.[0].challenge.id).toBe('usdc')
   })
 
+  test('method-owned challenge priority selects a later funded offer', async () => {
+    let callCount = 0
+    const unfunded = Challenge.from({
+      id: 'unfunded',
+      realm: 'test',
+      method: 'test',
+      intent: 'test',
+      request: { currency: 'mach' },
+    })
+    const funded = Challenge.from({
+      id: 'funded',
+      realm: 'test',
+      method: 'test',
+      intent: 'test',
+      request: { currency: 'usdc' },
+    })
+    const createCredential = vi.fn(
+      async ({ challenge }: { challenge: Challenge.Challenge }) => `credential-${challenge.id}`,
+    )
+    const mockFetch: typeof globalThis.fetch = async (_input, init) => {
+      callCount++
+      if (callCount === 1)
+        return new Response(null, {
+          status: 402,
+          headers: {
+            'WWW-Authenticate': `${Challenge.serialize(unfunded)}, ${Challenge.serialize(funded)}`,
+          },
+        })
+
+      expect(new Headers(init?.headers).get('Authorization')).toBe('credential-funded')
+      return new Response('OK', { status: 200 })
+    }
+    const fetch = Fetch.from({
+      fetch: mockFetch,
+      methods: [
+        {
+          ...noopMethod,
+          createCredential,
+          getChallengePriority: ({ challenge }: { challenge: Challenge.Challenge }) =>
+            challenge.id === 'funded' ? 1 : -1,
+        },
+      ],
+    })
+
+    const response = await fetch('https://example.com/api')
+
+    expect(response.status).toBe(200)
+    expect(createCredential.mock.calls[0]?.[0].challenge.id).toBe('funded')
+  })
+
   test('request-local orderChallenges overrides configured ordering', async () => {
     let callCount = 0
     const first = Challenge.from({

--- a/src/client/internal/Fetch.ts
+++ b/src/client/internal/Fetch.ts
@@ -1014,7 +1014,8 @@ async function resolveChallengeOrder<methods extends readonly Method.AnyClient[]
   candidates: readonly AcceptPayment.ChallengeCandidate<methods[number]>[],
   orderChallenges: AcceptPayment.OrderChallenges<methods> | undefined,
 ): Promise<readonly AcceptPayment.ChallengeCandidate<methods[number]>[]> {
-  return orderChallenges ? orderChallenges(candidates) : candidates
+  const prioritized = await AcceptPayment.prioritizeChallengeCandidates(candidates)
+  return orderChallenges ? orderChallenges(prioritized) : prioritized
 }
 
 /** @internal */

--- a/src/internal/AcceptPayment.test.ts
+++ b/src/internal/AcceptPayment.test.ts
@@ -179,6 +179,29 @@ describe('AcceptPayment', () => {
     ])
   })
 
+  test('prioritizeChallengeCandidates reorders offers only within the same method', async () => {
+    const tempo = {
+      name: 'tempo',
+      intent: 'charge',
+      getChallengePriority: async ({ challenge }: { challenge: { id: string } }) =>
+        challenge.id === 'funded' ? 1 : -1,
+    }
+    const stripe = { name: 'stripe', intent: 'charge' }
+    const candidates = AcceptPayment.selectChallengeCandidates(
+      [
+        { id: 'unfunded', intent: 'charge', method: 'tempo', realm: 'test', request: {} },
+        { id: 'card', intent: 'charge', method: 'stripe', realm: 'test', request: {} },
+        { id: 'funded', intent: 'charge', method: 'tempo', realm: 'test', request: {} },
+      ],
+      [tempo, stripe] as const,
+      AcceptPayment.parse('tempo/charge, stripe/charge'),
+    )
+
+    const ordered = await AcceptPayment.prioritizeChallengeCandidates(candidates)
+
+    expect(ordered.map(({ challenge }) => challenge.id)).toEqual(['funded', 'card', 'unfunded'])
+  })
+
   test('selectChallengeCandidates prefers Payment-auth offers before x402 offers', () => {
     const x402Challenge = x402_ChallengeBrand.mark({
       id: 'x402:0',

--- a/src/internal/AcceptPayment.ts
+++ b/src/internal/AcceptPayment.ts
@@ -4,6 +4,9 @@ import type { MaybePromise } from './types.js'
 
 type MethodLike = {
   canHandleChallenge?: ((parameters: { challenge: Challenge.Challenge }) => boolean) | undefined
+  getChallengePriority?:
+    | ((parameters: { challenge: Challenge.Challenge }) => MaybePromise<number>)
+    | undefined
   intent: string
   name: string
 }
@@ -219,6 +222,42 @@ export function selectChallengeCandidates<const methods extends readonly MethodL
       const { match: _match, ...rest } = candidate
       return rest as unknown as ChallengeCandidate<methods[number]>
     })
+}
+
+/**
+ * Applies method-owned challenge preferences without disturbing negotiation
+ * order between different configured methods.
+ */
+export async function prioritizeChallengeCandidates<method extends MethodLike>(
+  candidates: readonly ChallengeCandidate<method>[],
+): Promise<ChallengeCandidate<method>[]> {
+  const ordered = [...candidates]
+  const positionsByMethod = new Map<method, number[]>()
+
+  for (const [index, candidate] of candidates.entries()) {
+    if (!candidate.method.getChallengePriority) continue
+    const method = candidate.method as method
+    const positions = positionsByMethod.get(method)
+    if (positions) positions.push(index)
+    else positionsByMethod.set(method, [index])
+  }
+
+  for (const [method, positions] of positionsByMethod) {
+    if (positions.length < 2 || !method.getChallengePriority) continue
+    const ranked = await Promise.all(
+      positions.map(async (position, index) => {
+        const candidate = candidates[position]!
+        const priority = await method.getChallengePriority!({ challenge: candidate.challenge })
+        if (!Number.isFinite(priority)) throw new Error('Challenge priority must be finite.')
+        return { candidate, index, priority }
+      }),
+    )
+    ranked.sort((left, right) => right.priority - left.priority || left.index - right.index)
+    for (const [index, position] of positions.entries())
+      ordered[position] = ranked[index]!.candidate
+  }
+
+  return ordered
 }
 
 /** Returns the canonical `method/intent` key for a method or challenge-like value. */

--- a/src/mcp/client/McpClient.ts
+++ b/src/mcp/client/McpClient.ts
@@ -210,9 +210,10 @@ function createPaymentAwareCallTool<methods extends Methods>(
       methods,
       paymentPreferences.entries,
     )
+    const prioritizedCandidates = await AcceptPayment.prioritizeChallengeCandidates(candidates)
     const orderedCandidates = config.orderChallenges
-      ? await config.orderChallenges(candidates)
-      : candidates
+      ? await config.orderChallenges(prioritizedCandidates)
+      : prioritizedCandidates
     const selected = orderedCandidates[0]
 
     if (!selected) {

--- a/src/mcp/client/McpClient.unit.test.ts
+++ b/src/mcp/client/McpClient.unit.test.ts
@@ -7,6 +7,47 @@ import { describe, expect, test, vi } from 'vp/test'
 import * as McpClient from './McpClient.js'
 
 describe('MCP client payment approval', () => {
+  test('uses method-owned priority for multiple payment challenges', async () => {
+    const challenges = ['unfunded', 'funded'].map((id) =>
+      Challenge.from({
+        id,
+        intent: 'charge',
+        method: 'tempo',
+        realm: 'api.example.com',
+        request: { currency: id },
+      }),
+    )
+    let calls = 0
+    const client = {
+      async callTool() {
+        calls += 1
+        if (calls === 1)
+          throw new McpError(core_Mcp.paymentRequiredCode, 'Payment Required', {
+            challenges,
+            httpStatus: 402,
+          })
+        return { content: [{ type: 'text', text: 'ok' }] }
+      },
+    }
+    const createCredential = vi.fn(async ({ challenge }: { challenge: Challenge.Challenge }) =>
+      Credential.serialize({
+        challenge,
+        payload: { signature: '0xsignature', type: 'transaction' },
+      }),
+    )
+    const method = Method.toClient(Methods.charge, {
+      createCredential,
+      getChallengePriority: ({ challenge }) => (challenge.id === 'funded' ? 1 : -1),
+    })
+    const mcp = McpClient.wrap(client as unknown as Pick<Client, 'callTool'>, {
+      methods: [method],
+    })
+
+    await mcp.callTool({ name: 'paid_tool' })
+
+    expect(createCredential.mock.calls[0]?.[0].challenge.id).toBe('funded')
+  })
+
   test('calls an approval hook before creating a credential', async () => {
     const challenge = Challenge.from({
       id: 'approval-test',

--- a/src/tempo/client/Charge.test.ts
+++ b/src/tempo/client/Charge.test.ts
@@ -82,7 +82,7 @@ describe('tempo.charge client', () => {
             currency: Addresses.pathUsd,
           }),
         }),
-      ).resolves.toBe(1)
+      ).resolves.toBe(2)
       await expect(
         method.getChallengePriority?.({
           challenge: createChallenge({
@@ -94,6 +94,112 @@ describe('tempo.charge client', () => {
       ).resolves.toBe(-1)
       expect(getBalance).toHaveBeenCalledTimes(2)
       expect(getBalance.mock.calls.every(([, parameters]) => parameters.decimals === 0)).toBe(true)
+    } finally {
+      vi.doUnmock('viem/tempo')
+      vi.resetModules()
+    }
+  })
+
+  test('prioritizes an auto-swappable stablecoin over unfunded MACH', async () => {
+    vi.resetModules()
+    const chainId = 42431
+    const usdc = '0x20C000000000000000000000b9537d11c60E8b50'
+    const findCalls = vi.fn(
+      async (
+        _client: unknown,
+        _parameters: { account: Address; amountOut: bigint; tokenOut: Address },
+      ) => [{ to: Addresses.stablecoinDex }],
+    )
+    const getBalance = vi.fn(async () => ({ amount: 0n }))
+    vi.doMock('viem/tempo', async (importOriginal) => {
+      const original = await importOriginal<typeof import('viem/tempo')>()
+      return {
+        ...original,
+        Actions: {
+          ...original.Actions,
+          token: { ...original.Actions.token, getBalance },
+        },
+      }
+    })
+    vi.doMock('../internal/auto-swap.js', async (importOriginal) => {
+      const original = await importOriginal<typeof import('../internal/auto-swap.js')>()
+      return { ...original, findCalls }
+    })
+
+    try {
+      const { charge: chargeWithMockedBalance } = await import('./Charge.js')
+      const client = createClient({
+        account,
+        chain: tempoLocalnet,
+        transport: http('http://127.0.0.1'),
+      })
+      const method = chargeWithMockedBalance({ account, autoSwap: true, getClient: () => client })
+
+      await expect(
+        method.getChallengePriority?.({
+          challenge: createChallenge({ amount: '1', chainId, currency: mach(chainId).address }),
+        }),
+      ).resolves.toBe(-1)
+      await expect(
+        method.getChallengePriority?.({
+          challenge: createChallenge({ amount: '1', chainId, currency: usdc }),
+        }),
+      ).resolves.toBe(1)
+      expect(findCalls).toHaveBeenCalledOnce()
+      expect(findCalls.mock.calls[0]?.[1]).toMatchObject({
+        account: account.address,
+        amountOut: 1_000_000n,
+        tokenOut: usdc,
+      })
+    } finally {
+      vi.doUnmock('viem/tempo')
+      vi.doUnmock('../internal/auto-swap.js')
+      vi.resetModules()
+    }
+  })
+
+  test('does not prioritize unsponsored MACH without a funded fee token', async () => {
+    vi.resetModules()
+    const chainId = 42431
+    const getBalance = vi.fn(async (_client: unknown, parameters: { token: Address }) => ({
+      amount: isAddressEqual(parameters.token, mach(chainId).address) ? 1_000_000n : 0n,
+    }))
+    vi.doMock('viem/tempo', async (importOriginal) => {
+      const original = await importOriginal<typeof import('viem/tempo')>()
+      return {
+        ...original,
+        Actions: {
+          ...original.Actions,
+          fee: { ...original.Actions.fee, getUserToken: vi.fn(async () => undefined) },
+          token: { ...original.Actions.token, getBalance },
+        },
+      }
+    })
+
+    try {
+      const { charge: chargeWithMockedBalance } = await import('./Charge.js')
+      const client = createClient({
+        account,
+        chain: tempoLocalnet,
+        transport: http('http://127.0.0.1'),
+      })
+      const method = chargeWithMockedBalance({ account, getClient: () => client })
+
+      await expect(
+        method.getChallengePriority?.({
+          challenge: createChallenge({ amount: '1', chainId, currency: mach(chainId).address }),
+        }),
+      ).resolves.toBe(-1)
+      await expect(
+        method.getChallengePriority?.({
+          challenge: createChallenge({
+            amount: '1',
+            chainId,
+            currency: mach(chainId).address,
+            feePayer: true,
+          }),
+        }),
+      ).resolves.toBe(2)
     } finally {
       vi.doUnmock('viem/tempo')
       vi.resetModules()

--- a/src/tempo/client/Charge.test.ts
+++ b/src/tempo/client/Charge.test.ts
@@ -37,9 +37,11 @@ function createChallenge(
 }
 
 function mockMachFeeSelection() {
-  const getBalance = vi.fn(async (_client: unknown, parameters: { token: Address }) => ({
-    amount: isAddressEqual(parameters.token, Addresses.pathUsd) ? 1n : 0n,
-  }))
+  const getBalance = vi.fn(
+    async (_client: unknown, parameters: { decimals?: number; token: Address }) => ({
+      amount: isAddressEqual(parameters.token, Addresses.pathUsd) ? 1_000_000n : 0n,
+    }),
+  )
   const getUserToken = vi.fn(async () => ({ address: mach(42431).address }))
 
   vi.doMock('viem/tempo', async (importOriginal) => {
@@ -58,6 +60,46 @@ function mockMachFeeSelection() {
 }
 
 describe('tempo.charge client', () => {
+  test('prioritizes a funded charge currency over an unfunded one', async () => {
+    vi.resetModules()
+    const { getBalance } = mockMachFeeSelection()
+
+    try {
+      const { charge: chargeWithMockedBalance } = await import('./Charge.js')
+      const chainId = 42431
+      const client = createClient({
+        account,
+        chain: tempoLocalnet,
+        transport: http('http://127.0.0.1'),
+      })
+      const method = chargeWithMockedBalance({ account, getClient: () => client })
+
+      await expect(
+        method.getChallengePriority?.({
+          challenge: createChallenge({
+            amount: '1',
+            chainId,
+            currency: Addresses.pathUsd,
+          }),
+        }),
+      ).resolves.toBe(1)
+      await expect(
+        method.getChallengePriority?.({
+          challenge: createChallenge({
+            amount: '1',
+            chainId,
+            currency: mach(chainId).address,
+          }),
+        }),
+      ).resolves.toBe(-1)
+      expect(getBalance).toHaveBeenCalledTimes(2)
+      expect(getBalance.mock.calls.every(([, parameters]) => parameters.decimals === 0)).toBe(true)
+    } finally {
+      vi.doUnmock('viem/tempo')
+      vi.resetModules()
+    }
+  })
+
   test('uses client chain ID when the challenge omits chainId', async () => {
     const client = createClient({
       account,

--- a/src/tempo/client/Charge.ts
+++ b/src/tempo/client/Charge.ts
@@ -63,6 +63,46 @@ export function charge(parameters: charge.Parameters = {}) {
   return Method.toClient(Methods.charge, {
     context: chargeContextSchema,
 
+    canHandleChallenge({ challenge }) {
+      const challengeChainId = (challenge.request.methodDetails as { chainId?: number } | undefined)
+        ?.chainId
+      return (
+        parameters.expectedChainId === undefined ||
+        challengeChainId === undefined ||
+        challengeChainId === parameters.expectedChainId
+      )
+    },
+
+    async getChallengePriority({ challenge }) {
+      if (parameters.autoSwap) return 0
+      const { amount, currency } = challenge.request
+      const methodDetails = challenge.request.methodDetails as { chainId?: number } | undefined
+      if (typeof amount !== 'string' || typeof currency !== 'string') return 0
+
+      let amountRaw: bigint
+      try {
+        amountRaw = BigInt(amount)
+      } catch {
+        return 0
+      }
+      if (amountRaw === 0n) return 1
+
+      try {
+        const chainId = methodDetails?.chainId ?? parameters.expectedChainId
+        const client = await getClient({ chainId })
+        const account = getAccount(client)
+        const balance = await Actions.token.getBalance(client as never, {
+          account: account.address,
+          // Priority compares base units only; avoid a redundant decimals RPC.
+          decimals: 0,
+          token: currency as Address,
+        })
+        return balance.amount >= amountRaw ? 1 : -1
+      } catch {
+        return 0
+      }
+    },
+
     async createCredential({ challenge, context }) {
       // Chain pinning: reject a challenge whose chain ID conflicts with the
       // pinned one, and sign on the pin when the challenge omits a chain ID.

--- a/src/tempo/client/Charge.ts
+++ b/src/tempo/client/Charge.ts
@@ -74,15 +74,17 @@ export function charge(parameters: charge.Parameters = {}) {
     },
 
     async getChallengePriority({ challenge }) {
-      if (parameters.autoSwap) return 0
       const { amount, currency } = challenge.request
-      const methodDetails = challenge.request.methodDetails as { chainId?: number } | undefined
+      const methodDetails = challenge.request.methodDetails as
+        | { chainId?: number; feePayer?: boolean }
+        | undefined
       if (typeof amount !== 'string' || typeof currency !== 'string') return 0
 
       let amountRaw: bigint
       try {
         amountRaw = BigInt(amount)
-      } catch {
+      } catch (error) {
+        if (error instanceof AutoSwap.InsufficientFundsError) return -1
         return 0
       }
       if (amountRaw === 0n) return 1
@@ -97,7 +99,40 @@ export function charge(parameters: charge.Parameters = {}) {
           decimals: 0,
           token: currency as Address,
         })
-        return balance.amount >= amountRaw ? 1 : -1
+        if (balance.amount >= amountRaw) {
+          const machAddress = mach.addresses[chainId as keyof typeof mach.addresses]
+          if (
+            machAddress &&
+            isAddressEqual(currency as Address, machAddress) &&
+            !methodDetails?.feePayer
+          ) {
+            const allowedFeeTokens = defaultFeeTokens(chainId)
+            const feeToken = await resolveFeeToken({
+              account: account.address,
+              allowedTokens: allowedFeeTokens,
+              candidateTokens: allowedFeeTokens,
+              client,
+              prioritizeCandidates: true,
+              requireBalance: true,
+            })
+            if (!feeToken) return -1
+          }
+          return 2
+        }
+
+        const autoSwap = AutoSwap.resolve(parameters.autoSwap, AutoSwap.defaultCurrencies)
+        const machAddress = mach.addresses[chainId as keyof typeof mach.addresses]
+        if (!autoSwap || (machAddress && isAddressEqual(currency as Address, machAddress)))
+          return -1
+
+        const calls = await AutoSwap.findCalls(client, {
+          account: account.address,
+          amountOut: amountRaw,
+          tokenOut: currency as Address,
+          tokenIn: autoSwap.tokenIn,
+          slippage: autoSwap.slippage,
+        })
+        return calls ? 1 : 2
       } catch {
         return 0
       }

--- a/src/tempo/internal/fee-token.ts
+++ b/src/tempo/internal/fee-token.ts
@@ -56,8 +56,10 @@ export async function resolveFeeToken(parameters: {
   candidateTokens?: readonly Address[] | undefined
   client: Client
   prioritizeCandidates?: boolean | undefined
+  requireBalance?: boolean | undefined
 }): Promise<Address | undefined> {
-  const { account, allowedTokens, candidateTokens, client, prioritizeCandidates } = parameters
+  const { account, allowedTokens, candidateTokens, client, prioritizeCandidates, requireBalance } =
+    parameters
   const tokens: Address[] = []
 
   if (prioritizeCandidates)
@@ -76,5 +78,5 @@ export async function resolveFeeToken(parameters: {
     if (await hasBalance(client, account, token)) return token
   }
 
-  return tokens[0]
+  return requireBalance ? undefined : tokens[0]
 }

--- a/src/tempo/legacy/client/SessionManager.ts
+++ b/src/tempo/legacy/client/SessionManager.ts
@@ -909,5 +909,6 @@ async function resolveSessionChallengeOrder(
   override: SessionOrderChallenges | undefined,
 ): Promise<readonly AcceptPayment.ChallengeCandidate<SessionMethod>[]> {
   const orderChallenges = override
-  return orderChallenges ? orderChallenges(candidates) : candidates
+  const prioritized = await AcceptPayment.prioritizeChallengeCandidates(candidates)
+  return orderChallenges ? orderChallenges(prioritized) : prioritized
 }


### PR DESCRIPTION
## Why

When a server offers multiple Tempo charge currencies, selecting the first offer can choose an unfunded token even though a later offer is payable. Auto-swap and unsponsored MACH fee funding also affect whether an offer is actually payable.

## What

Add method-owned asynchronous challenge priority across fetch, MCP, and session clients. Tempo charge ranks direct balances ahead of viable stablecoin auto-swaps, excludes unfunded MACH from auto-swap, and requires a funded supported fee token for unsponsored MACH. Preserve server order when payability cannot be determined.