### PR TITLE
feat: support deferred EVM payments and MCP composition

### DIFF
--- a/.changeset/deferred-evm-signing.md
+++ b/.changeset/deferred-evm-signing.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Allowed EVM and x402 payments to be prepared without an account and signed using an account supplied during credential creation.

--- a/.changeset/evm-validation-lifecycle.md
+++ b/.changeset/evm-validation-lifecycle.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added non-mutating EVM credential validation with facilitator checks and revalidation before settlement through the existing broadcast lifecycle.

--- a/.changeset/mcp-offer-composition.md
+++ b/.changeset/mcp-offer-composition.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added typed multi-offer composition for MCP SDK and JSON-RPC transports while preserving selected-payment dispatch and receipt metadata.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Full documentation, API reference, and guides are available at **[mpp.dev/sdk/ty
 
 Contributors changing Tempo sessions should read the [session design](./src/tempo/session/README.md) before altering credential, recovery, accounting, or transport behavior.
 
+See [deferred EVM payments](./src/evm/README.md) for inspecting payments before signing and
+validating credentials before settlement, and [MCP composition](./src/mcp/server/README.md)
+for offering multiple payment options from one tool.
+
 ## Install
 
 ```bash

--- a/src/evm/DeferredPayment.test.ts
+++ b/src/evm/DeferredPayment.test.ts
@@ -1,0 +1,151 @@
+import { Challenge, Credential } from 'mppx'
+import { evm as clientEvm, Mppx as ClientMppx } from 'mppx/client'
+import { evm, Mppx } from 'mppx/server'
+import { Header, Types } from 'mppx/x402'
+import { privateKeyToAccount } from 'viem/accounts'
+import { describe, expect, test } from 'vp/test'
+
+const account = privateKeyToAccount(
+  '0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+)
+const recipient = '0x209693Bc6afc0C5328bA36FaF03C514EF312287C'
+const reference = `0x${'1'.repeat(64)}`
+const realm = 'example.test'
+const secretKey = 'test-secret-key-test-secret-key-32'
+
+async function fixture(protocol: 'mpp' | 'x402') {
+  const settlements: Types.PaymentPayload[] = []
+  const state = { valid: true, verifications: 0 }
+  const method = evm.charge({
+    currency: evm.assets.base.USDC,
+    recipient,
+    x402: {
+      facilitator: {
+        async verify() {
+          state.verifications++
+          return { isValid: state.valid, invalidReason: 'Authorization is no longer spendable' }
+        },
+        async settle(paymentPayload) {
+          settlements.push(paymentPayload)
+          return { success: true, transaction: reference, network: 'eip155:8453' }
+        },
+      },
+    },
+  })
+  const server = Mppx.create({ methods: [method], realm, secretKey })
+  const request = new Request('https://example.test/paid')
+  const route = server.charge({ amount: '0.25', scope: 'job' })
+  const offered = await route(request)
+  if (offered.status !== 402) throw new Error()
+  const challenge = await server.challenge.evm.charge({
+    amount: '0.25',
+    scope: 'job',
+    expires: Challenge.fromResponse(offered.challenge).expires,
+  })
+  const response =
+    protocol === 'mpp'
+      ? offered.challenge
+      : new Response(null, {
+          status: 402,
+          headers: {
+            [Types.paymentRequiredHeader]: offered.challenge.headers.get(
+              Types.paymentRequiredHeader,
+            )!,
+          },
+        })
+  const client = ClientMppx.create({
+    methods: [clientEvm.charge({ currencies: [clientEvm.assets.base.USDC], networks: [8453] })],
+    polyfill: false,
+  })
+  const prepared = await client.preparePayment(response)
+  const routeOptions = { realm, request: { amount: '0.25' }, scope: 'job' }
+  async function credential() {
+    const serialized = await prepared.createCredential({ account })
+    if (protocol === 'mpp') return Credential.deserialize(serialized)
+    const paidRequest = new Request(request, {
+      headers: { [Types.paymentSignatureHeader]: serialized },
+    })
+    const transport = method.transport!
+    return transport.bindCredential!({
+      challenge,
+      credential: transport.getCredential(paidRequest)!,
+      input: paidRequest,
+    })
+  }
+  return { credential, prepared, protocol, routeOptions, server, settlements, state }
+}
+
+describe.each(['mpp', 'x402'] as const)('deferred EVM payment (%s)', (protocol) => {
+  test('prepares without a signer, validates without settlement, and broadcasts once', async () => {
+    const context = await fixture(protocol)
+    expect(context.state.verifications).toBe(0)
+    expect(context.settlements).toEqual([])
+    const credential = await context.credential()
+    const first = await context.server.validateCredential(credential, context.routeOptions)
+    const second = await context.server.validateCredential(credential, context.routeOptions)
+    expect(first.source).toBe(`did:pkh:eip155:8453:${account.address}`)
+    expect(second.request.amount).toBe('250000')
+    expect(context.state.verifications).toBe(2)
+    expect(context.settlements).toEqual([])
+
+    const receipt = await context.server.broadcastCredential(credential, context.routeOptions)
+    expect(receipt.reference).toBe(reference)
+    expect(context.state.verifications).toBe(3)
+    expect(context.settlements).toHaveLength(1)
+    expect(context.settlements[0]?.payload).toMatchObject({
+      authorization: { from: account.address, to: recipient, value: '250000' },
+    })
+  })
+
+  test('fails clearly when credential creation has no signer', async () => {
+    const context = await fixture(protocol)
+    await expect(context.prepared.createCredential()).rejects.toThrow(
+      'requires a typed-data signer.',
+    )
+    expect(context.state.verifications).toBe(0)
+    expect(context.settlements).toEqual([])
+  })
+
+  test('rechecks facilitator approval at broadcast time', async () => {
+    const context = await fixture(protocol)
+    const credential = await context.credential()
+    await context.server.validateCredential(credential, context.routeOptions)
+    context.state.valid = false
+    await expect(
+      context.server.broadcastCredential(credential, context.routeOptions),
+    ).rejects.toThrow('Authorization is no longer spendable')
+    expect(context.state.verifications).toBe(2)
+    expect(context.settlements).toEqual([])
+  })
+})
+
+test('credential context takes precedence over a configured EVM account', async () => {
+  const configured = privateKeyToAccount(`0x${'02'.repeat(32)}`)
+  const client = ClientMppx.create({
+    methods: [clientEvm.charge({ account: configured, currencies: [clientEvm.assets.base.USDC] })],
+    polyfill: false,
+  })
+  const response = new Response(null, {
+    status: 402,
+    headers: {
+      [Types.paymentRequiredHeader]: Header.encodePaymentRequired({
+        x402Version: 2,
+        resource: { url: 'https://example.test/paid' },
+        accepts: [
+          {
+            scheme: 'exact',
+            network: 'eip155:8453',
+            asset: evm.assets.base.USDC.address,
+            amount: '250000',
+            payTo: recipient,
+            maxTimeoutSeconds: 300,
+            extra: { name: 'USD Coin', version: '2' },
+          },
+        ],
+      }),
+    },
+  })
+  const prepared = await client.preparePayment(response)
+  const credential = Header.decodePaymentSignature(await prepared.createCredential({ account }))
+  expect(credential.payload).toMatchObject({ authorization: { from: account.address } })
+})

--- a/src/evm/PublicInterface.test-d.ts
+++ b/src/evm/PublicInterface.test-d.ts
@@ -29,6 +29,14 @@ const facilitator = {
 }
 
 describe('evm public interface', () => {
+  test('defers the signer to prepared credential creation', async () => {
+    const client = ClientMppx.create({
+      methods: [clientCharge({ currencies: [clientAssets.base.USDC] })],
+      polyfill: false,
+    })
+    const payment = await client.preparePayment(new Response())
+    expectTypeOf(payment.createCredential({ account })).toEqualTypeOf<Promise<string>>()
+  })
   test('exports EVM asset metadata from root and subpaths', () => {
     expectTypeOf(evmRoot.assets.base.USDC).toMatchTypeOf<typeof serverAssets.base.USDC>()
     expectTypeOf(

--- a/src/evm/README.md
+++ b/src/evm/README.md
@@ -1,0 +1,70 @@
+# Deferred EVM payments
+
+## Choose the signer after preparation
+
+`evm.charge()` accepts an optional account. `preparePayment` selects and snapshots an offer
+without signing it. Supply the account to `createCredential` when ready to pay:
+
+```ts
+import { Mppx, evm } from 'mppx/client'
+import type { Account } from 'viem'
+
+async function prepare(response: Response, account: Account) {
+  const client = Mppx.create({
+    methods: [evm.charge({ currencies: [evm.assets.base.USDC], networks: [8453] })],
+    polyfill: false,
+  })
+  const payment = await client.preparePayment(response)
+  // Inspect payment.challenge and enforce the application's quote/budget policy here.
+  return payment.createCredential({ account })
+}
+```
+
+This works for native EVM Payment-auth and x402 exact offers. A credential-context account
+takes precedence over the configured account. If neither is a typed-data signer, credential
+creation rejects with a descriptive error; preparation remains available.
+
+## Validate before settlement
+
+An EVM server supports the same `validateCredential` and `broadcastCredential` lifecycle as
+Tempo. For a native Payment credential, use the server that issued the challenge:
+
+```ts
+const options = { realm: 'api.example.com', request: { amount: '0.25' }, scope: 'job:123' }
+const validation = await server.validateCredential(credential, options)
+// Atomically claim the application operation using validation.source and the job identity.
+const receipt = await server.broadcastCredential(credential, options)
+// Persist the completed operation and receipt.reference.
+```
+
+Validation checks payment terms, expiry, signature, and payer identity. With the default
+facilitator-backed settler it also calls the facilitator's verification endpoint, without
+calling settlement. A custom `settle` implementation remains responsible for chain-state
+checks and replay protection. Validation is not a reservation or a settlement receipt.
+
+Broadcast revalidates, then settles. Existing route handlers and `verifyCredential` still
+perform the complete validate-and-settle flow. The application owns durable claims,
+idempotency, and reconciliation if settlement succeeds but persisting its result fails.
+
+For x402, first normalize the transport-native payload with the configured EVM method's
+transport. The route challenge must be generated from the server's authoritative route
+configuration, including its scope, metadata, and expiration:
+
+```ts
+const transport = method.transport!
+const pending = transport.getCredential(paidRequest)
+if (!pending) throw new Error('Missing payment credential')
+const credential = await transport.bindCredential!({
+  challenge: routeChallenge,
+  credential: pending,
+  input: paidRequest,
+})
+const capturedRequest = await transport.captureRequest!(paidRequest)
+const options = { capturedRequest, request: { amount: '0.25' }, scope: 'job:123' }
+const validation = await server.validateCredential(credential, options)
+// Claim the operation before calling server.broadcastCredential(credential, options).
+```
+
+Use the bound credential object directly so its x402 provenance is retained. Do not treat
+an unbound `PAYMENT-SIGNATURE` value as a native Payment credential or bypass transport
+resource/body binding. Existing x402 route handlers still perform normalization automatically.

--- a/src/evm/client/Charge.ts
+++ b/src/evm/client/Charge.ts
@@ -37,7 +37,8 @@ export function charge(parameters: charge.Parameters) {
         })
 
       const account = (context?.account ?? parameters.account) as charge.Signer
-      if (!account.signTypedData) throw new Error('EVM authorization requires a typed-data signer.')
+      if (!account?.signTypedData)
+        throw new Error('EVM authorization requires a typed-data signer.')
 
       const request = challenge.request as Types.ChargeRequest
       assertPolicy(parameters, request)
@@ -100,8 +101,8 @@ export declare namespace charge {
   }
 
   type Parameters = {
-    /** Account used to sign EVM charge credentials. */
-    account: Account
+    /** Account used to sign credentials. May instead be supplied to `createCredential` after payment preparation. */
+    account?: Account | undefined
     /** EIP-3009 token domain metadata for custom currencies. */
     authorization?: Types.AuthorizationConfig | undefined
     /** Optional token decimals used to parse `maxAmount` when currency metadata is not provided. */

--- a/src/evm/server/Charge.ts
+++ b/src/evm/server/Charge.ts
@@ -14,10 +14,14 @@ import * as Types from '../Types.js'
  * Creates an EVM charge server method.
  *
  * Speaks the native Payment-auth `evm/charge` wire format.
+ * Supports non-mutating `validateCredential` checks before settlement through
+ * `broadcastCredential`. Validation checks the signature and payment terms, and
+ * checks the facilitator when using facilitator-backed settlement. Custom
+ * settlers remain responsible for chain-state checks and replay protection.
  */
 export function charge(
   parameters: charge.NativeConfig,
-): Method.Server<typeof Methods.charge, charge.Defaults>
+): Method.Server<typeof Methods.charge, charge.Defaults, ServerTransport.Http>
 export function charge(parameters: charge.NativeConfig): Method.AnyServer {
   const config = resolveConfig(parameters)
   const paths = createPaths(config)
@@ -34,7 +38,7 @@ export function charge(parameters: charge.NativeConfig): Method.AnyServer {
       recipient: config.recipient,
     },
     transport,
-    async verify({ credential }) {
+    async validate({ credential }) {
       const payload = credential.payload as Types.AuthorizationPayload
       const request = credential.challenge.request as Types.ChargeRequest
       const chainId = request.methodDetails.chainId
@@ -88,11 +92,35 @@ export function charge(parameters: charge.NativeConfig): Method.AnyServer {
         throw new VerificationFailedError({ reason: 'EVM authorization source mismatch' })
       }
 
-      const settled = await config.settle({
+      const authorization = {
         credential,
         payload,
         request,
         source,
+      }
+      await config.validate?.(authorization)
+
+      return {
+        challenge: credential.challenge,
+        credential,
+        details: { payer: getAddress(payload.from) },
+        intent: Methods.charge.intent,
+        method: Methods.charge.name,
+        request: credential.challenge.request,
+        source,
+      }
+    },
+    async broadcast({ credential }) {
+      const payload = credential.payload as Types.AuthorizationPayload
+      const request = credential.challenge.request as Types.ChargeRequest
+      const settled = await config.settle({
+        credential,
+        payload,
+        request,
+        source: Types.toSource({
+          address: getAddress(payload.from),
+          chainId: request.methodDetails.chainId,
+        }),
       })
 
       return Receipt.from({
@@ -107,7 +135,7 @@ export function charge(parameters: charge.NativeConfig): Method.AnyServer {
 
 export declare namespace charge {
   type Parameters = NativeConfig
-  type Native = Method.Server<typeof Methods.charge, Defaults>
+  type Native = Method.Server<typeof Methods.charge, Defaults, ServerTransport.Http>
 
   type NativeConfig = BaseConfig &
     CurrencyConfig &
@@ -172,6 +200,7 @@ type ResolvedConfig = {
   decimals: number
   recipient: `0x${string}`
   settle: charge.SettleAuthorization
+  validate?: ((parameters: Parameters<charge.SettleAuthorization>[0]) => Promise<void>) | undefined
   x402: X402.ResolvedOptions
 }
 
@@ -240,6 +269,10 @@ function resolveConfig(config: charge.NativeConfig): ResolvedConfig {
     decimals,
     recipient: getAddress(recipient),
     settle,
+    validate:
+      !config.settle && x402.facilitator
+        ? (parameters) => X402.verifyWithFacilitator(x402, parameters)
+        : undefined,
     x402,
   }
 }

--- a/src/mcp/server/README.md
+++ b/src/mcp/server/README.md
@@ -1,0 +1,38 @@
+# MCP payment composition
+
+`Mppx.create({ transport: Transport.mcpSdk(), ... })` supports the same instance `compose`
+entry tuples as HTTP. Each entry can reference a registered method, handler, or method key.
+
+```ts
+import { Mppx, tempo, Transport } from 'mppx/server'
+import { mach } from 'mppx/tempo'
+import { usdce } from 'viem/tokens'
+
+const server = Mppx.create({
+  methods: [tempo.charge({ recipient, decimals: 6 })],
+  realm: 'api.example.com',
+  secretKey,
+  transport: Transport.mcpSdk(),
+})
+const charge = server.compose(
+  ['tempo/charge', { amount: '1', currency: mach(4217).address }],
+  ['tempo/charge', { amount: '1', currency: usdce.addresses[4217] }],
+)
+
+// Inside an MCP SDK tool handler:
+const payment = await charge(extra)
+if (payment.status === 402) throw payment.challenge
+return payment.withReceipt({ content: [{ type: 'text', text: 'Result' }] })
+```
+
+Without a credential, the MCP error contains all offers in configured order. With a
+credential, composition dispatches to one matching offer, including when multiple offers
+share a method and intent. Verification failures retain their error code and retry
+challenge rather than attempting another payment. Receipts retain existing tool metadata.
+
+Use `Transport.mcp()` for raw JSON-RPC inputs and outputs; composition preserves the request
+ID and returns an MCP error response instead of an SDK `McpError`.
+
+All entries must use the configured MCP transport. HTTP-only `canOffer` and `selectOffers`
+hooks do not apply to MCP composition; select the application's offered entries before
+calling `compose`. Static `Mppx.compose(...)` remains an HTTP handler combinator.

--- a/src/server/Mppx.compose.mcp.test-d.ts
+++ b/src/server/Mppx.compose.mcp.test-d.ts
@@ -1,0 +1,24 @@
+import type { CallToolResult, McpError } from '@modelcontextprotocol/sdk/types.js'
+import { Mcp } from 'mppx'
+import { Mppx, tempo, Transport } from 'mppx/server'
+import { expectTypeOf, test } from 'vp/test'
+
+test('MCP composition preserves input, challenge, and receipt types', async () => {
+  const methods = [
+    tempo.charge({ currency: '0x0000000000000000000000000000000000000001', decimals: 6 }),
+  ] as const
+  const config = { methods, realm: 'example.test', secretKey: 'test-secret-key-test-secret-key-32' }
+  const sdk = Mppx.create({ ...config, transport: Transport.mcpSdk() })
+  const sdkHandler = sdk.compose(['tempo/charge', { amount: '1' }])
+  const sdkResult = await sdkHandler({ _meta: {} })
+  if (sdkResult.status === 402) expectTypeOf(sdkResult.challenge).toEqualTypeOf<McpError>()
+  else expectTypeOf(sdkResult.withReceipt({ content: [] })).toEqualTypeOf<CallToolResult>()
+
+  const rpc = Mppx.create({ ...config, transport: Transport.mcp() })
+  const rpcResult = await rpc.compose(['tempo/charge', { amount: '1' }])({
+    method: 'tools/call',
+    id: 1,
+  })
+  if (rpcResult.status === 402) expectTypeOf(rpcResult.challenge).toEqualTypeOf<Mcp.Response>()
+  else expectTypeOf(rpcResult.withReceipt({ result: {} })).toEqualTypeOf<Mcp.Response>()
+})

--- a/src/server/Mppx.compose.mcp.test.ts
+++ b/src/server/Mppx.compose.mcp.test.ts
@@ -1,0 +1,207 @@
+import { McpError } from '@modelcontextprotocol/sdk/types.js'
+import { Credential, Errors, Mcp, Method, z } from 'mppx'
+import { Mppx, Transport } from 'mppx/server'
+import { describe, expect, test } from 'vp/test'
+
+const realm = 'example.test'
+const secretKey = 'test-secret-key-test-secret-key-32'
+
+function fixture() {
+  const payments: string[] = []
+  const method = Method.toServer(
+    Method.from({
+      name: 'test',
+      intent: 'charge',
+      schema: {
+        credential: { payload: z.object({ token: z.string() }) },
+        request: z.object({ amount: z.string(), currency: z.string() }),
+      },
+    }),
+    {
+      async verify({ credential }) {
+        payments.push(credential.challenge.request.currency)
+        if (credential.payload.token !== 'valid')
+          throw new Errors.VerificationFailedError({ reason: 'Payment was declined' })
+        return {
+          method: 'test',
+          reference: credential.challenge.request.currency,
+          status: 'success' as const,
+          timestamp: new Date().toISOString(),
+        }
+      },
+    },
+  )
+  return { method, payments }
+}
+
+describe('MCP composition', () => {
+  test('SDK gathers all offers and settles only the chosen currency', async () => {
+    const { method, payments } = fixture()
+    const server = Mppx.create({
+      methods: [method],
+      realm,
+      secretKey,
+      transport: Transport.mcpSdk(),
+    })
+    const route = server.compose(
+      [method, { amount: '1', currency: 'A' }],
+      ['test/charge', { amount: '1', currency: 'B' }],
+    )
+    const offered = await route({ _meta: { trace: 'kept' } })
+    expect(offered.status).toBe(402)
+    if (offered.status !== 402) throw new Error()
+    expect(offered.challenge).toBeInstanceOf(McpError)
+    expect(offered.challenge.code).toBe(Mcp.paymentRequiredCode)
+    const data = offered.challenge.data as NonNullable<Mcp.ErrorObject['data']>
+    expect(data.challenges.map((challenge) => challenge.request.currency)).toEqual(['A', 'B'])
+    expect(payments).toEqual([])
+
+    const credential = Credential.from({
+      challenge: data.challenges[1]!,
+      payload: { token: 'valid' },
+    })
+    const paid = await route({ _meta: { [Mcp.credentialMetaKey]: credential } })
+    expect(paid.status).toBe(200)
+    expect(payments).toEqual(['B'])
+    if (paid.status !== 200) throw new Error()
+    const result = paid.withReceipt({
+      content: [{ type: 'text', text: 'paid' }],
+      _meta: { trace: 'kept' },
+    })
+    expect(result.content).toEqual([{ type: 'text', text: 'paid' }])
+    expect(result._meta).toMatchObject({
+      trace: 'kept',
+      [Mcp.receiptMetaKey]: { challengeId: credential.challenge.id, reference: 'B' },
+    })
+  })
+
+  test('SDK distinguishes offers with the same currency by amount and scope', async () => {
+    const { method, payments } = fixture()
+    const server = Mppx.create({
+      methods: [method],
+      realm,
+      secretKey,
+      transport: Transport.mcpSdk(),
+    })
+    const route = server.compose(
+      [method, { amount: '1', currency: 'A', scope: 'first' }],
+      [method, { amount: '2', currency: 'A', scope: 'second' }],
+    )
+    const offered = await route({})
+    if (offered.status !== 402) throw new Error()
+    const data = offered.challenge.data as NonNullable<Mcp.ErrorObject['data']>
+    const paid = await route({
+      _meta: {
+        [Mcp.credentialMetaKey]: Credential.from({
+          challenge: data.challenges[1]!,
+          payload: { token: 'valid' },
+        }),
+      },
+    })
+    expect(paid.status).toBe(200)
+    expect(payments).toEqual(['A'])
+  })
+
+  test('failed verification keeps its code and does not try another offer', async () => {
+    const { method, payments } = fixture()
+    const server = Mppx.create({
+      methods: [method],
+      realm,
+      secretKey,
+      transport: Transport.mcpSdk(),
+    })
+    const route = server.compose(
+      [method, { amount: '1', currency: 'A' }],
+      [method, { amount: '1', currency: 'B' }],
+    )
+    const offered = await route({})
+    if (offered.status !== 402) throw new Error()
+    const data = offered.challenge.data as NonNullable<Mcp.ErrorObject['data']>
+    const result = await route({
+      _meta: {
+        [Mcp.credentialMetaKey]: Credential.from({
+          challenge: data.challenges[1]!,
+          payload: { token: 'declined' },
+        }),
+      },
+    })
+    expect(result.status).toBe(402)
+    if (result.status !== 402) throw new Error()
+    expect(result.challenge.code).toBe(Mcp.paymentVerificationFailedCode)
+    expect(result.challenge.data).toMatchObject({
+      challenges: [{ request: { currency: 'B' } }],
+      problem: { status: 402 },
+    })
+    expect(payments).toEqual(['B'])
+  })
+
+  test('malformed credentials keep the MCP invalid-params code', async () => {
+    const { method, payments } = fixture()
+    const server = Mppx.create({
+      methods: [method],
+      realm,
+      secretKey,
+      transport: Transport.mcpSdk(),
+    })
+    const result = await server.compose([method, { amount: '1', currency: 'A' }])({
+      _meta: { [Mcp.credentialMetaKey]: 'invalid' as never },
+    })
+    if (result.status !== 402) throw new Error()
+    expect(result.challenge.code).toBe(Mcp.invalidParamsCode)
+    expect(payments).toEqual([])
+  })
+
+  test('JSON-RPC preserves the request ID and receipt metadata', async () => {
+    const { method, payments } = fixture()
+    const server = Mppx.create({ methods: [method], realm, secretKey, transport: Transport.mcp() })
+    const route = server.compose(
+      [method, { amount: '1', currency: 'A' }],
+      [method, { amount: '1', currency: 'B' }],
+    )
+    const offered = await route({ id: 42, method: 'tools/call' })
+    if (offered.status !== 402 || !offered.challenge.error?.data) throw new Error()
+    expect(offered.challenge.id).toBe(42)
+    expect(offered.challenge.error.data.challenges).toHaveLength(2)
+    const credential = Credential.from({
+      challenge: offered.challenge.error.data.challenges[1]!,
+      payload: { token: 'valid' },
+    })
+    const result = await route({
+      id: 43,
+      method: 'tools/call',
+      params: { _meta: { [Mcp.credentialMetaKey]: credential } },
+    })
+    if (result.status !== 200) throw new Error()
+    const response = result.withReceipt({
+      jsonrpc: '2.0',
+      id: 43,
+      result: { content: [], _meta: { trace: 'kept' } },
+    })
+    expect(response.id).toBe(43)
+    expect(response.result?._meta).toMatchObject({
+      trace: 'kept',
+      [Mcp.receiptMetaKey]: { reference: 'B' },
+    })
+    expect(payments).toEqual(['B'])
+  })
+
+  test('rejects empty composition and incompatible method transports', () => {
+    const { method } = fixture()
+    const server = Mppx.create({
+      methods: [method],
+      realm,
+      secretKey,
+      transport: Transport.mcpSdk(),
+    })
+    expect(() => server.compose()).toThrow('compose() requires at least one entry')
+    const mixed = Mppx.create({
+      methods: [{ ...method, transport: Transport.http() }],
+      realm,
+      secretKey,
+      transport: Transport.mcpSdk(),
+    })
+    expect(() => mixed.compose(['test/charge', { amount: '1', currency: 'A' }])).toThrow(
+      'MCP compose() requires methods using the configured MCP transport',
+    )
+  })
+})

--- a/src/server/Mppx.ts
+++ b/src/server/Mppx.ts
@@ -11,6 +11,7 @@ import * as Expires from '../Expires.js'
 import * as AcceptPayment from '../internal/AcceptPayment.js'
 import * as Env from '../internal/env.js'
 import type { DeepReadonly, MaybePromise } from '../internal/types.js'
+import * as Mcp from '../Mcp.js'
 import * as Method from '../Method.js'
 import * as PaymentRequest from '../PaymentRequest.js'
 import type * as Receipt from '../Receipt.js'
@@ -227,16 +228,17 @@ export type Mppx<
   onPaymentSuccess(
     handler: ServerEventHandler<FlattenMethods<methods>, transport, 'payment.success'>,
   ): Unsubscribe
-} & (transport extends Transport.Http
+} & (transport extends Transport.Http | Transport.Mcp | Transport.McpSdk
   ? {
       /**
        * Combines multiple method handlers into a single route handler that presents
-       * all methods to the client via multiple `WWW-Authenticate` headers.
+       * all methods through HTTP headers or an MCP payment-required challenge list.
        *
        * Each entry is a `[method, options]` tuple where `method` is one of the
        * server methods passed to `Mppx.create()`, looked up by `name`+`intent`.
        *
-       * Only available on HTTP transports.
+       * Available on HTTP, MCP JSON-RPC, and MCP SDK transports. MCP handlers
+       * accept the transport's input and return its challenge and receipt types.
        * No-credential authorize hooks run in entry order; the first 200 response
        * wins, and earlier hooks may have already run side effects.
        *
@@ -268,7 +270,7 @@ export type Mppx<
        * })
        * ```
        */
-      compose(...entries: ComposeEntry<FlattenMethods<methods>>[]): ComposedHandler
+      compose(...entries: ComposeEntry<FlattenMethods<methods>>[]): ComposedHandler<transport>
     }
   : {}) &
   Handlers<FlattenMethods<methods>, transport> & {
@@ -902,7 +904,9 @@ export function create<
       Record<string, unknown>,
     ][]
   ) {
-    if (transport.name !== 'http') throw new Error('compose() only supports HTTP transport')
+    const isMcp = transport.name === 'mcp' || transport.name === 'mcp-sdk'
+    if (transport.name !== 'http' && !isMcp)
+      throw new Error('compose() only supports HTTP and MCP transports')
     if (entries.length === 0) throw new Error('compose() requires at least one entry')
     const configured = entries.map(([methodOrKey, options]) => {
       const key =
@@ -914,8 +918,18 @@ export function create<
       const handlerFn = handlers[key] as AnyMethodFn | undefined
       if (!handlerFn)
         throw new Error(`No handler for "${key}". Is this method in your methods array?`)
+      const method = (handlerFn as AnyMethodFnWithMethod)._method
+      if (isMcp && method?.transport && method.transport.name !== transport.name)
+        throw new Error('MCP compose() requires methods using the configured MCP transport')
+      if (isMcp && method?.canOffer)
+        throw new Error('MCP compose() does not support HTTP canOffer hooks')
       return handlerFn(options)
     })
+    if (isMcp)
+      return composeMcpHandlers(
+        configured as ConfiguredHandler<Transport.Mcp | Transport.McpSdk>[],
+        transport as Transport.Mcp | Transport.McpSdk,
+      )
     return composeHandlers(
       configured as ConfiguredHandler[],
       undefined,
@@ -2398,7 +2412,9 @@ declare namespace MethodFn {
 }
 
 /** A configured handler — the return value of e.g. `mppx.charge({ ... })`. @internal */
-type ConfiguredHandler = ((input: Request) => Promise<MethodFn.Response<Transport.Http>>) & {
+type ConfiguredHandler<transport extends Transport.AnyTransport = Transport.Http> = ((
+  input: Transport.InputOf<transport>,
+) => Promise<MethodFn.Response<transport>>) & {
   _internal: {
     _method: Method.AnyServer
     description?: string | undefined
@@ -2412,7 +2428,9 @@ type ConfiguredHandler = ((input: Request) => Promise<MethodFn.Response<Transpor
   }
 }
 
-type ComposedHandler = ((input: Request) => Promise<MethodFn.Response<Transport.Http>>) & {
+type ComposedHandler<transport extends Transport.AnyTransport = Transport.Http> = ((
+  input: Transport.InputOf<transport>,
+) => Promise<MethodFn.Response<transport>>) & {
   _internal?: {
     offers: readonly ConfiguredHandler['_internal'][]
   }
@@ -2784,6 +2802,85 @@ function getConfiguredOffers(
   if (!internal) return []
   if (isComposedHandlerMetadata(internal)) return internal.offers
   return [internal]
+}
+
+/** Dispatches one MCP credential or gathers unsigned offers in their configured order. */
+function composeMcpHandlers(
+  handlers: readonly ConfiguredHandler<Transport.Mcp | Transport.McpSdk>[],
+  transport: Transport.Mcp | Transport.McpSdk,
+): ComposedHandler<Transport.Mcp | Transport.McpSdk> {
+  return async (input) => {
+    let credential: Credential.Credential | null
+    try {
+      const parsed = transport.getCredential(input as never)
+      credential = parsed ? hydrateCredentialMeta(parsed) : null
+    } catch {
+      // Let the method emit the normal malformed-credential error and retry challenge.
+      return handlers[0]!(input)
+    }
+    if (credential) {
+      const candidates = handlers.filter((handler) => {
+        const internal = handler._internal
+        return (
+          internal.name === credential.challenge.method &&
+          internal.intent === credential.challenge.intent
+        )
+      })
+      const match = candidates.find((handler) => {
+        const internal = handler._internal
+        try {
+          const mismatch = internal._stableBinding
+            ? getRequestBindingMismatch(
+                getStableBinding(internal._canonicalRequest, internal._stableBinding),
+                getStableBinding(credential.challenge.request, internal._stableBinding),
+              )
+            : getPinnedRequestBindingMismatch(
+                internal._canonicalRequest,
+                credential.challenge.request,
+              )
+          return !mismatch && opaqueValuesMatch(internal.meta, credential.challenge.meta)
+        } catch {
+          return false
+        }
+      })
+      // Verification and settlement belong to exactly one handler, including failures.
+      return (match ?? candidates[0] ?? handlers[0])!(input)
+    }
+
+    const challenges: Challenge.Challenge[] = []
+    let first: Transport.ChallengeOutputOf<Transport.Mcp | Transport.McpSdk> | undefined
+    for (const handler of handlers) {
+      const result = await handler(input)
+      if (result.status === 200) return result
+      const response = result.challenge
+      const error = 'code' in response ? response : response.error
+      // Request-hook and configuration failures must retain their original error semantics.
+      if (!error || error.code !== Mcp.paymentRequiredCode) return result
+      const data = error.data as Mcp.ErrorObject['data']
+      if (!data?.challenges?.length) return result
+      first ??= response
+      challenges.push(...data.challenges)
+    }
+    if (!first) throw new Error('compose() requires at least one handler')
+    if ('code' in first) {
+      const { McpError } = await import('@modelcontextprotocol/sdk/types.js')
+      return {
+        status: 402,
+        challenge: new McpError(first.code, 'Payment Required', {
+          ...(first.data as Mcp.ErrorObject['data']),
+          challenges,
+        }),
+      }
+    }
+    return {
+      status: 402,
+      challenge: {
+        jsonrpc: first.jsonrpc,
+        id: first.id,
+        error: { ...first.error!, data: { ...first.error!.data!, challenges } },
+      },
+    }
+  }
 }
 
 function isComposedHandlerMetadata(

--- a/src/x402/client/Exact.ts
+++ b/src/x402/client/Exact.ts
@@ -12,7 +12,7 @@ import * as Types from '../Types.js'
  */
 export async function createCredential(parameters: createCredential.Parameters): Promise<string> {
   const account = (parameters.context?.account ?? parameters.config.account) as Signer
-  if (!account.signTypedData) throw new Error('x402 exact requires a typed-data signer.')
+  if (!account?.signTypedData) throw new Error('x402 exact requires a typed-data signer.')
 
   const request = parameters.challenge.request as Types.ExactRequest
   const accepted = Types.toPaymentRequirements(request)
@@ -119,8 +119,8 @@ export type Signer = Account & {
 }
 
 export type Config = {
-  /** Account used to sign exact EVM payment payloads. */
-  account: Account
+  /** Account used to sign exact EVM payment payloads, unless supplied in credential context. */
+  account?: Account | undefined
   /** Optional token decimals used to parse `maxAmount` when currency metadata is not provided. */
   decimals?: number | undefined
   /** Optional maximum display-unit amount the client is willing to pay. */

--- a/src/x402/server/EvmCharge.ts
+++ b/src/x402/server/EvmCharge.ts
@@ -258,37 +258,11 @@ export function createPath(config: ResolvedOptions): Path {
 
 /** Settles a verified EVM authorization through an x402 facilitator. */
 export function settleWithFacilitator(parameters: ResolvedOptions): SettleWithFacilitator {
-  const { facilitator, maxTimeoutSeconds } = parameters
+  const { facilitator } = parameters
   if (!facilitator) throw new Error('EVM authorization x402 requires `facilitator`.')
 
-  return async ({ payload, request }) => {
-    const paymentRequirements = toPaymentRequirements(request, {
-      ...parameters,
-      maxTimeoutSeconds,
-    })
-    const paymentPayload: x402_Types.PaymentPayload = {
-      accepted: paymentRequirements,
-      payload: {
-        authorization: {
-          from: payload.from,
-          nonce: payload.nonce,
-          to: payload.to,
-          validAfter: payload.validAfter,
-          validBefore: payload.validBefore,
-          value: payload.value,
-        },
-        signature: payload.signature,
-      },
-      x402Version: 2,
-    }
-
-    const verified = await facilitator.verify(paymentPayload, paymentRequirements)
-    if (!verified.isValid)
-      throw new VerificationFailedError({
-        reason:
-          verified.invalidMessage ?? verified.invalidReason ?? 'EVM facilitator verify failed',
-      })
-
+  return async (authorization) => {
+    const { paymentPayload, paymentRequirements } = facilitatorPayment(parameters, authorization)
     const settled = await facilitator.settle(paymentPayload, paymentRequirements)
     if (!settled.success)
       throw new VerificationFailedError({
@@ -299,6 +273,44 @@ export function settleWithFacilitator(parameters: ResolvedOptions): SettleWithFa
       reference: settled.transaction,
     }
   }
+}
+
+/** Checks an EVM authorization with the facilitator without settling it. */
+export async function verifyWithFacilitator(
+  parameters: ResolvedOptions,
+  authorization: Parameters<SettleWithFacilitator>[0],
+): Promise<void> {
+  const { facilitator } = parameters
+  if (!facilitator) throw new Error('EVM authorization x402 requires `facilitator`.')
+  const { paymentPayload, paymentRequirements } = facilitatorPayment(parameters, authorization)
+  const verified = await facilitator.verify(paymentPayload, paymentRequirements)
+  if (!verified.isValid)
+    throw new VerificationFailedError({
+      reason: verified.invalidMessage ?? verified.invalidReason ?? 'EVM facilitator verify failed',
+    })
+}
+
+function facilitatorPayment(
+  parameters: ResolvedOptions,
+  { payload, request }: Parameters<SettleWithFacilitator>[0],
+) {
+  const paymentRequirements = toPaymentRequirements(request, parameters)
+  const paymentPayload: x402_Types.PaymentPayload = {
+    accepted: paymentRequirements,
+    payload: {
+      authorization: {
+        from: payload.from,
+        nonce: payload.nonce,
+        to: payload.to,
+        validAfter: payload.validAfter,
+        validBefore: payload.validBefore,
+        value: payload.value,
+      },
+      signature: payload.signature,
+    },
+    x402Version: 2,
+  }
+  return { paymentPayload, paymentRequirements }
 }
 
 export type SettleWithFacilitator = (parameters: {


### PR DESCRIPTION
Superseded by three independent PRs: [deferred EVM signer](https://github.com/wevm/mppx/pull/871), [EVM validation lifecycle](https://github.com/wevm/mppx/pull/872), and [MCP offer composition](https://github.com/wevm/mppx/pull/873).

Clients can now inspect EVM/x402 offers before supplying a signer, MCP tools can advertise multiple payment offers through `compose`, and EVM servers can validate a payment before claiming durable application work and settling it.

- Made the EVM account optional at client construction, with credential-context precedence and a clear error if signing is attempted without a signer.
- Added typed MCP SDK and JSON-RPC composition, preserving offer order, selected-payment dispatch, failure codes, request IDs, and receipt metadata. HTTP-only offer hooks and incompatible method transports are rejected.
- Split EVM verification into non-mutating validation and terminal broadcast hooks. Facilitator validation does not settle; broadcast revalidates before settlement. Existing route handlers retain their complete payment flow.
- Added usage guides, type coverage, and patch changesets. Fee-payer errors are unchanged.

Validation: 199 targeted tests passed across EVM, x402, method lifecycle, MCP transports, and HTTP composition; `pnpm check:ci`, `pnpm check:types`, and `pnpm build` passed. Payment tests use local signers and in-memory facilitators; live-chain settlement was not exercised.

Prompted by: @brendanjryan
