### PR TITLE
feat(client): validate paid application responses

### DIFF
--- a/.changeset/caller-owned-paid-response.md
+++ b/.changeset/caller-owned-paid-response.md
@@ -1,0 +1,5 @@
+---
+'mppx': minor
+---
+
+Added an optional caller-owned `validateResponse` hook and detached `PaidResponse` view so paid application output can be rejected after settlement without retrying payment or dropping receipt evidence.

--- a/src/client/Mppx.test-d.ts
+++ b/src/client/Mppx.test-d.ts
@@ -159,6 +159,17 @@ describe('create.Config', () => {
     expectTypeOf(methods).toMatchTypeOf<readonly Method.AnyClient[]>()
   })
 
+  test('validateResponse receives a paid Response', () => {
+    const mppx = Mppx.create({
+      methods: [tempo({ account: {} as Account })],
+      polyfill: false,
+      validateResponse: async (payload) => {
+        expectTypeOf(payload.response).toEqualTypeOf<Response>()
+      },
+    })
+    expectTypeOf(mppx.fetch).toBeFunction()
+  })
+
   test('orderChallenges receives supported challenge candidates', () => {
     const mppx = Mppx.create({
       methods: [tempo({ account: {} as Account })],

--- a/src/client/Mppx.ts
+++ b/src/client/Mppx.ts
@@ -6,6 +6,7 @@ import * as AcceptPayment from '../internal/AcceptPayment.js'
 import type * as Method from '../Method.js'
 import type * as z from '../zod.js'
 import * as Fetch from './internal/Fetch.js'
+import type * as PaidResponse from './PaidResponse.js'
 import * as Transport from './Transport.js'
 
 export type Methods = readonly (Method.AnyClient | readonly Method.AnyClient[])[]
@@ -175,6 +176,7 @@ export function create<
     ...(orderChallenges && { orderChallenges }),
     methods,
     transport,
+    ...(config.validateResponse && { validateResponse: config.validateResponse }),
   } satisfies Fetch.from.Config<FlattenMethods<methods>>
   const fetch = Fetch.from<FlattenMethods<methods>>(config_fetch)
 
@@ -420,6 +422,11 @@ export declare namespace create {
     orderChallenges?: AcceptPayment.OrderChallenges<FlattenMethods<methods>> | undefined
     /** Client-declared supported payment methods, keyed by typed `method/intent` strings. */
     paymentPreferences?: AcceptPayment.Config<FlattenMethods<methods>> | undefined
+    /**
+     * Optional caller-owned validator for paid application responses.
+     * Absent keeps current fetch behavior. Throwing does not retry payment.
+     */
+    validateResponse?: PaidResponse.Validate<FlattenMethods<methods>> | undefined
     /** Array of methods to use. Accepts individual clients or tuples (e.g. from `tempo()`). */
     methods: methods
     /** Whether to polyfill `globalThis.fetch` with the payment-aware wrapper. @default true */

--- a/src/client/PaidResponse.test-d.ts
+++ b/src/client/PaidResponse.test-d.ts
@@ -1,0 +1,45 @@
+import type { Account } from 'viem'
+import { describe, expectTypeOf, test } from 'vp/test'
+
+import * as Receipt from '../Receipt.js'
+import { charge } from '../tempo/client/Charge.js'
+import * as Fetch from './internal/Fetch.js'
+import * as Mppx from './Mppx.js'
+import * as PaidResponse from './PaidResponse.js'
+
+describe('PaidResponse', () => {
+  test('view and validate preserve Response', () => {
+    const response = new Response('{}')
+    expectTypeOf(PaidResponse.view(response).response).toEqualTypeOf<Response>()
+    expectTypeOf(PaidResponse.view(response).receipt).toEqualTypeOf<Receipt.Receipt | undefined>()
+    expectTypeOf(PaidResponse.validate(response, async () => undefined)).toEqualTypeOf<
+      Promise<Response>
+    >()
+  })
+
+  test('validator payload includes optional payment evidence', () => {
+    const method = charge()
+    const fetch = Fetch.from({
+      methods: [method],
+      validateResponse: async (payload) => {
+        expectTypeOf(payload.response).toEqualTypeOf<Response>()
+        expectTypeOf(payload.receipt).toEqualTypeOf<Receipt.Receipt | undefined>()
+        expectTypeOf(payload.credential).toEqualTypeOf<string | undefined>()
+        expectTypeOf(payload.method?.intent).toEqualTypeOf<'charge' | undefined>()
+      },
+    })
+    expectTypeOf(fetch).returns.toMatchTypeOf<Promise<Response>>()
+  })
+
+  test('Mppx.create accepts validateResponse', () => {
+    const mppx = Mppx.create({
+      methods: [charge({ account: {} as Account })],
+      polyfill: false,
+      validateResponse: async ({ response, receipt }) => {
+        expectTypeOf(response).toEqualTypeOf<Response>()
+        expectTypeOf(receipt).toEqualTypeOf<Receipt.Receipt | undefined>()
+      },
+    })
+    expectTypeOf(mppx.fetch).returns.toMatchTypeOf<Promise<Response>>()
+  })
+})

--- a/src/client/PaidResponse.test.ts
+++ b/src/client/PaidResponse.test.ts
@@ -1,0 +1,396 @@
+import { Challenge, Receipt } from 'mppx'
+import { Mppx } from 'mppx/client'
+import { describe, expect, test, vi } from 'vp/test'
+
+import * as Fetch from './internal/Fetch.js'
+import * as MethodResponse from './internal/MethodResponse.js'
+import * as PaidResponse from './PaidResponse.js'
+
+const paidReceipt = Receipt.from({
+  method: 'tempo',
+  reference: '0x1234',
+  status: 'success',
+  timestamp: '2025-01-21T12:00:00.000Z',
+})
+
+const foreignReceipt = Receipt.from({
+  method: 'stripe',
+  reference: 'pi_foreign',
+  status: 'success',
+  timestamp: '2024-01-01T00:00:00.000Z',
+})
+
+const currentChallenge = Challenge.from({
+  id: 'current',
+  intent: 'test',
+  method: 'test',
+  realm: 'test',
+  request: { amount: '1' },
+})
+
+const foreignChallenge = Challenge.from({
+  id: 'foreign',
+  intent: 'charge',
+  method: 'stripe',
+  realm: 'attacker.example',
+  request: { amount: '9' },
+})
+
+const noopMethod = {
+  name: 'test',
+  intent: 'test',
+  context: undefined,
+  createCredential: async () => 'credential',
+} as any
+
+function make402() {
+  const request = btoa(JSON.stringify({ amount: '1' }))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+  return new Response(null, {
+    status: 402,
+    headers: {
+      'WWW-Authenticate': `Payment id="abc", realm="test", method="test", intent="test", request="${request}"`,
+    },
+  })
+}
+
+function makePaid(body: string, status = 200) {
+  return new Response(body, {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      'Payment-Receipt': Receipt.serialize(paidReceipt),
+    },
+  })
+}
+
+describe('PaidResponse.view', () => {
+  test('default: reads receipt without consuming the body', async () => {
+    const response = makePaid('{"id":"1"}')
+    const viewed = PaidResponse.view(response)
+    expect(viewed.receipt).toEqual(paidReceipt)
+    expect(await response.json()).toEqual({ id: '1' })
+  })
+
+  test('behavior: missing or malformed receipt is undefined', () => {
+    expect(PaidResponse.receiptOf(new Response('{}'))).toBeUndefined()
+    expect(
+      PaidResponse.receiptOf(
+        new Response('{}', { headers: { 'Payment-Receipt': 'not-valid-base64url!!!' } }),
+      ),
+    ).toBeUndefined()
+  })
+})
+
+describe('PaidResponse.validate', () => {
+  test('default: returns the original response when the caller accepts it', async () => {
+    const response = makePaid('{"id":"1"}')
+    const validated = await PaidResponse.validate(response, async ({ response, receipt }) => {
+      expect(receipt).toEqual(paidReceipt)
+      expect(await response.json()).toEqual({ id: '1' })
+    })
+    expect(validated).toBe(response)
+    expect(await validated.json()).toEqual({ id: '1' })
+  })
+
+  test('error: keeps receipt and response when application output is invalid', async () => {
+    const response = makePaid('{"id":1}')
+    const error = await PaidResponse.validate(response, async ({ response }) => {
+      const body = (await response.json()) as { id: unknown }
+      if (typeof body.id !== 'string') throw new Error('id must be a string')
+    }).catch((value) => value)
+
+    expect(error).toBeInstanceOf(PaidResponse.InvalidError)
+    expect(PaidResponse.isInvalidError(error)).toBe(true)
+    expect(error).toMatchObject({
+      credential: undefined,
+      message: 'Paid application response failed caller validation: id must be a string',
+      name: 'PaidResponseInvalidError',
+      receipt: paidReceipt,
+    })
+    expect(error.response).toBe(response)
+    expect(Receipt.fromResponse(error.response)).toEqual(paidReceipt)
+    expect(await error.response.json()).toEqual({ id: 1 })
+  })
+
+  test('error: binds a foreign InvalidError to the current response and payment context', async () => {
+    const response = makePaid('{"id":"1"}')
+    const foreignResponse = new Response('{"id":"foreign"}', {
+      headers: { 'Payment-Receipt': Receipt.serialize(foreignReceipt) },
+    })
+    const foreignError = new PaidResponse.InvalidError({
+      challenge: foreignChallenge,
+      credential: 'foreign-credential',
+      message: 'foreign output',
+      receipt: foreignReceipt,
+      response: foreignResponse,
+    })
+
+    const error = await PaidResponse.validate(
+      response,
+      () => {
+        throw foreignError
+      },
+      { challenge: currentChallenge, credential: 'credential' },
+    ).catch((value) => value)
+
+    expect(error).toBeInstanceOf(PaidResponse.InvalidError)
+    expect(error).not.toBe(foreignError)
+    expect(error.cause).toBe(foreignError)
+    expect(error.challenge).toBe(currentChallenge)
+    expect(error.credential).toBe('credential')
+    expect(error.receipt).toEqual(paidReceipt)
+    expect(error.response).toBe(response)
+    expect(error.message).toBe('Paid application response failed caller validation: foreign output')
+    expect(Receipt.fromResponse(error.response)).toEqual(paidReceipt)
+    expect(await error.response.json()).toEqual({ id: '1' })
+    expect(foreignError.response).toBe(foreignResponse)
+    expect(foreignError.receipt).toEqual(foreignReceipt)
+  })
+
+  test('error: fails closed when the response body cannot be cloned', async () => {
+    const response = makePaid('{"id":"1"}')
+    await response.arrayBuffer()
+    let cloneThrows = false
+    try {
+      response.clone()
+    } catch {
+      cloneThrows = true
+    }
+    if (!cloneThrows) {
+      vi.spyOn(response, 'clone').mockImplementation(() => {
+        throw new TypeError('Response body is disturbed or locked')
+      })
+    }
+
+    const validator = vi.fn()
+    const error = await PaidResponse.validate(response, validator, {
+      challenge: currentChallenge,
+      credential: 'credential',
+    }).catch((value) => value)
+
+    expect(validator).not.toHaveBeenCalled()
+    expect(error).toBeInstanceOf(PaidResponse.InvalidError)
+    expect(error.cause).toBeInstanceOf(TypeError)
+    expect(error.challenge).toBe(currentChallenge)
+    expect(error.credential).toBe('credential')
+    expect(error.message).toBe(
+      'Paid application response could not be cloned for caller validation.',
+    )
+    expect(error.receipt).toEqual(paidReceipt)
+    expect(error.response).toBe(response)
+    expect(error.response.bodyUsed).toBe(true)
+  })
+})
+
+describe('Fetch.from: validateResponse', () => {
+  test('behavior: absent hook preserves invalid application output', async () => {
+    let calls = 0
+    const fetch = Fetch.from({
+      fetch: async (_input, init) => {
+        calls++
+        if (!new Headers(init?.headers).has('Authorization')) return make402()
+        return makePaid('{"id":1}')
+      },
+      methods: [noopMethod],
+    })
+
+    const response = await fetch('https://example.com/paid')
+    expect(calls).toBe(2)
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ id: 1 })
+    expect(Receipt.fromResponse(response)).toEqual(paidReceipt)
+  })
+
+  test('behavior: accepts ordinary paid JSON without retrying', async () => {
+    let calls = 0
+    const seen: unknown[] = []
+    const fetch = Fetch.from({
+      fetch: async (_input, init) => {
+        calls++
+        if (!new Headers(init?.headers).has('Authorization')) return make402()
+        return makePaid('{"id":"1"}')
+      },
+      methods: [noopMethod],
+      validateResponse: async ({ response, receipt, credential }) => {
+        seen.push(credential, receipt, await response.json())
+      },
+    })
+
+    const response = await fetch('https://example.com/paid')
+    expect(calls).toBe(2)
+    expect(seen).toEqual(['credential', paidReceipt, { id: '1' }])
+    expect(await response.json()).toEqual({ id: '1' })
+  })
+
+  test('error: invalid output does not retry or duplicate payment', async () => {
+    let calls = 0
+    const events: string[] = []
+    const eventDispatcher = Fetch.createEventDispatcher<[typeof noopMethod]>()
+    eventDispatcher.on('payment.failed', () => {
+      events.push('payment.failed')
+    })
+    eventDispatcher.on('payment.response', () => {
+      events.push('payment.response')
+    })
+
+    const fetch = Fetch.from({
+      eventDispatcher,
+      fetch: async (_input, init) => {
+        calls++
+        if (!new Headers(init?.headers).has('Authorization')) return make402()
+        return makePaid('{"id":1}')
+      },
+      methods: [noopMethod],
+      validateResponse: async ({ response }) => {
+        const body = (await response.json()) as { id: unknown }
+        if (typeof body.id !== 'string') throw new Error('id must be a string')
+      },
+    })
+
+    const error = await fetch('https://example.com/paid').catch((value) => value)
+    expect(calls).toBe(2)
+    expect(events).toEqual(['payment.response'])
+    expect(error).toBeInstanceOf(PaidResponse.InvalidError)
+    expect(error.credential).toBe('credential')
+    expect(error.receipt).toEqual(paidReceipt)
+    expect(error.challenge?.id).toBe('abc')
+    expect(Receipt.fromResponse(error.response)).toEqual(paidReceipt)
+    expect(await error.response.json()).toEqual({ id: 1 })
+  })
+
+  test('behavior: validates protocol recovery responses, not the raw paid body', async () => {
+    const method = { ...noopMethod }
+    MethodResponse.register(method, async ({ response }) => {
+      await response.text()
+      return new Response('{"id":"recovered"}', {
+        headers: response.headers,
+        status: response.status,
+      })
+    })
+
+    let calls = 0
+    const seen: unknown[] = []
+    const fetch = Fetch.from({
+      fetch: async (_input, init) => {
+        calls++
+        if (!new Headers(init?.headers).has('Authorization')) return make402()
+        return makePaid('{"id":"raw"}')
+      },
+      methods: [method],
+      validateResponse: async ({ response }) => {
+        seen.push(await response.json())
+      },
+    })
+
+    const response = await fetch('https://example.com/paid')
+    expect(calls).toBe(2)
+    expect(seen).toEqual([{ id: 'recovered' }])
+    expect(await response.json()).toEqual({ id: 'recovered' })
+    expect(Receipt.fromResponse(response)).toEqual(paidReceipt)
+  })
+
+  test('error: recovery dropping headers keeps the raw paid receipt', async () => {
+    const method = { ...noopMethod }
+    MethodResponse.register(method, async ({ response }) => {
+      await response.text()
+      return new Response('{"id":"recovered"}', {
+        headers: { 'Content-Type': 'application/json' },
+        status: 200,
+      })
+    })
+
+    let calls = 0
+    const seen: { body: unknown; header: string | null; receipt: unknown }[] = []
+    const fetch = Fetch.from({
+      fetch: async (_input, init) => {
+        calls++
+        if (!new Headers(init?.headers).has('Authorization')) return make402()
+        return makePaid('{"id":"raw"}')
+      },
+      methods: [method],
+      validateResponse: async ({ response, receipt }) => {
+        seen.push({
+          body: await response.json(),
+          header: response.headers.get('Payment-Receipt'),
+          receipt,
+        })
+        throw new Error('reject recovered body')
+      },
+    })
+
+    const error = await fetch('https://example.com/paid').catch((value) => value)
+    expect(calls).toBe(2)
+    expect(seen).toEqual([{ body: { id: 'recovered' }, header: null, receipt: paidReceipt }])
+    expect(error).toBeInstanceOf(PaidResponse.InvalidError)
+    expect(error.challenge?.id).toBe('abc')
+    expect(error.credential).toBe('credential')
+    expect(error.receipt).toEqual(paidReceipt)
+    expect(error.response.headers.get('Payment-Receipt')).toBeNull()
+    expect(await error.response.json()).toEqual({ id: 'recovered' })
+  })
+
+  test('behavior: validates non-ok paid responses without recovery wrapping', async () => {
+    const method = { ...noopMethod }
+    const handle = vi.fn(async ({ response }: MethodResponse.HandlerParameters) => response)
+    MethodResponse.register(method, handle)
+
+    let calls = 0
+    const fetch = Fetch.from({
+      fetch: async (_input, init) => {
+        calls++
+        if (!new Headers(init?.headers).has('Authorization')) return make402()
+        return makePaid('{"error":"rate limited"}', 429)
+      },
+      methods: [method],
+      validateResponse: async ({ response, receipt }) => {
+        expect(response.status).toBe(429)
+        expect(receipt).toEqual(paidReceipt)
+      },
+    })
+
+    const response = await fetch('https://example.com/paid')
+    expect(calls).toBe(2)
+    expect(handle).not.toHaveBeenCalled()
+    expect(response.status).toBe(429)
+    expect(Receipt.fromResponse(response)).toEqual(paidReceipt)
+  })
+
+  test('behavior: does not validate unpaid responses', async () => {
+    const validateResponse = vi.fn()
+    const fetch = Fetch.from({
+      fetch: async () => new Response('free'),
+      methods: [noopMethod],
+      validateResponse,
+    })
+
+    expect(await (await fetch('https://example.com/free')).text()).toBe('free')
+    expect(validateResponse).not.toHaveBeenCalled()
+  })
+})
+
+describe('Mppx.create: validateResponse', () => {
+  test('behavior: rejects invalid paid output through the public client', async () => {
+    let calls = 0
+    const mppx = Mppx.create({
+      fetch: (async (_input, init) => {
+        calls++
+        if (!new Headers(init?.headers).has('Authorization')) return make402()
+        return makePaid('{"id":1}')
+      }) as typeof globalThis.fetch,
+      methods: [noopMethod],
+      polyfill: false,
+      validateResponse: async ({ response }) => {
+        const body = (await response.json()) as { id: unknown }
+        if (typeof body.id !== 'string') throw new Error('id must be a string')
+      },
+    })
+
+    const error = await mppx.fetch('https://example.com/paid').catch((value) => value)
+    expect(calls).toBe(2)
+    expect(error).toBeInstanceOf(PaidResponse.InvalidError)
+    expect(error.receipt).toEqual(paidReceipt)
+  })
+})

--- a/src/client/PaidResponse.ts
+++ b/src/client/PaidResponse.ts
@@ -1,0 +1,197 @@
+import type * as Challenge from '../Challenge.js'
+import type { MaybePromise } from '../internal/types.js'
+import type * as Method from '../Method.js'
+import * as Receipt from '../Receipt.js'
+
+/**
+ * Caller-owned view of a paid application response.
+ *
+ * Settlement evidence lives on the HTTP response (`Payment-Receipt`). This
+ * helper does not create credentials, retry, or change payment behavior.
+ */
+export type View = {
+  /** Parsed `Payment-Receipt` when present and well-formed. */
+  receipt: Receipt.Receipt | undefined
+  /** Paid application response, including protocol recovery wrapping. */
+  response: Response
+}
+
+/**
+ * Inputs for caller-owned validation of a paid application response.
+ *
+ * The `response` is a clone when cloning is possible, so a validator can read
+ * the body without consuming the value returned to the caller.
+ */
+export type Payload<methods extends readonly Method.AnyClient[] = readonly Method.AnyClient[]> =
+  View & {
+    /** Challenge that produced the credential, when known. */
+    challenge?: Challenge.Challenge | undefined
+    /** Serialized credential sent on the paid retry, when known. */
+    credential?: string | undefined
+    /** Client method that created the credential, when known. */
+    method?: methods[number] | undefined
+  }
+
+/** Caller-owned validator. Throw to reject the application output. */
+export type Validate<methods extends readonly Method.AnyClient[] = readonly Method.AnyClient[]> = (
+  payload: Payload<methods>,
+) => MaybePromise<void>
+
+/**
+ * Paid application output failed caller validation after settlement.
+ *
+ * This is not a payment protocol error: the credential was already sent.
+ * Callers can still read {@link InvalidError.response} and
+ * {@link InvalidError.receipt}.
+ */
+export class InvalidError extends Error {
+  override readonly name = 'PaidResponseInvalidError'
+  /** Challenge used for the paid retry, when known. */
+  readonly challenge: Challenge.Challenge | undefined
+  /** Credential sent on the paid retry, when known. */
+  readonly credential: string | undefined
+  /** Parsed receipt when the paid response carried one. */
+  readonly receipt: Receipt.Receipt | undefined
+  /** Paid response whose application output failed validation. */
+  readonly response: Response
+
+  constructor(options: InvalidError.Options) {
+    const message = options.message ?? messageFromCause(options.cause)
+    super(message, options.cause === undefined ? undefined : { cause: options.cause })
+    this.challenge = options.challenge
+    this.credential = options.credential
+    this.receipt = options.receipt
+    this.response = options.response
+  }
+}
+
+export declare namespace InvalidError {
+  type Options = {
+    challenge?: Challenge.Challenge | undefined
+    cause?: unknown
+    credential?: string | undefined
+    message?: string | undefined
+    receipt?: Receipt.Receipt | undefined
+    response: Response
+  }
+}
+
+/** Returns whether `value` is a {@link InvalidError}. */
+export function isInvalidError(value: unknown): value is InvalidError {
+  return value instanceof InvalidError
+}
+
+/**
+ * Reads settlement evidence from a paid response without throwing when the
+ * receipt header is missing or malformed.
+ */
+export function receiptOf(response: Response): Receipt.Receipt | undefined {
+  try {
+    return Receipt.fromResponse(response)
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Detached view of a paid response: the HTTP response plus any parseable
+ * receipt. Does not consume the body.
+ */
+export function view(response: Response): View {
+  return { receipt: receiptOf(response), response }
+}
+
+/**
+ * Runs a caller-owned validator against a paid response without retrying
+ * payment. On failure, throws {@link InvalidError} bound to this invocation's
+ * response and payment context. Validator-thrown errors, including a prebuilt
+ * {@link InvalidError}, are preserved only as `cause`.
+ *
+ * @example
+ * ```ts
+ * import { PaidResponse } from 'mppx/client'
+ *
+ * const response = await mppx.fetch('/resource')
+ * await PaidResponse.validate(response, async ({ response, receipt }) => {
+ *   const body = await response.json()
+ *   if (typeof body.id !== 'string') throw new Error('missing id')
+ *   if (!receipt) throw new Error('missing receipt')
+ * })
+ * ```
+ */
+export async function validate<
+  const methods extends readonly Method.AnyClient[] = readonly Method.AnyClient[],
+>(
+  response: Response,
+  validator: Validate<methods>,
+  context?: validate.Context<methods> | undefined,
+): Promise<Response> {
+  const receipt = observedReceipt(response, context)
+  let validatorResponse: Response
+  try {
+    validatorResponse = response.clone()
+  } catch (cause) {
+    throw bindInvalidError({
+      cause,
+      context,
+      message: 'Paid application response could not be cloned for caller validation.',
+      receipt,
+      response,
+    })
+  }
+
+  try {
+    await validator({
+      ...(context?.challenge ? { challenge: context.challenge } : {}),
+      ...(context?.credential ? { credential: context.credential } : {}),
+      ...(context?.method ? { method: context.method } : {}),
+      receipt,
+      response: validatorResponse,
+    })
+  } catch (cause) {
+    throw bindInvalidError({ cause, context, receipt, response })
+  }
+  return response
+}
+
+export declare namespace validate {
+  type Context<methods extends readonly Method.AnyClient[] = readonly Method.AnyClient[]> = {
+    challenge?: Challenge.Challenge | undefined
+    credential?: string | undefined
+    method?: methods[number] | undefined
+    /** Observed settlement evidence. When present, recovery wrappers cannot replace it. */
+    receipt?: Receipt.Receipt | undefined
+  }
+}
+
+function messageFromCause(cause: unknown): string {
+  if (cause instanceof Error && cause.message) {
+    return `Paid application response failed caller validation: ${cause.message}`
+  }
+  return 'Paid application response failed caller validation.'
+}
+
+function observedReceipt(
+  response: Response,
+  context?: validate.Context | undefined,
+): Receipt.Receipt | undefined {
+  if (context && Object.hasOwn(context, 'receipt')) return context.receipt
+  return receiptOf(response)
+}
+
+function bindInvalidError(parameters: {
+  cause?: unknown
+  context?: validate.Context | undefined
+  message?: string | undefined
+  receipt: Receipt.Receipt | undefined
+  response: Response
+}): InvalidError {
+  return new InvalidError({
+    cause: parameters.cause,
+    ...(parameters.context?.challenge ? { challenge: parameters.context.challenge } : {}),
+    ...(parameters.context?.credential ? { credential: parameters.context.credential } : {}),
+    ...(parameters.message ? { message: parameters.message } : {}),
+    receipt: parameters.receipt,
+    response: parameters.response,
+  })
+}

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -26,4 +26,5 @@ export type {
   ResolveAccountOperation,
 } from '../tempo/client/ResolveAccount.js'
 export * as Mppx from './Mppx.js'
+export * as PaidResponse from './PaidResponse.js'
 export * as Transport from './Transport.js'

--- a/src/client/internal/Fetch.test-d.ts
+++ b/src/client/internal/Fetch.test-d.ts
@@ -57,6 +57,17 @@ describe('Fetch.from', () => {
     })
   })
 
+  test('behavior: accepts paid-response validator', () => {
+    const fetch = Fetch.from({
+      methods: [charge()],
+      validateResponse: async (payload) => {
+        expectTypeOf(payload.response).toEqualTypeOf<Response>()
+      },
+    })
+
+    expectTypeOf(fetch).toBeFunction()
+  })
+
   test('behavior: accepts payment retry cap', () => {
     const fetch = Fetch.from({
       maxPaymentRetries: 1,

--- a/src/client/internal/Fetch.ts
+++ b/src/client/internal/Fetch.ts
@@ -5,6 +5,7 @@ import * as AcceptPayment from '../../internal/AcceptPayment.js'
 import type { MaybePromise } from '../../internal/types.js'
 import type * as Method from '../../Method.js'
 import type * as z from '../../zod.js'
+import * as PaidResponse from '../PaidResponse.js'
 import * as Transport from '../Transport.js'
 import * as MethodChallenge from './MethodChallenge.js'
 import * as MethodResponse from './MethodResponse.js'
@@ -194,6 +195,7 @@ export function from<const methods extends readonly Method.AnyClient[]>(
     onChallenge,
     orderChallenges,
     transport = Transport.http(),
+    validateResponse,
   } = config
   const events = config.eventDispatcher ?? createEventDispatcher()
   const resolvedAcceptPayment = acceptPayment ?? AcceptPayment.resolve(methods)
@@ -399,20 +401,29 @@ export function from<const methods extends readonly Method.AnyClient[]>(
             }),
           )
         if (!paymentRequired) {
-          if (!response.ok) return response
-          return MethodResponse.handle(selected.method, {
+          const observedReceipt = PaidResponse.receiptOf(response)
+          const paid = !response.ok
+            ? response
+            : await MethodResponse.handle(selected.method, {
+                challenge: selectedChallenge,
+                credential,
+                fetch: baseFetch,
+                headers: initialRequest.headers,
+                input: paymentInput,
+                ...(canRefetch
+                  ? {
+                      refetch: () => request(cloneRequestInput(initialRequest.input), init, false),
+                    }
+                  : {}),
+                response,
+                signal: resolveRequestSignal(input, init),
+              })
+          if (!validateResponse) return paid
+          return PaidResponse.validate(paid, validateResponse, {
             challenge: selectedChallenge,
             credential,
-            fetch: baseFetch,
-            headers: initialRequest.headers,
-            input: paymentInput,
-            ...(canRefetch
-              ? {
-                  refetch: () => request(cloneRequestInput(initialRequest.input), init, false),
-                }
-              : {}),
-            response,
-            signal: resolveRequestSignal(input, init),
+            method: selected.method,
+            receipt: observedReceipt,
           })
         }
       }
@@ -432,18 +443,20 @@ export function from<const methods extends readonly Method.AnyClient[]>(
         response,
         status: 'rejected',
       })
-      await events.emit(
-        'payment.failed',
-        createPaymentFailedPayload({
-          challenge,
-          challenges,
-          error,
-          init,
-          input,
-          method: mi,
-          response,
-        }),
-      )
+      if (!PaidResponse.isInvalidError(error)) {
+        await events.emit(
+          'payment.failed',
+          createPaymentFailedPayload({
+            challenge,
+            challenges,
+            error,
+            init,
+            input,
+            method: mi,
+            response,
+          }),
+        )
+      }
       throw error
     }
   }
@@ -497,6 +510,13 @@ export declare namespace from {
     orderChallenges?: AcceptPayment.OrderChallenges<methods> | undefined
     /** Transport to use for challenge extraction and credential attachment. */
     transport?: Transport.AnyTransport | undefined
+    /**
+     * Optional caller-owned validator for paid application responses.
+     * Runs after payment settlement and protocol recovery. Throwing does not
+     * retry or duplicate payment; the original response and receipt remain on
+     * the thrown {@link PaidResponse.InvalidError}.
+     */
+    validateResponse?: PaidResponse.Validate<methods> | undefined
   }
 
   type Fetch<methods extends readonly Method.AnyClient[] = readonly Method.AnyClient[]> = (


### PR DESCRIPTION
## Summary

Add an optional caller-owned `validateResponse` hook to `Fetch.from` and `Mppx.create`, plus a detached `PaidResponse` helper.

The hook runs only after a paid retry has reached a final response and any method-specific recovery has completed. Throwing rejects the application output without another request, credential, or payment. The error retains the current response and the receipt observed on the exact paid retry.

When the hook is absent, existing fetch behavior is unchanged.

## Evidence boundaries

- a validator cannot substitute a foreign response, receipt, challenge, or credential by throwing a prebuilt error
- a method recovery wrapper cannot replace or erase the receipt observed on the paid retry
- a response that cannot be cloned fails closed before the validator runs
- invalid application output is not reported as `payment.failed` and does not retry payment
- seller-declared OpenAPI output remains discovery evidence; the caller owns runtime validation

## Verification

- 14 focused paid-response tests passed
- 194 related client tests passed; 15 existing Tempo-localnet cases require `localhost:18545` and fail with that service disabled
- lint passed with zero warnings and errors
- source and test TypeScript checks passed
- HTML build passed
- signed commit tree matches the remotely reviewed candidate tree exactly

Related specification context: tempoxyz/mpp-specs#326 documents seller-declared OpenAPI output contracts, while this PR covers the separate client runtime boundary after payment.
