### PR TITLE
fix: preserve multi-rail challenges in framework adapters

### DIFF
--- a/.changeset/fresh-rails-compose.md
+++ b/.changeset/fresh-rails-compose.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed framework adapters to preserve multi-method intent challenges.

--- a/src/middlewares/internal/mppx.test.ts
+++ b/src/middlewares/internal/mppx.test.ts
@@ -148,6 +148,21 @@ describe('wrap: nested handlers', () => {
     expect(nestedResult.options).toEqual(slashResult.options)
   })
 
+  test('shorthand intent composes methods that share an intent', async () => {
+    const mppx = Mppx.create({ methods: [alphaMethod, betaMethod], realm, secretKey })
+
+    const wrapped = wrap(mppx as any, (methodFn, options) => methodFn(options))
+    const handler = wrapped.charge(challengeOpts)
+    const result = await handler(new Request('https://example.com/resource'))
+
+    expect(handler._internal?.offers).toHaveLength(2)
+    expect(result.status).toBe(402)
+    if (result.status !== 402) throw new Error()
+    expect(
+      Challenge.fromResponseList(result.challenge).map((challenge) => challenge.method),
+    ).toEqual(['alpha', 'beta'])
+  })
+
   test('compose is omitted from wrapped object', () => {
     const mppx = Mppx.create({ methods: [alphaMethod], realm, secretKey }) as any
 

--- a/src/middlewares/internal/mppx.ts
+++ b/src/middlewares/internal/mppx.ts
@@ -55,9 +55,21 @@ export function wrap<mppx extends Mppx.Mppx<any, any>, handler>(
     }
     Object.assign(wrapWithMeta, methodFn)
     result[key] = wrapWithMeta
-    // Also set shorthand intent key if Mppx registered it (no collision)
-    if (!reservedMppxKeys.has(mi.intent) && (mppx as any)[mi.intent])
-      result[mi.intent] = wrapWithMeta
+    // Also set shorthand intent key, using the core-composed handler on collisions.
+    if (!reservedMppxKeys.has(mi.intent) && (mppx as any)[mi.intent]) {
+      const intentFn = (mppx as any)[mi.intent]
+      if (intentFn === methodFn) result[mi.intent] = wrapWithMeta
+      else {
+        const wrapIntentWithMeta = (options: any) => {
+          const configured = intentFn(options)
+          const handler = wrapper(intentFn, options) as any
+          if (configured._internal) handler._internal = configured._internal
+          return handler
+        }
+        Object.assign(wrapIntentWithMeta, intentFn)
+        result[mi.intent] = wrapIntentWithMeta
+      }
+    }
     // Build nested handlers: wrapped.tempo.charge(...)
     if (!result[mi.name] || typeof result[mi.name] !== 'object')
       result[mi.name] = {} as Record<string, unknown>


### PR DESCRIPTION
- Framework adapters rebuild shorthand intent handlers once per payment method. When multiple methods share an intent, each iteration replaces the previous shorthand, so the final method silently shadows the core composed handler and earlier payment offers disappear.

- This change wraps the shorthand handler already composed by the core when it differs from the per-method handler. Unique shorthand, slash, and nested handlers retain their existing behavior, and adapter `compose` remains intentionally omitted.

- Without this change, the following route returns only the Stripe challenge even though `defaultMethods()` supplies both Tempo and Stripe charge methods:

```ts
import express from "express"
import { Mppx, stripe } from "mppx/express"

const stripeMachinePayments = stripe.create({
  client: stripeClient,
  depositAddresses: { tempo: depositAddress },
  livemode: false,
  networkId,
})
const mppx = Mppx.create({
  methods: stripeMachinePayments.defaultMethods(),
  secretKey,
})

const app = express()
app.get("/paid", mppx.charge({ amount: "0.50" }), handler)
```

- An unauthenticated request to `/paid` now returns challenges for both `tempo/charge` and `stripe/charge`.