### PR TITLE
fix: enforce primary and split recipient allowlists

### DIFF
--- a/.changeset/charge-recipient-allowlist.md
+++ b/.changeset/charge-recipient-allowlist.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Enforced recipient allowlists for both primary and split recipients, including zero-amount proofs.

--- a/.changeset/charge-recipient-allowlist.md
+++ b/.changeset/charge-recipient-allowlist.md
@@ -1,5 +1,7 @@
 ---
-'mppx': patch
+'mppx': minor
 ---
 
 Enforced recipient allowlists for both primary and split recipients, including zero-amount proofs.
+
+Migration: include the primary recipient address as well as every split recipient in `expectedRecipients`. Configurations containing only split recipients are now rejected.

--- a/src/tempo/client/Charge.test.ts
+++ b/src/tempo/client/Charge.test.ts
@@ -708,3 +708,119 @@ describe('tempo.charge client', () => {
     })
   })
 })
+
+describe('recipient allowlist', () => {
+  test.each([
+    { name: 'no splits', splits: undefined },
+    { name: 'allowed split', splits: [{ recipient: currency, amount: '0.1' }] },
+  ])('rejects an unlisted primary recipient with $name', async ({ splits }) => {
+    const resolveAccount = vi.fn(() => account)
+    const client = createClient({
+      account,
+      chain: { ...tempoLocalnet, id: 42431 },
+      transport: http('http://127.0.0.1'),
+    })
+    const method = charge({
+      account,
+      getClient: () => client,
+      expectedRecipients: [currency],
+      resolveAccount,
+    })
+    await expect(
+      method.createCredential({
+        challenge: createChallenge({ amount: '1', splits }),
+        context: {},
+      }),
+    ).rejects.toThrow(`Unexpected primary recipient: ${recipient}`)
+    expect(resolveAccount).not.toHaveBeenCalled()
+  })
+
+  test.each([
+    {
+      name: 'matching recipients',
+      allowed: [recipient, currency],
+      splits: [{ recipient: currency, amount: '0.1' }],
+      error: undefined,
+    },
+    {
+      name: 'unlisted split',
+      allowed: [recipient],
+      splits: [{ recipient: currency, amount: '0.1' }],
+      error: `Unexpected split recipient: ${currency}`,
+    },
+    {
+      name: 'empty allowlist',
+      allowed: [],
+      splits: undefined,
+      error: `Unexpected primary recipient: ${recipient}`,
+    },
+    { name: 'no allowlist', allowed: undefined, splits: undefined, error: undefined },
+  ])('$name', async ({ allowed, splits, error }) => {
+    vi.resetModules()
+    const signTransaction = vi.fn(async () => '0xdeadbeef')
+    vi.doMock('viem/actions', () => ({
+      prepareTransactionRequest: vi.fn(async () => ({})),
+      signTransaction,
+      sendCallsSync: vi.fn(),
+      signTypedData: vi.fn(),
+    }))
+    try {
+      const { charge: mockedCharge } = await import('./Charge.js')
+      const client = createClient({
+        account,
+        chain: { ...tempoLocalnet, id: 42431 },
+        transport: http('http://127.0.0.1'),
+      })
+      const method = mockedCharge({
+        account,
+        getClient: () => client,
+        expectedRecipients: allowed as readonly Address[] | undefined,
+      })
+      const result = method.createCredential({
+        challenge: createChallenge({ amount: '1', splits, supportedModes: ['pull'] }),
+        context: {},
+      })
+      if (error) {
+        await expect(result).rejects.toThrow(error)
+        expect(signTransaction).not.toHaveBeenCalled()
+      } else {
+        expect(Credential.deserialize(await result).payload).toEqual({
+          signature: '0xdeadbeef',
+          type: 'transaction',
+        })
+        expect(signTransaction).toHaveBeenCalledOnce()
+      }
+    } finally {
+      vi.doUnmock('viem/actions')
+      vi.resetModules()
+    }
+  })
+})
+
+describe('zero-amount recipient policy', () => {
+  test.each([{ allowed: [] }, { allowed: [currency] }, { allowed: [recipient] }])(
+    'enforces allowlist %j before proof signing',
+    async ({ allowed }) => {
+      const signer = { ...account }
+      const signTypedData = vi.spyOn(signer, 'signTypedData')
+      const client = createClient({
+        account: signer,
+        chain: { ...tempoLocalnet, id: 42431 },
+        transport: http('http://127.0.0.1'),
+      })
+      const method = charge({
+        account: signer,
+        getClient: () => client,
+        expectedRecipients: allowed as Address[],
+      })
+      const pending = method.createCredential({ challenge: createChallenge(), context: {} })
+      if (allowed.includes(recipient)) {
+        expect(Credential.deserialize(await pending).payload).toMatchObject({ type: 'proof' })
+        expect(signTypedData).toHaveBeenCalledOnce()
+      } else {
+        await expect(pending).rejects.toThrow('Unexpected primary recipient')
+        expect(signTypedData).not.toHaveBeenCalled()
+      }
+    },
+  )
+})

--- a/src/tempo/client/Charge.ts
+++ b/src/tempo/client/Charge.ts
@@ -88,6 +88,19 @@ export function charge(parameters: charge.Parameters = {}) {
         | undefined) ?? ['pull', 'push']
       const defaultAccount = getAccount(client, context)
 
+      if (parameters.expectedRecipients) {
+        const allowed = new Set(parameters.expectedRecipients.map((a) => a.toLowerCase()))
+        if (!request.recipient || !allowed.has(request.recipient.toLowerCase()))
+          throw new Error(`Unexpected primary recipient: ${request.recipient}`)
+        const splits = methodDetails?.splits as readonly { recipient: string }[] | undefined
+        if (splits) {
+          for (const split of splits) {
+            if (!allowed.has(split.recipient.toLowerCase()))
+              throw new Error(`Unexpected split recipient: ${split.recipient}`)
+          }
+        }
+      }
+
       // Zero-amount: sign EIP-712 typed data instead of creating a transaction.
       if (BigInt(amount) === 0n) {
         const signature = await signTypedData(client, {
@@ -109,16 +122,6 @@ export function charge(parameters: charge.Parameters = {}) {
       }
 
       const currency = request.currency as Address
-      if (parameters.expectedRecipients) {
-        const allowed = new Set(parameters.expectedRecipients.map((a) => a.toLowerCase()))
-        const splits = methodDetails?.splits as readonly { recipient: string }[] | undefined
-        if (splits) {
-          for (const split of splits) {
-            if (!allowed.has(split.recipient.toLowerCase()))
-              throw new Error(`Unexpected split recipient: ${split.recipient}`)
-          }
-        }
-      }
       const memo = methodDetails?.memo
         ? (methodDetails.memo as Hex.Hex)
         : Attribution.encode({ challengeId: challenge.id, clientId, serverId: challenge.realm })
@@ -279,8 +282,8 @@ export declare namespace charge {
      */
     expectedChainId?: number | undefined
     /**
-     * Allowlist of expected split recipient addresses. When set, the client
-     * rejects any challenge whose split recipients are not in this list.
+     * Allowlist of payment recipient addresses. When set, both the primary
+     * recipient and every split recipient must be included in this list.
      */
     expectedRecipients?: readonly Address[] | undefined
     /**


### PR DESCRIPTION
## Motivation

Primary recipients and zero-amount proofs could bypass configured recipient allowlists.

## Summary

- Require the primary recipient and every split recipient to appear in the allowlist.
- Apply the same checks before signing zero-amount proofs.
- Clarify the option contract and add regression coverage.

## Key design considerations

- Compare addresses without case sensitivity and reject unexpected recipients before signing.
