### PR TITLE
fix: enforce payment recipient chain and amount policies

### DIFF
--- a/.changeset/payment-client-policies.md
+++ b/.changeset/payment-client-policies.md
@@ -3,3 +3,5 @@
 ---
 
 Fixed primary recipient allowlist enforcement, session chain pinning, and CLI precedence for configured payment methods so payment limits are preserved.
+
+Preserved configured method selection and Stripe validation, applied recipient allowlists to zero-amount proofs, and kept configured session policies from being replaced by CLI persistence defaults.

--- a/.changeset/payment-client-policies.md
+++ b/.changeset/payment-client-policies.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Fixed primary recipient allowlist enforcement, session chain pinning, and CLI precedence for configured payment methods so payment limits are preserved.

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -2713,3 +2713,106 @@ test.each(['auto', 'new'])(
     }
   },
 )
+
+test('configured session handles SSE voucher requests with its own channel store', async () => {
+  const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mppx-session-stream-'))
+  const configPath = path.join(configDir, 'mppx.config.mjs')
+  const sourceUrl = pathToFileURL(path.join(process.cwd(), 'src/tempo/session/')).href
+  fs.writeFileSync(
+    configPath,
+    `
+    import { createClient, custom, encodeFunctionResult } from '${import.meta.resolve('viem')}'
+    import { privateKeyToAccount } from '${import.meta.resolve('viem/accounts')}'
+    import { session } from '${sourceUrl}client/Session.ts'
+    import { createChannelStore } from '${sourceUrl}client/ChannelStore.ts'
+    import { computeId } from '${sourceUrl}precompile/Channel.ts'
+    import { escrowAbi } from '${sourceUrl}precompile/escrow.abi.ts'
+    const account = privateKeyToAccount('${testPrivateKey}')
+    const descriptor = {
+      payer: account.address, authorizedSigner: account.address,
+      payee: '${accounts[0].address}', token: '${Addresses.pathUsd}',
+      operator: '0x0000000000000000000000000000000000000000',
+      salt: '0x${'11'.repeat(32)}', expiringNonceHash: '0x${'22'.repeat(32)}',
+    }
+    const escrow = '${tip20ChannelEscrow}'
+    const channelStore = createChannelStore()
+    await channelStore.set({ descriptor, escrow, chainId: 42431,
+      channelId: computeId({ ...descriptor, escrow, chainId: 42431 }),
+      deposit: 1000n, cumulativeAmount: 0n, opened: true,
+    })
+    const client = createClient({ account, chain: { id: 42431 }, transport: custom({
+      async request({ method }) {
+        if (method === 'eth_call') return encodeFunctionResult({ abi: escrowAbi,
+          functionName: 'getChannelState', result: { settled: 0n, deposit: 1000n, closeRequestedAt: 0 },
+        })
+        throw new Error('unexpected RPC: ' + method)
+      }
+    }) })
+    export default { methods: [session({ account, expectedChainId: 42431,
+      channelStore, getClient: () => client, decimals: 0, maxDeposit: '1000',
+    })] }
+  `,
+  )
+  const challenge = Challenge.from({
+    id: 'configured-stream',
+    realm: 'localhost',
+    method: 'tempo',
+    intent: 'session',
+    request: {
+      amount: '100',
+      currency: Addresses.pathUsd,
+      recipient: accounts[0].address,
+      unitType: 'token',
+      methodDetails: {
+        chainId: 42431,
+        escrowContract: tip20ChannelEscrow,
+        sessionProtocol: Constants.SessionProtocols.v2,
+      },
+    },
+  })
+  const { formatMessageEvent, formatNeedVoucherEvent } =
+    await import('../tempo/session/precompile/Protocol.js')
+  const vouchers: string[] = []
+  const server = await Http.createServer((req, res) => {
+    if (!req.headers.authorization) {
+      res.writeHead(402, { [Constants.Headers.wwwAuthenticate]: Challenge.serialize(challenge) })
+      res.end()
+      return
+    }
+    const payload = Credential.deserialize<SessionCredentialPayload>(
+      req.headers.authorization,
+    ).payload
+    if (payload.action !== 'voucher') throw new Error('expected voucher')
+    vouchers.push(payload.cumulativeAmount)
+    if (req.method === 'POST') {
+      res.writeHead(204)
+      res.end()
+      return
+    }
+    res.writeHead(200, { 'content-type': 'text/event-stream' })
+    res.end(
+      formatMessageEvent('first') +
+        formatNeedVoucherEvent({
+          acceptedCumulative: '100',
+          channelId: payload.channelId,
+          deposit: '1000',
+          requiredCumulative: '200',
+        }) +
+        formatMessageEvent('second'),
+    )
+  })
+  try {
+    const { output, exitCode } = await serve(
+      [server.url, '-s', '--config', configPath, '-H', 'accept: text/event-stream'],
+      { env: { MPPX_PRIVATE_KEY: testPrivateKey } },
+    )
+    expect(exitCode).toBeUndefined()
+    expect(output).toContain('first')
+    expect(output).toContain('second')
+    expect(output).not.toContain('need-voucher')
+    expect(vouchers).toEqual(['100', '200'])
+  } finally {
+    server.close()
+    fs.rmSync(configDir, { recursive: true, force: true })
+  }
+})

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -2652,3 +2652,64 @@ export default defineConfig({
     },
   )
 })
+
+test.each(['auto', 'new'])(
+  'configured session policies cannot be replaced by persistent session %s',
+  async (selection) => {
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mppx-session-config-'))
+    const configPath = path.join(configDir, 'mppx.config.mjs')
+    const moduleUrl = pathToFileURL(
+      path.join(process.cwd(), 'src/tempo/session/client/Session.ts'),
+    ).href
+    fs.writeFileSync(
+      configPath,
+      `
+    import { session } from '${moduleUrl}'
+    export default { methods: [session({ expectedChainId: 4217,
+      getClient() { throw new Error('unexpected client resolution') }
+    })] }
+  `,
+    )
+    const challenge = Challenge.from({
+      id: 'pinned-session',
+      realm: 'localhost',
+      method: 'tempo',
+      intent: 'session',
+      request: {
+        amount: '100',
+        currency: Addresses.pathUsd,
+        recipient: accounts[0].address,
+        unitType: 'request',
+        methodDetails: {
+          chainId: 42431,
+          escrowContract: tip20ChannelEscrow,
+          sessionProtocol: Constants.SessionProtocols.v2,
+        },
+      },
+    })
+    let paidRequests = 0
+    const server = await Http.createServer((req, res) => {
+      if (req.headers.authorization) paidRequests++
+      res.writeHead(402, { [Constants.Headers.wwwAuthenticate]: Challenge.serialize(challenge) })
+      res.end()
+    })
+    try {
+      const { output, exitCode } = await serve(
+        [server.url, '-s', '--config', configPath, '--session', selection],
+        {
+          env: { MPPX_PRIVATE_KEY: testPrivateKey },
+        },
+      )
+      expect(exitCode).toBeDefined()
+      expect(output).toContain(
+        selection === 'auto'
+          ? 'Chain ID mismatch: expected 4217, got 42431.'
+          : '--session cannot override a configured session method',
+      )
+      expect(paidRequests).toBe(0)
+    } finally {
+      server.close()
+      fs.rmSync(configDir, { recursive: true, force: true })
+    }
+  },
+)

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -2816,3 +2816,70 @@ test('configured session handles SSE voucher requests with its own channel store
     fs.rmSync(configDir, { recursive: true, force: true })
   }
 })
+
+test('configured charge methods do not probe the CLI wallet to rank offers', async () => {
+  const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mppx-config-offers-'))
+  const configPath = path.join(configDir, 'mppx.config.mjs')
+  const moduleUrl = pathToFileURL(path.join(process.cwd(), 'src/index.ts')).href
+  fs.writeFileSync(
+    configPath,
+    `
+    import { Credential, Method, z } from '${moduleUrl}'
+    export default { methods: [[Method.toClient(Method.from({
+      name: 'tempo', intent: 'charge',
+      schema: { credential: { payload: z.object({}) },
+        request: z.object({ amount: z.string(), currency: z.string() }),
+      }
+    }), { async createCredential({ challenge }) {
+      return Credential.serialize({ challenge, payload: {} })
+    } })]] }
+  `,
+  )
+  let balanceRequests = 0
+  const balanceServer = await Http.createServer((_req, res) => {
+    balanceRequests++
+    res.writeHead(400)
+    res.end()
+  })
+  const offers = [unfundedToken, Addresses.pathUsd].map((currency, index) =>
+    Challenge.from({
+      id: `offer-${index}`,
+      realm: 'localhost',
+      method: 'tempo',
+      intent: 'charge',
+      request: {
+        amount: '100',
+        currency,
+        recipient: accounts[0].address,
+        methodDetails: { chainId: 42431 },
+      },
+    }),
+  )
+  let selectedCurrency: unknown
+  const server = await Http.createServer((req, res) => {
+    if (req.headers.authorization) {
+      selectedCurrency = Credential.deserialize(req.headers.authorization).challenge.request
+        .currency
+      res.end('configured-payer')
+      return
+    }
+    res.writeHead(402, {
+      [Constants.Headers.wwwAuthenticate]: offers.map(Challenge.serialize).join(', '),
+    })
+    res.end()
+  })
+  try {
+    const { output, exitCode } = await serve(
+      [server.url, '-s', '--config', configPath, '--rpc-url', balanceServer.url],
+      { env: { MPPX_PRIVATE_KEY: testPrivateKey } },
+    )
+    expect(exitCode).toBeUndefined()
+    expect(output).toContain('configured-payer')
+    expect(selectedCurrency).toBe(unfundedToken)
+    expect(balanceRequests).toBe(0)
+  } finally {
+    server.close()
+    balanceServer.close()
+    fs.rmSync(configDir, { recursive: true, force: true })
+  }
+})

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -456,7 +456,10 @@ export default defineConfig({
   })
 })
 
-async function serve(argv: string[], options?: { env?: Record<string, string | undefined> }) {
+async function serve(
+  argv: string[],
+  options?: { env?: Record<string, string | undefined>; onOutput?: (chunk: string) => void },
+) {
   const stdoutChunks: Buffer[] = []
   let stderr = ''
   let exitCode: number | undefined
@@ -481,6 +484,7 @@ async function serve(argv: string[], options?: { env?: Record<string, string | u
     if (typeof chunk === 'string') stdoutChunks.push(Buffer.from(chunk))
     else if (chunk instanceof Uint8Array) stdoutChunks.push(Buffer.from(chunk))
     else stdoutChunks.push(Buffer.from(String(chunk)))
+    options?.onOutput?.(stdoutChunks.at(-1)!.toString())
     return true
   }) as typeof process.stdout.write
   process.stderr.write = ((chunk: unknown) => {
@@ -2773,6 +2777,9 @@ test('configured session handles SSE voucher requests with its own channel store
   const { formatMessageEvent, formatNeedVoucherEvent } =
     await import('../tempo/session/precompile/Protocol.js')
   const vouchers: string[] = []
+  let closeStream: (() => void) | undefined
+  let streamClosed = false
+  let outputBeforeClose = false
   const server = await Http.createServer((req, res) => {
     if (!req.headers.authorization) {
       res.writeHead(402, { [Constants.Headers.wwwAuthenticate]: Challenge.serialize(challenge) })
@@ -2790,7 +2797,13 @@ test('configured session handles SSE voucher requests with its own channel store
       return
     }
     res.writeHead(200, { 'content-type': 'text/event-stream' })
-    res.end(
+    closeStream = () => {
+      clearTimeout(timeout)
+      streamClosed = true
+      res.end()
+    }
+    const timeout = setTimeout(() => closeStream?.(), 2000)
+    res.write(
       formatMessageEvent('first') +
         formatNeedVoucherEvent({
           acceptedCumulative: '100',
@@ -2804,14 +2817,23 @@ test('configured session handles SSE voucher requests with its own channel store
   try {
     const { output, exitCode } = await serve(
       [server.url, '-s', '--config', configPath, '-H', 'accept: text/event-stream'],
-      { env: { MPPX_PRIVATE_KEY: testPrivateKey } },
+      {
+        env: { MPPX_PRIVATE_KEY: testPrivateKey },
+        onOutput(chunk) {
+          if (!chunk.includes('first')) return
+          outputBeforeClose = !streamClosed
+          closeStream?.()
+        },
+      },
     )
     expect(exitCode).toBeUndefined()
+    expect(outputBeforeClose).toBe(true)
     expect(output).toContain('first')
     expect(output).toContain('second')
     expect(output).not.toContain('need-voucher')
     expect(vouchers).toEqual(['100', '200'])
   } finally {
+    closeStream?.()
     server.close()
     fs.rmSync(configDir, { recursive: true, force: true })
   }

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -725,57 +725,80 @@ const cli = Cli.create('mppx', {
         pluginResult?.credentialContext,
       )
 
-      // Create credential
-      let credential: string
-      if (pluginResult?.createCredential)
-        credential = await pluginResult.createCredential(
-          selectedChallengeResponse,
-          credentialContext,
-        )
-      else if (pluginResult) {
-        const mppx = Mppx.create({
-          methods: pluginResult.methods,
-          polyfill: false,
-          transport: selectedChallengeTransport(challenge),
-        })
-        credential = await mppx.createCredential(
-          selectedChallengeResponse,
-          credentialContext as undefined,
-        )
-      } else if (configMethod) {
+      let credentialResponse: Response
+      let credential: string | undefined
+      if (configMethod && isTempoSessionChallenge(challenge)) {
+        // Reuse the selected challenge, then let the method settle channel state
+        // and handle SSE vouchers through the payment-aware fetch lifecycle.
+        let initialResponse: Response | undefined = selectedChallengeResponse
         const mppx = Mppx.create({
           methods: [configMethod],
           polyfill: false,
-          transport: selectedChallengeTransport(challenge),
+          fetch: async (input, requestInit) => {
+            if (initialResponse) {
+              const response = initialResponse
+              initialResponse = undefined
+              return response
+            }
+            return targetFetch(input, requestInit)
+          },
         })
-        credential = await mppx.createCredential(
-          selectedChallengeResponse,
-          credentialContext as never,
-        )
-      } else throw new Error('unreachable')
+        credentialResponse = await mppx.fetch(fetchUrl, {
+          ...init,
+          context: credentialContext as never,
+        })
+      } else {
+        // Create credential
+        if (pluginResult?.createCredential)
+          credential = await pluginResult.createCredential(
+            selectedChallengeResponse,
+            credentialContext,
+          )
+        else if (pluginResult) {
+          const mppx = Mppx.create({
+            methods: pluginResult.methods,
+            polyfill: false,
+            transport: selectedChallengeTransport(challenge),
+          })
+          credential = await mppx.createCredential(
+            selectedChallengeResponse,
+            credentialContext as undefined,
+          )
+        } else if (configMethod) {
+          const mppx = Mppx.create({
+            methods: [configMethod],
+            polyfill: false,
+            transport: selectedChallengeTransport(challenge),
+          })
+          credential = await mppx.createCredential(
+            selectedChallengeResponse,
+            credentialContext as never,
+          )
+        } else throw new Error('unreachable')
 
-      // Send credential and get response
-      const credentialHeader = isX402Challenge
-        ? x402_Types.paymentSignatureHeader
-        : Challenge.credentialHeader(challenge)
-      const credentialHeaders = {
-        ...normalizeHeaders(init.headers),
-        [credentialHeader]: credential,
-      }
-      const credentialTarget = isX402Challenge
-        ? resolveFetchTarget((x402ResourceUrl(challenge) ?? challengeResponse.url) || url)
-        : initialTarget
-      if (isX402Challenge) setTargetHost(credentialHeaders, credentialTarget.host)
-      plugin?.prepareCredentialRequest?.({ challenge, credential, headers: credentialHeaders })
+        // Send credential and get response
+        const credentialHeader = isX402Challenge
+          ? x402_Types.paymentSignatureHeader
+          : Challenge.credentialHeader(challenge)
+        const credentialHeaders = {
+          ...normalizeHeaders(init.headers),
+          [credentialHeader]: credential,
+        }
+        const credentialTarget = isX402Challenge
+          ? resolveFetchTarget((x402ResourceUrl(challenge) ?? challengeResponse.url) || url)
+          : initialTarget
+        if (isX402Challenge) setTargetHost(credentialHeaders, credentialTarget.host)
+        plugin?.prepareCredentialRequest?.({ challenge, credential, headers: credentialHeaders })
 
-      const credentialFetchInit = {
-        ...init,
-        ...(isX402Challenge && { redirect: 'manual' as const }),
-        headers: credentialHeaders,
+        const credentialFetchInit = {
+          ...init,
+          ...(isX402Challenge && { redirect: 'manual' as const }),
+          headers: credentialHeaders,
+        }
+        if (c.options.verbose >= 2)
+          printRequestHeaders(credentialTarget.url, credentialFetchInit, info)
+        credentialResponse = await targetFetch(credentialTarget.url, credentialFetchInit)
       }
-      if (c.options.verbose >= 2)
-        printRequestHeaders(credentialTarget.url, credentialFetchInit, info)
-      const credentialResponse = await targetFetch(credentialTarget.url, credentialFetchInit)
 
       if (c.options.fail && credentialResponse.status >= 400)
         return c.error({
@@ -806,21 +829,23 @@ const cli = Cli.create('mppx', {
       printResponseHeaders(credentialResponse, headerOpts)
 
       // Let plugin own the response lifecycle if it wants to
-      const handled = await plugin?.handleResponse?.({
-        challenge,
-        credential,
-        response: credentialResponse,
-        fetchUrl,
-        fetchInit: init,
-        silent: c.options.silent,
-        verbose: c.options.verbose,
-        confirmEnabled,
-        confirm,
-        tokenSymbol,
-        tokenDecimals,
-        explorerUrl,
-        shownKeys,
-      })
+      const handled =
+        credential &&
+        (await plugin?.handleResponse?.({
+          challenge,
+          credential,
+          response: credentialResponse,
+          fetchUrl,
+          fetchInit: init,
+          silent: c.options.silent,
+          verbose: c.options.verbose,
+          confirmEnabled,
+          confirm,
+          tokenSymbol,
+          tokenDecimals,
+          explorerUrl,
+          shownKeys,
+        }))
 
       if (!handled) {
         // Default: print receipt + body

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -1,3 +1,4 @@
+import { once } from 'node:events'
 import * as fs from 'node:fs'
 import { createRequire } from 'node:module'
 import * as path from 'node:path'
@@ -118,7 +119,17 @@ function outputResult<Data>(
 }
 
 async function writeResponseBody(response: Response) {
-  process.stdout.write(Buffer.from(await response.arrayBuffer()))
+  if (!response.body) return
+  const reader = response.body.getReader()
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      if (!process.stdout.write(Buffer.from(value))) await once(process.stdout, 'drain')
+    }
+  } finally {
+    reader.releaseLock()
+  }
 }
 
 function canReadCommandStdin() {

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -673,7 +673,9 @@ const cli = Cli.create('mppx', {
       const persistentSessionAccount =
         process.env.MPPX_PRIVATE_KEY?.trim() ||
         !isTempoAccount(resolveAccountName(c.options.account))
-      if (isTempoSessionChallenge(challenge) && persistentSessionAccount) {
+      // Configured methods own their signing policies and channel storage.
+      // Rebuilding a persistent manager would discard those policies.
+      if (isTempoSessionChallenge(challenge) && persistentSessionAccount && !configMethod) {
         try {
           const credentialContext = await preparePayment(
             challenge,
@@ -710,7 +712,10 @@ const cli = Cli.create('mppx', {
       if (c.options.session !== 'auto')
         return c.error({
           code: 'UNSUPPORTED_SESSION',
-          message: '--session requires a tempo/session payment challenge.',
+          message:
+            configMethod && isTempoSessionChallenge(challenge)
+              ? '--session cannot override a configured session method. Configure its channelStore instead.'
+              : '--session requires a tempo/session payment challenge.',
           exitCode: 2,
         })
 

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -21,7 +21,13 @@ import * as x402_Header from '../x402/Header.js'
 import * as x402_ChallengeBrand from '../x402/internal/ChallengeBrand.js'
 import * as x402_Types from '../x402/Types.js'
 import { createDefaultStore, createKeychain, resolveAccountName } from './account.js'
-import { loadConfig, preparePayment, resolveAcceptPayment, selectChallenge } from './internal.js'
+import {
+  flattenConfigMethods,
+  loadConfig,
+  preparePayment,
+  resolveAcceptPayment,
+  selectChallenge,
+} from './internal.js'
 import type { Plugin } from './plugins/plugin.js'
 import {
   orderTempoChargeChallengesByBalance,
@@ -543,13 +549,17 @@ const cli = Cli.create('mppx', {
           exitCode: 2,
         })
       }
-      const challenges = await orderTempoChargeChallengesByBalance(currencyChallenges, {
-        options: {
-          account: c.options.account,
-          network: c.options.network,
-          rpcUrl: c.options.rpcUrl,
-        },
-      })
+      // Configured methods own their payer and preference ordering. The CLI
+      // wallet's balances cannot determine which of their offers are payable.
+      const challenges = flattenConfigMethods(loaded?.config)?.length
+        ? currencyChallenges
+        : await orderTempoChargeChallengesByBalance(currencyChallenges, {
+            options: {
+              account: c.options.account,
+              network: c.options.network,
+              rpcUrl: c.options.rpcUrl,
+            },
+          })
 
       const selected = selectChallenge(challenges, loaded?.config)
       if (!selected) {

--- a/src/cli/internal.test.ts
+++ b/src/cli/internal.test.ts
@@ -1,0 +1,56 @@
+import { privateKeyToAccount } from 'viem/accounts'
+import { describe, expect, test, vi } from 'vp/test'
+
+import * as Challenge from '../Challenge.js'
+import * as Assets from '../evm/Assets.js'
+import { charge } from '../evm/client/Charge.js'
+import { resolvePlugin, selectChallenge } from './internal.js'
+import { evm } from './plugins/evm.js'
+
+const account = privateKeyToAccount(
+  '0x0000000000000000000000000000000000000000000000000000000000000001',
+)
+const challenge = Challenge.from({
+  id: 'payment-policy',
+  realm: 'example.com',
+  method: 'evm',
+  intent: 'charge',
+  request: {
+    amount: '2000000',
+    currency: Assets.baseSepolia.USDC.address,
+    recipient: '0x2222222222222222222222222222222222222222',
+    methodDetails: { chainId: 84532, credentialTypes: ['authorization'] },
+  },
+})
+
+describe('configured payment policies', () => {
+  test.each([{ maxAmount: '1' }, { maxAtomicAmount: '1000000' }])(
+    'preserves the configured cap %j through challenge selection',
+    async (limits) => {
+      const signTypedData = vi.fn(async () => '0x1234' as const)
+      const method = charge({
+        account: { ...account, signTypedData },
+        currencies: [Assets.baseSepolia.USDC],
+        ...limits,
+      })
+      const selected = selectChallenge([challenge], { methods: [[method]] })
+      expect(selected?.method).toBe(method)
+      expect(selected?.plugin).toBeUndefined()
+      await expect(selected!.method!.createCredential({ challenge, context: {} })).rejects.toThrow(
+        /amount exceeds max/,
+      )
+      expect(signTypedData).not.toHaveBeenCalled()
+    },
+  )
+
+  test('retains explicit plugin precedence', () => {
+    const method = charge({ account, maxAmount: '1' })
+    const plugin = evm()
+    expect(resolvePlugin(challenge, { methods: [method], plugins: [plugin] })).toEqual({ plugin })
+  })
+
+  test('falls back to the built-in plugin without a matching configured method', () => {
+    expect(resolvePlugin(challenge).plugin?.method).toBe('evm')
+    expect(resolvePlugin({ ...challenge, method: 'unknown' })).toEqual({})
+  })
+})

--- a/src/cli/internal.test.ts
+++ b/src/cli/internal.test.ts
@@ -54,3 +54,13 @@ describe('configured payment policies', () => {
     expect(resolvePlugin({ ...challenge, method: 'unknown' })).toEqual({})
   })
 })
+
+test('preserves the configured method selected by challenge filtering', () => {
+  const first = { ...charge({ account }), canHandleChallenge: () => false }
+  const second = { ...charge({ account }), canHandleChallenge: () => true }
+  const config = { methods: [first, second] }
+  expect(selectChallenge([challenge], config)?.method).toBe(second)
+  expect(resolvePlugin(challenge, config).method).toBe(second)
+  expect(resolvePlugin(challenge, { methods: [first] })).toEqual({})
+  expect(selectChallenge([challenge], { methods: [first] })).toBeUndefined()
+})

--- a/src/cli/internal.ts
+++ b/src/cli/internal.ts
@@ -42,10 +42,12 @@ export function resolvePlugin(
   if (configPlugin) return { plugin: configPlugin }
 
   const configMethods = flattenConfigMethods(config)
-  const matched = configMethods?.find(
+  const matching = configMethods?.filter(
     (m) => m.name === challenge.method && m.intent === challenge.intent,
   )
+  const matched = matching?.find((m) => m.canHandleChallenge?.({ challenge }) ?? true)
   if (matched) return { method: matched }
+  if (matching?.length) return {}
 
   const builtin = builtinPlugins.find((p) => supportsPlugin(p, challenge))
   if (builtin) return { plugin: builtin }
@@ -74,7 +76,11 @@ export function selectChallenge(
       resolvedPreferences.entries,
     )
     if (selected) {
-      return { challenge: selected.challenge, ...resolvePlugin(selected.challenge, config) }
+      const plugin = config?.plugins?.find((plugin) => supportsPlugin(plugin, selected.challenge))
+      return {
+        challenge: selected.challenge,
+        ...(plugin ? { plugin } : { method: selected.method }),
+      }
     }
 
     return undefined

--- a/src/cli/internal.ts
+++ b/src/cli/internal.ts
@@ -33,6 +33,7 @@ export async function preparePayment(
   return current
 }
 
+/** Resolves explicit payment configuration before falling back to built-in plugins. */
 export function resolvePlugin(
   challenge: Challenge.Challenge,
   config?: { plugins?: Plugin[] | undefined; methods?: any },
@@ -40,14 +41,14 @@ export function resolvePlugin(
   const configPlugin = config?.plugins?.find((p) => supportsPlugin(p, challenge))
   if (configPlugin) return { plugin: configPlugin }
 
-  const builtin = builtinPlugins.find((p) => supportsPlugin(p, challenge))
-  if (builtin) return { plugin: builtin }
-
   const configMethods = flattenConfigMethods(config)
   const matched = configMethods?.find(
     (m) => m.name === challenge.method && m.intent === challenge.intent,
   )
   if (matched) return { method: matched }
+
+  const builtin = builtinPlugins.find((p) => supportsPlugin(p, challenge))
+  if (builtin) return { plugin: builtin }
 
   return {}
 }

--- a/src/cli/validate.test.ts
+++ b/src/cli/validate.test.ts
@@ -898,7 +898,11 @@ describe('validate: JSON mode', () => {
   })
 })
 
-test('validate uses a configured Stripe method without a plugin', async () => {
+test.each([
+  { yes: true, status: 200 },
+  { yes: true, status: 500 },
+  { yes: false, status: 200 },
+])('configured Stripe method ignores ambient test key ($yes, $status)', async ({ yes, status }) => {
   const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mppx-stripe-config-'))
   const configPath = path.join(configDir, 'mppx.config.mjs')
   const moduleUrl = pathToFileURL(path.join(process.cwd(), 'src/index.ts')).href
@@ -925,16 +929,81 @@ test('validate uses a configured Stripe method without a plugin', async () => {
       methodDetails: { networkId: 'profile_test123', paymentMethodTypes: ['card'] },
     },
   })
-  const server = await mppServer(challenge)
+  const server = await mppServer(challenge, { postPaymentStatus: status })
+  const previousKey = process.env.MPPX_STRIPE_SECRET_KEY
+  process.env.MPPX_STRIPE_SECRET_KEY = 'sk_test_unrelated'
   const previousConfig = process.env.MPPX_CONFIG
   process.env.MPPX_CONFIG = configPath
   try {
-    const { output } = await serve(['validate', server.url, '--outputJson', '--yes'])
-    expect(output).toContain('Payment [stripe]: submitted')
-    expect(output).not.toContain('no Stripe')
+    const { output } = await serve([
+      'validate',
+      server.url,
+      '--outputJson',
+      ...(yes ? ['--yes'] : []),
+    ])
+    expect(output).not.toContain('server is in livemode')
+    if (yes) {
+      expect(output).toContain('Payment [stripe]: submitted')
+      if (status === 500) expect(output).toContain('Got 500')
+    } else {
+      expect(output).toContain('non-interactive mode, use --yes to approve')
+      expect(output).not.toContain('Payment [stripe]: submitted')
+    }
   } finally {
+    if (previousKey === undefined) delete process.env.MPPX_STRIPE_SECRET_KEY
+    else process.env.MPPX_STRIPE_SECRET_KEY = previousKey
     if (previousConfig === undefined) delete process.env.MPPX_CONFIG
     else process.env.MPPX_CONFIG = previousConfig
     fs.rmSync(configDir, { recursive: true, force: true })
   }
 })
+
+test.each([
+  ['tempo', 4217],
+  ['tempo', 42431],
+  ['evm', 1],
+] as const)(
+  'validate uses configured %s payer on chain %i without a CLI wallet',
+  async (method, chainId) => {
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mppx-direct-config-'))
+    const configPath = path.join(configDir, 'mppx.config.mjs')
+    const moduleUrl = pathToFileURL(path.join(process.cwd(), 'src/index.ts')).href
+    fs.writeFileSync(
+      configPath,
+      `
+      import { Method, z } from '${moduleUrl}'
+      export default { methods: [[Method.toClient(Method.from({
+        name: '${method}', intent: 'charge',
+        schema: { credential: { payload: z.object({}) }, request: z.object({ amount: z.string() }) }
+      }), { async createCredential() { throw new Error('configured payer reached') } })]] }
+    `,
+    )
+    const previousConfig = process.env.MPPX_CONFIG
+    const previousAccount = process.env.MPPX_ACCOUNT
+    process.env.MPPX_CONFIG = configPath
+    process.env.MPPX_ACCOUNT = 'missing-validation-wallet'
+    const challenge = makeChallenge({
+      method,
+      request: {
+        amount: '10000',
+        currency: '0x20c0000000000000000000000000000000000000',
+        recipient: '0x1234567890123456789012345678901234567890',
+        methodDetails: { chainId },
+      },
+    })
+    const server = await mppServer(challenge)
+    try {
+      const { output } = await serve(['validate', server.url, '--outputJson', '--yes'])
+      expect(output).toContain('configured payer reached')
+      expect(output).not.toContain('no wallet configured')
+      expect(output).not.toContain('insufficient balance')
+      expect(output).not.toContain('ephemeral testnet wallet')
+    } finally {
+      if (previousConfig === undefined) delete process.env.MPPX_CONFIG
+      else process.env.MPPX_CONFIG = previousConfig
+      if (previousAccount === undefined) delete process.env.MPPX_ACCOUNT
+      else process.env.MPPX_ACCOUNT = previousAccount
+      fs.rmSync(configDir, { recursive: true, force: true })
+    }
+  },
+)

--- a/src/cli/validate.test.ts
+++ b/src/cli/validate.test.ts
@@ -897,3 +897,44 @@ describe('validate: JSON mode', () => {
     expect(result.suggestions).toEqual([missingDiscoverySuggestion])
   })
 })
+
+test('validate uses a configured Stripe method without a plugin', async () => {
+  const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mppx-stripe-config-'))
+  const configPath = path.join(configDir, 'mppx.config.mjs')
+  const moduleUrl = pathToFileURL(path.join(process.cwd(), 'src/index.ts')).href
+  fs.writeFileSync(
+    configPath,
+    `
+    import { Credential, Method, z } from '${moduleUrl}'
+    export default { methods: [Method.toClient(Method.from({
+      name: 'stripe', intent: 'charge',
+      schema: {
+        credential: { payload: z.object({ spt: z.string() }) },
+        request: z.object({ amount: z.string(), currency: z.string() }),
+      },
+    }), { async createCredential({ challenge }) {
+      return Credential.serialize({ challenge, payload: { spt: 'configured-token' } })
+    } })] }
+  `,
+  )
+  const challenge = makeChallenge({
+    method: 'stripe',
+    request: {
+      amount: '100',
+      currency: 'usd',
+      methodDetails: { networkId: 'profile_test123', paymentMethodTypes: ['card'] },
+    },
+  })
+  const server = await mppServer(challenge)
+  const previousConfig = process.env.MPPX_CONFIG
+  process.env.MPPX_CONFIG = configPath
+  try {
+    const { output } = await serve(['validate', server.url, '--outputJson', '--yes'])
+    expect(output).toContain('Payment [stripe]: submitted')
+    expect(output).not.toContain('no Stripe')
+  } finally {
+    if (previousConfig === undefined) delete process.env.MPPX_CONFIG
+    else process.env.MPPX_CONFIG = previousConfig
+    fs.rmSync(configDir, { recursive: true, force: true })
+  }
+})

--- a/src/cli/validate.test.ts
+++ b/src/cli/validate.test.ts
@@ -4,6 +4,7 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 import { pathToFileURL } from 'node:url'
 
+import { tempo as tempoMainnet, tempoModerato } from 'viem/tempo/chains'
 import { afterEach, describe, expect, test, vi } from 'vp/test'
 import * as Http from '~test/Http.js'
 
@@ -899,18 +900,23 @@ describe('validate: JSON mode', () => {
 })
 
 test.each([
-  { yes: true, status: 200 },
-  { yes: true, status: 500 },
-  { yes: false, status: 200 },
-])('configured Stripe method ignores ambient test key ($yes, $status)', async ({ yes, status }) => {
-  const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mppx-stripe-config-'))
-  const configPath = path.join(configDir, 'mppx.config.mjs')
-  const moduleUrl = pathToFileURL(path.join(process.cwd(), 'src/index.ts')).href
-  fs.writeFileSync(
-    configPath,
-    `
+  { kind: 'method', yes: true, status: 200 },
+  { kind: 'method', yes: true, status: 500 },
+  { kind: 'method', yes: false, status: 200 },
+  { kind: 'plugin', yes: true, status: 200 },
+  { kind: 'plugin', yes: true, status: 500 },
+  { kind: 'plugin', yes: false, status: 200 },
+])(
+  'configured Stripe $kind ignores ambient test key ($yes, $status)',
+  async ({ kind, yes, status }) => {
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mppx-stripe-config-'))
+    const configPath = path.join(configDir, 'mppx.config.mjs')
+    const moduleUrl = pathToFileURL(path.join(process.cwd(), 'src/index.ts')).href
+    fs.writeFileSync(
+      configPath,
+      `
     import { Credential, Method, z } from '${moduleUrl}'
-    export default { methods: [Method.toClient(Method.from({
+    const method = Method.toClient(Method.from({
       name: 'stripe', intent: 'charge',
       schema: {
         credential: { payload: z.object({ spt: z.string() }) },
@@ -918,45 +924,53 @@ test.each([
       },
     }), { async createCredential({ challenge }) {
       return Credential.serialize({ challenge, payload: { spt: 'configured-token' } })
-    } })] }
-  `,
-  )
-  const challenge = makeChallenge({
-    method: 'stripe',
-    request: {
-      amount: '100',
-      currency: 'usd',
-      methodDetails: { networkId: 'profile_test123', paymentMethodTypes: ['card'] },
-    },
-  })
-  const server = await mppServer(challenge, { postPaymentStatus: status })
-  const previousKey = process.env.MPPX_STRIPE_SECRET_KEY
-  process.env.MPPX_STRIPE_SECRET_KEY = 'sk_test_unrelated'
-  const previousConfig = process.env.MPPX_CONFIG
-  process.env.MPPX_CONFIG = configPath
-  try {
-    const { output } = await serve([
-      'validate',
-      server.url,
-      '--outputJson',
-      ...(yes ? ['--yes'] : []),
-    ])
-    expect(output).not.toContain('server is in livemode')
-    if (yes) {
-      expect(output).toContain('Payment [stripe]: submitted')
-      if (status === 500) expect(output).toContain('Got 500')
-    } else {
-      expect(output).toContain('non-interactive mode, use --yes to approve')
-      expect(output).not.toContain('Payment [stripe]: submitted')
+    } })
+    export default ${
+      kind == 'plugin'
+        ? `{ plugins: [{ method: 'stripe', async setup() {
+      return { methods: [method], tokenSymbol: 'USD', tokenDecimals: 2 }
+    } }] }`
+        : '{ methods: [method] }'
     }
-  } finally {
-    if (previousKey === undefined) delete process.env.MPPX_STRIPE_SECRET_KEY
-    else process.env.MPPX_STRIPE_SECRET_KEY = previousKey
-    if (previousConfig === undefined) delete process.env.MPPX_CONFIG
-    else process.env.MPPX_CONFIG = previousConfig
-    fs.rmSync(configDir, { recursive: true, force: true })
-  }
-})
+  `,
+    )
+    const challenge = makeChallenge({
+      method: 'stripe',
+      request: {
+        amount: '100',
+        currency: 'usd',
+        methodDetails: { networkId: 'profile_test123', paymentMethodTypes: ['card'] },
+      },
+    })
+    const server = await mppServer(challenge, { postPaymentStatus: status })
+    const previousKey = process.env.MPPX_STRIPE_SECRET_KEY
+    process.env.MPPX_STRIPE_SECRET_KEY = 'sk_test_unrelated'
+    const previousConfig = process.env.MPPX_CONFIG
+    process.env.MPPX_CONFIG = configPath
+    try {
+      const { output } = await serve([
+        'validate',
+        server.url,
+        '--outputJson',
+        ...(yes ? ['--yes'] : []),
+      ])
+      expect(output).not.toContain('server is in livemode')
+      if (yes) {
+        expect(output).toContain('Payment [stripe]: submitted')
+        if (status === 500) expect(output).toContain('Got 500')
+      } else {
+        expect(output).toContain('non-interactive mode, use --yes to approve')
+        expect(output).not.toContain('Payment [stripe]: submitted')
+      }
+    } finally {
+      if (previousKey === undefined) delete process.env.MPPX_STRIPE_SECRET_KEY
+      else process.env.MPPX_STRIPE_SECRET_KEY = previousKey
+      if (previousConfig === undefined) delete process.env.MPPX_CONFIG
+      else process.env.MPPX_CONFIG = previousConfig
+      fs.rmSync(configDir, { recursive: true, force: true })
+    }
+  },
+)
 
 test.each([
   ['tempo', 4217],
@@ -971,11 +985,11 @@ test.each([
     fs.writeFileSync(
       configPath,
       `
-      import { Method, z } from '${moduleUrl}'
+      import { Credential, Method, z } from '${moduleUrl}'
       export default { methods: [[Method.toClient(Method.from({
         name: '${method}', intent: 'charge',
         schema: { credential: { payload: z.object({}) }, request: z.object({ amount: z.string() }) }
-      }), { async createCredential() { throw new Error('configured payer reached') } })]] }
+      }), { async createCredential({ challenge }) { return Credential.serialize({ challenge, payload: {} }) } })]] }
     `,
     )
     const previousConfig = process.env.MPPX_CONFIG
@@ -994,7 +1008,11 @@ test.each([
     const server = await mppServer(challenge)
     try {
       const { output } = await serve(['validate', server.url, '--outputJson', '--yes'])
-      expect(output).toContain('configured payer reached')
+      expect(output).toContain(`Payment [${method}]: submitted`)
+      if (method === 'tempo') {
+        const chain = chainId === tempoModerato.id ? tempoModerato : tempoMainnet
+        expect(output).toContain(`${chain.blockExplorers.default.url}/receipt/`)
+      }
       expect(output).not.toContain('no wallet configured')
       expect(output).not.toContain('insufficient balance')
       expect(output).not.toContain('ephemeral testnet wallet')

--- a/src/cli/validate/payment.ts
+++ b/src/cli/validate/payment.ts
@@ -364,8 +364,10 @@ async function attemptCryptoPayment(
 
   // Pre-flight balance check and chain resolution
   let paymentChain: Chain | undefined
-  if (challenge.method === Constants.Methods.tempo) paymentChain = tempoMainnetChain
-  else if (challenge.method === Constants.Methods.evm) {
+  if (challenge.method === Constants.Methods.tempo) {
+    const chainId = (methodDetails?.chainId as number | undefined) ?? tempoMainnetChain.id
+    paymentChain = chainId === tempoModerato.id ? tempoModerato : resolveEvmChain(chainId)
+  } else if (challenge.method === Constants.Methods.evm) {
     const chainId = methodDetails?.chainId as number | undefined
     if (chainId) paymentChain = resolveEvmChain(chainId)
   }
@@ -375,7 +377,7 @@ async function attemptCryptoPayment(
     try {
       let balance: bigint
       if (challenge.method === Constants.Methods.tempo) {
-        const client = createClient({ chain: tempoMainnetChain, transport: http() })
+        const client = createClient({ chain: paymentChain, transport: http() })
         const info = await fetchTokenInfo(client, currency as Address, walletAddress as Address)
         balance = info.balance
         tokenSymbol = info.symbol
@@ -495,7 +497,9 @@ async function attemptStripePayment(
     results.push(skip(tag, 'no Stripe payment method available'))
     return
   }
-  const isStripeTestKey = !directMethod && ctx.isStripeTestKey
+  const isStripeTestKey = Boolean(
+    plugin && !loaded?.config.plugins?.includes(plugin) && ctx.isStripeTestKey,
+  )
   const request = challenge.request as Record<string, unknown>
   const requiredAmount = isValidIntegerAmount(request.amount)
     ? BigInt(request.amount as string)

--- a/src/cli/validate/payment.ts
+++ b/src/cli/validate/payment.ts
@@ -514,11 +514,11 @@ async function attemptStripePayment(
     if (!options.silent) console.log(pc.dim(`    Auto-approved: ${paymentDesc}`))
   }
 
-  // Resolve plugin
   const resolved = resolvePlugin(challenge, loaded?.config)
   const plugin = resolved.plugin
-  if (!plugin) {
-    results.push(skip(tag, 'no Stripe plugin available'))
+  const directMethod = resolved.method
+  if (!plugin && !directMethod) {
+    results.push(skip(tag, 'no Stripe payment method available'))
     return
   }
 
@@ -527,20 +527,24 @@ async function attemptStripePayment(
     | ((response: Response, credentialContext?: unknown) => Promise<string>)
     | undefined
   let credentialContext: unknown
-  try {
-    const methodOpts: Record<string, string> = { paymentMethod: 'pm_card_visa' }
-    if (stripeKey) methodOpts.secretKey = stripeKey
-    const pluginResult = await plugin.setup({
-      challenge,
-      options: {},
-      methodOpts,
-    })
-    methods = pluginResult.methods
-    createCredentialFn = pluginResult.createCredential
-    credentialContext = pluginResult.credentialContext
-  } catch (error) {
-    results.push(skip(tag, (error as Error).message))
-    return
+  if (plugin) {
+    try {
+      const methodOpts: Record<string, string> = { paymentMethod: 'pm_card_visa' }
+      if (stripeKey) methodOpts.secretKey = stripeKey
+      const pluginResult = await plugin.setup({
+        challenge,
+        options: {},
+        methodOpts,
+      })
+      methods = pluginResult.methods
+      createCredentialFn = pluginResult.createCredential
+      credentialContext = pluginResult.credentialContext
+    } catch (error) {
+      results.push(skip(tag, (error as Error).message))
+      return
+    }
+  } else {
+    methods = [directMethod!]
   }
 
   const credential = await createAndSend(
@@ -554,7 +558,7 @@ async function attemptStripePayment(
   )
   if (!credential) return
 
-  plugin.prepareCredentialRequest?.({ challenge, credential, headers: fetchHeaders })
+  plugin?.prepareCredentialRequest?.({ challenge, credential, headers: fetchHeaders })
 
   // Stripe testmode: detect livemode rejection gracefully
   if (isStripeTestKey) {

--- a/src/cli/validate/payment.ts
+++ b/src/cli/validate/payment.ts
@@ -17,7 +17,7 @@ import { chainId as tempoChainIds } from '../../tempo/internal/defaults.js'
 import { resolveAccount, resolveAccountName } from '../account.js'
 import type { Config } from '../config.js'
 import type * as Extension from '../Extension.js'
-import { loadConfig, preparePayment, resolvePlugin } from '../internal.js'
+import { flattenConfigMethods, loadConfig, preparePayment, resolvePlugin } from '../internal.js'
 import { fetchTokenInfo, confirm, pc } from '../utils.js'
 import { buildUrl } from './discovery.js'
 import type { CheckResult, EndpointSpec } from './helpers.js'
@@ -197,6 +197,12 @@ export async function validatePaymentFlow(
   // Testnet Tempo: always use ephemeral wallet (zero-setup, free money)
   const tempoTestnetChallenge = challenges.find((ch) => {
     if (ch.method !== Constants.Methods.tempo) return false
+    if (
+      flattenConfigMethods(loaded?.config)?.some(
+        (method) => method.name === ch.method && method.intent === ch.intent,
+      )
+    )
+      return false
     const req = ch.request as Record<string, unknown>
     const md = req.methodDetails as Record<string, unknown> | undefined
     return typeof md?.chainId === 'number' && md.chainId !== tempoChainIds.mainnet
@@ -338,14 +344,22 @@ async function attemptCryptoPayment(
     (methodDetails?.decimals as number | undefined) ?? (request.decimals as number | undefined) ?? 6
   const currency = request.currency as string | undefined
 
-  // Resolve wallet
-  let walletAddress: string | undefined
-  try {
-    walletAddress = await resolveWalletAddress()
-  } catch {}
-  if (!walletAddress) {
-    results.push(skip(tag, 'no wallet configured. Run "mppx account create" to create one.'))
+  const { plugin, method: directMethod } = resolvePlugin(challenge, loaded?.config)
+  if (!plugin && !directMethod) {
+    results.push(skip(tag, methodSetupHint(challenge)))
     return
+  }
+
+  // Direct methods own their payer; the CLI wallet may be unrelated or absent.
+  let walletAddress: string | undefined
+  if (!directMethod) {
+    try {
+      walletAddress = await resolveWalletAddress()
+    } catch {}
+    if (!walletAddress) {
+      results.push(skip(tag, 'no wallet configured. Run "mppx account create" to create one.'))
+      return
+    }
   }
 
   // Pre-flight balance check and chain resolution
@@ -357,7 +371,7 @@ async function attemptCryptoPayment(
   }
 
   let tokenSymbol: string | undefined
-  if (requiredAmount && currency && paymentChain) {
+  if (walletAddress && requiredAmount && currency && paymentChain) {
     try {
       let balance: bigint
       if (challenge.method === Constants.Methods.tempo) {
@@ -398,9 +412,16 @@ async function attemptCryptoPayment(
   const chainName = paymentChain?.name
   const paymentDesc = `${amountDisplay}${tokenDisplay ? ` ${tokenDisplay}` : ''}${chainName ? ` on ${chainName}` : ''}`
 
-  if (!options.silent) console.log(pc.dim(`    Attempting payment with wallet ${walletAddress}`))
+  if (!options.silent)
+    console.log(
+      pc.dim(
+        walletAddress
+          ? `    Attempting payment with wallet ${walletAddress}`
+          : '    Attempting payment with configured method',
+      ),
+    )
 
-  if (paymentChain?.testnet) {
+  if (!directMethod && paymentChain?.testnet) {
     if (!options.silent) console.log(pc.dim(`    Auto-approved: ${paymentDesc} (testnet)`))
   } else if (!options.yes && !ctx.isInteractive) {
     results.push(skip(tag, 'non-interactive mode, use --yes to approve'))
@@ -413,15 +434,6 @@ async function attemptCryptoPayment(
     }
   } else {
     if (!options.silent) console.log(pc.dim(`    Auto-approved: ${paymentDesc}`))
-  }
-
-  // Resolve plugin and pay
-  const resolved = resolvePlugin(challenge, loaded?.config)
-  const plugin = resolved.plugin
-  const directMethod = resolved.method
-  if (!plugin && !directMethod) {
-    results.push(skip(tag, methodSetupHint(challenge)))
-    return
   }
 
   let methods: AnyClient[]
@@ -476,18 +488,14 @@ async function attemptStripePayment(
   tag: string,
   ctx: PaymentContext & { isStripeTestKey: boolean; stripeKey?: string | undefined },
 ): Promise<void> {
-  const {
-    results,
-    url,
-    endpoint,
-    fetchHeaders,
-    fetchBody,
-    verbose,
-    loaded,
-    options,
-    isStripeTestKey,
-    stripeKey,
-  } = ctx
+  const { results, url, endpoint, fetchHeaders, fetchBody, verbose, loaded, options, stripeKey } =
+    ctx
+  const { plugin, method: directMethod } = resolvePlugin(challenge, loaded?.config)
+  if (!plugin && !directMethod) {
+    results.push(skip(tag, 'no Stripe payment method available'))
+    return
+  }
+  const isStripeTestKey = !directMethod && ctx.isStripeTestKey
   const request = challenge.request as Record<string, unknown>
   const requiredAmount = isValidIntegerAmount(request.amount)
     ? BigInt(request.amount as string)
@@ -512,14 +520,6 @@ async function attemptStripePayment(
     }
   } else {
     if (!options.silent) console.log(pc.dim(`    Auto-approved: ${paymentDesc}`))
-  }
-
-  const resolved = resolvePlugin(challenge, loaded?.config)
-  const plugin = resolved.plugin
-  const directMethod = resolved.method
-  if (!plugin && !directMethod) {
-    results.push(skip(tag, 'no Stripe payment method available'))
-    return
   }
 
   let methods: AnyClient[]

--- a/src/tempo/client/Charge.test.ts
+++ b/src/tempo/client/Charge.test.ts
@@ -708,3 +708,91 @@ describe('tempo.charge client', () => {
     })
   })
 })
+
+describe('recipient allowlist', () => {
+  test.each([
+    { name: 'no splits', splits: undefined },
+    { name: 'allowed split', splits: [{ recipient: currency, amount: '0.1' }] },
+  ])('rejects an unlisted primary recipient with $name', async ({ splits }) => {
+    const resolveAccount = vi.fn(() => account)
+    const client = createClient({
+      account,
+      chain: tempoLocalnet,
+      transport: http('http://127.0.0.1'),
+    })
+    const method = charge({
+      account,
+      getClient: () => client,
+      expectedRecipients: [currency],
+      resolveAccount,
+    })
+    await expect(
+      method.createCredential({
+        challenge: createChallenge({ amount: '1', splits }),
+        context: {},
+      }),
+    ).rejects.toThrow(`Unexpected primary recipient: ${recipient}`)
+    expect(resolveAccount).not.toHaveBeenCalled()
+  })
+
+  test.each([
+    {
+      name: 'matching recipients',
+      allowed: [recipient, currency],
+      splits: [{ recipient: currency, amount: '0.1' }],
+      error: undefined,
+    },
+    {
+      name: 'unlisted split',
+      allowed: [recipient],
+      splits: [{ recipient: currency, amount: '0.1' }],
+      error: `Unexpected split recipient: ${currency}`,
+    },
+    {
+      name: 'empty allowlist',
+      allowed: [],
+      splits: undefined,
+      error: `Unexpected primary recipient: ${recipient}`,
+    },
+    { name: 'no allowlist', allowed: undefined, splits: undefined, error: undefined },
+  ])('$name', async ({ allowed, splits, error }) => {
+    vi.resetModules()
+    const signTransaction = vi.fn(async () => '0xdeadbeef')
+    vi.doMock('viem/actions', () => ({
+      prepareTransactionRequest: vi.fn(async () => ({})),
+      signTransaction,
+      sendCallsSync: vi.fn(),
+      signTypedData: vi.fn(),
+    }))
+    try {
+      const { charge: mockedCharge } = await import('./Charge.js')
+      const client = createClient({
+        account,
+        chain: tempoLocalnet,
+        transport: http('http://127.0.0.1'),
+      })
+      const method = mockedCharge({
+        account,
+        getClient: () => client,
+        expectedRecipients: allowed as readonly Address[] | undefined,
+      })
+      const result = method.createCredential({
+        challenge: createChallenge({ amount: '1', splits, supportedModes: ['pull'] }),
+        context: {},
+      })
+      if (error) {
+        await expect(result).rejects.toThrow(error)
+        expect(signTransaction).not.toHaveBeenCalled()
+      } else {
+        expect(Credential.deserialize(await result).payload).toEqual({
+          signature: '0xdeadbeef',
+          type: 'transaction',
+        })
+        expect(signTransaction).toHaveBeenCalledOnce()
+      }
+    } finally {
+      vi.doUnmock('viem/actions')
+      vi.resetModules()
+    }
+  })
+})

--- a/src/tempo/client/Charge.test.ts
+++ b/src/tempo/client/Charge.test.ts
@@ -796,3 +796,31 @@ describe('recipient allowlist', () => {
     }
   })
 })
+
+describe('zero-amount recipient policy', () => {
+  test.each([{ allowed: [] }, { allowed: [currency] }, { allowed: [recipient] }])(
+    'enforces allowlist %j before proof signing',
+    async ({ allowed }) => {
+      const signer = { ...account }
+      const signTypedData = vi.spyOn(signer, 'signTypedData')
+      const client = createClient({
+        account: signer,
+        chain: tempoLocalnet,
+        transport: http('http://127.0.0.1'),
+      })
+      const method = charge({
+        account: signer,
+        getClient: () => client,
+        expectedRecipients: allowed as Address[],
+      })
+      const pending = method.createCredential({ challenge: createChallenge(), context: {} })
+      if (allowed.includes(recipient)) {
+        expect(Credential.deserialize(await pending).payload).toMatchObject({ type: 'proof' })
+        expect(signTypedData).toHaveBeenCalledOnce()
+      } else {
+        await expect(pending).rejects.toThrow('Unexpected primary recipient')
+        expect(signTypedData).not.toHaveBeenCalled()
+      }
+    },
+  )
+})

--- a/src/tempo/client/Charge.test.ts
+++ b/src/tempo/client/Charge.test.ts
@@ -624,9 +624,16 @@ describe('tempo.charge client', () => {
   })
 
   describe('chain pinning', () => {
+    test('rejects a resolved client whose chain conflicts with the pin', async () => {
+      const method = charge({ account, expectedChainId: 4217, getClient: () => client })
+      await expect(
+        method.createCredential({ challenge: createChallenge(), context: {} }),
+      ).rejects.toThrow('Chain ID mismatch: expected 4217, got 42431.')
+    })
+
     const client = createClient({
       account,
-      chain: tempoLocalnet,
+      chain: { ...tempoLocalnet, id: 42431 },
       transport: http('http://127.0.0.1'),
     })
 

--- a/src/tempo/client/Charge.test.ts
+++ b/src/tempo/client/Charge.test.ts
@@ -84,7 +84,7 @@ describe('tempo.charge client', () => {
     const chainId = 42431
     const client = createClient({
       account,
-      chain: tempoLocalnet,
+      chain: { ...tempoLocalnet, id: 42431 },
       transport: http('http://127.0.0.1'),
     })
     const method = charge({
@@ -137,7 +137,7 @@ describe('tempo.charge client', () => {
       const { charge: chargeWithMockedTempo } = await import('./Charge.js')
       const client = createClient({
         account,
-        chain: tempoLocalnet,
+        chain: { ...tempoLocalnet, id: 42431 },
         transport: http('http://127.0.0.1'),
       })
       const method = chargeWithMockedTempo({
@@ -190,7 +190,7 @@ describe('tempo.charge client', () => {
       const { charge: chargeWithMockedActions } = await import('./Charge.js')
       const client = createClient({
         account,
-        chain: tempoLocalnet,
+        chain: { ...tempoLocalnet, id: 42431 },
         transport: http('http://127.0.0.1'),
       })
       const method = chargeWithMockedActions({
@@ -242,12 +242,12 @@ describe('tempo.charge client', () => {
       const { charge: chargeWithMockedActions } = await import('./Charge.js')
       const localClient = createClient({
         account,
-        chain: tempoLocalnet,
+        chain: { ...tempoLocalnet, id: 42431 },
         transport: http('http://127.0.0.1'),
       })
       const rpcClient = createClient({
         account: account.address,
-        chain: tempoLocalnet,
+        chain: { ...tempoLocalnet, id: 42431 },
         transport: http('http://127.0.0.1'),
       })
       const challenge = createChallenge({
@@ -301,7 +301,7 @@ describe('tempo.charge client', () => {
       const { charge: chargeWithMockedActions } = await import('./Charge.js')
       const client = createClient({
         account,
-        chain: tempoLocalnet,
+        chain: { ...tempoLocalnet, id: 42431 },
         transport: http('http://127.0.0.1'),
       })
       const method = chargeWithMockedActions({
@@ -363,7 +363,7 @@ describe('tempo.charge client', () => {
       const { charge: chargeWithMockedActions } = await import('./Charge.js')
       const client = createClient({
         account,
-        chain: tempoLocalnet,
+        chain: { ...tempoLocalnet, id: 42431 },
         transport: http('http://127.0.0.1'),
       })
       const method = chargeWithMockedActions({
@@ -415,7 +415,7 @@ describe('tempo.charge client', () => {
       const { charge: chargeWithMockedActions } = await import('./Charge.js')
       const client = createClient({
         account,
-        chain: tempoLocalnet,
+        chain: { ...tempoLocalnet, id: 42431 },
         transport: http('http://127.0.0.1'),
       })
       const method = chargeWithMockedActions({
@@ -488,7 +488,7 @@ describe('tempo.charge client', () => {
 
       const client = createClient({
         account: accessKey,
-        chain: tempoLocalnet,
+        chain: { ...tempoLocalnet, id: 42431 },
         transport: http('http://127.0.0.1'),
       })
       const resolveAccount = vi.fn()
@@ -532,7 +532,7 @@ describe('tempo.charge client', () => {
       const chainId = 42431
       const client = createClient({
         account,
-        chain: tempoLocalnet,
+        chain: { ...tempoLocalnet, id: 42431 },
         transport: http('http://127.0.0.1'),
       })
       const method = chargeWithMockedActions({
@@ -581,7 +581,7 @@ describe('tempo.charge client', () => {
       const chainId = 42431
       const client = createClient({
         account,
-        chain: tempoLocalnet,
+        chain: { ...tempoLocalnet, id: 42431 },
         transport: http('http://127.0.0.1'),
       })
       const method = chargeWithMockedActions({
@@ -697,21 +697,11 @@ describe('tempo.charge client', () => {
       expect(credential.source).toBe(`did:pkh:eip155:${chainId}:${account.address}`)
     })
 
-    test('unpinned client accepts any challenge chainId', async () => {
-      const chainId = 1
-      const method = charge({
-        account,
-        getClient: () => client,
-      })
-
-      const credential = Credential.deserialize(
-        await method.createCredential({
-          challenge: createChallenge({ chainId }),
-          context: {},
-        }),
-      )
-
-      expect(credential.source).toBe(`did:pkh:eip155:${chainId}:${account.address}`)
+    test('unpinned client rejects a resolved client on another chain', async () => {
+      const method = charge({ account, getClient: () => client })
+      await expect(
+        method.createCredential({ challenge: createChallenge({ chainId: 1 }), context: {} }),
+      ).rejects.toThrow('Chain ID mismatch: expected 1, got 42431.')
     })
   })
 })
@@ -724,7 +714,7 @@ describe('recipient allowlist', () => {
     const resolveAccount = vi.fn(() => account)
     const client = createClient({
       account,
-      chain: tempoLocalnet,
+      chain: { ...tempoLocalnet, id: 42431 },
       transport: http('http://127.0.0.1'),
     })
     const method = charge({
@@ -775,7 +765,7 @@ describe('recipient allowlist', () => {
       const { charge: mockedCharge } = await import('./Charge.js')
       const client = createClient({
         account,
-        chain: tempoLocalnet,
+        chain: { ...tempoLocalnet, id: 42431 },
         transport: http('http://127.0.0.1'),
       })
       const method = mockedCharge({
@@ -812,7 +802,7 @@ describe('zero-amount recipient policy', () => {
       const signTypedData = vi.spyOn(signer, 'signTypedData')
       const client = createClient({
         account: signer,
-        chain: tempoLocalnet,
+        chain: { ...tempoLocalnet, id: 42431 },
         transport: http('http://127.0.0.1'),
       })
       const method = charge({

--- a/src/tempo/client/Charge.ts
+++ b/src/tempo/client/Charge.ts
@@ -88,6 +88,19 @@ export function charge(parameters: charge.Parameters = {}) {
         | undefined) ?? ['pull', 'push']
       const defaultAccount = getAccount(client, context)
 
+      if (parameters.expectedRecipients) {
+        const allowed = new Set(parameters.expectedRecipients.map((a) => a.toLowerCase()))
+        if (!request.recipient || !allowed.has(request.recipient.toLowerCase()))
+          throw new Error(`Unexpected primary recipient: ${request.recipient}`)
+        const splits = methodDetails?.splits as readonly { recipient: string }[] | undefined
+        if (splits) {
+          for (const split of splits) {
+            if (!allowed.has(split.recipient.toLowerCase()))
+              throw new Error(`Unexpected split recipient: ${split.recipient}`)
+          }
+        }
+      }
+
       // Zero-amount: sign EIP-712 typed data instead of creating a transaction.
       if (BigInt(amount) === 0n) {
         const signature = await signTypedData(client, {
@@ -109,18 +122,6 @@ export function charge(parameters: charge.Parameters = {}) {
       }
 
       const currency = request.currency as Address
-      if (parameters.expectedRecipients) {
-        const allowed = new Set(parameters.expectedRecipients.map((a) => a.toLowerCase()))
-        if (!request.recipient || !allowed.has(request.recipient.toLowerCase()))
-          throw new Error(`Unexpected primary recipient: ${request.recipient}`)
-        const splits = methodDetails?.splits as readonly { recipient: string }[] | undefined
-        if (splits) {
-          for (const split of splits) {
-            if (!allowed.has(split.recipient.toLowerCase()))
-              throw new Error(`Unexpected split recipient: ${split.recipient}`)
-          }
-        }
-      }
       const memo = methodDetails?.memo
         ? (methodDetails.memo as Hex.Hex)
         : Attribution.encode({ challengeId: challenge.id, clientId, serverId: challenge.realm })

--- a/src/tempo/client/Charge.ts
+++ b/src/tempo/client/Charge.ts
@@ -111,6 +111,8 @@ export function charge(parameters: charge.Parameters = {}) {
       const currency = request.currency as Address
       if (parameters.expectedRecipients) {
         const allowed = new Set(parameters.expectedRecipients.map((a) => a.toLowerCase()))
+        if (!request.recipient || !allowed.has(request.recipient.toLowerCase()))
+          throw new Error(`Unexpected primary recipient: ${request.recipient}`)
         const splits = methodDetails?.splits as readonly { recipient: string }[] | undefined
         if (splits) {
           for (const split of splits) {

--- a/src/tempo/client/Charge.ts
+++ b/src/tempo/client/Charge.ts
@@ -77,7 +77,7 @@ export function charge(parameters: charge.Parameters = {}) {
         )
       const resolvedChainId = challengeChainId ?? parameters.expectedChainId
       const client = await getClient({ chainId: resolvedChainId })
-      Client.assertChainId(client, parameters.expectedChainId)
+      Client.assertChainId(client, resolvedChainId)
       const chainId = resolvedChainId ?? client.chain?.id
       if (chainId === undefined)
         throw new Error('No `chainId` provided. Pass a chain ID in the challenge or client.')

--- a/src/tempo/client/Charge.ts
+++ b/src/tempo/client/Charge.ts
@@ -77,6 +77,7 @@ export function charge(parameters: charge.Parameters = {}) {
         )
       const resolvedChainId = challengeChainId ?? parameters.expectedChainId
       const client = await getClient({ chainId: resolvedChainId })
+      Client.assertChainId(client, parameters.expectedChainId)
       const chainId = resolvedChainId ?? client.chain?.id
       if (chainId === undefined)
         throw new Error('No `chainId` provided. Pass a chain ID in the challenge or client.')

--- a/src/tempo/client/Charge.ts
+++ b/src/tempo/client/Charge.ts
@@ -282,8 +282,8 @@ export declare namespace charge {
      */
     expectedChainId?: number | undefined
     /**
-     * Allowlist of expected split recipient addresses. When set, the client
-     * rejects any challenge whose split recipients are not in this list.
+     * Allowlist of payment recipient addresses. When set, both the primary
+     * recipient and every split recipient must be included in this list.
      */
     expectedRecipients?: readonly Address[] | undefined
     /**

--- a/src/tempo/session/client/CredentialState.test.ts
+++ b/src/tempo/session/client/CredentialState.test.ts
@@ -398,14 +398,14 @@ describe('CredentialPlan', () => {
       await expect(
         resolveChallengeContext({
           challenge: paymentChallenge({ recipient: undefined }),
-          getClient: async () => ({ chain: { id: 4217 } }) as Client,
+          getClient: async () => ({ chain: { id: 42431 } }) as Client,
         }),
       ).rejects.toThrow('tempo session challenge missing recipient')
 
       await expect(
         resolveChallengeContext({
           challenge: paymentChallenge({ currency: 'pathUSD' }),
-          getClient: async () => ({ chain: { id: 4217 } }) as Client,
+          getClient: async () => ({ chain: { id: 42431 } }) as Client,
         }),
       ).rejects.toThrow('tempo session challenge missing currency')
     })

--- a/src/tempo/session/client/CredentialState.ts
+++ b/src/tempo/session/client/CredentialState.ts
@@ -220,6 +220,8 @@ export type ResolveChallengeContextParameters = {
   challenge: Challenge.Challenge
   /** Optional local escrow override. */
   escrowOverride?: Address | undefined
+  /** Locally pinned chain, enforced before resolving a client or authorizing payment. */
+  expectedChainId?: number | undefined
   /** Resolves the viem client for the challenge chain. */
   getClient(parameters: { chainId?: number | undefined }): Client | Promise<Client>
 }
@@ -427,10 +429,17 @@ function readSuggestedDeposit(value: unknown): string | undefined {
 export async function resolveChallengeContext(
   parameters: ResolveChallengeContextParameters,
 ): Promise<ChallengeContext> {
-  const { allowCustomEscrow, challenge, escrowOverride, getClient } = parameters
+  const { allowCustomEscrow, challenge, escrowOverride, expectedChainId, getClient } = parameters
   const methodDetails = readMethodDetails(challenge)
-  const client = await getClient({ chainId: methodDetails.chainId })
-  const chainId = methodDetails.chainId ?? client.chain?.id
+  if (
+    expectedChainId !== undefined &&
+    methodDetails.chainId !== undefined &&
+    methodDetails.chainId !== expectedChainId
+  )
+    throw new Error(`Chain ID mismatch: expected ${expectedChainId}, got ${methodDetails.chainId}.`)
+  const requestedChainId = methodDetails.chainId ?? expectedChainId
+  const client = await getClient({ chainId: requestedChainId })
+  const chainId = requestedChainId ?? client.chain?.id
   if (!chainId) throw new Error('No chainId configured for TIP-1034 session challenge.')
 
   const escrow = resolveEscrow(challenge, escrowOverride, allowCustomEscrow)

--- a/src/tempo/session/client/CredentialState.ts
+++ b/src/tempo/session/client/CredentialState.ts
@@ -10,6 +10,7 @@ import {
 import type * as Challenge from '../../../Challenge.js'
 import * as Constants from '../../../Constants.js'
 import * as Account from '../../../viem/Account.js'
+import { assertChainId } from '../../../viem/Client.js'
 import * as z from '../../../zod.js'
 import * as AutoSwap from '../../internal/auto-swap.js'
 import * as Chain from '../precompile/Chain.js'
@@ -439,6 +440,7 @@ export async function resolveChallengeContext(
     throw new Error(`Chain ID mismatch: expected ${expectedChainId}, got ${methodDetails.chainId}.`)
   const requestedChainId = methodDetails.chainId ?? expectedChainId
   const client = await getClient({ chainId: requestedChainId })
+  assertChainId(client, requestedChainId)
   const chainId = requestedChainId ?? client.chain?.id
   if (!chainId) throw new Error('No chainId configured for TIP-1034 session challenge.')
 

--- a/src/tempo/session/client/Session.test.ts
+++ b/src/tempo/session/client/Session.test.ts
@@ -1494,6 +1494,24 @@ describe('precompile client session', () => {
 })
 
 describe('session chain pinning', () => {
+  test.each([chainId, undefined])(
+    'accepts a chain-agnostic client with advertised chain %s',
+    async (advertised) => {
+      const getClient = vi.fn(() => ({ ...client, chain: undefined }))
+      const method = session({ account, expectedChainId: chainId, getClient })
+      const challenge = makeSessionChallenge()
+      if (advertised === undefined) delete challenge.request.methodDetails!.chainId
+      const credential = await method.createCredential({
+        challenge,
+        context: { action: 'voucher', descriptor, cumulativeAmountRaw: '100' },
+      })
+      expect(getClient).toHaveBeenCalledWith({ chainId })
+      expect(Credential.deserialize(credential).source).toBe(
+        `did:pkh:eip155:${chainId}:${account.address}`,
+      )
+    },
+  )
+
   test.each(['automatic', 'open', 'topUp', 'voucher', 'close', 'recover'] as const)(
     'rejects a resolved client on another chain for %s',
     async (action) => {

--- a/src/tempo/session/client/Session.test.ts
+++ b/src/tempo/session/client/Session.test.ts
@@ -1492,3 +1492,64 @@ describe('precompile client session', () => {
     ).toBe(true)
   })
 })
+
+describe('session chain pinning', () => {
+  test.each(['automatic', 'open', 'topUp', 'voucher', 'close', 'recover'] as const)(
+    'rejects a foreign chain before resolving a client for %s',
+    async (action) => {
+      const getClient = vi.fn(() => client)
+      const method = session({ account, expectedChainId: chainId, getClient })
+      const context =
+        action === 'automatic'
+          ? {}
+          : action === 'recover'
+            ? { descriptor }
+            : { action, descriptor, transaction: '0x1234' as const, cumulativeAmountRaw: '100' }
+      await expect(
+        method.createCredential({
+          challenge: makeSessionChallenge({
+            methodDetails: { chainId: 4217, escrowContract: tip20ChannelEscrow },
+          }),
+          context,
+        }),
+      ).rejects.toThrow(`Chain ID mismatch: expected ${chainId}, got 4217.`)
+      expect(getClient).not.toHaveBeenCalled()
+    },
+  )
+
+  test('rejects a foreign chain in the automatic top-up hook', async () => {
+    const getClient = vi.fn(() => client)
+    const fetch = vi.fn()
+    const method = session({ account, expectedChainId: chainId, getClient })
+    await expect(
+      MethodChallenge.handle(method, {
+        challenge: makeSessionChallenge({
+          methodDetails: { chainId: 4217, escrowContract: tip20ChannelEscrow },
+        }),
+        context: {},
+        fetch,
+        input: 'https://example.com/paid',
+      }),
+    ).rejects.toThrow('Chain ID mismatch')
+    expect(getClient).not.toHaveBeenCalled()
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  test.each([chainId, undefined])(
+    'signs on the pin with advertised chain %s',
+    async (advertised) => {
+      const getClient = vi.fn(() => client)
+      const method = session({ account, expectedChainId: chainId, getClient })
+      const challenge = makeSessionChallenge()
+      if (advertised === undefined) delete challenge.request.methodDetails!.chainId
+      const credential = await method.createCredential({
+        challenge,
+        context: { action: 'voucher', descriptor, cumulativeAmountRaw: '100' },
+      })
+      expect(getClient).toHaveBeenCalledWith({ chainId })
+      expect(Credential.deserialize(credential).source).toBe(
+        `did:pkh:eip155:${chainId}:${account.address}`,
+      )
+    },
+  )
+})

--- a/src/tempo/session/client/Session.test.ts
+++ b/src/tempo/session/client/Session.test.ts
@@ -1495,6 +1495,26 @@ describe('precompile client session', () => {
 
 describe('session chain pinning', () => {
   test.each(['automatic', 'open', 'topUp', 'voucher', 'close', 'recover'] as const)(
+    'rejects a resolved client on another chain for %s',
+    async (action) => {
+      const getClient = vi.fn(() => client)
+      const method = session({ account, expectedChainId: 4217, getClient })
+      const challenge = makeSessionChallenge()
+      delete challenge.request.methodDetails!.chainId
+      const context =
+        action === 'automatic'
+          ? {}
+          : action === 'recover'
+            ? { descriptor }
+            : { action, descriptor, transaction: '0x1234' as const, cumulativeAmountRaw: '100' }
+      await expect(method.createCredential({ challenge, context })).rejects.toThrow(
+        `Chain ID mismatch: expected 4217, got ${chainId}.`,
+      )
+      expect(getClient).toHaveBeenCalledWith({ chainId: 4217 })
+    },
+  )
+
+  test.each(['automatic', 'open', 'topUp', 'voucher', 'close', 'recover'] as const)(
     'rejects a foreign chain before resolving a client for %s',
     async (action) => {
       const getClient = vi.fn(() => client)

--- a/src/tempo/session/client/Session.ts
+++ b/src/tempo/session/client/Session.ts
@@ -124,6 +124,7 @@ export function session(parameters: session.Parameters = {}) {
     channelStore,
     decimals = defaults.decimals,
     escrow: escrowOverride,
+    expectedChainId,
     getClient: getClientParameter,
     maxDeposit: maxDepositParameter,
     topUpAmount: topUpAmountParameter,
@@ -188,6 +189,7 @@ export function session(parameters: session.Parameters = {}) {
         allowCustomEscrow,
         challenge,
         escrowOverride,
+        expectedChainId,
         getClient,
       })
       const attempt = MethodResponse.getAttempt(parameters)
@@ -328,6 +330,7 @@ export function session(parameters: session.Parameters = {}) {
       allowCustomEscrow,
       challenge,
       escrowOverride,
+      expectedChainId,
       getClient,
     })
     const channel = await store.get(resolved.key)
@@ -375,6 +378,7 @@ export function session(parameters: session.Parameters = {}) {
           allowCustomEscrow,
           challenge,
           escrowOverride,
+          expectedChainId,
           getClient,
         })
       ).key
@@ -426,6 +430,8 @@ export declare namespace session {
       decimals?: number | undefined
       /** Exact TIP20EscrowChannel address pin. Takes precedence over `allowCustomEscrow`. */
       escrow?: Address | undefined
+      /** Only authorize sessions on this chain. Used when the challenge omits a chain ID. */
+      expectedChainId?: number | undefined
       /** Maximum channel deposit in human-readable units. Caps server-suggested opens and automatic top-ups. */
       maxDeposit?: string | undefined
       /**

--- a/src/tempo/session/client/SessionManager.test.ts
+++ b/src/tempo/session/client/SessionManager.test.ts
@@ -1990,10 +1990,12 @@ describe('expectedChainId', () => {
     expect(fetch).toHaveBeenCalledTimes(1)
   })
 
-  test.each(['challenge', 'snapshot'] as const)(
-    'rejects cross-chain bootstrap %s before resolving a client',
+  test.each(['challenge', 'snapshot', 'resolved client'] as const)(
+    'rejects cross-chain bootstrap %s before hydration or signing',
     async (mode) => {
-      const getClient = vi.fn(() => client)
+      const getClient = vi.fn(() =>
+        mode === 'resolved client' ? { ...client, chain: { id: 42431 } as never } : client,
+      )
       const store = makeChannelStore()
       const fetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
         if (init?.method !== 'HEAD') return makeOkResponse()
@@ -2019,13 +2021,13 @@ describe('expectedChainId', () => {
       const manager = sessionManager({
         account,
         bootstrap: true,
-        expectedChainId: 42431,
+        expectedChainId: mode === 'resolved client' ? 4217 : 42431,
         getClient,
         fetch,
         channelStore: store.store,
       })
       expect((await manager.fetch('https://api.example.com')).status).toBe(200)
-      expect(getClient).not.toHaveBeenCalled()
+      expect(getClient).toHaveBeenCalledTimes(mode === 'resolved client' ? 1 : 0)
       expect(store.set).not.toHaveBeenCalled()
       expect(fetch).toHaveBeenCalledTimes(2)
     },

--- a/src/tempo/session/client/SessionManager.test.ts
+++ b/src/tempo/session/client/SessionManager.test.ts
@@ -1964,6 +1964,21 @@ describe('Session', () => {
 })
 
 describe('expectedChainId', () => {
+  test('rejects a fixed client on a different chain before any request', () => {
+    const fetch = vi.fn()
+    expect(() => sessionManager({ account, client, expectedChainId: 42431, fetch })).toThrow(
+      'Chain ID mismatch: expected 42431, got 4217.',
+    )
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  test.each([4217, undefined])(
+    'accepts a fixed client with compatible pin %s',
+    (expectedChainId) => {
+      expect(() => sessionManager({ account, client, expectedChainId })).not.toThrow()
+    },
+  )
+
   test('rejects session challenges before resolving a client or signing', async () => {
     const getClient = vi.fn(() => client)
     const fetch = vi.fn(async () => make402Response())

--- a/src/tempo/session/client/SessionManager.test.ts
+++ b/src/tempo/session/client/SessionManager.test.ts
@@ -1962,3 +1962,86 @@ describe('Session', () => {
     })
   })
 })
+
+describe('expectedChainId', () => {
+  test('rejects session challenges before resolving a client or signing', async () => {
+    const getClient = vi.fn(() => client)
+    const fetch = vi.fn(async () => make402Response())
+    const manager = sessionManager({ account, expectedChainId: 42431, getClient, fetch })
+    await expect(manager.fetch('https://api.example.com')).rejects.toThrow(
+      'Chain ID mismatch: expected 42431, got 4217.',
+    )
+    expect(getClient).not.toHaveBeenCalled()
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  test.each(['challenge', 'snapshot'] as const)(
+    'rejects cross-chain bootstrap %s before resolving a client',
+    async (mode) => {
+      const getClient = vi.fn(() => client)
+      const store = makeChannelStore()
+      const fetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method !== 'HEAD') return makeOkResponse()
+        if (mode === 'challenge') return make402Response(makeChargeChallenge())
+        return new Response(null, {
+          status: 204,
+          headers: {
+            [Constants.Headers.paymentSessionSnapshot]: sessionManager.serializeSnapshot({
+              acceptedCumulative: '0',
+              chainId: 4217,
+              channelId: storedChannelId,
+              deposit: '10000000',
+              descriptor: storedDescriptor,
+              escrow: tip20ChannelEscrow,
+              requiredCumulative: '0',
+              settled: '0',
+              spent: '0',
+              units: 0,
+            }),
+          },
+        })
+      })
+      const manager = sessionManager({
+        account,
+        bootstrap: true,
+        expectedChainId: 42431,
+        getClient,
+        fetch,
+        channelStore: store.store,
+      })
+      expect((await manager.fetch('https://api.example.com')).status).toBe(200)
+      expect(getClient).not.toHaveBeenCalled()
+      expect(store.set).not.toHaveBeenCalled()
+      expect(fetch).toHaveBeenCalledTimes(2)
+    },
+  )
+
+  test.each([4217, undefined])(
+    'signs vouchers on the pinned chain when advertised chain is %s',
+    async (chainId) => {
+      const getClient = vi.fn(() => client)
+      const store = makeChannelStore([channelEntry()])
+      const challenge = makeChallenge({
+        methodDetails: {
+          chainId,
+          escrowContract: tip20ChannelEscrow,
+          sessionProtocol: Constants.SessionProtocols.v2,
+        },
+      })
+      const fetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        if (!new Headers(init?.headers).has(Constants.Headers.authorization))
+          return make402Response(challenge)
+        return makeOkResponse()
+      })
+      const manager = sessionManager({
+        account,
+        expectedChainId: 4217,
+        getClient,
+        fetch,
+        channelStore: store.store,
+      })
+      expect((await manager.fetch('https://api.example.com')).status).toBe(200)
+      expect(getClient).toHaveBeenCalledWith({ chainId: 4217 })
+    },
+  )
+})

--- a/src/tempo/session/client/SessionManager.ts
+++ b/src/tempo/session/client/SessionManager.ts
@@ -202,6 +202,15 @@ function resolveSessionManagerConfig(parameters: sessionManager.Parameters): Ses
  * `channelStore` can persist reusable channels between manager instances.
  */
 export function sessionManager(parameters: sessionManager.Parameters): SessionManager {
+  const clientChainId = parameters.client?.chain?.id
+  if (
+    parameters.expectedChainId !== undefined &&
+    clientChainId !== undefined &&
+    clientChainId !== parameters.expectedChainId
+  )
+    throw new Error(
+      `Chain ID mismatch: expected ${parameters.expectedChainId}, got ${clientChainId}.`,
+    )
   const allowCustomEscrow = parameters.allowCustomEscrow ?? false
   const config = resolveSessionManagerConfig(parameters)
   const getClient = Client.getResolver({

--- a/src/tempo/session/client/SessionManager.ts
+++ b/src/tempo/session/client/SessionManager.ts
@@ -445,6 +445,7 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
         `Chain ID mismatch: expected ${parameters.expectedChainId}, got ${snapshot.chainId}.`,
       )
     const client = await getClient({ chainId: snapshot.chainId })
+    Client.assertChainId(client, snapshot.chainId)
     const defaultAccount = getAccount(client)
     const account =
       (await parameters.resolveAccount?.({

--- a/src/tempo/session/client/SessionManager.ts
+++ b/src/tempo/session/client/SessionManager.ts
@@ -342,6 +342,7 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
     getClient: parameters.client ? () => parameters.client! : parameters.getClient,
     resolveAccount: parameters.resolveAccount,
     escrow: parameters.escrow,
+    expectedChainId: parameters.expectedChainId,
     decimals: config.decimals,
     maxDeposit: parameters.maxDeposit,
     topUpAmount: parameters.topUpAmount,
@@ -363,6 +364,7 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
   })
   MethodResponse.unregister(method)
   const chargeMethod = chargePlugin({
+    expectedChainId: parameters.expectedChainId,
     account: parameters.account,
     getClient: parameters.client ? () => parameters.client! : parameters.getClient,
   })
@@ -429,6 +431,10 @@ export function sessionManager(parameters: sessionManager.Parameters): SessionMa
     const header = response.headers.get(Constants.Headers.paymentSessionSnapshot)
     if (!header) return undefined
     const snapshot = deserializeSessionSnapshot(header)
+    if (parameters.expectedChainId !== undefined && snapshot.chainId !== parameters.expectedChainId)
+      throw new Error(
+        `Chain ID mismatch: expected ${parameters.expectedChainId}, got ${snapshot.chainId}.`,
+      )
     const client = await getClient({ chainId: snapshot.chainId })
     const defaultAccount = getAccount(client)
     const account =
@@ -1006,6 +1012,8 @@ export namespace sessionManager {
       decimals?: number | undefined
       /** Exact TIP20EscrowChannel address pin. Takes precedence over `allowCustomEscrow`. */
       escrow?: Address | undefined
+      /** Reject challenges and bootstrap snapshots on other chains; use this chain when omitted. */
+      expectedChainId?: number | undefined
       /** Fetch implementation used for HTTP probes, management posts, and paid retries. */
       fetch?: typeof globalThis.fetch | undefined
       /** Base context supplied to every session credential created by the manager. */

--- a/src/viem/Client.test.ts
+++ b/src/viem/Client.test.ts
@@ -323,6 +323,18 @@ describe('feePayer transaction serialization', () => {
 })
 
 describe('getResolver serializer injection', () => {
+  test.each([tempoModerato.id, undefined])(
+    'uses requested chain %s when injecting serializers into a chain-agnostic client',
+    async (chainId) => {
+      const client = createClient({ transport: mockTransport })
+      const resolver = Client.getResolver({ chain: tempoMainnetChain, getClient: () => client })
+      const resolved = await resolver({ chainId })
+      expect(resolved.chain?.id).toBe(chainId ?? tempoMainnetChain.id)
+      expect(resolved.chain?.serializers?.transaction).toBeDefined()
+      expect(client.chain).toBeUndefined()
+    },
+  )
+
   test('behavior: injects Tempo serializer onto plain clients', async () => {
     const plainClient = createPlainClient()
     expect(plainClient.chain?.serializers?.transaction).toBeUndefined()

--- a/src/viem/Client.test.ts
+++ b/src/viem/Client.test.ts
@@ -405,3 +405,19 @@ describe('getResolver serializer injection', () => {
     ).rejects.toThrow()
   })
 })
+
+describe('assertChainId', () => {
+  test.each([
+    { actual: 4217, expected: 42431, rejects: true },
+    { actual: 4217, expected: 4217, rejects: false },
+    { actual: undefined, expected: 4217, rejects: false },
+    { actual: 4217, expected: undefined, rejects: false },
+  ])('validates known chain $actual against $expected', ({ actual, expected, rejects }) => {
+    const client = createClient({
+      chain: actual === undefined ? undefined : ({ id: actual } as never),
+      transport: custom({ request: vi.fn() }),
+    })
+    if (rejects) expect(() => Client.assertChainId(client, expected)).toThrow('Chain ID mismatch')
+    else expect(() => Client.assertChainId(client, expected)).not.toThrow()
+  })
+})

--- a/src/viem/Client.ts
+++ b/src/viem/Client.ts
@@ -75,6 +75,8 @@ export function getResolver(
       return Object.assign({}, resolvedClient, {
         chain: {
           ...chain,
+          // Serializer defaults must not replace an explicitly requested network.
+          ...(params.chainId !== undefined ? { id: params.chainId } : {}),
           ...resolvedClient.chain,
           formatters: resolvedClient.chain?.formatters ?? chain.formatters,
           prepareTransactionRequest:

--- a/src/viem/Client.ts
+++ b/src/viem/Client.ts
@@ -108,3 +108,9 @@ export declare namespace getResolver {
     getClient?: ((parameters: { chainId?: number | undefined }) => MaybePromise<Client>) | undefined
   }
 }
+
+/** Rejects a resolved client whose known chain conflicts with the requested payment chain. */
+export function assertChainId(client: Client, chainId: number | undefined): void {
+  if (chainId !== undefined && client.chain?.id !== undefined && client.chain.id !== chainId)
+    throw new Error(`Chain ID mismatch: expected ${chainId}, got ${client.chain.id}.`)
+}


### PR DESCRIPTION
## Motivation

Payment clients could ignore primary-recipient allowlists, session chain pins, and CLI-configured EVM spending limits.

## Summary

- Validate the primary transfer recipient alongside split recipients.
- Enforce session chain pins during credential creation, recovery, and automatic top-ups.
- Prefer configured payment methods over built-in CLI plugins.
- Add regression coverage for each policy boundary.

## Key design considerations

- Reject conflicting session chains before resolving a client; use the pin when the challenge omits its chain.
- Preserve explicit plugin precedence and built-in fallbacks for unconfigured methods.
