### PR TITLE
Additional Payment Intent Options

### DIFF
--- a/.changeset/customer-payment-intent-options.md
+++ b/.changeset/customer-payment-intent-options.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added request-scoped PaymentIntent customer options to Stripe machine payment charge handlers.

--- a/.changeset/customer-payment-intent-options.md
+++ b/.changeset/customer-payment-intent-options.md
@@ -2,4 +2,4 @@
 'mppx': patch
 ---
 
-Added request-scoped PaymentIntent customer options to Stripe machine payment charge handlers.
+Added request-scoped PaymentIntent customer options and fallback recording without rejected optional fields for completed crypto payments.

--- a/.changeset/customer-payment-intent-options.md
+++ b/.changeset/customer-payment-intent-options.md
@@ -2,4 +2,4 @@
 'mppx': patch
 ---
 
-Added request-scoped PaymentIntent customer options and fallback recording without rejected optional fields for completed crypto payments.
+Added request-scoped PaymentIntent customer, receipt email, and Tax calculation options, with fallback recording without rejected optional fields for completed crypto payments.

--- a/src/stripe/Methods.test.ts
+++ b/src/stripe/Methods.test.ts
@@ -68,6 +68,22 @@ describe('charge', () => {
     expect(result.success).toBe(false)
   })
 
+  test.each([{ hooks: { inputs: { tax: { calculation: '' } } } }, { receipt_email: '' }])(
+    'schema: rejects empty PaymentIntent option strings',
+    (paymentIntentOptions) => {
+      const result = Methods.charge.schema.request.safeParse({
+        amount: '1',
+        currency: 'usd',
+        decimals: 2,
+        networkId: 'profile_123',
+        paymentIntentOptions,
+        paymentMethodTypes: ['card'],
+      })
+
+      expect(result.success).toBe(false)
+    },
+  )
+
   test('schema: requires decimals when no server default supplies it', () => {
     const result = Methods.charge.schema.request.safeParse({
       amount: '1',

--- a/src/stripe/Methods.test.ts
+++ b/src/stripe/Methods.test.ts
@@ -24,7 +24,12 @@ describe('charge', () => {
       networkId: 'profile_123',
       paymentMethodTypes: ['card'],
       metadata: { example: 'metadata' },
-      paymentIntentOptions: { customer: 'cus_123', metadata: { order: '123' } },
+      paymentIntentOptions: {
+        customer: 'cus_123',
+        hooks: { inputs: { tax: { calculation: 'taxcalc_123' } } },
+        metadata: { order: '123' },
+        receipt_email: 'customer@example.com',
+      },
     })
     expect(result.success).toBe(true)
     if (result.success) expect(result.data).not.toHaveProperty('paymentIntentOptions')

--- a/src/stripe/Methods.test.ts
+++ b/src/stripe/Methods.test.ts
@@ -24,7 +24,7 @@ describe('charge', () => {
       networkId: 'profile_123',
       paymentMethodTypes: ['card'],
       metadata: { example: 'metadata' },
-      paymentIntentOptions: { metadata: { order: '123' } },
+      paymentIntentOptions: { customer: 'cus_123', metadata: { order: '123' } },
     })
     expect(result.success).toBe(true)
     if (result.success) expect(result.data).not.toHaveProperty('paymentIntentOptions')
@@ -34,6 +34,32 @@ describe('charge', () => {
     const result = Methods.charge.schema.request.safeParse({
       amount: '1',
     })
+    expect(result.success).toBe(false)
+  })
+
+  test('schema: accepts a customer without metadata', () => {
+    const result = Methods.charge.schema.request.safeParse({
+      amount: '1',
+      currency: 'usd',
+      decimals: 2,
+      networkId: 'profile_123',
+      paymentIntentOptions: { customer: 'cus_123' },
+      paymentMethodTypes: ['card'],
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  test('schema: rejects an empty customer', () => {
+    const result = Methods.charge.schema.request.safeParse({
+      amount: '1',
+      currency: 'usd',
+      decimals: 2,
+      networkId: 'profile_123',
+      paymentIntentOptions: { customer: '' },
+      paymentMethodTypes: ['card'],
+    })
+
     expect(result.success).toBe(false)
   })
 

--- a/src/stripe/internal/payment-intent.ts
+++ b/src/stripe/internal/payment-intent.ts
@@ -2,7 +2,8 @@ import * as z from '../../zod.js'
 
 /** Stripe PaymentIntent options accepted only by server-side method input. */
 export const Schema = z.object({
-  metadata: z.record(z.string(), z.string()),
+  customer: z.optional(z.string().check(z.minLength(1))),
+  metadata: z.optional(z.record(z.string(), z.string())),
 })
 
 export type Options = z.infer<typeof Schema>

--- a/src/stripe/internal/payment-intent.ts
+++ b/src/stripe/internal/payment-intent.ts
@@ -6,12 +6,12 @@ export const Schema = z.object({
   hooks: z.optional(
     z.object({
       inputs: z.object({
-        tax: z.object({ calculation: z.string() }),
+        tax: z.object({ calculation: z.string().check(z.minLength(1)) }),
       }),
     }),
   ),
   metadata: z.optional(z.record(z.string(), z.string())),
-  receipt_email: z.optional(z.string()),
+  receipt_email: z.optional(z.string().check(z.minLength(1))),
 })
 
 export type Options = z.infer<typeof Schema>

--- a/src/stripe/internal/payment-intent.ts
+++ b/src/stripe/internal/payment-intent.ts
@@ -3,7 +3,15 @@ import * as z from '../../zod.js'
 /** Stripe PaymentIntent options accepted only by server-side method input. */
 export const Schema = z.object({
   customer: z.optional(z.string().check(z.minLength(1))),
+  hooks: z.optional(
+    z.object({
+      inputs: z.object({
+        tax: z.object({ calculation: z.string() }),
+      }),
+    }),
+  ),
   metadata: z.optional(z.record(z.string(), z.string())),
+  receipt_email: z.optional(z.string()),
 })
 
 export type Options = z.infer<typeof Schema>

--- a/src/stripe/server/Charge.test.ts
+++ b/src/stripe/server/Charge.test.ts
@@ -193,7 +193,10 @@ describe('stripe.charge with client', () => {
           currency: 'usd',
           decimals: 2,
           paymentIntentOptions: {
+            amount: 999,
+            confirm: false,
             customer: 'cus_123',
+            currency: 'eur',
             hooks: { inputs: { tax: { calculation: 'taxcalc_123' } } },
             metadata: {
               machine_payment: 'custom',
@@ -202,7 +205,7 @@ describe('stripe.charge with client', () => {
               request_id: 'req_123',
             },
             receipt_email: 'customer@example.com',
-          },
+          } as any,
         }),
       )(req, res)
       if (result.status === 402) return
@@ -222,7 +225,10 @@ describe('stripe.charge with client', () => {
     })
 
     const [params] = create.mock.calls[0]!
+    expect(params.amount).toBe(100)
+    expect(params.confirm).toBe(true)
     expect(params.customer).toBe('cus_123')
+    expect(params.currency).toBe('usd')
     expect(params.hooks).toEqual({ inputs: { tax: { calculation: 'taxcalc_123' } } })
     expect(params.metadata).toMatchObject({
       machine_payment: 'custom',

--- a/src/stripe/server/Charge.test.ts
+++ b/src/stripe/server/Charge.test.ts
@@ -194,12 +194,14 @@ describe('stripe.charge with client', () => {
           decimals: 2,
           paymentIntentOptions: {
             customer: 'cus_123',
+            hooks: { inputs: { tax: { calculation: 'taxcalc_123' } } },
             metadata: {
               machine_payment: 'custom',
               mpp_challenge_id: 'custom',
               plan: 'enterprise',
               request_id: 'req_123',
             },
+            receipt_email: 'customer@example.com',
           },
         }),
       )(req, res)
@@ -221,6 +223,7 @@ describe('stripe.charge with client', () => {
 
     const [params] = create.mock.calls[0]!
     expect(params.customer).toBe('cus_123')
+    expect(params.hooks).toEqual({ inputs: { tax: { calculation: 'taxcalc_123' } } })
     expect(params.metadata).toMatchObject({
       machine_payment: 'custom',
       mpp_challenge_id: 'custom',
@@ -229,6 +232,7 @@ describe('stripe.charge with client', () => {
     })
     expect(params.metadata).not.toHaveProperty('mpp_is_mpp')
     expect(params.metadata).not.toHaveProperty('mpp_version')
+    expect(params.receipt_email).toBe('customer@example.com')
   })
 
   test('behavior: applies Connect settlement parameters in client call', async () => {
@@ -314,7 +318,16 @@ describe('stripe.charge with client', () => {
       secretKey,
     })
 
-    const handle = server.charge({ amount: '1', currency: 'usd', decimals: 2 })
+    const handle = server.charge({
+      amount: '1',
+      currency: 'usd',
+      decimals: 2,
+      paymentIntentOptions: {
+        customer: 'cus_123',
+        hooks: { inputs: { tax: { calculation: 'taxcalc_123' } } },
+        receipt_email: 'customer@example.com',
+      },
+    })
     const firstResult = await handle(new Request('https://example.com'))
     expect(firstResult.status).toBe(402)
     if (firstResult.status !== 402) throw new Error()
@@ -342,6 +355,9 @@ describe('stripe.charge with client', () => {
     expect(body.get('transfer_data[amount]')).toBe('88')
     expect(body.get('transfer_data[destination]')).toBe('acct_destination')
     expect(body.get('transfer_group')).toBe('order_123')
+    expect(body.get('customer')).toBe('cus_123')
+    expect(body.get('hooks[inputs][tax][calculation]')).toBe('taxcalc_123')
+    expect(body.get('receipt_email')).toBe('customer@example.com')
   })
 
   test('security: attributes receipt externalId from the server-bound request', async () => {

--- a/src/stripe/server/Charge.test.ts
+++ b/src/stripe/server/Charge.test.ts
@@ -192,7 +192,15 @@ describe('stripe.charge with client', () => {
           amount: '1',
           currency: 'usd',
           decimals: 2,
-          paymentIntentOptions: { metadata: { plan: 'enterprise', request_id: 'req_123' } },
+          paymentIntentOptions: {
+            customer: 'cus_123',
+            metadata: {
+              machine_payment: 'custom',
+              mpp_challenge_id: 'custom',
+              plan: 'enterprise',
+              request_id: 'req_123',
+            },
+          },
         }),
       )(req, res)
       if (result.status === 402) return
@@ -212,8 +220,13 @@ describe('stripe.charge with client', () => {
     })
 
     const [params] = create.mock.calls[0]!
-    expect(params.metadata).toMatchObject({ plan: 'enterprise', request_id: 'req_123' })
-    expect(params.metadata).toHaveProperty('machine_payment', 'true')
+    expect(params.customer).toBe('cus_123')
+    expect(params.metadata).toMatchObject({
+      machine_payment: 'custom',
+      mpp_challenge_id: 'custom',
+      plan: 'enterprise',
+      request_id: 'req_123',
+    })
     expect(params.metadata).not.toHaveProperty('mpp_is_mpp')
     expect(params.metadata).not.toHaveProperty('mpp_version')
   })

--- a/src/stripe/server/Charge.ts
+++ b/src/stripe/server/Charge.ts
@@ -182,9 +182,9 @@ export function charge<const parameters extends charge.Parameters>(parameters: p
         | undefined
       const resolvedMetadata = {
         ...buildAnalytics({ credential }),
+        ...machinePaymentMetadata,
         ...userMetadata,
         ...paymentIntentOptions?.metadata,
-        ...machinePaymentMetadata,
       }
       const settlement = validateConnectSettlement({
         amount: resolvedRequest.amount,
@@ -193,11 +193,13 @@ export function charge<const parameters extends charge.Parameters>(parameters: p
             ? await connect({ challenge, credential, envelope, request: resolvedRequest })
             : connect,
       })
+      const customer = paymentIntentOptions?.customer
 
       const pi = client
         ? await createWithClient({
             client,
             challenge,
+            customer,
             request: resolvedRequest,
             spt,
             metadata: resolvedMetadata,
@@ -206,6 +208,7 @@ export function charge<const parameters extends charge.Parameters>(parameters: p
         : await createWithSecretKey({
             secretKey: secretKey!,
             challenge,
+            customer,
             request: resolvedRequest,
             spt,
             metadata: resolvedMetadata,
@@ -318,18 +321,20 @@ export declare namespace charge {
 async function createWithClient(parameters: {
   client: StripeClient
   challenge: { id: string }
+  customer?: string | undefined
   metadata: Record<string, string>
   request: { amount: unknown; currency: unknown }
   settlement: charge.ConnectSettlement | undefined
   spt: string
 }): Promise<{ id: string; status: string; replayed: boolean }> {
-  const { client, challenge, metadata, request, settlement, spt } = parameters
+  const { client, challenge, customer, metadata, request, settlement, spt } = parameters
   try {
     const paymentIntentParams = {
       amount: Number(request.amount),
       automatic_payment_methods: { allow_redirects: 'never', enabled: true },
       confirm: true,
       currency: request.currency as string,
+      ...(customer !== undefined && { customer }),
       metadata,
       ...(settlement?.applicationFeeAmount !== undefined && {
         application_fee_amount: settlement.applicationFeeAmount,
@@ -371,12 +376,13 @@ async function createWithClient(parameters: {
 async function createWithSecretKey(parameters: {
   secretKey: string
   challenge: { id: string }
+  customer?: string | undefined
   metadata: Record<string, string>
   request: { amount: unknown; currency: unknown }
   settlement: charge.ConnectSettlement | undefined
   spt: string
 }): Promise<{ id: string; status: string; replayed: boolean }> {
-  const { secretKey, challenge, metadata, request, settlement, spt } = parameters
+  const { secretKey, challenge, customer, metadata, request, settlement, spt } = parameters
 
   const body = new URLSearchParams({
     amount: request.amount as string,
@@ -384,6 +390,7 @@ async function createWithSecretKey(parameters: {
     'automatic_payment_methods[enabled]': 'true',
     confirm: 'true',
     currency: request.currency as string,
+    ...(customer !== undefined && { customer }),
     shared_payment_granted_token: spt,
   })
   for (const [key, value] of Object.entries(metadata)) {

--- a/src/stripe/server/Charge.ts
+++ b/src/stripe/server/Charge.ts
@@ -11,6 +11,7 @@ import * as Method from '../../Method.js'
 import type * as Html from '../../server/internal/html/config.ts'
 import type * as z from '../../zod.js'
 import { machinePaymentMetadata, stripePreviewVersion } from '../internal/constants.js'
+import type * as PaymentIntent from '../internal/payment-intent.js'
 import type {
   StripeClient,
   CreatePaymentMethodFromElements,
@@ -193,13 +194,11 @@ export function charge<const parameters extends charge.Parameters>(parameters: p
             ? await connect({ challenge, credential, envelope, request: resolvedRequest })
             : connect,
       })
-      const customer = paymentIntentOptions?.customer
-
       const pi = client
         ? await createWithClient({
             client,
             challenge,
-            customer,
+            paymentIntentOptions,
             request: resolvedRequest,
             spt,
             metadata: resolvedMetadata,
@@ -208,7 +207,7 @@ export function charge<const parameters extends charge.Parameters>(parameters: p
         : await createWithSecretKey({
             secretKey: secretKey!,
             challenge,
-            customer,
+            paymentIntentOptions,
             request: resolvedRequest,
             spt,
             metadata: resolvedMetadata,
@@ -321,20 +320,21 @@ export declare namespace charge {
 async function createWithClient(parameters: {
   client: StripeClient
   challenge: { id: string }
-  customer?: string | undefined
   metadata: Record<string, string>
+  paymentIntentOptions?: PaymentIntent.Options | undefined
   request: { amount: unknown; currency: unknown }
   settlement: charge.ConnectSettlement | undefined
   spt: string
 }): Promise<{ id: string; status: string; replayed: boolean }> {
-  const { client, challenge, customer, metadata, request, settlement, spt } = parameters
+  const { client, challenge, metadata, paymentIntentOptions, request, settlement, spt } = parameters
+  const { metadata: _, ...additionalParams } = paymentIntentOptions ?? {}
   try {
     const paymentIntentParams = {
       amount: Number(request.amount),
       automatic_payment_methods: { allow_redirects: 'never', enabled: true },
       confirm: true,
       currency: request.currency as string,
-      ...(customer !== undefined && { customer }),
+      ...additionalParams,
       metadata,
       ...(settlement?.applicationFeeAmount !== undefined && {
         application_fee_amount: settlement.applicationFeeAmount,
@@ -352,15 +352,12 @@ async function createWithClient(parameters: {
       // `shared_payment_granted_token` is not yet in the Stripe SDK types (SPTs are in private preview).
       shared_payment_granted_token: spt,
     }
-    const paymentIntentOptions = {
+    const requestOptions = {
       apiVersion: stripePreviewVersion,
       idempotencyKey: `mpp_${challenge.id}_${spt}`,
       ...(settlement?.stripeAccount !== undefined && { stripeAccount: settlement.stripeAccount }),
     }
-    const result = await client.paymentIntents.create(
-      paymentIntentParams as any,
-      paymentIntentOptions,
-    )
+    const result = await client.paymentIntents.create(paymentIntentParams as any, requestOptions)
     // https://docs.stripe.com/error-low-level#idempotency
     const replayed = result.lastResponse?.headers?.['idempotent-replayed'] === 'true'
     return { id: result.id, status: result.status, replayed }
@@ -376,13 +373,15 @@ async function createWithClient(parameters: {
 async function createWithSecretKey(parameters: {
   secretKey: string
   challenge: { id: string }
-  customer?: string | undefined
   metadata: Record<string, string>
+  paymentIntentOptions?: PaymentIntent.Options | undefined
   request: { amount: unknown; currency: unknown }
   settlement: charge.ConnectSettlement | undefined
   spt: string
 }): Promise<{ id: string; status: string; replayed: boolean }> {
-  const { secretKey, challenge, customer, metadata, request, settlement, spt } = parameters
+  const { secretKey, challenge, metadata, paymentIntentOptions, request, settlement, spt } =
+    parameters
+  const { customer, hooks, receipt_email: receiptEmail } = paymentIntentOptions ?? {}
 
   const body = new URLSearchParams({
     amount: request.amount as string,
@@ -396,6 +395,8 @@ async function createWithSecretKey(parameters: {
   for (const [key, value] of Object.entries(metadata)) {
     body.set(`metadata[${key}]`, value)
   }
+  if (receiptEmail !== undefined) body.set('receipt_email', receiptEmail)
+  if (hooks !== undefined) body.set('hooks[inputs][tax][calculation]', hooks.inputs.tax.calculation)
   if (settlement?.applicationFeeAmount !== undefined)
     body.set('application_fee_amount', String(settlement.applicationFeeAmount))
   if (settlement?.onBehalfOf !== undefined) body.set('on_behalf_of', settlement.onBehalfOf)

--- a/src/stripe/server/Charge.ts
+++ b/src/stripe/server/Charge.ts
@@ -381,7 +381,7 @@ async function createWithSecretKey(parameters: {
 }): Promise<{ id: string; status: string; replayed: boolean }> {
   const { secretKey, challenge, metadata, paymentIntentOptions, request, settlement, spt } =
     parameters
-  const { customer, hooks, receipt_email: receiptEmail } = paymentIntentOptions ?? {}
+  const { customer, hooks, receipt_email } = paymentIntentOptions ?? {}
 
   const body = new URLSearchParams({
     amount: request.amount as string,
@@ -390,12 +390,12 @@ async function createWithSecretKey(parameters: {
     confirm: 'true',
     currency: request.currency as string,
     ...(customer !== undefined && { customer }),
+    ...(receipt_email !== undefined && { receipt_email }),
     shared_payment_granted_token: spt,
   })
   for (const [key, value] of Object.entries(metadata)) {
     body.set(`metadata[${key}]`, value)
   }
-  if (receiptEmail !== undefined) body.set('receipt_email', receiptEmail)
   if (hooks !== undefined) body.set('hooks[inputs][tax][calculation]', hooks.inputs.tax.calculation)
   if (settlement?.applicationFeeAmount !== undefined)
     body.set('application_fee_amount', String(settlement.applicationFeeAmount))

--- a/src/stripe/server/Charge.ts
+++ b/src/stripe/server/Charge.ts
@@ -327,15 +327,17 @@ async function createWithClient(parameters: {
   spt: string
 }): Promise<{ id: string; status: string; replayed: boolean }> {
   const { client, challenge, metadata, paymentIntentOptions, request, settlement, spt } = parameters
-  const { metadata: _, ...additionalParams } = paymentIntentOptions ?? {}
+  const { customer, hooks, receipt_email } = paymentIntentOptions ?? {}
   try {
     const paymentIntentParams = {
       amount: Number(request.amount),
       automatic_payment_methods: { allow_redirects: 'never', enabled: true },
       confirm: true,
       currency: request.currency as string,
-      ...additionalParams,
+      ...(customer !== undefined && { customer }),
+      ...(hooks !== undefined && { hooks }),
       metadata,
+      ...(receipt_email !== undefined && { receipt_email }),
       ...(settlement?.applicationFeeAmount !== undefined && {
         application_fee_amount: settlement.applicationFeeAmount,
       }),

--- a/src/stripe/server/Charge.ts
+++ b/src/stripe/server/Charge.ts
@@ -181,11 +181,22 @@ export function charge<const parameters extends charge.Parameters>(parameters: p
       const userMetadata = resolvedRequest.methodDetails?.metadata as
         | Record<string, string>
         | undefined
-      const resolvedMetadata = {
-        ...buildAnalytics({ credential }),
-        ...machinePaymentMetadata,
-        ...userMetadata,
-        ...paymentIntentOptions?.metadata,
+      const {
+        customer,
+        hooks,
+        metadata: optionMetadata,
+        receipt_email,
+      } = paymentIntentOptions ?? {}
+      const resolvedPaymentIntentOptions: ResolvedPaymentIntentOptions = {
+        ...(customer !== undefined && { customer }),
+        ...(hooks !== undefined && { hooks }),
+        metadata: {
+          ...buildAnalytics({ credential }),
+          ...machinePaymentMetadata,
+          ...userMetadata,
+          ...optionMetadata,
+        },
+        ...(receipt_email !== undefined && { receipt_email }),
       }
       const settlement = validateConnectSettlement({
         amount: resolvedRequest.amount,
@@ -198,19 +209,17 @@ export function charge<const parameters extends charge.Parameters>(parameters: p
         ? await createWithClient({
             client,
             challenge,
-            paymentIntentOptions,
+            paymentIntentOptions: resolvedPaymentIntentOptions,
             request: resolvedRequest,
             spt,
-            metadata: resolvedMetadata,
             settlement,
           })
         : await createWithSecretKey({
             secretKey: secretKey!,
             challenge,
-            paymentIntentOptions,
+            paymentIntentOptions: resolvedPaymentIntentOptions,
             request: resolvedRequest,
             spt,
-            metadata: resolvedMetadata,
             settlement,
           })
 
@@ -316,18 +325,21 @@ export declare namespace charge {
   }) => MaybePromise<ConnectSettlement | undefined>
 }
 
+type ResolvedPaymentIntentOptions = PaymentIntent.Options & {
+  metadata: Record<string, string>
+}
+
 /** Creates a PaymentIntent using the Stripe SDK client. */
 async function createWithClient(parameters: {
   client: StripeClient
   challenge: { id: string }
-  metadata: Record<string, string>
-  paymentIntentOptions?: PaymentIntent.Options | undefined
+  paymentIntentOptions: ResolvedPaymentIntentOptions
   request: { amount: unknown; currency: unknown }
   settlement: charge.ConnectSettlement | undefined
   spt: string
 }): Promise<{ id: string; status: string; replayed: boolean }> {
-  const { client, challenge, metadata, paymentIntentOptions, request, settlement, spt } = parameters
-  const { customer, hooks, receipt_email } = paymentIntentOptions ?? {}
+  const { client, challenge, paymentIntentOptions, request, settlement, spt } = parameters
+  const { customer, hooks, metadata, receipt_email } = paymentIntentOptions
   try {
     const paymentIntentParams = {
       amount: Number(request.amount),
@@ -375,15 +387,13 @@ async function createWithClient(parameters: {
 async function createWithSecretKey(parameters: {
   secretKey: string
   challenge: { id: string }
-  metadata: Record<string, string>
-  paymentIntentOptions?: PaymentIntent.Options | undefined
+  paymentIntentOptions: ResolvedPaymentIntentOptions
   request: { amount: unknown; currency: unknown }
   settlement: charge.ConnectSettlement | undefined
   spt: string
 }): Promise<{ id: string; status: string; replayed: boolean }> {
-  const { secretKey, challenge, metadata, paymentIntentOptions, request, settlement, spt } =
-    parameters
-  const { customer, hooks, receipt_email } = paymentIntentOptions ?? {}
+  const { secretKey, challenge, paymentIntentOptions, request, settlement, spt } = parameters
+  const { customer, hooks, metadata, receipt_email } = paymentIntentOptions
 
   const body = new URLSearchParams({
     amount: request.amount as string,

--- a/src/stripe/server/Methods.test-d.ts
+++ b/src/stripe/server/Methods.test-d.ts
@@ -16,7 +16,12 @@ test('async defaultMethods() produces types compose can use', async () => {
       {
         amount: '0.01',
         description: 'test',
-        paymentIntentOptions: { customer: 'cus_123', metadata: { key: 'value' } },
+        paymentIntentOptions: {
+          customer: 'cus_123',
+          hooks: { inputs: { tax: { calculation: 'taxcalc_123' } } },
+          metadata: { key: 'value' },
+          receipt_email: 'customer@example.com',
+        },
       },
     ],
     [

--- a/src/stripe/server/Methods.test-d.ts
+++ b/src/stripe/server/Methods.test-d.ts
@@ -16,7 +16,7 @@ test('async defaultMethods() produces types compose can use', async () => {
       {
         amount: '0.01',
         description: 'test',
-        paymentIntentOptions: { metadata: { key: 'value' } },
+        paymentIntentOptions: { customer: 'cus_123', metadata: { key: 'value' } },
       },
     ],
     [
@@ -26,7 +26,7 @@ test('async defaultMethods() produces types compose can use', async () => {
         currency: 'usd',
         decimals: 2,
         description: 'test',
-        paymentIntentOptions: { metadata: { key: 'value' } },
+        paymentIntentOptions: { customer: 'cus_123' },
       },
     ],
   )(new Request('http://localhost'))

--- a/src/stripe/server/Methods.test.ts
+++ b/src/stripe/server/Methods.test.ts
@@ -74,7 +74,9 @@ describe('stripe.create() defaultMethods', () => {
       requestInput: {
         paymentIntentOptions: {
           customer: 'cus_123',
+          hooks: { inputs: { tax: { calculation: 'taxcalc_123' } } },
           metadata: { machine_payment: 'custom', request_id: 'req_123' },
+          receipt_email: 'customer@example.com',
         },
       },
     })
@@ -82,7 +84,9 @@ describe('stripe.create() defaultMethods', () => {
     expect(client.paymentIntents.create).toHaveBeenCalledWith(
       expect.objectContaining({
         customer: 'cus_123',
+        hooks: { inputs: { tax: { calculation: 'taxcalc_123' } } },
         metadata: { agent_id: 'test-agent', machine_payment: 'custom', request_id: 'req_123' },
+        receipt_email: 'customer@example.com',
       }),
       expect.anything(),
     )

--- a/src/stripe/server/Methods.test.ts
+++ b/src/stripe/server/Methods.test.ts
@@ -71,12 +71,18 @@ describe('stripe.create() defaultMethods', () => {
     await tempoMethod.onPaymentSuccess!({
       receipt: { reference: '0xtx123' },
       request: { amount: '500000' },
-      requestInput: { paymentIntentOptions: { metadata: { request_id: 'req_123' } } },
+      requestInput: {
+        paymentIntentOptions: {
+          customer: 'cus_123',
+          metadata: { machine_payment: 'custom', request_id: 'req_123' },
+        },
+      },
     })
 
     expect(client.paymentIntents.create).toHaveBeenCalledWith(
       expect.objectContaining({
-        metadata: { agent_id: 'test-agent', machine_payment: 'true', request_id: 'req_123' },
+        customer: 'cus_123',
+        metadata: { agent_id: 'test-agent', machine_payment: 'custom', request_id: 'req_123' },
       }),
       expect.anything(),
     )

--- a/src/stripe/server/Methods.ts
+++ b/src/stripe/server/Methods.ts
@@ -456,15 +456,16 @@ function createPaymentSuccessHandler(
         ...metadata,
         ...requestInput?.paymentIntentOptions?.metadata,
       }
+      const paymentIntentOptions = {
+        ...requestInput?.paymentIntentOptions,
+        ...(Object.keys(resolvedMetadata).length > 0 && { metadata: resolvedMetadata }),
+      }
       return recordCryptoPayment(client, {
         network,
         reference: receipt.reference,
         amount: String(request.amount),
         ...(connect && { connect }),
-        ...(requestInput?.paymentIntentOptions?.customer && {
-          customer: requestInput.paymentIntentOptions.customer,
-        }),
-        ...(Object.keys(resolvedMetadata).length > 0 && { metadata: resolvedMetadata }),
+        ...(Object.keys(paymentIntentOptions).length > 0 && { paymentIntentOptions }),
       })
     }
   }

--- a/src/stripe/server/Methods.ts
+++ b/src/stripe/server/Methods.ts
@@ -187,6 +187,11 @@ class DefaultMethodsBuilder implements PromiseLike<DefaultMethods> {
  *   secretKey: mppSecretKey,
  * })
  * ```
+ *
+ * Caller-provided `paymentIntentOptions` are best-effort when recording completed
+ * crypto payments. If Stripe rejects those options, mppx retries the recording
+ * once without them so the on-chain payment can still be represented by a
+ * PaymentIntent. SPT payments do not use this fallback.
  */
 export function stripe<const P extends stripe.Parameters>(parameters: P): StripeMachinePayments<P> {
   const { client, networkId, livemode, connect, depositAddresses, metadata } = parameters

--- a/src/stripe/server/Methods.ts
+++ b/src/stripe/server/Methods.ts
@@ -456,6 +456,9 @@ function createPaymentSuccessHandler(
         reference: receipt.reference,
         amount: String(request.amount),
         ...(connect && { connect }),
+        ...(requestInput?.paymentIntentOptions?.customer && {
+          customer: requestInput.paymentIntentOptions.customer,
+        }),
         ...(Object.keys(resolvedMetadata).length > 0 && { metadata: resolvedMetadata }),
       })
     }

--- a/src/stripe/server/internal/record-payment.test.ts
+++ b/src/stripe/server/internal/record-payment.test.ts
@@ -22,18 +22,24 @@ describe('recordCryptoPayment', () => {
       amount: '500000',
       network: 'tempo',
       paymentIntentOptions: {
+        amount: 999,
+        confirm: false,
         customer: 'cus_123',
+        currency: 'eur',
         hooks: { inputs: { tax: { calculation: 'taxcalc_123' } } },
         metadata: { machine_payment: 'custom', request_id: 'req_123' },
         receipt_email: 'customer@example.com',
-      },
+      } as any,
       reference: '0xtx123',
     })
 
     expect(create).toHaveBeenCalledTimes(2)
     expect(create.mock.calls[0]?.[0]).toEqual(
       expect.objectContaining({
+        amount: 50,
+        confirm: true,
         customer: 'cus_123',
+        currency: 'usd',
         hooks: { inputs: { tax: { calculation: 'taxcalc_123' } } },
         metadata: { machine_payment: 'custom', request_id: 'req_123' },
         receipt_email: 'customer@example.com',

--- a/src/stripe/server/internal/record-payment.test.ts
+++ b/src/stripe/server/internal/record-payment.test.ts
@@ -20,9 +20,13 @@ describe('recordCryptoPayment', () => {
 
     await recordCryptoPayment(createClient(create), {
       amount: '500000',
-      customer: 'cus_123',
-      metadata: { machine_payment: 'custom', request_id: 'req_123' },
       network: 'tempo',
+      paymentIntentOptions: {
+        customer: 'cus_123',
+        hooks: { inputs: { tax: { calculation: 'taxcalc_123' } } },
+        metadata: { machine_payment: 'custom', request_id: 'req_123' },
+        receipt_email: 'customer@example.com',
+      },
       reference: '0xtx123',
     })
 
@@ -30,10 +34,14 @@ describe('recordCryptoPayment', () => {
     expect(create.mock.calls[0]?.[0]).toEqual(
       expect.objectContaining({
         customer: 'cus_123',
+        hooks: { inputs: { tax: { calculation: 'taxcalc_123' } } },
         metadata: { machine_payment: 'custom', request_id: 'req_123' },
+        receipt_email: 'customer@example.com',
       }),
     )
     expect(create.mock.calls[1]?.[0]).not.toHaveProperty('customer')
+    expect(create.mock.calls[1]?.[0]).not.toHaveProperty('hooks')
+    expect(create.mock.calls[1]?.[0]).not.toHaveProperty('receipt_email')
     expect(create.mock.calls[1]?.[0]).toEqual(
       expect.objectContaining({ metadata: { machine_payment: 'true' } }),
     )
@@ -50,8 +58,8 @@ describe('recordCryptoPayment', () => {
 
     await recordCryptoPayment(createClient(create), {
       amount: '500000',
-      customer: 'cus_123',
       network: 'tempo',
+      paymentIntentOptions: { customer: 'cus_123' },
       reference: '0xtx123',
     })
 

--- a/src/stripe/server/internal/record-payment.test.ts
+++ b/src/stripe/server/internal/record-payment.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test, vi } from 'vp/test'
+
+import type { StripeClient } from '../../internal/types.js'
+import { recordCryptoPayment } from './record-payment.js'
+
+function createClient(create: (...args: any[]) => Promise<any>): StripeClient {
+  return { paymentIntents: { create } }
+}
+
+describe('recordCryptoPayment', () => {
+  test('retries without optional fields after a definitive invalid request', async () => {
+    const invalidRequest = Object.assign(new Error('Invalid customer'), {
+      type: 'StripeInvalidRequestError',
+    })
+    const create = vi
+      .fn()
+      .mockRejectedValueOnce(invalidRequest)
+      .mockResolvedValueOnce({ id: 'pi_123', status: 'succeeded' })
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await recordCryptoPayment(createClient(create), {
+      amount: '500000',
+      customer: 'cus_123',
+      metadata: { machine_payment: 'custom', request_id: 'req_123' },
+      network: 'tempo',
+      reference: '0xtx123',
+    })
+
+    expect(create).toHaveBeenCalledTimes(2)
+    expect(create.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        customer: 'cus_123',
+        metadata: { machine_payment: 'custom', request_id: 'req_123' },
+      }),
+    )
+    expect(create.mock.calls[1]?.[0]).not.toHaveProperty('customer')
+    expect(create.mock.calls[1]?.[0]).toEqual(
+      expect.objectContaining({ metadata: { machine_payment: 'true' } }),
+    )
+    expect(create.mock.calls[1]?.[1]).toEqual(create.mock.calls[0]?.[1])
+    expect(warning).toHaveBeenCalledWith(
+      expect.stringContaining('retrying without them'),
+      invalidRequest,
+    )
+  })
+
+  test('does not retry after an ambiguous failure', async () => {
+    const create = vi.fn().mockRejectedValue(new Error('Connection reset'))
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await recordCryptoPayment(createClient(create), {
+      amount: '500000',
+      customer: 'cus_123',
+      network: 'tempo',
+      reference: '0xtx123',
+    })
+
+    expect(create).toHaveBeenCalledOnce()
+    expect(error).toHaveBeenCalledWith(
+      '[stripe] failed to record crypto payment:',
+      expect.any(Error),
+    )
+  })
+})

--- a/src/stripe/server/internal/record-payment.ts
+++ b/src/stripe/server/internal/record-payment.ts
@@ -60,7 +60,7 @@ export function recordCryptoPayment(
     ...(connect && { connect }),
   }
   const hasOptionalParams = paymentIntentOptions !== undefined
-  const recording = createPaymentIntent(
+  return createPaymentIntent(
     client,
     {
       ...requiredParams,
@@ -68,21 +68,21 @@ export function recordCryptoPayment(
       metadata: { ...machinePaymentMetadata, ...metadata },
     },
     options,
-  ).catch((error: unknown) => {
-    if (!hasOptionalParams || !isDefinitiveInvalidRequestError(error)) throw error
-    console.warn(
-      '[stripe] optional PI recording fields were rejected; retrying without them:',
-      error,
-    )
-    return createPaymentIntent(client, requiredParams, options)
-  })
-
-  return recording.then(
-    () => {},
-    (err) => {
-      console.error('[stripe] failed to record crypto payment:', err)
-    },
   )
+    .catch((error: unknown) => {
+      if (!hasOptionalParams || !isDefinitiveInvalidRequestError(error)) throw error
+      console.warn(
+        '[stripe] optional PI recording fields were rejected; retrying without them:',
+        error,
+      )
+      return createPaymentIntent(client, requiredParams, options)
+    })
+    .then(
+      () => {},
+      (err) => {
+        console.error('[stripe] failed to record crypto payment:', err)
+      },
+    )
 }
 
 /** Returns whether Stripe definitively rejected request parameters before creating a PI. */

--- a/src/stripe/server/internal/record-payment.ts
+++ b/src/stripe/server/internal/record-payment.ts
@@ -21,10 +21,11 @@ export function recordCryptoPayment(
     reference: string
     amount: string
     connect?: ConnectConfig
+    customer?: string
     metadata?: Record<string, string>
   },
 ): Promise<void> {
-  const { network, reference, amount, connect, metadata } = parameters
+  const { network, reference, amount, connect, customer, metadata } = parameters
   const { stripeNetworkName, tokenDecimals } = NETWORK_CONFIG[network]
 
   const amountCents = Math.round(Number(amount) / 10 ** (tokenDecimals - 2))
@@ -41,6 +42,7 @@ export function recordCryptoPayment(
       amount: amountCents,
       currency: 'usd',
       confirm: true,
+      ...(customer && { customer }),
       payment_method_data: { type: 'crypto' },
       payment_method_types: ['crypto'],
       payment_method_options: {
@@ -52,7 +54,7 @@ export function recordCryptoPayment(
           },
         },
       },
-      metadata: { ...metadata, ...machinePaymentMetadata },
+      metadata: { ...machinePaymentMetadata, ...metadata },
     },
     {
       idempotencyKey: reference,

--- a/src/stripe/server/internal/record-payment.ts
+++ b/src/stripe/server/internal/record-payment.ts
@@ -27,7 +27,7 @@ export function recordCryptoPayment(
   },
 ): Promise<void> {
   const { network, reference, amount, connect, paymentIntentOptions } = parameters
-  const { metadata, ...additionalParams } = paymentIntentOptions ?? {}
+  const { customer, hooks, metadata, receipt_email } = paymentIntentOptions ?? {}
   const { stripeNetworkName, tokenDecimals } = NETWORK_CONFIG[network]
 
   const amountCents = Math.round(Number(amount) / 10 ** (tokenDecimals - 2))
@@ -64,8 +64,10 @@ export function recordCryptoPayment(
     client,
     {
       ...requiredParams,
-      ...additionalParams,
+      ...(customer !== undefined && { customer }),
+      ...(hooks !== undefined && { hooks }),
       metadata: { ...machinePaymentMetadata, ...metadata },
+      ...(receipt_email !== undefined && { receipt_email }),
     },
     options,
   )

--- a/src/stripe/server/internal/record-payment.ts
+++ b/src/stripe/server/internal/record-payment.ts
@@ -1,4 +1,5 @@
 import { machinePaymentMetadata } from '../../internal/constants.js'
+import type * as PaymentIntent from '../../internal/payment-intent.js'
 import type { StripeClient } from '../../internal/types.js'
 import type { stripe } from '../Methods.js'
 import { createPaymentIntent, type ConnectConfig } from './request.js'
@@ -22,11 +23,11 @@ export function recordCryptoPayment(
     reference: string
     amount: string
     connect?: ConnectConfig
-    customer?: string
-    metadata?: Record<string, string>
+    paymentIntentOptions?: PaymentIntent.Options | undefined
   },
 ): Promise<void> {
-  const { network, reference, amount, connect, customer, metadata } = parameters
+  const { network, reference, amount, connect, paymentIntentOptions } = parameters
+  const { metadata, ...additionalParams } = paymentIntentOptions ?? {}
   const { stripeNetworkName, tokenDecimals } = NETWORK_CONFIG[network]
 
   const amountCents = Math.round(Number(amount) / 10 ** (tokenDecimals - 2))
@@ -58,12 +59,12 @@ export function recordCryptoPayment(
     idempotencyKey: reference,
     ...(connect && { connect }),
   }
-  const hasOptionalParams = customer !== undefined || metadata !== undefined
+  const hasOptionalParams = paymentIntentOptions !== undefined
   const recording = createPaymentIntent(
     client,
     {
       ...requiredParams,
-      ...(customer !== undefined && { customer }),
+      ...additionalParams,
       metadata: { ...machinePaymentMetadata, ...metadata },
     },
     options,

--- a/src/stripe/server/internal/record-payment.ts
+++ b/src/stripe/server/internal/record-payment.ts
@@ -12,6 +12,7 @@ const NETWORK_CONFIG: Record<stripe.Network, { stripeNetworkName: string; tokenD
 
 /**
  * Records a crypto payment as a Stripe PaymentIntent using transaction_verification mode.
+ * If Stripe rejects caller-provided optional fields, retries once without them.
  * Errors are logged but never thrown (the returned Promise always resolves).
  */
 export function recordCryptoPayment(
@@ -36,34 +37,64 @@ export function recordCryptoPayment(
     return Promise.resolve()
   }
 
-  return createPaymentIntent(
-    client,
-    {
-      amount: amountCents,
-      currency: 'usd',
-      confirm: true,
-      ...(customer && { customer }),
-      payment_method_data: { type: 'crypto' },
-      payment_method_types: ['crypto'],
-      payment_method_options: {
-        crypto: {
-          mode: 'transaction_verification',
-          transaction_verification_options: {
-            network: stripeNetworkName,
-            transaction_hash: reference,
-          },
+  const requiredParams = {
+    amount: amountCents,
+    currency: 'usd',
+    confirm: true,
+    payment_method_data: { type: 'crypto' },
+    payment_method_types: ['crypto'],
+    payment_method_options: {
+      crypto: {
+        mode: 'transaction_verification',
+        transaction_verification_options: {
+          network: stripeNetworkName,
+          transaction_hash: reference,
         },
       },
+    },
+    metadata: machinePaymentMetadata,
+  }
+  const options = {
+    idempotencyKey: reference,
+    ...(connect && { connect }),
+  }
+  const hasOptionalParams = customer !== undefined || metadata !== undefined
+  const recording = createPaymentIntent(
+    client,
+    {
+      ...requiredParams,
+      ...(customer !== undefined && { customer }),
       metadata: { ...machinePaymentMetadata, ...metadata },
     },
-    {
-      idempotencyKey: reference,
-      ...(connect && { connect }),
-    },
-  ).then(
+    options,
+  ).catch((error: unknown) => {
+    if (!hasOptionalParams || !isDefinitiveInvalidRequestError(error)) throw error
+    console.warn(
+      '[stripe] optional PI recording fields were rejected; retrying without them:',
+      error,
+    )
+    return createPaymentIntent(client, requiredParams, options)
+  })
+
+  return recording.then(
     () => {},
     (err) => {
       console.error('[stripe] failed to record crypto payment:', err)
     },
+  )
+}
+
+/** Returns whether Stripe definitively rejected request parameters before creating a PI. */
+function isDefinitiveInvalidRequestError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false
+  const candidate = error as {
+    raw?: { type?: unknown } | undefined
+    rawType?: unknown
+    type?: unknown
+  }
+  return (
+    candidate.type === 'StripeInvalidRequestError' ||
+    candidate.rawType === 'invalid_request_error' ||
+    candidate.raw?.type === 'invalid_request_error'
   )
 }


### PR DESCRIPTION
Builds on https://github.com/wevm/mppx/pull/849 to add 3 additional payment intent options: receipt email, customer id, and tax hooks. Since these additional options are more opportunities for the transaction verification to PI to fail, also adds more validation and a fallback in the crypto path to retry without the paymentIntentOptions.