### PR TITLE
fix: update audited transitive dependencies

### DIFF
--- a/.changeset/patch-fast-uri-qs.md
+++ b/.changeset/patch-fast-uri-qs.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Updated `fast-uri` and `qs` to patched versions, resolving their latest security advisories.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ overrides:
   nanoid@<3.3.18: 3.3.18
   '@modelcontextprotocol/sdk@>=1.10.0 <=1.25.3': 1.26.0
   '@modelcontextprotocol/server': 2.0.0-alpha.2
-  qs@>=6.7.0 <=6.15.1: 6.15.2
+  qs@>=6.7.0 <6.16.0: 6.16.0
   ip-address@<=10.3.0: 10.3.1
   readdir-glob@<3.0.0: 3.0.0
   minimatch@>=5.0.0 <5.1.8: 5.1.8
@@ -27,7 +27,7 @@ overrides:
   file-type: 22.0.1
   flatted@<=3.4.1: '>=3.4.2'
   follow-redirects@<=1.15.11: 1.16.0
-  fast-uri@<3.1.5: 3.1.5
+  fast-uri@<3.1.6: 3.1.6
   hono@<4.12.34: 4.12.34
   '@hono/node-server@<2.0.10': 2.0.10
   undici@>=7.0.0 <7.28.0: 7.28.0
@@ -3239,8 +3239,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -4054,8 +4054,8 @@ packages:
   pure-rand@8.4.2:
     resolution: {integrity: sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==}
 
-  qs@6.15.2:
-    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   range-parser@1.2.1:
@@ -4176,8 +4176,8 @@ packages:
     resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
     engines: {node: '>= 0.4'}
 
-  side-channel-list@1.0.0:
-    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
     engines: {node: '>= 0.4'}
 
   side-channel-map@1.0.1:
@@ -4188,8 +4188,8 @@ packages:
     resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
     engines: {node: '>= 0.4'}
 
-  side-channel@1.1.0:
-    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -6446,7 +6446,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6567,7 +6567,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.2
+      qs: 6.16.0
       raw-body: 3.0.2
       type-is: 2.1.0
     transitivePeerDependencies:
@@ -7049,7 +7049,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.2
+      qs: 6.16.0
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -7087,7 +7087,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -7876,9 +7876,10 @@ snapshots:
 
   pure-rand@8.4.2: {}
 
-  qs@6.15.2:
+  qs@6.16.0:
     dependencies:
-      side-channel: 1.1.0
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
 
   range-parser@1.2.1: {}
 
@@ -8058,7 +8059,7 @@ snapshots:
 
   shell-quote@1.10.0: {}
 
-  side-channel-list@1.0.0:
+  side-channel-list@1.0.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
@@ -8078,11 +8079,11 @@ snapshots:
       object-inspect: 1.13.4
       side-channel-map: 1.0.1
 
-  side-channel@1.1.0:
+  side-channel@1.1.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
-      side-channel-list: 1.0.0
+      side-channel-list: 1.0.1
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
@@ -8183,7 +8184,7 @@ snapshots:
   stripe@17.7.0:
     dependencies:
       '@types/node': 26.2.0
-      qs: 6.15.2
+      qs: 6.16.0
 
   strtok3@10.3.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,7 +26,7 @@ overrides:
   nanoid@<3.3.18: '3.3.18'
   '@modelcontextprotocol/sdk@>=1.10.0 <=1.25.3': '1.26.0'
   '@modelcontextprotocol/server': '2.0.0-alpha.2'
-  qs@>=6.7.0 <=6.15.1: '6.15.2'
+  qs@>=6.7.0 <6.16.0: '6.16.0'
   ip-address@<=10.3.0: '10.3.1'
   readdir-glob@<3.0.0: '3.0.0'
   minimatch@>=5.0.0 <5.1.8: '5.1.8'
@@ -37,7 +37,7 @@ overrides:
   file-type: 'catalog:'
   flatted@<=3.4.1: '>=3.4.2'
   follow-redirects@<=1.15.11: '1.16.0'
-  fast-uri@<3.1.5: '3.1.5'
+  fast-uri@<3.1.6: '3.1.6'
   hono@<4.12.34: '4.12.34'
   '@hono/node-server@<2.0.10': '2.0.10'
   undici@>=7.0.0 <7.28.0: '7.28.0'
@@ -73,7 +73,7 @@ minimumReleaseAgeExclude:
   - esbuild@0.28.1
   - body-parser@2.3.0
   - brace-expansion@5.0.9
-  - fast-uri@3.1.5
+  - fast-uri@3.1.6
   - hono@4.12.34
   - ip-address@10.3.1
   - js-yaml@4.3.1
@@ -81,6 +81,7 @@ minimumReleaseAgeExclude:
   - ox@0.14.33
   - postcss@8.5.23
   - protobufjs@7.6.5
+  - qs@6.16.0
   - tar@7.5.21
   - tmp@0.2.7
   - socket.io-parser@4.2.7


### PR DESCRIPTION
## Motivation

Dependency audit failures block pull request checks.

## Summary

- Bumped `fast-uri` to 3.1.6
- Bumped `qs` to 6.16.0
- Refreshed the lockfile and release-age exclusions

## Key design considerations

- Kept remediation scoped to workspace overrides for transitive dependencies