### PR TITLE
fix: honor configured payers and approvals during validation

### DIFF
--- a/.changeset/validate-configured-payment-methods.md
+++ b/.changeset/validate-configured-payment-methods.md
@@ -1,0 +1,5 @@
+---
+'mppx': patch
+---
+
+Used configured payment methods during validation without unrelated CLI-wallet preflights, limited Stripe test-key shortcuts to the built-in plugin, and reported the advertised Tempo chain.

--- a/src/cli/internal.test.ts
+++ b/src/cli/internal.test.ts
@@ -60,5 +60,7 @@ test('preserves the configured method selected by challenge filtering', () => {
   const second = { ...charge({ account }), canHandleChallenge: () => true }
   const config = { methods: [first, second] }
   expect(selectChallenge([challenge], config)?.method).toBe(second)
+  expect(resolvePlugin(challenge, config).method).toBe(second)
+  expect(resolvePlugin(challenge, { methods: [first] })).toEqual({})
   expect(selectChallenge([challenge], { methods: [first] })).toBeUndefined()
 })

--- a/src/cli/internal.ts
+++ b/src/cli/internal.ts
@@ -33,6 +33,7 @@ export async function preparePayment(
   return current
 }
 
+/** Resolves explicit payment configuration before falling back to built-in plugins. */
 export function resolvePlugin(
   challenge: Challenge.Challenge,
   config?: { plugins?: Plugin[] | undefined; methods?: any },
@@ -40,14 +41,16 @@ export function resolvePlugin(
   const configPlugin = config?.plugins?.find((p) => supportsPlugin(p, challenge))
   if (configPlugin) return { plugin: configPlugin }
 
-  const builtin = builtinPlugins.find((p) => supportsPlugin(p, challenge))
-  if (builtin) return { plugin: builtin }
-
   const configMethods = flattenConfigMethods(config)
-  const matched = configMethods?.find(
+  const matching = configMethods?.filter(
     (m) => m.name === challenge.method && m.intent === challenge.intent,
   )
+  const matched = matching?.find((m) => m.canHandleChallenge?.({ challenge }) ?? true)
   if (matched) return { method: matched }
+  if (matching?.length) return {}
+
+  const builtin = builtinPlugins.find((p) => supportsPlugin(p, challenge))
+  if (builtin) return { plugin: builtin }
 
   return {}
 }

--- a/src/cli/validate.test.ts
+++ b/src/cli/validate.test.ts
@@ -4,6 +4,7 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 import { pathToFileURL } from 'node:url'
 
+import { tempo as tempoMainnet, tempoModerato } from 'viem/tempo/chains'
 import { afterEach, describe, expect, test, vi } from 'vp/test'
 import * as Http from '~test/Http.js'
 
@@ -897,3 +898,130 @@ describe('validate: JSON mode', () => {
     expect(result.suggestions).toEqual([missingDiscoverySuggestion])
   })
 })
+
+test.each([
+  { kind: 'method', yes: true, status: 200 },
+  { kind: 'method', yes: true, status: 500 },
+  { kind: 'method', yes: false, status: 200 },
+  { kind: 'plugin', yes: true, status: 200 },
+  { kind: 'plugin', yes: true, status: 500 },
+  { kind: 'plugin', yes: false, status: 200 },
+])(
+  'configured Stripe $kind ignores ambient test key ($yes, $status)',
+  async ({ kind, yes, status }) => {
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mppx-stripe-config-'))
+    const configPath = path.join(configDir, 'mppx.config.mjs')
+    const moduleUrl = pathToFileURL(path.join(process.cwd(), 'src/index.ts')).href
+    fs.writeFileSync(
+      configPath,
+      `
+    import { Credential, Method, z } from '${moduleUrl}'
+    const method = Method.toClient(Method.from({
+      name: 'stripe', intent: 'charge',
+      schema: {
+        credential: { payload: z.object({ spt: z.string() }) },
+        request: z.object({ amount: z.string(), currency: z.string() }),
+      },
+    }), { async createCredential({ challenge }) {
+      return Credential.serialize({ challenge, payload: { spt: 'configured-token' } })
+    } })
+    export default ${
+      kind == 'plugin'
+        ? `{ plugins: [{ method: 'stripe', async setup() {
+      return { methods: [method], tokenSymbol: 'USD', tokenDecimals: 2 }
+    } }] }`
+        : '{ methods: [method] }'
+    }
+  `,
+    )
+    const challenge = makeChallenge({
+      method: 'stripe',
+      request: {
+        amount: '100',
+        currency: 'usd',
+        methodDetails: { networkId: 'profile_test123', paymentMethodTypes: ['card'] },
+      },
+    })
+    const server = await mppServer(challenge, { postPaymentStatus: status })
+    const previousKey = process.env.MPPX_STRIPE_SECRET_KEY
+    process.env.MPPX_STRIPE_SECRET_KEY = 'sk_test_unrelated'
+    const previousConfig = process.env.MPPX_CONFIG
+    process.env.MPPX_CONFIG = configPath
+    try {
+      const { output } = await serve([
+        'validate',
+        server.url,
+        '--outputJson',
+        ...(yes ? ['--yes'] : []),
+      ])
+      expect(output).not.toContain('server is in livemode')
+      if (yes) {
+        expect(output).toContain('Payment [stripe]: submitted')
+        if (status === 500) expect(output).toContain('Got 500')
+      } else {
+        expect(output).toContain('non-interactive mode, use --yes to approve')
+        expect(output).not.toContain('Payment [stripe]: submitted')
+      }
+    } finally {
+      if (previousKey === undefined) delete process.env.MPPX_STRIPE_SECRET_KEY
+      else process.env.MPPX_STRIPE_SECRET_KEY = previousKey
+      if (previousConfig === undefined) delete process.env.MPPX_CONFIG
+      else process.env.MPPX_CONFIG = previousConfig
+      fs.rmSync(configDir, { recursive: true, force: true })
+    }
+  },
+)
+
+test.each([
+  ['tempo', 4217],
+  ['tempo', 42431],
+  ['evm', 1],
+] as const)(
+  'validate uses configured %s payer on chain %i without a CLI wallet',
+  async (method, chainId) => {
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mppx-direct-config-'))
+    const configPath = path.join(configDir, 'mppx.config.mjs')
+    const moduleUrl = pathToFileURL(path.join(process.cwd(), 'src/index.ts')).href
+    fs.writeFileSync(
+      configPath,
+      `
+      import { Credential, Method, z } from '${moduleUrl}'
+      export default { methods: [[Method.toClient(Method.from({
+        name: '${method}', intent: 'charge',
+        schema: { credential: { payload: z.object({}) }, request: z.object({ amount: z.string() }) }
+      }), { async createCredential({ challenge }) { return Credential.serialize({ challenge, payload: {} }) } })]] }
+    `,
+    )
+    const previousConfig = process.env.MPPX_CONFIG
+    const previousAccount = process.env.MPPX_ACCOUNT
+    process.env.MPPX_CONFIG = configPath
+    process.env.MPPX_ACCOUNT = 'missing-validation-wallet'
+    const challenge = makeChallenge({
+      method,
+      request: {
+        amount: '10000',
+        currency: '0x20c0000000000000000000000000000000000000',
+        recipient: '0x1234567890123456789012345678901234567890',
+        methodDetails: { chainId },
+      },
+    })
+    const server = await mppServer(challenge)
+    try {
+      const { output } = await serve(['validate', server.url, '--outputJson', '--yes'])
+      expect(output).toContain(`Payment [${method}]: submitted`)
+      if (method === 'tempo') {
+        const chain = chainId === tempoModerato.id ? tempoModerato : tempoMainnet
+        expect(output).toContain(`${chain.blockExplorers.default.url}/receipt/`)
+      }
+      expect(output).not.toContain('no wallet configured')
+      expect(output).not.toContain('insufficient balance')
+      expect(output).not.toContain('ephemeral testnet wallet')
+    } finally {
+      if (previousConfig === undefined) delete process.env.MPPX_CONFIG
+      else process.env.MPPX_CONFIG = previousConfig
+      if (previousAccount === undefined) delete process.env.MPPX_ACCOUNT
+      else process.env.MPPX_ACCOUNT = previousAccount
+      fs.rmSync(configDir, { recursive: true, force: true })
+    }
+  },
+)

--- a/src/cli/validate/payment.ts
+++ b/src/cli/validate/payment.ts
@@ -17,7 +17,7 @@ import { chainId as tempoChainIds } from '../../tempo/internal/defaults.js'
 import { resolveAccount, resolveAccountName } from '../account.js'
 import type { Config } from '../config.js'
 import type * as Extension from '../Extension.js'
-import { loadConfig, preparePayment, resolvePlugin } from '../internal.js'
+import { flattenConfigMethods, loadConfig, preparePayment, resolvePlugin } from '../internal.js'
 import { fetchTokenInfo, confirm, pc } from '../utils.js'
 import { buildUrl } from './discovery.js'
 import type { CheckResult, EndpointSpec } from './helpers.js'
@@ -197,6 +197,12 @@ export async function validatePaymentFlow(
   // Testnet Tempo: always use ephemeral wallet (zero-setup, free money)
   const tempoTestnetChallenge = challenges.find((ch) => {
     if (ch.method !== Constants.Methods.tempo) return false
+    if (
+      flattenConfigMethods(loaded?.config)?.some(
+        (method) => method.name === ch.method && method.intent === ch.intent,
+      )
+    )
+      return false
     const req = ch.request as Record<string, unknown>
     const md = req.methodDetails as Record<string, unknown> | undefined
     return typeof md?.chainId === 'number' && md.chainId !== tempoChainIds.mainnet
@@ -338,30 +344,40 @@ async function attemptCryptoPayment(
     (methodDetails?.decimals as number | undefined) ?? (request.decimals as number | undefined) ?? 6
   const currency = request.currency as string | undefined
 
-  // Resolve wallet
-  let walletAddress: string | undefined
-  try {
-    walletAddress = await resolveWalletAddress()
-  } catch {}
-  if (!walletAddress) {
-    results.push(skip(tag, 'no wallet configured. Run "mppx account create" to create one.'))
+  const { plugin, method: directMethod } = resolvePlugin(challenge, loaded?.config)
+  if (!plugin && !directMethod) {
+    results.push(skip(tag, methodSetupHint(challenge)))
     return
+  }
+
+  // Direct methods own their payer; the CLI wallet may be unrelated or absent.
+  let walletAddress: string | undefined
+  if (!directMethod) {
+    try {
+      walletAddress = await resolveWalletAddress()
+    } catch {}
+    if (!walletAddress) {
+      results.push(skip(tag, 'no wallet configured. Run "mppx account create" to create one.'))
+      return
+    }
   }
 
   // Pre-flight balance check and chain resolution
   let paymentChain: Chain | undefined
-  if (challenge.method === Constants.Methods.tempo) paymentChain = tempoMainnetChain
-  else if (challenge.method === Constants.Methods.evm) {
+  if (challenge.method === Constants.Methods.tempo) {
+    const chainId = (methodDetails?.chainId as number | undefined) ?? tempoMainnetChain.id
+    paymentChain = chainId === tempoModerato.id ? tempoModerato : resolveEvmChain(chainId)
+  } else if (challenge.method === Constants.Methods.evm) {
     const chainId = methodDetails?.chainId as number | undefined
     if (chainId) paymentChain = resolveEvmChain(chainId)
   }
 
   let tokenSymbol: string | undefined
-  if (requiredAmount && currency && paymentChain) {
+  if (walletAddress && requiredAmount && currency && paymentChain) {
     try {
       let balance: bigint
       if (challenge.method === Constants.Methods.tempo) {
-        const client = createClient({ chain: tempoMainnetChain, transport: http() })
+        const client = createClient({ chain: paymentChain, transport: http() })
         const info = await fetchTokenInfo(client, currency as Address, walletAddress as Address)
         balance = info.balance
         tokenSymbol = info.symbol
@@ -398,9 +414,16 @@ async function attemptCryptoPayment(
   const chainName = paymentChain?.name
   const paymentDesc = `${amountDisplay}${tokenDisplay ? ` ${tokenDisplay}` : ''}${chainName ? ` on ${chainName}` : ''}`
 
-  if (!options.silent) console.log(pc.dim(`    Attempting payment with wallet ${walletAddress}`))
+  if (!options.silent)
+    console.log(
+      pc.dim(
+        walletAddress
+          ? `    Attempting payment with wallet ${walletAddress}`
+          : '    Attempting payment with configured method',
+      ),
+    )
 
-  if (paymentChain?.testnet) {
+  if (!directMethod && paymentChain?.testnet) {
     if (!options.silent) console.log(pc.dim(`    Auto-approved: ${paymentDesc} (testnet)`))
   } else if (!options.yes && !ctx.isInteractive) {
     results.push(skip(tag, 'non-interactive mode, use --yes to approve'))
@@ -413,15 +436,6 @@ async function attemptCryptoPayment(
     }
   } else {
     if (!options.silent) console.log(pc.dim(`    Auto-approved: ${paymentDesc}`))
-  }
-
-  // Resolve plugin and pay
-  const resolved = resolvePlugin(challenge, loaded?.config)
-  const plugin = resolved.plugin
-  const directMethod = resolved.method
-  if (!plugin && !directMethod) {
-    results.push(skip(tag, methodSetupHint(challenge)))
-    return
   }
 
   let methods: AnyClient[]
@@ -476,18 +490,16 @@ async function attemptStripePayment(
   tag: string,
   ctx: PaymentContext & { isStripeTestKey: boolean; stripeKey?: string | undefined },
 ): Promise<void> {
-  const {
-    results,
-    url,
-    endpoint,
-    fetchHeaders,
-    fetchBody,
-    verbose,
-    loaded,
-    options,
-    isStripeTestKey,
-    stripeKey,
-  } = ctx
+  const { results, url, endpoint, fetchHeaders, fetchBody, verbose, loaded, options, stripeKey } =
+    ctx
+  const { plugin, method: directMethod } = resolvePlugin(challenge, loaded?.config)
+  if (!plugin && !directMethod) {
+    results.push(skip(tag, 'no Stripe payment method available'))
+    return
+  }
+  const isStripeTestKey = Boolean(
+    plugin && !loaded?.config.plugins?.includes(plugin) && ctx.isStripeTestKey,
+  )
   const request = challenge.request as Record<string, unknown>
   const requiredAmount = isValidIntegerAmount(request.amount)
     ? BigInt(request.amount as string)
@@ -514,33 +526,29 @@ async function attemptStripePayment(
     if (!options.silent) console.log(pc.dim(`    Auto-approved: ${paymentDesc}`))
   }
 
-  // Resolve plugin
-  const resolved = resolvePlugin(challenge, loaded?.config)
-  const plugin = resolved.plugin
-  if (!plugin) {
-    results.push(skip(tag, 'no Stripe plugin available'))
-    return
-  }
-
   let methods: AnyClient[]
   let createCredentialFn:
     | ((response: Response, credentialContext?: unknown) => Promise<string>)
     | undefined
   let credentialContext: unknown
-  try {
-    const methodOpts: Record<string, string> = { paymentMethod: 'pm_card_visa' }
-    if (stripeKey) methodOpts.secretKey = stripeKey
-    const pluginResult = await plugin.setup({
-      challenge,
-      options: {},
-      methodOpts,
-    })
-    methods = pluginResult.methods
-    createCredentialFn = pluginResult.createCredential
-    credentialContext = pluginResult.credentialContext
-  } catch (error) {
-    results.push(skip(tag, (error as Error).message))
-    return
+  if (plugin) {
+    try {
+      const methodOpts: Record<string, string> = { paymentMethod: 'pm_card_visa' }
+      if (stripeKey) methodOpts.secretKey = stripeKey
+      const pluginResult = await plugin.setup({
+        challenge,
+        options: {},
+        methodOpts,
+      })
+      methods = pluginResult.methods
+      createCredentialFn = pluginResult.createCredential
+      credentialContext = pluginResult.credentialContext
+    } catch (error) {
+      results.push(skip(tag, (error as Error).message))
+      return
+    }
+  } else {
+    methods = [directMethod!]
   }
 
   const credential = await createAndSend(
@@ -554,7 +562,7 @@ async function attemptStripePayment(
   )
   if (!credential) return
 
-  plugin.prepareCredentialRequest?.({ challenge, credential, headers: fetchHeaders })
+  plugin?.prepareCredentialRequest?.({ challenge, credential, headers: fetchHeaders })
 
   // Stripe testmode: detect livemode rejection gracefully
   if (isStripeTestKey) {


### PR DESCRIPTION
## Motivation

Payment validation could ignore configured methods, preflight an unrelated CLI wallet, or treat custom live Stripe credentials as test-mode payments.

## Summary

- Resolve configured methods before built-ins and honor their challenge filters.
- Use configured crypto payers without unrelated wallet checks or ephemeral-wallet replacement.
- Restrict automatic Stripe test-mode approval to the built-in plugin and report the advertised Tempo chain.

## Key design considerations

- Built on #889; this diff isolates validation behavior from CLI request execution.
- Preserve explicit plugin precedence and require normal approval for custom Stripe credentials.
