### PR TITLE
fix(tempo): commit http charges after session settlement

### DIFF
--- a/.changeset/session-settlement-accounting.md
+++ b/.changeset/session-settlement-accounting.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed HTTP session charges being retained when scheduled settlement failed, while preserving atomic balance checks for concurrent requests.

--- a/.changeset/session-settlement-accounting.md
+++ b/.changeset/session-settlement-accounting.md
@@ -2,4 +2,4 @@
 'mppx': patch
 ---
 
-Fixed HTTP session charges being retained when scheduled settlement failed, while preserving atomic balance checks for concurrent requests.
+Fixed HTTP session charges being retained after failed settlement and duplicate scheduled settlements across concurrent requests.

--- a/src/tempo/PublicExports.test-d.ts
+++ b/src/tempo/PublicExports.test-d.ts
@@ -81,6 +81,7 @@ test('tempo session chain exports canonical transaction options', () => {
     feePayer?: import('viem').Account | true | undefined
     feePayerPolicy?: Partial<import('./internal/fee-payer.js').Policy> | undefined
     feeToken?: import('viem').Address | undefined
+    validBefore?: number | undefined
   }>()
 })
 

--- a/src/tempo/session/precompile/Chain.test.ts
+++ b/src/tempo/session/precompile/Chain.test.ts
@@ -364,7 +364,8 @@ describe('precompile server transactions', () => {
             maxPriorityFeePerGas: 1n,
           } as never)) as never,
       }))
-      const options = { feeToken: descriptor.token }
+      const validBefore = Math.floor(Date.now() / 1_000) + 20
+      const options = { feeToken: descriptor.token, validBefore }
       const signature = `0x${'11'.repeat(65)}` as const
       if (operation === 'settle')
         await Chain.settleOnChain(client, descriptor, 1n, signature, tip20ChannelEscrow, options)
@@ -377,13 +378,14 @@ describe('precompile server transactions', () => {
       )
       expect(transaction.nonce).toBe(0)
       expect(transaction.nonceKey).toBe(maxUint256)
-      expect(transaction.validBefore).toBeDefined()
+      expect(transaction.validBefore).toBe(validBefore)
       expect(transaction.validAfter).toBeDefined()
       expect(rpcMethods).toEqual(['eth_sendRawTransaction'])
     },
   )
 
   test('marks server transactions for hosted sponsorship and preserves their fee token', async () => {
+    const validBefore = Math.floor(Date.now() / 1_000) + 20
     const rpcMethods: string[] = []
     const preparedRequests: Record<string, unknown>[] = []
     const signedRequests: Record<string, unknown>[] = []
@@ -413,15 +415,21 @@ describe('precompile server transactions', () => {
         account: sender,
         feePayer: true,
         feeToken: sourceToken,
+        validBefore,
       },
     )
     await Chain.settleOnChain(client, descriptor, 1n, `0x${'11'.repeat(65)}`, tip20ChannelEscrow, {
       account: sender,
       feePayer: true,
       feeToken: sourceToken,
+      validBefore,
     })
     expect(preparedRequests.map(({ feePayer }) => feePayer)).toEqual([true, true])
     expect(preparedRequests.map(({ feeToken }) => feeToken)).toEqual([sourceToken, sourceToken])
+    expect(preparedRequests.map(({ validBefore }) => validBefore)).toEqual([
+      validBefore,
+      validBefore,
+    ])
     expect(signedRequests.map(({ feePayer }) => feePayer)).toEqual([true, true])
     expect(signedRequests.map(({ feeToken }) => feeToken)).toEqual([sourceToken, sourceToken])
     expect(rpcMethods.filter((method) => method === 'eth_sendRawTransaction')).toHaveLength(2)

--- a/src/tempo/session/precompile/Chain.ts
+++ b/src/tempo/session/precompile/Chain.ts
@@ -397,6 +397,8 @@ export type ChannelTransactionOptions = {
   feePayerPolicy?: Partial<FeePayer.Policy> | undefined
   /** Explicit fee token for the transaction. */
   feeToken?: Address | undefined
+  /** Expiry for an expiring-nonce transaction, in Unix seconds. */
+  validBefore?: number | undefined
 }
 
 type ParsedPrecompileCredentialTransaction = {
@@ -582,6 +584,7 @@ async function prepareFeePayerCallTransaction(
     data: Hex
     feeToken?: Address | undefined
     to: Address
+    validBefore?: number | undefined
   },
 ) {
   const { account, data, feeToken, to } = parameters
@@ -592,6 +595,7 @@ async function prepareFeePayerCallTransaction(
     calls: [{ to, data }],
     feePayer: true,
     nonceKey: 'expiring',
+    ...(parameters.validBefore !== undefined ? { validBefore: parameters.validBefore } : {}),
     ...(feeToken ? { feeToken } : {}),
   } as never)
 }
@@ -604,6 +608,7 @@ function sendPrecompileContractCall(
     feePayer?: true | undefined
     feeToken?: Address | undefined
     to: Address
+    validBefore?: number | undefined
   },
 ): Promise<Hex> {
   const { account, data, feePayer, feeToken, to } = parameters
@@ -615,6 +620,7 @@ function sendPrecompileContractCall(
     data,
     // Server processes can share a signer without sharing viem's concurrency detection.
     nonceKey: 'expiring',
+    ...(parameters.validBefore !== undefined ? { validBefore: parameters.validBefore } : {}),
     ...(feePayer ? { feePayer } : {}),
     ...(feeToken ? { feeToken } : {}),
   } as never)
@@ -1237,6 +1243,7 @@ async function sendPrecompileTransaction(
       feePayer: true,
       feeToken: options.feeToken,
       to,
+      validBefore: options.validBefore,
     })
   }
 
@@ -1254,6 +1261,7 @@ async function sendPrecompileTransaction(
       data,
       feeToken,
       to,
+      validBefore: options.validBefore,
     })
     assertPrecompileFeePayerPolicy({ prepared, policy: options.feePayerPolicy })
     const serialized = await signTempoTransaction(client, {
@@ -1286,5 +1294,6 @@ async function sendPrecompileTransaction(
     to,
     data,
     feeToken,
+    validBefore: options?.validBefore,
   })
 }

--- a/src/tempo/session/server/ChannelStore.ts
+++ b/src/tempo/session/server/ChannelStore.ts
@@ -315,6 +315,15 @@ export interface BaseState {
   lastSettlementSpent?: bigint | undefined
   /** Charge operation count when the last server-scheduled settlement ran. */
   lastSettlementUnits?: number | undefined
+  /** Shared ownership of a scheduled settlement while its expiring transaction can still execute. */
+  settlementAttempt?:
+    | {
+        /** Identity used to fence release and settlement callbacks. */
+        id: string
+        /** Transaction expiry and reservation deadline, in Unix seconds. */
+        validBefore: number
+      }
+    | undefined
 }
 
 /** Returns whether a channel is backed by the TIP20EscrowChannel precompile. */

--- a/src/tempo/session/server/ChannelStore.ts
+++ b/src/tempo/session/server/ChannelStore.ts
@@ -822,11 +822,12 @@ export async function deductFromChannel(
   store: ChannelStore,
   channelId: State['channelId'],
   amount: bigint,
+  options: DeductOptions = {},
 ): Promise<DeductResult> {
   if (store.updateChannelResult) {
     const result = await store.updateChannelResult<DeductResult | null>(
       channelId,
-      (current): DeductionChange => planDeduction(current, amount),
+      (current): DeductionChange => planDeduction(current, amount, options),
     )
     if (!result) throw new Error('channel not found')
     return result
@@ -834,7 +835,7 @@ export async function deductFromChannel(
 
   let result: DeductResult | null = null
   const channel = await store.updateChannel(channelId, (current) => {
-    const change = planDeduction(current, amount)
+    const change = planDeduction(current, amount, options)
     result = change.result
     if (change.op === 'set') return change.value
     return current
@@ -843,8 +844,26 @@ export async function deductFromChannel(
   return result ?? { ok: false, channel }
 }
 
-function planDeduction(current: State | null, amount: bigint): DeductionChange {
+/** Conditions and settlement metadata for an atomic charge. */
+export type DeductOptions = {
+  /** Counters used to evaluate settlement; changed counters require another evaluation. */
+  expected?: Pick<State, 'spent' | 'units'> | undefined
+  /** Confirmation time for the settlement boundary committed with this charge. */
+  settledAt?: string | undefined
+}
+
+/** Computes a charge without mutating the channel, optionally including its confirmed settlement boundary. */
+export function planDeduction(
+  current: State | null,
+  amount: bigint,
+  options: DeductOptions = {},
+): DeductionChange {
   if (!current) return { op: 'noop', result: null }
+  if (
+    options.expected &&
+    (current.spent !== options.expected.spent || current.units !== options.expected.units)
+  )
+    return { op: 'noop', result: { ok: false, channel: current } }
   if (current.finalized) return { op: 'noop', result: { ok: false, channel: current } }
   if (current.closeRequestedAt !== 0n)
     return { op: 'noop', result: { ok: false, channel: current } }
@@ -852,5 +871,10 @@ function planDeduction(current: State | null, amount: bigint): DeductionChange {
     return { op: 'noop', result: { ok: false, channel: current } }
 
   const next = { ...current, spent: current.spent + amount, units: current.units + 1 }
+  if (options.settledAt !== undefined) {
+    next.lastSettlementAt = options.settledAt
+    next.lastSettlementSpent = next.spent
+    next.lastSettlementUnits = next.units
+  }
   return { op: 'set', value: next, result: { ok: true, channel: next } }
 }

--- a/src/tempo/session/server/Session.test.ts
+++ b/src/tempo/session/server/Session.test.ts
@@ -4010,7 +4010,12 @@ describe('session settlement extensions', () => {
 })
 
 describe('onSessionSettlement', () => {
-  function createSettleClient(channelId: Hex, settledAmount: bigint) {
+  function createSettleClient(
+    channelId: Hex,
+    settledAmount: bigint,
+    onSend?: () => void | Promise<void>,
+  ) {
+    let sent = false
     return createClient({
       account: payer,
       chain: testChain,
@@ -4021,15 +4026,18 @@ describe('onSessionSettlement', () => {
           if (args.method === 'eth_estimateGas') return '0x5208'
           if (args.method === 'eth_maxPriorityFeePerGas') return '0x1'
           if (args.method === 'eth_getBlockByNumber') return { baseFeePerGas: '0x1' }
-          if (args.method === 'eth_sendRawTransaction') return `0x${'cc'.repeat(32)}`
-          if (args.method === 'eth_sendTransaction') return `0x${'cc'.repeat(32)}`
+          if (args.method === 'eth_sendRawTransaction' || args.method === 'eth_sendTransaction') {
+            sent = true
+            await onSend?.()
+            return `0x${'cc'.repeat(32)}`
+          }
           if (args.method === 'eth_getTransactionReceipt')
             return transactionReceipt([settledLog(channelId, settledAmount)])
           if (args.method === 'eth_call') {
             return encodeFunctionResult({
               abi: escrowAbi,
               functionName: 'getChannelState',
-              result: { settled: settledAmount, deposit: 1_000n, closeRequestedAt: 0 },
+              result: { settled: sent ? settledAmount : 0n, deposit: 1_000n, closeRequestedAt: 0 },
             })
           }
           throw new Error(`unexpected rpc request: ${args.method}`)
@@ -4119,6 +4127,159 @@ describe('onSessionSettlement', () => {
       amount: 500n,
       delta: 500n,
     })
+  })
+
+  test('shares one scheduled settlement across concurrent channel requests', async () => {
+    const rawStore = Store.memory()
+    const store = channelStore(rawStore)
+    const openPayload = await createOpenPayload()
+    await persistPrecompileChannel(store, openPayload, {
+      payee: payer.address,
+      spent: 0n,
+      units: 0,
+    })
+    let broadcasts = 0
+    const events: unknown[] = []
+    const client = createSettleClient(openPayload.channelId, 100n, () => {
+      broadcasts++
+    })
+    const { applyVerifiedHttpAccounting, maybeSettleScheduled } = await import('./Settlement.js')
+    const parameters = {
+      account: payer,
+      client,
+      schedule: { units: 1 },
+      store,
+      onSessionSettlement: (event: unknown) => {
+        events.push(event)
+      },
+    }
+
+    await Promise.all(
+      [store, channelStore({ ...rawStore })].map((store) =>
+        applyVerifiedHttpAccounting({
+          capturedRequest: {
+            hasBody: false,
+            headers: new Headers(),
+            method: 'GET',
+            url: new URL('https://api.example.com/session'),
+          },
+          getRequestAmount: () => 25n,
+          payloadAction: 'voucher',
+          receipt: Types.createSessionReceipt({
+            acceptedCumulative: 100n,
+            challengeId: 'challenge-1',
+            channelId: openPayload.channelId,
+            spent: 0n,
+            units: 0,
+          }),
+          settleCharged: (channel) => maybeSettleScheduled({ ...parameters, channel, store }),
+          sseEnabled: false,
+          store,
+        }),
+      ),
+    )
+
+    expect(broadcasts).toBe(1)
+    expect(events).toHaveLength(1)
+    expect((await store.getChannel(openPayload.channelId))?.settlementAttempt).toBeUndefined()
+    expect(await store.getChannel(openPayload.channelId)).toMatchObject({ spent: 50n, units: 2 })
+  })
+
+  test.each([false, true])(
+    'recovers an expired attempt after an RPC error (confirmed: %s)',
+    async (confirmed) => {
+      const store = channelStore(Store.memory())
+      const openPayload = await createOpenPayload()
+      await persistPrecompileChannel(store, openPayload, {
+        payee: payer.address,
+        spent: 25n,
+        units: 1,
+      })
+      const channel = (await store.getChannel(openPayload.channelId))!
+      const { maybeSettleScheduled } = await import('./Settlement.js')
+      let broadcasts = 0
+      const client = createSettleClient(openPayload.channelId, 100n, () => {
+        broadcasts++
+        throw new Error('broadcast response lost')
+      })
+      const events: unknown[] = []
+      const parameters = {
+        account: payer,
+        channel,
+        client,
+        schedule: { units: 1 },
+        store,
+        onSessionSettlement: (event: unknown) => {
+          events.push(event)
+        },
+      }
+
+      await expect(maybeSettleScheduled(parameters)).rejects.toThrow('broadcast response lost')
+      const attempt = (await store.getChannel(openPayload.channelId))?.settlementAttempt
+      expect(attempt).toBeDefined()
+      expect(events).toHaveLength(0)
+      const previousBroadcasts = broadcasts
+      vi.useFakeTimers({ toFake: ['Date'] })
+      try {
+        vi.setSystemTime((attempt!.validBefore + 1) * 1_000)
+        await maybeSettleScheduled({
+          ...parameters,
+          client: confirmed
+            ? client
+            : createSettleClient(openPayload.channelId, 100n, () => {
+                broadcasts++
+              }),
+        })
+        expect(broadcasts - previousBroadcasts).toBe(confirmed ? 0 : 1)
+        expect(events).toHaveLength(confirmed ? 0 : 1)
+        expect(await store.getChannel(openPayload.channelId)).toMatchObject({
+          settledOnChain: 100n,
+          spent: 25n,
+          units: 1,
+        })
+        expect((await store.getChannel(openPayload.channelId))?.settlementAttempt).toBeUndefined()
+      } finally {
+        vi.useRealTimers()
+      }
+    },
+  )
+
+  test('preserves a replacement reservation when an older attempt finishes', async () => {
+    const store = channelStore(Store.memory())
+    const openPayload = await createOpenPayload()
+    await persistPrecompileChannel(store, openPayload, {
+      payee: payer.address,
+      spent: 25n,
+      units: 1,
+    })
+    const channel = (await store.getChannel(openPayload.channelId))!
+    const replacement = { id: 'replacement', validBefore: Math.floor(Date.now() / 1_000) + 25 }
+    const client = createSettleClient(openPayload.channelId, 100n, async () => {
+      await store.updateChannel(openPayload.channelId, (current) =>
+        current
+          ? {
+              ...current,
+              settlementAttempt: replacement,
+            }
+          : current,
+      )
+    })
+    const events: unknown[] = []
+    const { maybeSettleScheduled } = await import('./Settlement.js')
+
+    await maybeSettleScheduled({
+      account: payer,
+      channel,
+      client,
+      schedule: { units: 1 },
+      store,
+      onSessionSettlement: (event) => {
+        events.push(event)
+      },
+    })
+
+    expect(events).toHaveLength(0)
+    expect((await store.getChannel(openPayload.channelId))?.settlementAttempt).toEqual(replacement)
   })
 
   test('delta reflects incremental scheduled settlement with prior on-chain settlement', async () => {

--- a/src/tempo/session/server/Session.test.ts
+++ b/src/tempo/session/server/Session.test.ts
@@ -3599,7 +3599,7 @@ describe('precompile server session unit guardrails', () => {
                   functionName: 'getChannelState',
                   result: { settled: 0n, deposit: 1_000n, closeRequestedAt: 0 },
                 })
-              if (args.method === 'eth_getTransactionCount') {
+              if (args.method === 'eth_sendRawTransaction') {
                 observedPending =
                   (await store.getChannel(openPayload.channelId))!.closeRequestedAt !== 0n
                 throw new Error('broadcast failed')

--- a/src/tempo/session/server/Session.test.ts
+++ b/src/tempo/session/server/Session.test.ts
@@ -2067,6 +2067,79 @@ describe('precompile server session unit guardrails', () => {
   })
 
   describe('default HTTP auto-billing', () => {
+    test('retries a failed mandatory settlement without charging the failed HTTP request', async () => {
+      const rawStore = Store.memory()
+      const store = channelStore(rawStore)
+      const openPayload = await createOpenPayload({ initialAmount: 1n, operator: payer.address })
+      await persistPrecompileChannel(store, openPayload)
+      let settled = 0n
+      let ready = false
+      const state = () => ({ settled, deposit: 1_000n, closeRequestedAt: 0 })
+      const unavailable = createServerClient([], null, openPayload.channelId, { state })
+      const available = createServerClient([], payer, openPayload.channelId, {
+        state,
+        receipt: () => {
+          settled = 1n
+          return transactionReceipt([settledLog(openPayload.channelId, 1n)])
+        },
+      })
+      const route = Mppx_server.create({
+        methods: [
+          tempo_server.session({
+            amount: '1',
+            chainId,
+            currency: token,
+            decimals: 0,
+            getClient: () => (ready ? available : unavailable),
+            operator: payer.address,
+            recipient: payee,
+            settlementSchedule: { units: 1 },
+            store: rawStore,
+            unitType: 'request',
+          }),
+        ],
+        realm: 'api.example.com',
+        secretKey: 'test-secret-key-test-secret-key-32',
+      }).session({ amount: '1', decimals: 0, unitType: 'request' })
+      const initial = await route(new Request('https://api.example.com/resource'))
+      if (initial.status !== 402) throw new Error('expected challenge')
+      const voucher = await ClientOps.createVoucherPayload(
+        createSigningClient(),
+        payer,
+        openPayload.descriptor,
+        Types.uint96(1n),
+        chainId,
+      )
+      const authorization = Credential.serialize({
+        challenge: Challenge.fromResponse(initial.challenge),
+        payload: voucher,
+        source: sourceFor(),
+      })
+      const request = () =>
+        new Request('https://api.example.com/resource', {
+          headers: { authorization },
+        })
+
+      const failed = await route(request())
+      expect(failed.status).toBe(402)
+      expect(await store.getChannel(openPayload.channelId)).toMatchObject({ spent: 0n, units: 0 })
+
+      ready = true
+      const paid = await route(request())
+      expect(paid.status).toBe(200)
+      if (paid.status !== 200) throw new Error('expected paid response')
+      const response = paid.withReceipt(new Response('paid-content'))
+      const receipt = deserializeSessionReceipt(response.headers.get('Payment-Receipt')!)
+      expect(receipt).toMatchObject({ spent: '1', units: 1 })
+      expect(await store.getChannel(openPayload.channelId)).toMatchObject({
+        spent: 1n,
+        units: 1,
+        settledOnChain: 1n,
+        lastSettlementSpent: 1n,
+        lastSettlementUnits: 1,
+      })
+    })
+
     function createRoute(rawStore: Store.AtomicStore) {
       return Mppx_server.create({
         methods: [

--- a/src/tempo/session/server/Session.ts
+++ b/src/tempo/session/server/Session.ts
@@ -461,8 +461,7 @@ export function session<const parameters extends session.Parameters>(
       getRequestAmount: () => BigInt(context.request.amount ?? challenge.request.amount),
       sseEnabled: Boolean(parameters.sse),
       markPrepaidReceipt: Transport.markPrepaidSessionTick,
-      charge: (channelId, requestAmount) =>
-        chargeSessionChannel({ store, channelId, amount: requestAmount }),
+      store,
       settleCharged: (channel) =>
         maybeSettleScheduled({
           account,

--- a/src/tempo/session/server/Settlement.test.ts
+++ b/src/tempo/session/server/Settlement.test.ts
@@ -4,16 +4,20 @@ import { describe, expect, test, vi } from 'vp/test'
 
 import * as Challenge from '../../../Challenge.js'
 import type * as Credential from '../../../Credential.js'
+import { VerificationFailedError } from '../../../Errors.js'
 import type * as Method from '../../../Method.js'
+import * as Store from '../../../Store.js'
 import { createSessionReceipt } from '../precompile/Protocol.js'
-import type * as ChannelStore from './ChannelStore.js'
+import * as ChannelStore from './ChannelStore.js'
 import {
   applyVerifiedHttpAccounting,
+  chargeSessionChannel,
   isSettlementDue,
   readRequestFeePayer,
   resolveCredentialFeePayer,
   resolveRequestFeePayer,
   resolveSettlementProgress,
+  type SettleChargedSessionChannel,
 } from './Settlement.js'
 
 describe('FeePayerResolution', () => {
@@ -197,21 +201,30 @@ describe('applyVerifiedHttpAccounting', () => {
     }
   }
 
-  function chargedChannel(): ChannelStore.State {
-    return {
+  async function channelStore() {
+    const store = ChannelStore.fromStore(Store.memory())
+    await store.updateChannel(
       channelId,
-      spent: 75n,
-      units: 1,
-    } as ChannelStore.State
+      () =>
+        ({
+          channelId,
+          closeRequestedAt: 0n,
+          finalized: false,
+          highestVoucherAmount: 200n,
+          spent: 0n,
+          units: 0,
+        }) as ChannelStore.State,
+    )
+    return store
   }
 
   test('precharges SSE GET content and marks the receipt as prepaid', async () => {
-    const charge = vi.fn(async () => chargedChannel())
+    const store = await channelStore()
     const markPrepaidReceipt = vi.fn((value) => value)
 
     await applyVerifiedHttpAccounting({
       capturedRequest: capturedRequest({ method: 'GET' }),
-      charge,
+      store,
       getRequestAmount: () => 75n,
       markPrepaidReceipt,
       payloadAction: 'voucher',
@@ -220,16 +233,16 @@ describe('applyVerifiedHttpAccounting', () => {
       sseEnabled: true,
     })
 
-    expect(charge).toHaveBeenCalledWith(channelId, 75n)
+    expect(await store.getChannel(channelId)).toMatchObject({ spent: 75n, units: 1 })
     expect(markPrepaidReceipt).toHaveBeenCalledOnce()
   })
 
   test('does not charge SSE voucher management POSTs', async () => {
-    const charge = vi.fn(async () => chargedChannel())
+    const store = await channelStore()
 
     const result = await applyVerifiedHttpAccounting({
       capturedRequest: capturedRequest({ hasBody: true, method: 'POST' }),
-      charge,
+      store,
       getRequestAmount: () => 75n,
       payloadAction: 'voucher',
       receipt: receipt(),
@@ -237,16 +250,16 @@ describe('applyVerifiedHttpAccounting', () => {
       sseEnabled: true,
     })
 
-    expect(charge).not.toHaveBeenCalled()
+    expect(await store.getChannel(channelId)).toMatchObject({ spent: 0n, units: 0 })
     expect(result.spent).toBe('0')
   })
 
   test('keeps non-SSE POST content accounting unchanged', async () => {
-    const charge = vi.fn(async () => chargedChannel())
+    const store = await channelStore()
 
     await applyVerifiedHttpAccounting({
       capturedRequest: capturedRequest({ hasBody: true, method: 'POST' }),
-      charge,
+      store,
       getRequestAmount: () => 75n,
       payloadAction: 'voucher',
       receipt: receipt(),
@@ -254,7 +267,7 @@ describe('applyVerifiedHttpAccounting', () => {
       sseEnabled: false,
     })
 
-    expect(charge).toHaveBeenCalledWith(channelId, 75n)
+    expect(await store.getChannel(channelId)).toMatchObject({ spent: 75n, units: 1 })
   })
 })
 
@@ -302,6 +315,129 @@ describe('SettlementSchedule', () => {
       ...overrides,
     }
   }
+
+  describe('HTTP settlement accounting', () => {
+    async function setup(settleCharged: SettleChargedSessionChannel) {
+      const store = ChannelStore.fromStore(Store.memory())
+      await store.updateChannel(channelId, () =>
+        channel({
+          spent: 0n,
+          units: 0,
+          settledOnChain: 0n,
+          highestVoucherAmount: 100n,
+          highestVoucher: { channelId, cumulativeAmount: 100n, signature: '0x1234' },
+        }),
+      )
+      const parameters = {
+        capturedRequest: {
+          hasBody: false,
+          headers: new Headers(),
+          method: 'GET',
+          url: new URL('https://api.example.com/session'),
+        },
+        getRequestAmount: () => 25n,
+        payloadAction: 'voucher' as const,
+        receipt: createSessionReceipt({
+          acceptedCumulative: 100n,
+          challengeId: 'challenge-1',
+          channelId,
+          spent: 0n,
+          units: 0,
+        }),
+        settleCharged,
+        sseEnabled: false,
+        store,
+      }
+      return { parameters, store }
+    }
+
+    test('preserves the charge balance after failed settlement and charges a retry once', async () => {
+      const { parameters, store } = await setup(async (projected) => {
+        expect(projected).toMatchObject({ spent: 25n, units: 1 })
+        throw new Error('settlement unavailable')
+      })
+      await expect(applyVerifiedHttpAccounting(parameters)).rejects.toMatchObject({
+        message: 'Session settlement failed',
+        cause: { message: 'settlement unavailable' },
+      })
+      expect(await store.getChannel(channelId)).toMatchObject({ spent: 0n, units: 0 })
+
+      const result = await applyVerifiedHttpAccounting({
+        ...parameters,
+        settleCharged: async () => `0x${'ab'.repeat(32)}`,
+      })
+      expect(result).toMatchObject({ spent: '25', units: 1 })
+      expect(await store.getChannel(channelId)).toMatchObject({
+        spent: 25n,
+        units: 1,
+        lastSettlementSpent: 25n,
+        lastSettlementUnits: 1,
+      })
+    })
+
+    test('preserves another request charge when settlement fails', async () => {
+      const { parameters, store } = await setup(async () => {
+        await chargeSessionChannel({ store, channelId, amount: 10n })
+        throw new Error('settlement unavailable')
+      })
+      await expect(applyVerifiedHttpAccounting(parameters)).rejects.toMatchObject({
+        message: 'Session settlement failed',
+        cause: { message: 'settlement unavailable' },
+      })
+      expect(await store.getChannel(channelId)).toMatchObject({ spent: 10n, units: 1 })
+    })
+
+    test('rechecks voucher coverage after settlement before committing the charge', async () => {
+      const { parameters, store } = await setup(async () => {
+        await chargeSessionChannel({ store, channelId, amount: 100n })
+        return `0x${'ab'.repeat(32)}`
+      })
+      await expect(applyVerifiedHttpAccounting(parameters)).rejects.toThrow('available 0')
+      expect(await store.getChannel(channelId)).toMatchObject({ spent: 100n, units: 1 })
+    })
+
+    test('reevaluates the settlement threshold when another request commits a charge', async () => {
+      const projections: number[] = []
+      const { parameters, store } = await setup(async (projected) => {
+        projections.push(projected.units)
+        if (projected.units === 1) {
+          await chargeSessionChannel({ store, channelId, amount: 10n })
+          return undefined
+        }
+        return `0x${'ab'.repeat(32)}`
+      })
+      const receipt = await applyVerifiedHttpAccounting(parameters)
+      expect(projections).toEqual([1, 2])
+      expect(receipt).toMatchObject({ spent: '35', units: 2, txHash: `0x${'ab'.repeat(32)}` })
+      expect(await store.getChannel(channelId)).toMatchObject({
+        spent: 35n,
+        units: 2,
+        lastSettlementSpent: 35n,
+        lastSettlementUnits: 2,
+      })
+    })
+
+    test('reports settlement receipt validation errors as operational failures', async () => {
+      const cause = new VerificationFailedError({ reason: 'precompile transaction reverted' })
+      const { parameters, store } = await setup(async () => {
+        throw cause
+      })
+      await expect(applyVerifiedHttpAccounting(parameters)).rejects.toMatchObject({
+        message: 'Session settlement failed',
+        cause,
+      })
+      expect(await store.getChannel(channelId)).toMatchObject({ spent: 0n, units: 0 })
+    })
+
+    test('rejects a channel closed during settlement without committing a charge', async () => {
+      const { parameters, store } = await setup(async () => {
+        await store.updateChannel(channelId, (current) => ({ ...current!, closeRequestedAt: 1n }))
+        return `0x${'ab'.repeat(32)}`
+      })
+      await expect(applyVerifiedHttpAccounting(parameters)).rejects.toThrow('pending close request')
+      expect(await store.getChannel(channelId)).toMatchObject({ spent: 0n, units: 0 })
+    })
+  })
 
   describe('SettlementSchedule', () => {
     test('resolves progress from the previous scheduled settlement boundary', () => {

--- a/src/tempo/session/server/Settlement.ts
+++ b/src/tempo/session/server/Settlement.ts
@@ -244,9 +244,6 @@ export async function markSettlementComplete(parameters: MarkSettlementCompleteP
   )
 }
 
-/** Callback used by post-verification accounting to deduct spend from a channel. */
-export type ChargeSessionChannel = (channelId: Hex, amount: bigint) => Promise<ChannelStore.State>
-
 /** Callback used by post-verification accounting to run server-owned settlement policy. */
 export type SettleChargedSessionChannel = (channel: ChannelStore.State) => Promise<Hex | undefined>
 
@@ -264,8 +261,8 @@ export type ChargeParameters = {
 export type ApplyVerifiedHttpAccountingParameters = {
   /** Captured request metadata from the verified envelope, when this is a request-backed flow. */
   capturedRequest?: Method.CapturedRequest | undefined
-  /** Deducts the configured request amount from channel spend. */
-  charge: ChargeSessionChannel
+  /** Channel store used to preview and atomically commit the request charge. */
+  store: ChannelStore.ChannelStore
   /** Returns the raw request amount to deduct for one content response. Called only when charging. */
   getRequestAmount: () => bigint
   /** Credential action that produced the receipt. Only open/voucher can pay for content. */
@@ -276,7 +273,7 @@ export type ApplyVerifiedHttpAccountingParameters = {
   markPrepaidReceipt?: ((receipt: SessionReceipt) => SessionReceipt) | undefined
   /** Whether SSE transport is enabled. SSE accounting is stream-driven, not HTTP-response-driven. */
   sseEnabled: boolean
-  /** Runs optional server settlement policy after a successful content charge. */
+  /** Runs server settlement policy against the projected charge before committing it. */
   settleCharged: SettleChargedSessionChannel
 }
 
@@ -291,8 +288,39 @@ export async function applyVerifiedHttpAccounting(
   if (!isSessionContentRequest(capturedRequest)) return receipt
 
   const requestAmount = parameters.getRequestAmount()
-  const charged = await parameters.charge(receipt.channelId, requestAmount)
-  const settlementTxHash = await parameters.settleCharged(charged)
+  let settlementTxHash: Hex | undefined
+  let charged: ChannelStore.State
+  while (true) {
+    const current = await parameters.store.getChannel(receipt.channelId)
+    if (!current) throw new ChannelClosedError({ reason: 'channel not found' })
+    const projected = requireCharge(
+      ChannelStore.planDeduction(current, requestAmount).result,
+      requestAmount,
+    )
+    // Settlement failures must not consume a content charge.
+    settlementTxHash =
+      (await parameters.settleCharged(projected).catch((cause) => {
+        // Receipt validation errors during scheduled settlement are operational failures, not invalid credentials.
+        throw new Error('Session settlement failed', { cause })
+      })) ?? settlementTxHash
+    const result = await ChannelStore.deductFromChannel(
+      parameters.store,
+      receipt.channelId,
+      requestAmount,
+      {
+        expected: current,
+        ...(settlementTxHash ? { settledAt: new Date().toISOString() } : {}),
+      },
+    )
+    // Another charge can cross a settlement threshold while awaiting the RPC. Evaluate its updated counters before committing.
+    if (
+      !result.ok &&
+      (result.channel.spent !== current.spent || result.channel.units !== current.units)
+    )
+      continue
+    charged = requireCharge(result, requestAmount)
+    break
+  }
   const chargedReceipt = {
     ...receipt,
     spent: charged.spent.toString(),
@@ -315,6 +343,14 @@ export async function chargeSessionChannel(
   } catch {
     throw new ChannelClosedError({ reason: 'channel not found' })
   }
+  return requireCharge(result, amount)
+}
+
+function requireCharge(
+  result: ChannelStore.DeductResult | null,
+  amount: bigint,
+): ChannelStore.State {
+  if (!result) throw new ChannelClosedError({ reason: 'channel not found' })
   if (!result.ok) {
     if (result.channel.finalized) throw new ChannelClosedError({ reason: 'channel is finalized' })
     if (result.channel.closeRequestedAt !== 0n)

--- a/src/tempo/session/server/Settlement.ts
+++ b/src/tempo/session/server/Settlement.ts
@@ -391,6 +391,8 @@ export type SettlementTransactionOptions = {
   feeToken?: Address | undefined
   /** Callback invoked after the settlement transaction is confirmed. */
   onSessionSettlement?: OnSessionSettlement | undefined
+  /** Expiry for the settlement transaction, in Unix seconds. */
+  validBefore?: number | undefined
 }
 
 /** Inputs for applying a server-owned automatic settlement schedule. */
@@ -448,17 +450,79 @@ export async function maybeSettleScheduled(
 ): Promise<Hex | undefined> {
   const { channel, schedule, store } = parameters
   if (!isSettlementDue(channel, schedule)) return undefined
-  const txHash = await settle(store, parameters.client, channel.channelId, {
-    account: parameters.account,
-    ...(parameters.feePayer ? { feePayer: parameters.feePayer } : {}),
-    ...(parameters.feePayerPolicy ? { feePayerPolicy: parameters.feePayerPolicy } : {}),
-    ...(parameters.feeToken ? { feeToken: parameters.feeToken } : {}),
-    onSessionSettlement: parameters.onSessionSettlement
-      ? (ctx) => parameters.onSessionSettlement!({ ...ctx, trigger: 'scheduled' })
-      : undefined,
-  })
-  await markSettlementComplete({ channelId: channel.channelId, store })
-  return txHash
+  const id = crypto.randomUUID()
+  while (true) {
+    const now = Math.floor(Date.now() / 1_000)
+    // Match Tempo's expiring transaction window so abandoned attempts cannot execute after a new owner takes over.
+    const validBefore = now + 25
+    const reserved = await store.updateChannel(channel.channelId, (current) => {
+      if (!current || (current.settlementAttempt?.validBefore ?? 0) > now) return current
+      return { ...current, settlementAttempt: { id, validBefore } }
+    })
+    if (!reserved) throw new ChannelNotFoundError({ reason: 'channel not found' })
+    if (reserved.settlementAttempt?.id !== id) {
+      if (reserved.highestVoucherAmount <= reserved.settledOnChain) return undefined
+      await new Promise((resolve) => setTimeout(resolve, 100))
+      continue
+    }
+
+    let release = true
+    try {
+      // Reconcile an earlier attempt that confirmed on-chain before its owner could persist the result.
+      const state = await Chain.getChannelState(
+        parameters.client,
+        channel.channelId,
+        reserved.escrowContract,
+      )
+      const refreshed = await store.updateChannel(channel.channelId, (current) =>
+        current
+          ? {
+              ...current,
+              settledOnChain: ChannelStore.keepGreater(current.settledOnChain, state.settled),
+            }
+          : current,
+      )
+      if (!refreshed) throw new ChannelNotFoundError({ reason: 'channel not found' })
+      if (!ChannelStore.isPrecompileState(refreshed)) return undefined
+      if (refreshed.settlementAttempt?.id !== id || Date.now() >= validBefore * 1_000)
+        throw new Error('Scheduled settlement reservation expired')
+      if (!isSettlementDue({ ...refreshed, spent: channel.spent, units: channel.units }, schedule))
+        return undefined
+
+      assertSettlementSender({
+        operation: 'settle',
+        channelId: channel.channelId,
+        operator: refreshed.operator,
+        payee: refreshed.payee,
+        sender: (parameters.account ?? getClientAccount(parameters.client))?.address,
+      })
+      // An RPC failure can leave a broadcast transaction pending. Keep ownership until that transaction expires.
+      release = false
+      const txHash = await settle(store, parameters.client, channel.channelId, {
+        account: parameters.account,
+        ...(parameters.feePayer ? { feePayer: parameters.feePayer } : {}),
+        ...(parameters.feePayerPolicy ? { feePayerPolicy: parameters.feePayerPolicy } : {}),
+        ...(parameters.feeToken ? { feeToken: parameters.feeToken } : {}),
+        validBefore,
+        onSessionSettlement: parameters.onSessionSettlement
+          ? async (ctx) => {
+              const current = await store.getChannel(channel.channelId)
+              if (current?.settlementAttempt?.id === id)
+                await parameters.onSessionSettlement!({ ...ctx, trigger: 'scheduled' })
+            }
+          : undefined,
+      })
+      release = true
+      return txHash
+    } finally {
+      if (release)
+        await store.updateChannel(channel.channelId, (current) => {
+          if (current?.settlementAttempt?.id !== id) return current
+          const { settlementAttempt: _, ...released } = current
+          return released
+        })
+    }
+  }
 }
 
 /** Settles the highest accepted voucher for a precompile-backed session channel. */
@@ -498,6 +562,7 @@ export async function settle(
           ...(options?.feePayerPolicy ? { feePayerPolicy: options.feePayerPolicy } : {}),
           ...(options?.feeToken ? { feeToken: options.feeToken } : {}),
           candidateFeeTokens: options?.candidateFeeTokens ?? [channel.token],
+          validBefore: options?.validBefore,
         }
       : undefined,
   )


### PR DESCRIPTION
Commit HTTP session charges after scheduled settlement succeeds, preserving atomic balance checks during concurrent requests. Failed settlement returns `402` without consuming the request charge. Update the close-failure fixture for expiring nonces.
