### PR TITLE
fix: make sponsored key authorizations configurable

### DIFF
--- a/.changeset/reject-sponsored-key-authorizations.md
+++ b/.changeset/reject-sponsored-key-authorizations.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Added a fee-payer policy option to reject sponsored key authorizations while allowing them by default.

--- a/src/tempo/internal/fee-payer.test.ts
+++ b/src/tempo/internal/fee-payer.test.ts
@@ -972,7 +972,7 @@ describe('prepareSponsoredTransaction', () => {
     ).toThrow('maxPriorityFeePerGas exceeds sponsor policy')
   })
 
-  test('preserves keyAuthorization', () => {
+  test('preserves keyAuthorization by default', () => {
     const keyAuthorization = {
       address: bogus,
       chainId: 42431,
@@ -991,6 +991,28 @@ describe('prepareSponsoredTransaction', () => {
     }) as { keyAuthorization?: unknown }
 
     expect(sponsored.keyAuthorization).toEqual(keyAuthorization)
+  })
+
+  test('error: rejects keyAuthorization when explicitly disallowed', () => {
+    const keyAuthorization = {
+      address: bogus,
+      chainId: 42431,
+      nonce: 1n,
+      r: 1n,
+      s: 2n,
+      yParity: 0,
+    }
+
+    expect(() =>
+      prepareSponsoredTransaction({
+        account: sponsor,
+        chainId: 42431,
+        details,
+        allowedFeeTokens: [bogus],
+        policy: { allowKeyAuthorization: false },
+        transaction: { ...baseTransaction, keyAuthorization } as any,
+      }),
+    ).toThrow('keyAuthorization is not allowed')
   })
 
   test('error: rejects unknown top-level fields from the sponsored transaction', () => {

--- a/src/tempo/internal/fee-payer.ts
+++ b/src/tempo/internal/fee-payer.ts
@@ -31,6 +31,8 @@ export const callScopes = [
 ]
 
 export type Policy = {
+  /** Allows a sponsored transaction to install a new access key. @default true */
+  allowKeyAuthorization: boolean
   maxGas: bigint
   maxFeePerGas: bigint
   maxPriorityFeePerGas: bigint
@@ -327,6 +329,7 @@ export async function preflightSponsorship<sponsorship extends PreflightSponsors
  * swap transactions at peak gas prices. Bumped from 0.01 ETH in #327.
  */
 const defaultPolicy: Policy = {
+  allowKeyAuthorization: true,
   maxGas: 2_000_000n,
   maxFeePerGas: 100_000_000_000n,
   maxPriorityFeePerGas: 10_000_000_000n,
@@ -348,6 +351,7 @@ function getPolicy(chainId: number, overrides: Partial<Policy> | undefined): Pol
   if (!overrides) return base
 
   return {
+    allowKeyAuthorization: overrides.allowKeyAuthorization ?? base.allowKeyAuthorization,
     maxGas: overrides.maxGas ?? base.maxGas,
     maxFeePerGas: overrides.maxFeePerGas ?? base.maxFeePerGas,
     maxPriorityFeePerGas: overrides.maxPriorityFeePerGas ?? base.maxPriorityFeePerGas,
@@ -596,6 +600,9 @@ export function assertTransactionPolicy(parameters: {
     })
 
   assertCanonicalSponsoredTransaction(transaction, fail)
+
+  if (transaction.keyAuthorization !== undefined && !policy.allowKeyAuthorization)
+    fail('fee-sponsored transaction keyAuthorization is not allowed')
 
   if (gas === undefined || gas <= 0n) fail('fee-sponsored transaction must declare gas')
   const gasLimit = gas


### PR DESCRIPTION
## Motivation

Let fee sponsors reject access-key installation when their policy requires it without changing existing default behavior.

## Summary

- Allow fee-sponsored key authorizations by default
- Add an explicit policy opt-out for sponsors that reject access-key installation
- Update audited dependencies required by CI

## Key design considerations

- Preserve compatibility for existing sponsorship flows
- Apply rejection only when `allowKeyAuthorization` is explicitly false