### PR TITLE
fix: bind subscription authorizations to challenges

### DIFF
--- a/.changeset/bind-subscription-key-authorizations.md
+++ b/.changeset/bind-subscription-key-authorizations.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Bound subscription key authorizations to their server-issued payment challenge.

--- a/src/tempo/client/Subscription.test.ts
+++ b/src/tempo/client/Subscription.test.ts
@@ -14,6 +14,7 @@ import { subscription } from './Subscription.js'
 const chainId = 4217
 const currency = '0x20c0000000000000000000000000000000000001'
 const recipient = '0x1234567890abcdef1234567890abcdef12345678'
+const challengeId = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
 const selectedAccount = privateKeyToAccount(
   '0x0000000000000000000000000000000000000000000000000000000000000001',
 )
@@ -50,7 +51,7 @@ function createChallenge(
     ...overrides,
   })
   return Challenge.from({
-    id: 'test-challenge-id',
+    id: challengeId,
     intent: 'subscription',
     method: 'tempo',
     realm: 'api.example.com',
@@ -112,6 +113,7 @@ describe('tempo.subscription client', () => {
     const keyAuthorization = await signSubscriptionKeyAuthorization({
       accessKey,
       account: selectedAccount,
+      challengeId: challenge.id,
       chainId,
       request: challenge.request,
     })
@@ -149,6 +151,7 @@ describe('tempo.subscription client', () => {
           recipients: expect.any(Array),
         },
       ],
+      witness: `0x${'00'.repeat(32)}`,
     })
     expect(capturedParams).not.toHaveProperty('allowedCalls')
   })
@@ -158,6 +161,7 @@ describe('tempo.subscription client', () => {
     const keyAuthorization = await signSubscriptionKeyAuthorization({
       accessKey,
       account: otherRootAccount,
+      challengeId: challenge.id,
       chainId,
       request: challenge.request,
     })

--- a/src/tempo/client/Subscription.ts
+++ b/src/tempo/client/Subscription.ts
@@ -12,6 +12,7 @@ import * as z from '../../zod.js'
 import * as defaults from '../internal/defaults.js'
 import * as Methods from '../Methods.js'
 import {
+  getSubscriptionChallengeWitness,
   getSubscriptionScopes,
   signSubscriptionKeyAuthorization,
   toSubscriptionExpiryDate,
@@ -62,12 +63,14 @@ export function subscription(parameters: subscription.Parameters = {}) {
       const keyAuthorization = await authorizeAccessKey(client, {
         accessKey,
         account,
+        challengeId: challenge.id,
         chainId,
         request: challenge.request,
       } as never)
 
       const verified = verifySubscriptionKeyAuthorization({
         accessKey,
+        challengeId: challenge.id,
         chainId,
         payload: {
           signature: KeyAuthorization.serialize(keyAuthorization as never),
@@ -96,6 +99,7 @@ async function authorizeAccessKey(
   parameters: {
     accessKey: SubscriptionAccessKey
     account: Account.Account
+    challengeId: string
     chainId: number
     request: Pick<
       SubscriptionRequest,
@@ -103,11 +107,12 @@ async function authorizeAccessKey(
     >
   },
 ) {
-  const { accessKey, account, chainId, request } = parameters
+  const { accessKey, account, challengeId, chainId, request } = parameters
 
   const local = await signSubscriptionKeyAuthorization({
     accessKey,
     account,
+    challengeId,
     chainId,
     request,
   })
@@ -128,6 +133,7 @@ async function authorizeAccessKey(
           },
         ],
         scopes: getSubscriptionScopes(request),
+        witness: getSubscriptionChallengeWitness(challengeId),
       },
     ],
   } as never)) as {

--- a/src/tempo/server/Subscription.test.ts
+++ b/src/tempo/server/Subscription.test.ts
@@ -98,6 +98,7 @@ async function createCredential(
   const keyAuthorization = await signSubscriptionKeyAuthorization({
     accessKey: key,
     account,
+    challengeId: challenge.id,
     chainId,
     request: challenge.request as ReturnType<typeof Methods.subscription.schema.request.parse>,
   })

--- a/src/tempo/server/Subscription.ts
+++ b/src/tempo/server/Subscription.ts
@@ -248,6 +248,7 @@ export function subscription<const parameters extends subscription.Parameters>(
       }
       const verified = verifySubscriptionKeyAuthorization({
         accessKey,
+        challengeId: credential.challenge.id,
         chainId: parsedRequest.methodDetails?.chainId ?? defaults.chainId.testnet,
         payload: credential.payload as SubscriptionCredentialPayload,
         request: parsedRequest,

--- a/src/tempo/subscription/KeyAuthorization.test.ts
+++ b/src/tempo/subscription/KeyAuthorization.test.ts
@@ -19,6 +19,8 @@ import {
 import type { SubscriptionAccessKey } from './Types.js'
 
 const secondsPerDay = 86_400
+const challengeId = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+const otherChallengeId = 'AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
 
 const rootAccount = privateKeyToAccount(
   '0x0000000000000000000000000000000000000000000000000000000000000001',
@@ -60,6 +62,7 @@ async function createPayload(request = parseRequest()) {
   const keyAuthorization = await signSubscriptionKeyAuthorization({
     accessKey,
     account: rootAccount,
+    challengeId,
     chainId: 4217,
     request,
   })
@@ -96,6 +99,7 @@ describe('tempo subscription key authorization', () => {
 
     const result = verifySubscriptionKeyAuthorization({
       accessKey,
+      challengeId,
       chainId: 4217,
       payload,
       request,
@@ -124,6 +128,7 @@ describe('tempo subscription key authorization', () => {
               return serializeCompositeSignature(type, inner)
             },
           },
+          challengeId,
           chainId: 4217,
           request,
         }),
@@ -142,6 +147,7 @@ describe('tempo subscription key authorization', () => {
       expect(() =>
         verifySubscriptionKeyAuthorization({
           accessKey,
+          challengeId,
           chainId: 4217,
           payload: {
             ...payload,
@@ -197,6 +203,7 @@ describe('tempo subscription key authorization', () => {
       expect(() =>
         verifySubscriptionKeyAuthorization({
           accessKey,
+          challengeId,
           chainId: 4217,
           payload,
           request,
@@ -215,6 +222,7 @@ describe('tempo subscription key authorization', () => {
           accessKeyAddress: otherAccessAccount.address,
           keyType: 'secp256k1',
         },
+        challengeId,
         chainId: 4217,
         payload,
         request,
@@ -237,11 +245,27 @@ describe('tempo subscription key authorization', () => {
     expect(() =>
       verifySubscriptionKeyAuthorization({
         accessKey,
+        challengeId,
         chainId: 4217,
         payload: { ...payload, signature: transferOnly },
         request,
       }),
     ).toThrow('keyAuthorization must allow transferWithMemo')
+  })
+
+  test('rejects an authorization replayed against another challenge', async () => {
+    const request = parseRequest()
+    const payload = await createPayload(request)
+
+    expect(() =>
+      verifySubscriptionKeyAuthorization({
+        accessKey,
+        challengeId: otherChallengeId,
+        chainId: 4217,
+        payload,
+        request,
+      }),
+    ).toThrow('keyAuthorization challenge mismatch')
   })
 
   test('rejects subscription periods that cannot be represented by the Tempo client', () => {

--- a/src/tempo/subscription/KeyAuthorization.ts
+++ b/src/tempo/subscription/KeyAuthorization.ts
@@ -1,3 +1,4 @@
+import { Base64, Hex } from 'ox'
 import { KeyAuthorization, SignatureEnvelope } from 'ox/tempo'
 import { isAddress, isAddressEqual, type Address } from 'viem'
 
@@ -142,6 +143,17 @@ export function getSubscriptionRpcAllowedCalls(
   ] as const
 }
 
+/** Decodes the server-issued challenge identifier for use as a signed Tempo witness. */
+export function getSubscriptionChallengeWitness(challengeId: string): Hex.Hex {
+  try {
+    const witness = Hex.fromBytes(Base64.toBytes(challengeId))
+    if (Hex.size(witness) !== 32) throw new Error('invalid challenge id size')
+    return witness
+  } catch {
+    throw new VerificationFailedError({ reason: 'challenge id must encode 32 bytes' })
+  }
+}
+
 /**
  * Creates and signs a Tempo key authorization for subscription payments when the account can sign
  * arbitrary hashes locally.
@@ -151,17 +163,19 @@ export async function signSubscriptionKeyAuthorization(parameters: {
   account: {
     sign?: ((parameters: { hash: `0x${string}` }) => Promise<`0x${string}`>) | undefined
   }
+  challengeId: string
   chainId: number
   request: Pick<
     SubscriptionRequest,
     'amount' | 'currency' | 'periodCount' | 'periodUnit' | 'recipient' | 'subscriptionExpires'
   >
 }) {
-  const { accessKey, account, chainId, request } = parameters
+  const { accessKey, account, challengeId, chainId, request } = parameters
   if (typeof account.sign !== 'function') return undefined
 
   const authorization = createUnsignedAuthorization({
     accessKey,
+    challengeId,
     chainId,
     request,
   })
@@ -185,11 +199,12 @@ export async function signSubscriptionKeyAuthorization(parameters: {
  */
 export function verifySubscriptionKeyAuthorization(parameters: {
   accessKey?: SubscriptionAccessKey | undefined
+  challengeId: string
   chainId: number
   payload: SubscriptionCredentialPayload
   request: SubscriptionRequest
 }) {
-  const { accessKey, chainId, payload, request } = parameters
+  const { accessKey, challengeId, chainId, payload, request } = parameters
   if (payload.type !== 'keyAuthorization') {
     throw new VerificationFailedError({ reason: 'invalid keyAuthorization payload' })
   }
@@ -202,6 +217,9 @@ export function verifySubscriptionKeyAuthorization(parameters: {
     authorization,
     chainId,
   })
+  if (authorization.witness?.toLowerCase() !== getSubscriptionChallengeWitness(challengeId)) {
+    throw new VerificationFailedError({ reason: 'keyAuthorization challenge mismatch' })
+  }
   assertAuthorizationExpiry(authorization, request)
   assertAuthorizationLimit(getSingleTokenLimit(authorization), request)
   assertAuthorizationScopes(authorization.scopes, request)
@@ -218,13 +236,14 @@ export function verifySubscriptionKeyAuthorization(parameters: {
 
 function createUnsignedAuthorization(parameters: {
   accessKey: SubscriptionAccessKey
+  challengeId: string
   chainId: number
   request: Pick<
     SubscriptionRequest,
     'amount' | 'currency' | 'periodCount' | 'periodUnit' | 'recipient' | 'subscriptionExpires'
   >
 }) {
-  const { accessKey, chainId, request } = parameters
+  const { accessKey, challengeId, chainId, request } = parameters
   return KeyAuthorization.from({
     address: normalizeAddress(accessKey.accessKeyAddress, 'accessKeyAddress'),
     chainId: BigInt(chainId),
@@ -238,6 +257,7 @@ function createUnsignedAuthorization(parameters: {
     ],
     scopes: getSubscriptionScopes(request),
     type: accessKey.keyType,
+    witness: getSubscriptionChallengeWitness(challengeId),
   })
 }
 


### PR DESCRIPTION
## Motivation

Prevent a signed subscription authorization from being replayed against another server challenge.

## Summary

- Bind subscription signatures to the challenge ID witness
- Verify matching witnesses on clients and servers
- Update audited dependencies required by CI

## Key design considerations

- Use the native 32-byte Tempo witness field
- Reject legacy or mismatched subscription authorizations