### PR TITLE
fix: secure sponsored key authorizations

### DIFF
--- a/.changeset/secure-payment-authorizations.md
+++ b/.changeset/secure-payment-authorizations.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Bound subscription key authorizations to server challenges and rejected sponsored key authorizations by default.

--- a/src/tempo/client/Subscription.test.ts
+++ b/src/tempo/client/Subscription.test.ts
@@ -14,6 +14,7 @@ import { subscription } from './Subscription.js'
 const chainId = 4217
 const currency = '0x20c0000000000000000000000000000000000001'
 const recipient = '0x1234567890abcdef1234567890abcdef12345678'
+const challengeId = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
 const selectedAccount = privateKeyToAccount(
   '0x0000000000000000000000000000000000000000000000000000000000000001',
 )
@@ -50,7 +51,7 @@ function createChallenge(
     ...overrides,
   })
   return Challenge.from({
-    id: 'test-challenge-id',
+    id: challengeId,
     intent: 'subscription',
     method: 'tempo',
     realm: 'api.example.com',
@@ -112,6 +113,7 @@ describe('tempo.subscription client', () => {
     const keyAuthorization = await signSubscriptionKeyAuthorization({
       accessKey,
       account: selectedAccount,
+      challengeId: challenge.id,
       chainId,
       request: challenge.request,
     })
@@ -149,6 +151,7 @@ describe('tempo.subscription client', () => {
           recipients: expect.any(Array),
         },
       ],
+      witness: `0x${'00'.repeat(32)}`,
     })
     expect(capturedParams).not.toHaveProperty('allowedCalls')
   })
@@ -158,6 +161,7 @@ describe('tempo.subscription client', () => {
     const keyAuthorization = await signSubscriptionKeyAuthorization({
       accessKey,
       account: otherRootAccount,
+      challengeId: challenge.id,
       chainId,
       request: challenge.request,
     })

--- a/src/tempo/client/Subscription.ts
+++ b/src/tempo/client/Subscription.ts
@@ -13,6 +13,7 @@ import * as defaults from '../internal/defaults.js'
 import * as Methods from '../Methods.js'
 import {
   getSubscriptionScopes,
+  getSubscriptionChallengeWitness,
   signSubscriptionKeyAuthorization,
   toSubscriptionExpiryDate,
   toSubscriptionExpirySeconds,
@@ -62,12 +63,14 @@ export function subscription(parameters: subscription.Parameters = {}) {
       const keyAuthorization = await authorizeAccessKey(client, {
         accessKey,
         account,
+        challengeId: challenge.id,
         chainId,
         request: challenge.request,
       } as never)
 
       const verified = verifySubscriptionKeyAuthorization({
         accessKey,
+        challengeId: challenge.id,
         chainId,
         payload: {
           signature: KeyAuthorization.serialize(keyAuthorization as never),
@@ -96,6 +99,7 @@ async function authorizeAccessKey(
   parameters: {
     accessKey: SubscriptionAccessKey
     account: Account.Account
+    challengeId: string
     chainId: number
     request: Pick<
       SubscriptionRequest,
@@ -103,11 +107,12 @@ async function authorizeAccessKey(
     >
   },
 ) {
-  const { accessKey, account, chainId, request } = parameters
+  const { accessKey, account, challengeId, chainId, request } = parameters
 
   const local = await signSubscriptionKeyAuthorization({
     accessKey,
     account,
+    challengeId,
     chainId,
     request,
   })
@@ -128,6 +133,7 @@ async function authorizeAccessKey(
           },
         ],
         scopes: getSubscriptionScopes(request),
+        witness: getSubscriptionChallengeWitness(challengeId),
       },
     ],
   } as never)) as {

--- a/src/tempo/internal/fee-payer.test.ts
+++ b/src/tempo/internal/fee-payer.test.ts
@@ -972,7 +972,28 @@ describe('prepareSponsoredTransaction', () => {
     ).toThrow('maxPriorityFeePerGas exceeds sponsor policy')
   })
 
-  test('preserves keyAuthorization', () => {
+  test('error: rejects keyAuthorization by default', () => {
+    const keyAuthorization = {
+      address: bogus,
+      chainId: 42431,
+      nonce: 1n,
+      r: 1n,
+      s: 2n,
+      yParity: 0,
+    }
+
+    expect(() =>
+      prepareSponsoredTransaction({
+        account: sponsor,
+        chainId: 42431,
+        details,
+        allowedFeeTokens: [bogus],
+        transaction: { ...baseTransaction, keyAuthorization } as any,
+      }),
+    ).toThrow('keyAuthorization is not allowed')
+  })
+
+  test('preserves keyAuthorization when explicitly allowed', () => {
     const keyAuthorization = {
       address: bogus,
       chainId: 42431,
@@ -987,6 +1008,7 @@ describe('prepareSponsoredTransaction', () => {
       chainId: 42431,
       details,
       allowedFeeTokens: [bogus],
+      policy: { allowKeyAuthorization: true },
       transaction: { ...baseTransaction, keyAuthorization } as any,
     }) as { keyAuthorization?: unknown }
 

--- a/src/tempo/internal/fee-payer.ts
+++ b/src/tempo/internal/fee-payer.ts
@@ -31,6 +31,8 @@ export const callScopes = [
 ]
 
 export type Policy = {
+  /** Allows a sponsored transaction to install a new access key. @default false */
+  allowKeyAuthorization: boolean
   maxGas: bigint
   maxFeePerGas: bigint
   maxPriorityFeePerGas: bigint
@@ -327,6 +329,7 @@ export async function preflightSponsorship<sponsorship extends PreflightSponsors
  * swap transactions at peak gas prices. Bumped from 0.01 ETH in #327.
  */
 const defaultPolicy: Policy = {
+  allowKeyAuthorization: false,
   maxGas: 2_000_000n,
   maxFeePerGas: 100_000_000_000n,
   maxPriorityFeePerGas: 10_000_000_000n,
@@ -348,6 +351,7 @@ function getPolicy(chainId: number, overrides: Partial<Policy> | undefined): Pol
   if (!overrides) return base
 
   return {
+    allowKeyAuthorization: overrides.allowKeyAuthorization ?? base.allowKeyAuthorization,
     maxGas: overrides.maxGas ?? base.maxGas,
     maxFeePerGas: overrides.maxFeePerGas ?? base.maxFeePerGas,
     maxPriorityFeePerGas: overrides.maxPriorityFeePerGas ?? base.maxPriorityFeePerGas,
@@ -596,6 +600,9 @@ export function assertTransactionPolicy(parameters: {
     })
 
   assertCanonicalSponsoredTransaction(transaction, fail)
+
+  if (transaction.keyAuthorization !== undefined && !policy.allowKeyAuthorization)
+    fail('fee-sponsored transaction keyAuthorization is not allowed')
 
   if (gas === undefined || gas <= 0n) fail('fee-sponsored transaction must declare gas')
   const gasLimit = gas

--- a/src/tempo/server/Subscription.test.ts
+++ b/src/tempo/server/Subscription.test.ts
@@ -98,6 +98,7 @@ async function createCredential(
   const keyAuthorization = await signSubscriptionKeyAuthorization({
     accessKey: key,
     account,
+    challengeId: challenge.id,
     chainId,
     request: challenge.request as ReturnType<typeof Methods.subscription.schema.request.parse>,
   })

--- a/src/tempo/server/Subscription.ts
+++ b/src/tempo/server/Subscription.ts
@@ -248,6 +248,7 @@ export function subscription<const parameters extends subscription.Parameters>(
       }
       const verified = verifySubscriptionKeyAuthorization({
         accessKey,
+        challengeId: credential.challenge.id,
         chainId: parsedRequest.methodDetails?.chainId ?? defaults.chainId.testnet,
         payload: credential.payload as SubscriptionCredentialPayload,
         request: parsedRequest,
@@ -382,6 +383,7 @@ export function subscription<const parameters extends subscription.Parameters>(
 
 // Access-key provisioning can cost around 4M gas.
 const defaultFeePayerPolicy = {
+  allowKeyAuthorization: true,
   maxGas: 5_000_000n,
   maxTotalFee: 200_000_000_000_000_000n,
 } satisfies Partial<FeePayer.Policy>

--- a/src/tempo/subscription/KeyAuthorization.test.ts
+++ b/src/tempo/subscription/KeyAuthorization.test.ts
@@ -19,6 +19,8 @@ import {
 import type { SubscriptionAccessKey } from './Types.js'
 
 const secondsPerDay = 86_400
+const challengeId = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+const otherChallengeId = 'AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
 
 const rootAccount = privateKeyToAccount(
   '0x0000000000000000000000000000000000000000000000000000000000000001',
@@ -60,6 +62,7 @@ async function createPayload(request = parseRequest()) {
   const keyAuthorization = await signSubscriptionKeyAuthorization({
     accessKey,
     account: rootAccount,
+    challengeId,
     chainId: 4217,
     request,
   })
@@ -96,6 +99,7 @@ describe('tempo subscription key authorization', () => {
 
     const result = verifySubscriptionKeyAuthorization({
       accessKey,
+      challengeId,
       chainId: 4217,
       payload,
       request,
@@ -124,6 +128,7 @@ describe('tempo subscription key authorization', () => {
               return serializeCompositeSignature(type, inner)
             },
           },
+          challengeId,
           chainId: 4217,
           request,
         }),
@@ -142,6 +147,7 @@ describe('tempo subscription key authorization', () => {
       expect(() =>
         verifySubscriptionKeyAuthorization({
           accessKey,
+          challengeId,
           chainId: 4217,
           payload: {
             ...payload,
@@ -197,6 +203,7 @@ describe('tempo subscription key authorization', () => {
       expect(() =>
         verifySubscriptionKeyAuthorization({
           accessKey,
+          challengeId,
           chainId: 4217,
           payload,
           request,
@@ -215,6 +222,7 @@ describe('tempo subscription key authorization', () => {
           accessKeyAddress: otherAccessAccount.address,
           keyType: 'secp256k1',
         },
+        challengeId,
         chainId: 4217,
         payload,
         request,
@@ -237,11 +245,27 @@ describe('tempo subscription key authorization', () => {
     expect(() =>
       verifySubscriptionKeyAuthorization({
         accessKey,
+        challengeId,
         chainId: 4217,
         payload: { ...payload, signature: transferOnly },
         request,
       }),
     ).toThrow('keyAuthorization must allow transferWithMemo')
+  })
+
+  test('rejects an authorization replayed against another challenge', async () => {
+    const request = parseRequest()
+    const payload = await createPayload(request)
+
+    expect(() =>
+      verifySubscriptionKeyAuthorization({
+        accessKey,
+        challengeId: otherChallengeId,
+        chainId: 4217,
+        payload,
+        request,
+      }),
+    ).toThrow('keyAuthorization challenge mismatch')
   })
 
   test('rejects subscription periods that cannot be represented by the Tempo client', () => {

--- a/src/tempo/subscription/KeyAuthorization.ts
+++ b/src/tempo/subscription/KeyAuthorization.ts
@@ -1,3 +1,4 @@
+import { Base64, Hex } from 'ox'
 import { KeyAuthorization, SignatureEnvelope } from 'ox/tempo'
 import { isAddress, isAddressEqual, type Address } from 'viem'
 
@@ -142,6 +143,17 @@ export function getSubscriptionRpcAllowedCalls(
   ] as const
 }
 
+/** Decodes the server-issued challenge identifier for use as a signed Tempo witness. */
+export function getSubscriptionChallengeWitness(challengeId: string): Hex.Hex {
+  try {
+    const witness = Hex.fromBytes(Base64.toBytes(challengeId))
+    if (Hex.size(witness) !== 32) throw new Error('invalid challenge id size')
+    return witness
+  } catch {
+    throw new VerificationFailedError({ reason: 'challenge id must encode 32 bytes' })
+  }
+}
+
 /**
  * Creates and signs a Tempo key authorization for subscription payments when the account can sign
  * arbitrary hashes locally.
@@ -151,17 +163,19 @@ export async function signSubscriptionKeyAuthorization(parameters: {
   account: {
     sign?: ((parameters: { hash: `0x${string}` }) => Promise<`0x${string}`>) | undefined
   }
+  challengeId: string
   chainId: number
   request: Pick<
     SubscriptionRequest,
     'amount' | 'currency' | 'periodCount' | 'periodUnit' | 'recipient' | 'subscriptionExpires'
   >
 }) {
-  const { accessKey, account, chainId, request } = parameters
+  const { accessKey, account, challengeId, chainId, request } = parameters
   if (typeof account.sign !== 'function') return undefined
 
   const authorization = createUnsignedAuthorization({
     accessKey,
+    challengeId,
     chainId,
     request,
   })
@@ -185,11 +199,12 @@ export async function signSubscriptionKeyAuthorization(parameters: {
  */
 export function verifySubscriptionKeyAuthorization(parameters: {
   accessKey?: SubscriptionAccessKey | undefined
+  challengeId: string
   chainId: number
   payload: SubscriptionCredentialPayload
   request: SubscriptionRequest
 }) {
-  const { accessKey, chainId, payload, request } = parameters
+  const { accessKey, challengeId, chainId, payload, request } = parameters
   if (payload.type !== 'keyAuthorization') {
     throw new VerificationFailedError({ reason: 'invalid keyAuthorization payload' })
   }
@@ -202,6 +217,9 @@ export function verifySubscriptionKeyAuthorization(parameters: {
     authorization,
     chainId,
   })
+  if (authorization.witness?.toLowerCase() !== getSubscriptionChallengeWitness(challengeId)) {
+    throw new VerificationFailedError({ reason: 'keyAuthorization challenge mismatch' })
+  }
   assertAuthorizationExpiry(authorization, request)
   assertAuthorizationLimit(getSingleTokenLimit(authorization), request)
   assertAuthorizationScopes(authorization.scopes, request)
@@ -218,13 +236,14 @@ export function verifySubscriptionKeyAuthorization(parameters: {
 
 function createUnsignedAuthorization(parameters: {
   accessKey: SubscriptionAccessKey
+  challengeId: string
   chainId: number
   request: Pick<
     SubscriptionRequest,
     'amount' | 'currency' | 'periodCount' | 'periodUnit' | 'recipient' | 'subscriptionExpires'
   >
 }) {
-  const { accessKey, chainId, request } = parameters
+  const { accessKey, challengeId, chainId, request } = parameters
   return KeyAuthorization.from({
     address: normalizeAddress(accessKey.accessKeyAddress, 'accessKeyAddress'),
     chainId: BigInt(chainId),
@@ -238,6 +257,7 @@ function createUnsignedAuthorization(parameters: {
     ],
     scopes: getSubscriptionScopes(request),
     type: accessKey.keyType,
+    witness: getSubscriptionChallengeWitness(challengeId),
   })
 }
 


### PR DESCRIPTION
## Motivation

Prevent fee sponsors from installing unapproved access keys and bind subscription authorizations to a single server challenge.

## Summary

- Reject sponsored key authorizations unless explicitly allowed
- Bind subscription key signatures to the challenge ID witness
- Require matching witnesses during client and server verification

## Key design considerations

- Keep generic sponsorship locked down by default
- Allow key installation only in the verified subscription flow