### PR TITLE
fix: preserve configured methods throughout CLI payments

### DIFF
--- a/.changeset/cli-configured-payment-methods.md
+++ b/.changeset/cli-configured-payment-methods.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Preserved configured payment methods, challenge preferences, and session policies in the CLI, including incremental SSE output and follow-up vouchers.

--- a/.changeset/validate-configured-payment-methods.md
+++ b/.changeset/validate-configured-payment-methods.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Used configured payment methods during validation without unrelated CLI-wallet preflights, limited Stripe test-key shortcuts to the built-in plugin, and reported the advertised Tempo chain.

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -456,7 +456,10 @@ export default defineConfig({
   })
 })
 
-async function serve(argv: string[], options?: { env?: Record<string, string | undefined> }) {
+async function serve(
+  argv: string[],
+  options?: { env?: Record<string, string | undefined>; onOutput?: (chunk: string) => void },
+) {
   const stdoutChunks: Buffer[] = []
   let stderr = ''
   let exitCode: number | undefined
@@ -481,6 +484,7 @@ async function serve(argv: string[], options?: { env?: Record<string, string | u
     if (typeof chunk === 'string') stdoutChunks.push(Buffer.from(chunk))
     else if (chunk instanceof Uint8Array) stdoutChunks.push(Buffer.from(chunk))
     else stdoutChunks.push(Buffer.from(String(chunk)))
+    options?.onOutput?.(stdoutChunks.at(-1)!.toString())
     return true
   }) as typeof process.stdout.write
   process.stderr.write = ((chunk: unknown) => {
@@ -2651,4 +2655,253 @@ export default defineConfig({
       }
     },
   )
+})
+
+test.each(['auto', 'new'])(
+  'configured session policies cannot be replaced by persistent session %s',
+  async (selection) => {
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mppx-session-config-'))
+    const configPath = path.join(configDir, 'mppx.config.mjs')
+    const moduleUrl = pathToFileURL(
+      path.join(process.cwd(), 'src/tempo/session/client/Session.ts'),
+    ).href
+    fs.writeFileSync(
+      configPath,
+      `
+    import { session } from '${moduleUrl}'
+    export default { methods: [session({ expectedChainId: 4217,
+      getClient() { throw new Error('unexpected client resolution') }
+    })] }
+  `,
+    )
+    const challenge = Challenge.from({
+      id: 'pinned-session',
+      realm: 'localhost',
+      method: 'tempo',
+      intent: 'session',
+      request: {
+        amount: '100',
+        currency: Addresses.pathUsd,
+        recipient: accounts[0].address,
+        unitType: 'request',
+        methodDetails: {
+          chainId: 42431,
+          escrowContract: tip20ChannelEscrow,
+          sessionProtocol: Constants.SessionProtocols.v2,
+        },
+      },
+    })
+    let paidRequests = 0
+    const server = await Http.createServer((req, res) => {
+      if (req.headers.authorization) paidRequests++
+      res.writeHead(402, { [Constants.Headers.wwwAuthenticate]: Challenge.serialize(challenge) })
+      res.end()
+    })
+    try {
+      const { output, exitCode } = await serve(
+        [server.url, '-s', '--config', configPath, '--session', selection],
+        {
+          env: { MPPX_PRIVATE_KEY: testPrivateKey },
+        },
+      )
+      expect(exitCode).toBeDefined()
+      expect(output).toContain(
+        selection === 'auto'
+          ? 'Chain ID mismatch: expected 4217, got 42431.'
+          : '--session cannot override a configured session method',
+      )
+      expect(paidRequests).toBe(0)
+    } finally {
+      server.close()
+      fs.rmSync(configDir, { recursive: true, force: true })
+    }
+  },
+)
+
+test('configured session handles SSE voucher requests with its own channel store', async () => {
+  const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mppx-session-stream-'))
+  const configPath = path.join(configDir, 'mppx.config.mjs')
+  const sourceUrl = pathToFileURL(path.join(process.cwd(), 'src/tempo/session/')).href
+  fs.writeFileSync(
+    configPath,
+    `
+    import { createClient, custom, encodeFunctionResult } from '${import.meta.resolve('viem')}'
+    import { privateKeyToAccount } from '${import.meta.resolve('viem/accounts')}'
+    import { session } from '${sourceUrl}client/Session.ts'
+    import { createChannelStore } from '${sourceUrl}client/ChannelStore.ts'
+    import { computeId } from '${sourceUrl}precompile/Channel.ts'
+    import { escrowAbi } from '${sourceUrl}precompile/escrow.abi.ts'
+    const account = privateKeyToAccount('${testPrivateKey}')
+    const descriptor = {
+      payer: account.address, authorizedSigner: account.address,
+      payee: '${accounts[0].address}', token: '${Addresses.pathUsd}',
+      operator: '0x0000000000000000000000000000000000000000',
+      salt: '0x${'11'.repeat(32)}', expiringNonceHash: '0x${'22'.repeat(32)}',
+    }
+    const escrow = '${tip20ChannelEscrow}'
+    const channelStore = createChannelStore()
+    await channelStore.set({ descriptor, escrow, chainId: 42431,
+      channelId: computeId({ ...descriptor, escrow, chainId: 42431 }),
+      deposit: 1000n, cumulativeAmount: 0n, opened: true,
+    })
+    const client = createClient({ account, chain: { id: 42431 }, transport: custom({
+      async request({ method }) {
+        if (method === 'eth_call') return encodeFunctionResult({ abi: escrowAbi,
+          functionName: 'getChannelState', result: { settled: 0n, deposit: 1000n, closeRequestedAt: 0 },
+        })
+        throw new Error('unexpected RPC: ' + method)
+      }
+    }) })
+    export default { methods: [session({ account, expectedChainId: 42431,
+      channelStore, getClient: () => client, decimals: 0, maxDeposit: '1000',
+    })] }
+  `,
+  )
+  const challenge = Challenge.from({
+    id: 'configured-stream',
+    realm: 'localhost',
+    method: 'tempo',
+    intent: 'session',
+    request: {
+      amount: '100',
+      currency: Addresses.pathUsd,
+      recipient: accounts[0].address,
+      unitType: 'token',
+      methodDetails: {
+        chainId: 42431,
+        escrowContract: tip20ChannelEscrow,
+        sessionProtocol: Constants.SessionProtocols.v2,
+      },
+    },
+  })
+  const { formatMessageEvent, formatNeedVoucherEvent } =
+    await import('../tempo/session/precompile/Protocol.js')
+  const vouchers: string[] = []
+  let closeStream: (() => void) | undefined
+  let streamClosed = false
+  let outputBeforeClose = false
+  const server = await Http.createServer((req, res) => {
+    if (!req.headers.authorization) {
+      res.writeHead(402, { [Constants.Headers.wwwAuthenticate]: Challenge.serialize(challenge) })
+      res.end()
+      return
+    }
+    const payload = Credential.deserialize<SessionCredentialPayload>(
+      req.headers.authorization,
+    ).payload
+    if (payload.action !== 'voucher') throw new Error('expected voucher')
+    vouchers.push(payload.cumulativeAmount)
+    if (req.method === 'POST') {
+      res.writeHead(204)
+      res.end()
+      return
+    }
+    res.writeHead(200, { 'content-type': 'text/event-stream' })
+    closeStream = () => {
+      clearTimeout(timeout)
+      streamClosed = true
+      res.end()
+    }
+    const timeout = setTimeout(() => closeStream?.(), 2000)
+    res.write(
+      formatMessageEvent('first') +
+        formatNeedVoucherEvent({
+          acceptedCumulative: '100',
+          channelId: payload.channelId,
+          deposit: '1000',
+          requiredCumulative: '200',
+        }) +
+        formatMessageEvent('second'),
+    )
+  })
+  try {
+    const { output, exitCode } = await serve(
+      [server.url, '-s', '--config', configPath, '-H', 'accept: text/event-stream'],
+      {
+        env: { MPPX_PRIVATE_KEY: testPrivateKey },
+        onOutput(chunk) {
+          if (!chunk.includes('first')) return
+          outputBeforeClose = !streamClosed
+          closeStream?.()
+        },
+      },
+    )
+    expect(exitCode).toBeUndefined()
+    expect(outputBeforeClose).toBe(true)
+    expect(output).toContain('first')
+    expect(output).toContain('second')
+    expect(output).not.toContain('need-voucher')
+    expect(vouchers).toEqual(['100', '200'])
+  } finally {
+    closeStream?.()
+    server.close()
+    fs.rmSync(configDir, { recursive: true, force: true })
+  }
+})
+
+test('configured charge methods do not probe the CLI wallet to rank offers', async () => {
+  const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mppx-config-offers-'))
+  const configPath = path.join(configDir, 'mppx.config.mjs')
+  const moduleUrl = pathToFileURL(path.join(process.cwd(), 'src/index.ts')).href
+  fs.writeFileSync(
+    configPath,
+    `
+    import { Credential, Method, z } from '${moduleUrl}'
+    export default { methods: [[Method.toClient(Method.from({
+      name: 'tempo', intent: 'charge',
+      schema: { credential: { payload: z.object({}) },
+        request: z.object({ amount: z.string(), currency: z.string() }),
+      }
+    }), { async createCredential({ challenge }) {
+      return Credential.serialize({ challenge, payload: {} })
+    } })]] }
+  `,
+  )
+  let balanceRequests = 0
+  const balanceServer = await Http.createServer((_req, res) => {
+    balanceRequests++
+    res.writeHead(400)
+    res.end()
+  })
+  const offers = [unfundedToken, Addresses.pathUsd].map((currency, index) =>
+    Challenge.from({
+      id: `offer-${index}`,
+      realm: 'localhost',
+      method: 'tempo',
+      intent: 'charge',
+      request: {
+        amount: '100',
+        currency,
+        recipient: accounts[0].address,
+        methodDetails: { chainId: 42431 },
+      },
+    }),
+  )
+  let selectedCurrency: unknown
+  const server = await Http.createServer((req, res) => {
+    if (req.headers.authorization) {
+      selectedCurrency = Credential.deserialize(req.headers.authorization).challenge.request
+        .currency
+      res.end('configured-payer')
+      return
+    }
+    res.writeHead(402, {
+      [Constants.Headers.wwwAuthenticate]: offers.map(Challenge.serialize).join(', '),
+    })
+    res.end()
+  })
+  try {
+    const { output, exitCode } = await serve(
+      [server.url, '-s', '--config', configPath, '--rpc-url', balanceServer.url],
+      { env: { MPPX_PRIVATE_KEY: testPrivateKey } },
+    )
+    expect(exitCode).toBeUndefined()
+    expect(output).toContain('configured-payer')
+    expect(selectedCurrency).toBe(unfundedToken)
+    expect(balanceRequests).toBe(0)
+  } finally {
+    server.close()
+    balanceServer.close()
+    fs.rmSync(configDir, { recursive: true, force: true })
+  }
 })

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -1,3 +1,4 @@
+import { once } from 'node:events'
 import * as fs from 'node:fs'
 import { createRequire } from 'node:module'
 import * as path from 'node:path'
@@ -21,7 +22,13 @@ import * as x402_Header from '../x402/Header.js'
 import * as x402_ChallengeBrand from '../x402/internal/ChallengeBrand.js'
 import * as x402_Types from '../x402/Types.js'
 import { createDefaultStore, createKeychain, resolveAccountName } from './account.js'
-import { loadConfig, preparePayment, resolveAcceptPayment, selectChallenge } from './internal.js'
+import {
+  flattenConfigMethods,
+  loadConfig,
+  preparePayment,
+  resolveAcceptPayment,
+  selectChallenge,
+} from './internal.js'
 import type { Plugin } from './plugins/plugin.js'
 import {
   orderTempoChargeChallengesByBalance,
@@ -112,7 +119,17 @@ function outputResult<Data>(
 }
 
 async function writeResponseBody(response: Response) {
-  process.stdout.write(Buffer.from(await response.arrayBuffer()))
+  if (!response.body) return
+  const reader = response.body.getReader()
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      if (!process.stdout.write(Buffer.from(value))) await once(process.stdout, 'drain')
+    }
+  } finally {
+    reader.releaseLock()
+  }
 }
 
 function canReadCommandStdin() {
@@ -543,13 +560,17 @@ const cli = Cli.create('mppx', {
           exitCode: 2,
         })
       }
-      const challenges = await orderTempoChargeChallengesByBalance(currencyChallenges, {
-        options: {
-          account: c.options.account,
-          network: c.options.network,
-          rpcUrl: c.options.rpcUrl,
-        },
-      })
+      // Configured methods own their payer and preference ordering. The CLI
+      // wallet's balances cannot determine which of their offers are payable.
+      const challenges = flattenConfigMethods(loaded?.config)?.length
+        ? currencyChallenges
+        : await orderTempoChargeChallengesByBalance(currencyChallenges, {
+            options: {
+              account: c.options.account,
+              network: c.options.network,
+              rpcUrl: c.options.rpcUrl,
+            },
+          })
 
       const selected = selectChallenge(challenges, loaded?.config)
       if (!selected) {
@@ -673,7 +694,9 @@ const cli = Cli.create('mppx', {
       const persistentSessionAccount =
         process.env.MPPX_PRIVATE_KEY?.trim() ||
         !isTempoAccount(resolveAccountName(c.options.account))
-      if (isTempoSessionChallenge(challenge) && persistentSessionAccount) {
+      // Configured methods own their signing policies and channel storage.
+      // Rebuilding a persistent manager would discard those policies.
+      if (isTempoSessionChallenge(challenge) && persistentSessionAccount && !configMethod) {
         try {
           const credentialContext = await preparePayment(
             challenge,
@@ -710,7 +733,10 @@ const cli = Cli.create('mppx', {
       if (c.options.session !== 'auto')
         return c.error({
           code: 'UNSUPPORTED_SESSION',
-          message: '--session requires a tempo/session payment challenge.',
+          message:
+            configMethod && isTempoSessionChallenge(challenge)
+              ? '--session cannot override a configured session method. Configure its channelStore instead.'
+              : '--session requires a tempo/session payment challenge.',
           exitCode: 2,
         })
 
@@ -720,57 +746,80 @@ const cli = Cli.create('mppx', {
         pluginResult?.credentialContext,
       )
 
-      // Create credential
-      let credential: string
-      if (pluginResult?.createCredential)
-        credential = await pluginResult.createCredential(
-          selectedChallengeResponse,
-          credentialContext,
-        )
-      else if (pluginResult) {
-        const mppx = Mppx.create({
-          methods: pluginResult.methods,
-          polyfill: false,
-          transport: selectedChallengeTransport(challenge),
-        })
-        credential = await mppx.createCredential(
-          selectedChallengeResponse,
-          credentialContext as undefined,
-        )
-      } else if (configMethod) {
+      let credentialResponse: Response
+      let credential: string | undefined
+      if (configMethod && isTempoSessionChallenge(challenge)) {
+        // Reuse the selected challenge, then let the method settle channel state
+        // and handle SSE vouchers through the payment-aware fetch lifecycle.
+        let initialResponse: Response | undefined = selectedChallengeResponse
         const mppx = Mppx.create({
           methods: [configMethod],
           polyfill: false,
-          transport: selectedChallengeTransport(challenge),
+          fetch: async (input, requestInit) => {
+            if (initialResponse) {
+              const response = initialResponse
+              initialResponse = undefined
+              return response
+            }
+            return targetFetch(input, requestInit)
+          },
         })
-        credential = await mppx.createCredential(
-          selectedChallengeResponse,
-          credentialContext as never,
-        )
-      } else throw new Error('unreachable')
+        credentialResponse = await mppx.fetch(fetchUrl, {
+          ...init,
+          context: credentialContext as never,
+        })
+      } else {
+        // Create credential
+        if (pluginResult?.createCredential)
+          credential = await pluginResult.createCredential(
+            selectedChallengeResponse,
+            credentialContext,
+          )
+        else if (pluginResult) {
+          const mppx = Mppx.create({
+            methods: pluginResult.methods,
+            polyfill: false,
+            transport: selectedChallengeTransport(challenge),
+          })
+          credential = await mppx.createCredential(
+            selectedChallengeResponse,
+            credentialContext as undefined,
+          )
+        } else if (configMethod) {
+          const mppx = Mppx.create({
+            methods: [configMethod],
+            polyfill: false,
+            transport: selectedChallengeTransport(challenge),
+          })
+          credential = await mppx.createCredential(
+            selectedChallengeResponse,
+            credentialContext as never,
+          )
+        } else throw new Error('unreachable')
 
-      // Send credential and get response
-      const credentialHeader = isX402Challenge
-        ? x402_Types.paymentSignatureHeader
-        : Challenge.credentialHeader(challenge)
-      const credentialHeaders = {
-        ...normalizeHeaders(init.headers),
-        [credentialHeader]: credential,
-      }
-      const credentialTarget = isX402Challenge
-        ? resolveFetchTarget((x402ResourceUrl(challenge) ?? challengeResponse.url) || url)
-        : initialTarget
-      if (isX402Challenge) setTargetHost(credentialHeaders, credentialTarget.host)
-      plugin?.prepareCredentialRequest?.({ challenge, credential, headers: credentialHeaders })
+        // Send credential and get response
+        const credentialHeader = isX402Challenge
+          ? x402_Types.paymentSignatureHeader
+          : Challenge.credentialHeader(challenge)
+        const credentialHeaders = {
+          ...normalizeHeaders(init.headers),
+          [credentialHeader]: credential,
+        }
+        const credentialTarget = isX402Challenge
+          ? resolveFetchTarget((x402ResourceUrl(challenge) ?? challengeResponse.url) || url)
+          : initialTarget
+        if (isX402Challenge) setTargetHost(credentialHeaders, credentialTarget.host)
+        plugin?.prepareCredentialRequest?.({ challenge, credential, headers: credentialHeaders })
 
-      const credentialFetchInit = {
-        ...init,
-        ...(isX402Challenge && { redirect: 'manual' as const }),
-        headers: credentialHeaders,
+        const credentialFetchInit = {
+          ...init,
+          ...(isX402Challenge && { redirect: 'manual' as const }),
+          headers: credentialHeaders,
+        }
+        if (c.options.verbose >= 2)
+          printRequestHeaders(credentialTarget.url, credentialFetchInit, info)
+        credentialResponse = await targetFetch(credentialTarget.url, credentialFetchInit)
       }
-      if (c.options.verbose >= 2)
-        printRequestHeaders(credentialTarget.url, credentialFetchInit, info)
-      const credentialResponse = await targetFetch(credentialTarget.url, credentialFetchInit)
 
       if (c.options.fail && credentialResponse.status >= 400)
         return c.error({
@@ -801,21 +850,23 @@ const cli = Cli.create('mppx', {
       printResponseHeaders(credentialResponse, headerOpts)
 
       // Let plugin own the response lifecycle if it wants to
-      const handled = await plugin?.handleResponse?.({
-        challenge,
-        credential,
-        response: credentialResponse,
-        fetchUrl,
-        fetchInit: init,
-        silent: c.options.silent,
-        verbose: c.options.verbose,
-        confirmEnabled,
-        confirm,
-        tokenSymbol,
-        tokenDecimals,
-        explorerUrl,
-        shownKeys,
-      })
+      const handled =
+        credential &&
+        (await plugin?.handleResponse?.({
+          challenge,
+          credential,
+          response: credentialResponse,
+          fetchUrl,
+          fetchInit: init,
+          silent: c.options.silent,
+          verbose: c.options.verbose,
+          confirmEnabled,
+          confirm,
+          tokenSymbol,
+          tokenDecimals,
+          explorerUrl,
+          shownKeys,
+        }))
 
       if (!handled) {
         // Default: print receipt + body

--- a/src/cli/internal.test.ts
+++ b/src/cli/internal.test.ts
@@ -60,5 +60,7 @@ test('preserves the configured method selected by challenge filtering', () => {
   const second = { ...charge({ account }), canHandleChallenge: () => true }
   const config = { methods: [first, second] }
   expect(selectChallenge([challenge], config)?.method).toBe(second)
+  expect(resolvePlugin(challenge, config).method).toBe(second)
+  expect(resolvePlugin(challenge, { methods: [first] })).toEqual({})
   expect(selectChallenge([challenge], { methods: [first] })).toBeUndefined()
 })

--- a/src/cli/internal.test.ts
+++ b/src/cli/internal.test.ts
@@ -1,0 +1,64 @@
+import { privateKeyToAccount } from 'viem/accounts'
+import { describe, expect, test, vi } from 'vp/test'
+
+import * as Challenge from '../Challenge.js'
+import * as Assets from '../evm/Assets.js'
+import { charge } from '../evm/client/Charge.js'
+import { resolvePlugin, selectChallenge } from './internal.js'
+import { evm } from './plugins/evm.js'
+
+const account = privateKeyToAccount(
+  '0x0000000000000000000000000000000000000000000000000000000000000001',
+)
+const challenge = Challenge.from({
+  id: 'payment-policy',
+  realm: 'example.com',
+  method: 'evm',
+  intent: 'charge',
+  request: {
+    amount: '2000000',
+    currency: Assets.baseSepolia.USDC.address,
+    recipient: '0x2222222222222222222222222222222222222222',
+    methodDetails: { chainId: 84532, credentialTypes: ['authorization'] },
+  },
+})
+
+describe('configured payment policies', () => {
+  test.each([{ maxAmount: '1' }, { maxAtomicAmount: '1000000' }])(
+    'preserves the configured cap %j through challenge selection',
+    async (limits) => {
+      const signTypedData = vi.fn(async () => '0x1234' as const)
+      const method = charge({
+        account: { ...account, signTypedData },
+        currencies: [Assets.baseSepolia.USDC],
+        ...limits,
+      })
+      const selected = selectChallenge([challenge], { methods: [[method]] })
+      expect(selected?.method).toBe(method)
+      expect(selected?.plugin).toBeUndefined()
+      await expect(selected!.method!.createCredential({ challenge, context: {} })).rejects.toThrow(
+        /amount exceeds max/,
+      )
+      expect(signTypedData).not.toHaveBeenCalled()
+    },
+  )
+
+  test('retains explicit plugin precedence', () => {
+    const method = charge({ account, maxAmount: '1' })
+    const plugin = evm()
+    expect(resolvePlugin(challenge, { methods: [method], plugins: [plugin] })).toEqual({ plugin })
+  })
+
+  test('falls back to the built-in plugin without a matching configured method', () => {
+    expect(resolvePlugin(challenge).plugin?.method).toBe('evm')
+    expect(resolvePlugin({ ...challenge, method: 'unknown' })).toEqual({})
+  })
+})
+
+test('preserves the configured method selected by challenge filtering', () => {
+  const first = { ...charge({ account }), canHandleChallenge: () => false }
+  const second = { ...charge({ account }), canHandleChallenge: () => true }
+  const config = { methods: [first, second] }
+  expect(selectChallenge([challenge], config)?.method).toBe(second)
+  expect(selectChallenge([challenge], { methods: [first] })).toBeUndefined()
+})

--- a/src/cli/internal.ts
+++ b/src/cli/internal.ts
@@ -33,6 +33,7 @@ export async function preparePayment(
   return current
 }
 
+/** Resolves explicit payment configuration before falling back to built-in plugins. */
 export function resolvePlugin(
   challenge: Challenge.Challenge,
   config?: { plugins?: Plugin[] | undefined; methods?: any },
@@ -40,14 +41,16 @@ export function resolvePlugin(
   const configPlugin = config?.plugins?.find((p) => supportsPlugin(p, challenge))
   if (configPlugin) return { plugin: configPlugin }
 
-  const builtin = builtinPlugins.find((p) => supportsPlugin(p, challenge))
-  if (builtin) return { plugin: builtin }
-
   const configMethods = flattenConfigMethods(config)
-  const matched = configMethods?.find(
+  const matching = configMethods?.filter(
     (m) => m.name === challenge.method && m.intent === challenge.intent,
   )
+  const matched = matching?.find((m) => m.canHandleChallenge?.({ challenge }) ?? true)
   if (matched) return { method: matched }
+  if (matching?.length) return {}
+
+  const builtin = builtinPlugins.find((p) => supportsPlugin(p, challenge))
+  if (builtin) return { plugin: builtin }
 
   return {}
 }

--- a/src/cli/internal.ts
+++ b/src/cli/internal.ts
@@ -73,7 +73,11 @@ export function selectChallenge(
       resolvedPreferences.entries,
     )
     if (selected) {
-      return { challenge: selected.challenge, ...resolvePlugin(selected.challenge, config) }
+      const plugin = config?.plugins?.find((plugin) => supportsPlugin(plugin, selected.challenge))
+      return {
+        challenge: selected.challenge,
+        ...(plugin ? { plugin } : { method: selected.method }),
+      }
     }
 
     return undefined

--- a/src/cli/validate.test.ts
+++ b/src/cli/validate.test.ts
@@ -4,6 +4,7 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 import { pathToFileURL } from 'node:url'
 
+import { tempo as tempoMainnet, tempoModerato } from 'viem/tempo/chains'
 import { afterEach, describe, expect, test, vi } from 'vp/test'
 import * as Http from '~test/Http.js'
 
@@ -897,3 +898,130 @@ describe('validate: JSON mode', () => {
     expect(result.suggestions).toEqual([missingDiscoverySuggestion])
   })
 })
+
+test.each([
+  { kind: 'method', yes: true, status: 200 },
+  { kind: 'method', yes: true, status: 500 },
+  { kind: 'method', yes: false, status: 200 },
+  { kind: 'plugin', yes: true, status: 200 },
+  { kind: 'plugin', yes: true, status: 500 },
+  { kind: 'plugin', yes: false, status: 200 },
+])(
+  'configured Stripe $kind ignores ambient test key ($yes, $status)',
+  async ({ kind, yes, status }) => {
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mppx-stripe-config-'))
+    const configPath = path.join(configDir, 'mppx.config.mjs')
+    const moduleUrl = pathToFileURL(path.join(process.cwd(), 'src/index.ts')).href
+    fs.writeFileSync(
+      configPath,
+      `
+    import { Credential, Method, z } from '${moduleUrl}'
+    const method = Method.toClient(Method.from({
+      name: 'stripe', intent: 'charge',
+      schema: {
+        credential: { payload: z.object({ spt: z.string() }) },
+        request: z.object({ amount: z.string(), currency: z.string() }),
+      },
+    }), { async createCredential({ challenge }) {
+      return Credential.serialize({ challenge, payload: { spt: 'configured-token' } })
+    } })
+    export default ${
+      kind == 'plugin'
+        ? `{ plugins: [{ method: 'stripe', async setup() {
+      return { methods: [method], tokenSymbol: 'USD', tokenDecimals: 2 }
+    } }] }`
+        : '{ methods: [method] }'
+    }
+  `,
+    )
+    const challenge = makeChallenge({
+      method: 'stripe',
+      request: {
+        amount: '100',
+        currency: 'usd',
+        methodDetails: { networkId: 'profile_test123', paymentMethodTypes: ['card'] },
+      },
+    })
+    const server = await mppServer(challenge, { postPaymentStatus: status })
+    const previousKey = process.env.MPPX_STRIPE_SECRET_KEY
+    process.env.MPPX_STRIPE_SECRET_KEY = 'sk_test_unrelated'
+    const previousConfig = process.env.MPPX_CONFIG
+    process.env.MPPX_CONFIG = configPath
+    try {
+      const { output } = await serve([
+        'validate',
+        server.url,
+        '--outputJson',
+        ...(yes ? ['--yes'] : []),
+      ])
+      expect(output).not.toContain('server is in livemode')
+      if (yes) {
+        expect(output).toContain('Payment [stripe]: submitted')
+        if (status === 500) expect(output).toContain('Got 500')
+      } else {
+        expect(output).toContain('non-interactive mode, use --yes to approve')
+        expect(output).not.toContain('Payment [stripe]: submitted')
+      }
+    } finally {
+      if (previousKey === undefined) delete process.env.MPPX_STRIPE_SECRET_KEY
+      else process.env.MPPX_STRIPE_SECRET_KEY = previousKey
+      if (previousConfig === undefined) delete process.env.MPPX_CONFIG
+      else process.env.MPPX_CONFIG = previousConfig
+      fs.rmSync(configDir, { recursive: true, force: true })
+    }
+  },
+)
+
+test.each([
+  ['tempo', 4217],
+  ['tempo', 42431],
+  ['evm', 1],
+] as const)(
+  'validate uses configured %s payer on chain %i without a CLI wallet',
+  async (method, chainId) => {
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mppx-direct-config-'))
+    const configPath = path.join(configDir, 'mppx.config.mjs')
+    const moduleUrl = pathToFileURL(path.join(process.cwd(), 'src/index.ts')).href
+    fs.writeFileSync(
+      configPath,
+      `
+      import { Credential, Method, z } from '${moduleUrl}'
+      export default { methods: [[Method.toClient(Method.from({
+        name: '${method}', intent: 'charge',
+        schema: { credential: { payload: z.object({}) }, request: z.object({ amount: z.string() }) }
+      }), { async createCredential({ challenge }) { return Credential.serialize({ challenge, payload: {} }) } })]] }
+    `,
+    )
+    const previousConfig = process.env.MPPX_CONFIG
+    const previousAccount = process.env.MPPX_ACCOUNT
+    process.env.MPPX_CONFIG = configPath
+    process.env.MPPX_ACCOUNT = 'missing-validation-wallet'
+    const challenge = makeChallenge({
+      method,
+      request: {
+        amount: '10000',
+        currency: '0x20c0000000000000000000000000000000000000',
+        recipient: '0x1234567890123456789012345678901234567890',
+        methodDetails: { chainId },
+      },
+    })
+    const server = await mppServer(challenge)
+    try {
+      const { output } = await serve(['validate', server.url, '--outputJson', '--yes'])
+      expect(output).toContain(`Payment [${method}]: submitted`)
+      if (method === 'tempo') {
+        const chain = chainId === tempoModerato.id ? tempoModerato : tempoMainnet
+        expect(output).toContain(`${chain.blockExplorers.default.url}/receipt/`)
+      }
+      expect(output).not.toContain('no wallet configured')
+      expect(output).not.toContain('insufficient balance')
+      expect(output).not.toContain('ephemeral testnet wallet')
+    } finally {
+      if (previousConfig === undefined) delete process.env.MPPX_CONFIG
+      else process.env.MPPX_CONFIG = previousConfig
+      if (previousAccount === undefined) delete process.env.MPPX_ACCOUNT
+      else process.env.MPPX_ACCOUNT = previousAccount
+      fs.rmSync(configDir, { recursive: true, force: true })
+    }
+  },
+)

--- a/src/cli/validate/payment.ts
+++ b/src/cli/validate/payment.ts
@@ -17,7 +17,7 @@ import { chainId as tempoChainIds } from '../../tempo/internal/defaults.js'
 import { resolveAccount, resolveAccountName } from '../account.js'
 import type { Config } from '../config.js'
 import type * as Extension from '../Extension.js'
-import { loadConfig, preparePayment, resolvePlugin } from '../internal.js'
+import { flattenConfigMethods, loadConfig, preparePayment, resolvePlugin } from '../internal.js'
 import { fetchTokenInfo, confirm, pc } from '../utils.js'
 import { buildUrl } from './discovery.js'
 import type { CheckResult, EndpointSpec } from './helpers.js'
@@ -197,6 +197,12 @@ export async function validatePaymentFlow(
   // Testnet Tempo: always use ephemeral wallet (zero-setup, free money)
   const tempoTestnetChallenge = challenges.find((ch) => {
     if (ch.method !== Constants.Methods.tempo) return false
+    if (
+      flattenConfigMethods(loaded?.config)?.some(
+        (method) => method.name === ch.method && method.intent === ch.intent,
+      )
+    )
+      return false
     const req = ch.request as Record<string, unknown>
     const md = req.methodDetails as Record<string, unknown> | undefined
     return typeof md?.chainId === 'number' && md.chainId !== tempoChainIds.mainnet
@@ -338,30 +344,40 @@ async function attemptCryptoPayment(
     (methodDetails?.decimals as number | undefined) ?? (request.decimals as number | undefined) ?? 6
   const currency = request.currency as string | undefined
 
-  // Resolve wallet
-  let walletAddress: string | undefined
-  try {
-    walletAddress = await resolveWalletAddress()
-  } catch {}
-  if (!walletAddress) {
-    results.push(skip(tag, 'no wallet configured. Run "mppx account create" to create one.'))
+  const { plugin, method: directMethod } = resolvePlugin(challenge, loaded?.config)
+  if (!plugin && !directMethod) {
+    results.push(skip(tag, methodSetupHint(challenge)))
     return
+  }
+
+  // Direct methods own their payer; the CLI wallet may be unrelated or absent.
+  let walletAddress: string | undefined
+  if (!directMethod) {
+    try {
+      walletAddress = await resolveWalletAddress()
+    } catch {}
+    if (!walletAddress) {
+      results.push(skip(tag, 'no wallet configured. Run "mppx account create" to create one.'))
+      return
+    }
   }
 
   // Pre-flight balance check and chain resolution
   let paymentChain: Chain | undefined
-  if (challenge.method === Constants.Methods.tempo) paymentChain = tempoMainnetChain
-  else if (challenge.method === Constants.Methods.evm) {
+  if (challenge.method === Constants.Methods.tempo) {
+    const chainId = (methodDetails?.chainId as number | undefined) ?? tempoMainnetChain.id
+    paymentChain = chainId === tempoModerato.id ? tempoModerato : resolveEvmChain(chainId)
+  } else if (challenge.method === Constants.Methods.evm) {
     const chainId = methodDetails?.chainId as number | undefined
     if (chainId) paymentChain = resolveEvmChain(chainId)
   }
 
   let tokenSymbol: string | undefined
-  if (requiredAmount && currency && paymentChain) {
+  if (walletAddress && requiredAmount && currency && paymentChain) {
     try {
       let balance: bigint
       if (challenge.method === Constants.Methods.tempo) {
-        const client = createClient({ chain: tempoMainnetChain, transport: http() })
+        const client = createClient({ chain: paymentChain, transport: http() })
         const info = await fetchTokenInfo(client, currency as Address, walletAddress as Address)
         balance = info.balance
         tokenSymbol = info.symbol
@@ -398,9 +414,16 @@ async function attemptCryptoPayment(
   const chainName = paymentChain?.name
   const paymentDesc = `${amountDisplay}${tokenDisplay ? ` ${tokenDisplay}` : ''}${chainName ? ` on ${chainName}` : ''}`
 
-  if (!options.silent) console.log(pc.dim(`    Attempting payment with wallet ${walletAddress}`))
+  if (!options.silent)
+    console.log(
+      pc.dim(
+        walletAddress
+          ? `    Attempting payment with wallet ${walletAddress}`
+          : '    Attempting payment with configured method',
+      ),
+    )
 
-  if (paymentChain?.testnet) {
+  if (!directMethod && paymentChain?.testnet) {
     if (!options.silent) console.log(pc.dim(`    Auto-approved: ${paymentDesc} (testnet)`))
   } else if (!options.yes && !ctx.isInteractive) {
     results.push(skip(tag, 'non-interactive mode, use --yes to approve'))
@@ -413,15 +436,6 @@ async function attemptCryptoPayment(
     }
   } else {
     if (!options.silent) console.log(pc.dim(`    Auto-approved: ${paymentDesc}`))
-  }
-
-  // Resolve plugin and pay
-  const resolved = resolvePlugin(challenge, loaded?.config)
-  const plugin = resolved.plugin
-  const directMethod = resolved.method
-  if (!plugin && !directMethod) {
-    results.push(skip(tag, methodSetupHint(challenge)))
-    return
   }
 
   let methods: AnyClient[]
@@ -476,18 +490,16 @@ async function attemptStripePayment(
   tag: string,
   ctx: PaymentContext & { isStripeTestKey: boolean; stripeKey?: string | undefined },
 ): Promise<void> {
-  const {
-    results,
-    url,
-    endpoint,
-    fetchHeaders,
-    fetchBody,
-    verbose,
-    loaded,
-    options,
-    isStripeTestKey,
-    stripeKey,
-  } = ctx
+  const { results, url, endpoint, fetchHeaders, fetchBody, verbose, loaded, options, stripeKey } =
+    ctx
+  const { plugin, method: directMethod } = resolvePlugin(challenge, loaded?.config)
+  if (!plugin && !directMethod) {
+    results.push(skip(tag, 'no Stripe payment method available'))
+    return
+  }
+  const isStripeTestKey = Boolean(
+    plugin && !loaded?.config.plugins?.includes(plugin) && ctx.isStripeTestKey,
+  )
   const request = challenge.request as Record<string, unknown>
   const requiredAmount = isValidIntegerAmount(request.amount)
     ? BigInt(request.amount as string)
@@ -514,33 +526,29 @@ async function attemptStripePayment(
     if (!options.silent) console.log(pc.dim(`    Auto-approved: ${paymentDesc}`))
   }
 
-  // Resolve plugin
-  const resolved = resolvePlugin(challenge, loaded?.config)
-  const plugin = resolved.plugin
-  if (!plugin) {
-    results.push(skip(tag, 'no Stripe plugin available'))
-    return
-  }
-
   let methods: AnyClient[]
   let createCredentialFn:
     | ((response: Response, credentialContext?: unknown) => Promise<string>)
     | undefined
   let credentialContext: unknown
-  try {
-    const methodOpts: Record<string, string> = { paymentMethod: 'pm_card_visa' }
-    if (stripeKey) methodOpts.secretKey = stripeKey
-    const pluginResult = await plugin.setup({
-      challenge,
-      options: {},
-      methodOpts,
-    })
-    methods = pluginResult.methods
-    createCredentialFn = pluginResult.createCredential
-    credentialContext = pluginResult.credentialContext
-  } catch (error) {
-    results.push(skip(tag, (error as Error).message))
-    return
+  if (plugin) {
+    try {
+      const methodOpts: Record<string, string> = { paymentMethod: 'pm_card_visa' }
+      if (stripeKey) methodOpts.secretKey = stripeKey
+      const pluginResult = await plugin.setup({
+        challenge,
+        options: {},
+        methodOpts,
+      })
+      methods = pluginResult.methods
+      createCredentialFn = pluginResult.createCredential
+      credentialContext = pluginResult.credentialContext
+    } catch (error) {
+      results.push(skip(tag, (error as Error).message))
+      return
+    }
+  } else {
+    methods = [directMethod!]
   }
 
   const credential = await createAndSend(
@@ -554,7 +562,7 @@ async function attemptStripePayment(
   )
   if (!credential) return
 
-  plugin.prepareCredentialRequest?.({ challenge, credential, headers: fetchHeaders })
+  plugin?.prepareCredentialRequest?.({ challenge, credential, headers: fetchHeaders })
 
   // Stripe testmode: detect livemode rejection gracefully
   if (isStripeTestKey) {


### PR DESCRIPTION
## Motivation

CLI challenge selection could replace configured client methods with built-in plugins, losing spending limits, signing policies, and session storage.

## Summary

- Keep the configured method selected by challenge filtering and skip unrelated CLI-wallet balance ranking.
- Route configured sessions through payment-aware fetch for channel settlement and follow-up vouchers.
- Write response chunks incrementally with stdout backpressure handling.

## Key design considerations

- Built on #888 for session chain-policy coverage.
- Preserve explicitly configured plugin precedence and let configured session methods own their channel storage.
